### PR TITLE
Fail tests when catching an AssertionError

### DIFF
--- a/test/azure/azureCustomBaseUri.ts
+++ b/test/azure/azureCustomBaseUri.ts
@@ -33,20 +33,20 @@ describe('typescript', function () {
         await Promise.race([testClient.paths.getEmpty('local'), timeoutPromise(1000)]);
         assert.fail('');
       } catch (error) {
-        should.exist(error);
+        should(error).not.be.instanceof(assert.AssertionError);
       }
       testClient.host = 'host:3000';
       try {
         await Promise.race([testClient.paths.getEmpty('bad'), timeoutPromise(1000)]);
         assert.fail('');
       } catch (error) {
-        should.exist(error);
+        should(error).not.be.instanceof(assert.AssertionError);
       }
 
       try {
         await Promise.race([testClient.paths.getEmpty(null), timeoutPromise(1000)]);
       } catch (error) {
-        should.exist(error);
+        should(error).not.be.instanceof(assert.AssertionError);
       }
     });
   });


### PR DESCRIPTION
Looking over the logic, one realizes that the catch will take the AssertionError produced by assert.fail and let the test pass, giving a false positive. Let's fix the problem by ensuring that the error that is caught is not an AssertionError.