### PR TITLE
Add missing xmlName property to mappers

### DIFF
--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -658,7 +658,7 @@ namespace AutoRest.TypeScript
             return builder;
         }
 
-        public static string ConstructMapper(this IModelType type, string serializedName, IVariable parameter, bool isPageable, bool expandComposite, bool isXML)
+        public static string ConstructMapper(this IModelType type, string serializedName, IVariable parameter, bool isPageable, bool expandComposite, bool isXML, string xmlName = null)
         {
             var builder = new IndentedStringBuilder("  ");
             string defaultValue = null;
@@ -677,6 +677,12 @@ namespace AutoRest.TypeScript
 
             builder.AppendLine("").Indent();
 
+            bool wroteXmlName = isXML && !string.IsNullOrEmpty(xmlName) && xmlName != serializedName;
+            if (wroteXmlName)
+            {
+                builder.AppendLine($"xmlName: '{xmlName}',");
+            }
+
             if (property != null)
             {
                 isReadOnly = property.IsReadOnly;
@@ -693,7 +699,7 @@ namespace AutoRest.TypeScript
                         builder.AppendLine("xmlIsWrapped: true,");
                     }
 
-                    if (!string.IsNullOrEmpty(property.XmlName))
+                    if (!wroteXmlName && !string.IsNullOrEmpty(property.XmlName))
                     {
                         builder.AppendLine($"xmlName: '{property.XmlName}',");
                     }

--- a/src/vanilla/Model/CompositeTypeTS.cs
+++ b/src/vanilla/Model/CompositeTypeTS.cs
@@ -232,7 +232,8 @@ namespace AutoRest.TypeScript.Model
 
         public virtual string ConstructModelMapper()
         {
-            var modelMapper = this.ConstructMapper(SerializedName, null, isPageable: false, expandComposite: true, isXML: CodeModel?.ShouldGenerateXmlSerialization == true);
+            bool isXML = CodeModel?.ShouldGenerateXmlSerialization == true;
+            var modelMapper = this.ConstructMapper(SerializedName, null, isPageable: false, expandComposite: true, isXML: isXML, xmlName: isXML ? XmlName : null);
             var builder = new IndentedStringBuilder("  ");
             builder.AppendLine("export const {0} = {{{1}}};", Name, modelMapper);
             return builder.ToString();

--- a/test/xml/generated/Xml/models/mappers.ts
+++ b/test/xml/generated/Xml/models/mappers.ts
@@ -37,6 +37,7 @@ export const ErrorModel = {
 };
 
 export const Slide = {
+  xmlName: 'slide',
   required: false,
   serializedName: 'Slide',
   type: {
@@ -81,6 +82,7 @@ export const Slide = {
 };
 
 export const Slideshow = {
+  xmlName: 'slideshow',
   required: false,
   serializedName: 'Slideshow',
   type: {
@@ -181,6 +183,7 @@ export const AppleBarrel = {
 };
 
 export const Banana = {
+  xmlName: 'banana',
   required: false,
   serializedName: 'Banana',
   type: {
@@ -321,6 +324,7 @@ export const Container = {
 };
 
 export const ListContainersResponse = {
+  xmlName: 'EnumerationResults',
   required: false,
   serializedName: 'ListContainersResponse',
   type: {
@@ -934,6 +938,7 @@ export const Blobs = {
 };
 
 export const ListBlobsResponse = {
+  xmlName: 'EnumerationResults',
   required: false,
   serializedName: 'ListBlobsResponse',
   type: {


### PR DESCRIPTION
While doing work on moving serialization into the HTTP pipeline, I found that xmlName wasn't being set properly in the top level of mappers. These changes should fix that.