### PR TITLE
Add config to support tests in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,5 +24,6 @@
   },
   "files.associations": {
     "*.iced": "coffeescript"
-  }
+  },
+  "mocha.files.glob": "test/**/dist/AcceptanceTests/*.js"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
   "files.associations": {
     "*.iced": "coffeescript"
   },
-  "mocha.files.glob": "test/**/dist/AcceptanceTests/*.js"
+  "mocha.files.glob": "test/**/dist/AcceptanceTests/*.js",
+  "mocha.logVerbose": true
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "autorest": "autorest",
     "start": "dotnet src/bin/netcoreapp2.0/autorest.typescript.dll --server",
+    "start-test-server": "npm --prefix node_modules/@microsoft.azure/autorest.testserver run start",
     "test": "gulp test",
     "testci": "gulp testci",
     "build": "gulp build",


### PR DESCRIPTION
These config tweaks support using [Mocha Sidebar](https://marketplace.visualstudio.com/items?itemName=maty.vscode-mocha-sidebar) which seems to make the experience of running a particular subset of tests or debugging the tests more pleasant :)

For this to work it's necessary to pop open a terminal, run `npm run start-test-server` and then try to run tests in VSCode.