### PR TITLE
Integrate serialization request policy into generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "mocha-chrome": "^1.0.3",
     "moment": "~2.21.0",
     "ms-rest-azure-js": "^0.3.50",
-    "ms-rest-js": "^0.5.149",
+    "ms-rest-js": "^0.5.156",
     "run-sequence": "*",
     "should": "5.2.0",
     "shx": "^0.2.2",

--- a/src/azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/azure/Templates/AzureServiceClientTemplate.cshtml
@@ -84,7 +84,15 @@ foreach (var methodGroup in Model.MethodGroupModels)
   @:  }
 }
     @EmptyLine
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, @(Model.ShouldGenerateXmlSerialization.ToString().ToLower()))
+      };
+    }
     @EmptyLine
     super(@(requiredParameters.Any(p => p.ModelType.IsPrimaryType(KnownPrimaryType.Credentials)) ? "credentials" : "undefined"), options);
     @EmptyLine

--- a/src/vanilla/Templates/MethodJsonPipelineTemplate.cshtml
+++ b/src/vanilla/Templates/MethodJsonPipelineTemplate.cshtml
@@ -4,8 +4,28 @@
 // Send Request
 let operationRes: msRest.HttpOperationResponse;
 try {
+@if (Model.RequestBody != null)
+{
+<text>
+  @(Model.ConstructRequestBodyMapper)
+</text>
+}
   operationRes = await client.sendOperationRequest(httpRequest, {
+@if (Model.RequestBody == null)
+{
+<text>
     httpMethod: "@(Model.HttpMethod.ToString().ToUpper())"
+</text>
+}
+else
+{
+<text>
+    httpMethod: "@(Model.HttpMethod.ToString().ToUpper())",
+    requestBodyMapper: requestModelMapper,
+    requestBodyName: "@(Model.RequestBody.Name)",
+    isXML: @(Model.CodeModel.ShouldGenerateXmlSerialization.ToString().ToLower())
+</text>
+}
   });
   let statusCode = operationRes.status;
   if (@(Model.FailureStatusCodePredicate)) {

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -95,43 +95,8 @@ async @(Model.Name.ToCamelCase())WithHttpOperationResponse(@(Model.MethodParamet
   @if (Model.RequestBody != null)
   {
   <text>
-  // SerializedRequest
+  httpRequest.body = @(Model.RequestBody.Name);
   </text>
-      if (Model.RequestBody.ModelType.IsPrimaryType(KnownPrimaryType.Stream))
-      {
-  <text>
-  httpRequest.unserializedBody = @(Model.RequestBody.Name);
-  </text>
-      }
-      else
-      {
-  <text>
-  try {
-    if (@(Model.RequestBody.Name) !== null && @(Model.RequestBody.Name) !== undefined) {
-      httpRequest.unserializedBody = @(Model.RequestBody.Name);
-      @(Model.ConstructRequestBodyMapper)
-      httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, '@(Model.RequestBody.Name)');
-      @if (Model.CodeModel.ShouldGenerateXmlSerialization)
-      {
-        if (Model.RequestBody.ModelType is SequenceType sequenceType)
-        {
-@:      httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, '@(sequenceType.ElementXmlName)'), { rootName: '@(Model.RequestBody.ModelType.XmlName)' });
-        }
-        else
-        {
-@:      httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: '@(Model.RequestBody.ModelType.XmlName)' });
-        }
-      }
-      else
-      {
-@:      httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    }
-  } catch (error) {
-    return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-  }
-  </text>
-      }
   }
   else if (Model.LogicalParameters.Where(p => p.Location == ParameterLocation.FormData).Any())
   {

--- a/src/vanilla/Templates/MethodTemplate.cshtml
+++ b/src/vanilla/Templates/MethodTemplate.cshtml
@@ -94,48 +94,42 @@ async @(Model.Name.ToCamelCase())WithHttpOperationResponse(@(Model.MethodParamet
 
   @if (Model.RequestBody != null)
   {
+  <text>
+  // SerializedRequest
+  </text>
       if (Model.RequestBody.ModelType.IsPrimaryType(KnownPrimaryType.Stream))
       {
   <text>
-  // Serialize Request
-  let requestContent = @(Model.RequestBody.Name);
-  httpRequest.body = requestContent;
+  httpRequest.unserializedBody = @(Model.RequestBody.Name);
   </text>
       }
       else
       {
   <text>
-  // Serialize Request
-  let requestContent = null;
-  let requestModel = null;
   try {
     if (@(Model.RequestBody.Name) !== null && @(Model.RequestBody.Name) !== undefined) {
+      httpRequest.unserializedBody = @(Model.RequestBody.Name);
       @(Model.ConstructRequestBodyMapper)
-      requestModel = client.serializer.serialize(requestModelMapper, @(Model.RequestBody.Name), '@(Model.RequestBody.Name)');
+      httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, '@(Model.RequestBody.Name)');
       @if (Model.CodeModel.ShouldGenerateXmlSerialization)
       {
         if (Model.RequestBody.ModelType is SequenceType sequenceType)
         {
-@:      requestContent = msRest.stringifyXML(msRest.prepareXMLRootList(requestModel, '@(sequenceType.ElementXmlName)'), { rootName: '@(Model.RequestBody.ModelType.XmlName)' });
+@:      httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, '@(sequenceType.ElementXmlName)'), { rootName: '@(Model.RequestBody.ModelType.XmlName)' });
         }
         else
         {
-@:      requestContent = msRest.stringifyXML(requestModel, { rootName: '@(Model.RequestBody.ModelType.XmlName)' });
+@:      httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: '@(Model.RequestBody.ModelType.XmlName)' });
         }
-
       }
       else
       {
-@:      requestContent = JSON.stringify(requestModel);
+@:      httpRequest.body = JSON.stringify(httpRequest.body);
       }
     }
   } catch (error) {
-    let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-        `payload - ${JSON.stringify(@(Model.RequestBody.Name), null, 2)}.`);
-    return Promise.reject(serializationError);
+    return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
   }
-
-  httpRequest.body = requestContent;
   </text>
       }
   }

--- a/src/vanilla/Templates/ServiceClientTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientTemplate.cshtml
@@ -40,14 +40,18 @@ class @(Model.Name) extends msRest.ServiceClient {
 @if (Model.MethodGroupModels.Any())
 {
   @EmptyLine
-  @:// Operation groups
-foreach (var methodGroup in Model.MethodGroupModels)
+<text>
+  // Operation groups
+@foreach (var methodGroup in Model.MethodGroupModels)
 {
-  @:@(methodGroup.NameForProperty): operations.@(methodGroup.TypeName);
+<text>
+  @(methodGroup.NameForProperty): operations.@(methodGroup.TypeName);
+</text>
 }
+</text>
 }
   serializer: msRest.Serializer;
-  @EmptyLine
+@EmptyLine
   /**
    * @@class
    * Initializes a new instance of the @Model.Name class.
@@ -55,13 +59,17 @@ foreach (var methodGroup in Model.MethodGroupModels)
    *
 @foreach (var param in requiredParameters)
 {
-   @:* @@param {@param.ModelType.Name.ToCamelCase()} @param.Name - @param.Documentation
-   @:*
+<text>
+   * @@param {@param.ModelType.Name.ToCamelCase()} @param.Name - @param.Documentation
+   *
+</text>
 }
-@if(!Model.IsCustomBaseUri)
+@if (!Model.IsCustomBaseUri)
 {
-   @:* @@param {string} [baseUri] - The base URI of the service.
-   @:*
+<text>
+   * @@param {string} [baseUri] - The base URI of the service.
+   *
+</text>
 }
    * @@param {object} [options] - The parameter options
    *
@@ -74,70 +82,98 @@ foreach (var methodGroup in Model.MethodGroupModels)
    *
 @foreach (var param in optionalParameters)
 {
-   @:* @@param {@param.ModelType.Name.ToCamelCase()} [options.@param.Name] - @param.Documentation
-   @:*
+<text>
+   * @@param {@param.ModelType.Name.ToCamelCase()} [options.@param.Name] - @param.Documentation
+   *
+</text>
 }
    */
 @{ var clientOptionType = Model.OptionalParameterTypeForClientConstructor == "ServiceClientOptions" ? "msRest.ServiceClientOptions" : Model.OptionalParameterTypeForClientConstructor;}
-  constructor(@(!string.IsNullOrEmpty(Model.RequiredConstructorParametersTS) ? Model.RequiredConstructorParametersTS + ", ": "")options?: @clientOptionType) {
+  constructor(@(!string.IsNullOrEmpty(Model.RequiredConstructorParametersTS) ? Model.RequiredConstructorParametersTS + ", " : "")options?: @clientOptionType) {
 @foreach (var param in requiredParameters)
 {
-  @:  if (@(param.Name) === null || @(param.Name) === undefined) {
-  @:    throw new Error('\'@(param.Name)\' cannot be null.');
-  @:  }
+<text>
+    if (@(param.Name) === null || @(param.Name) === undefined) {
+      throw new Error('\'@(param.Name)\' cannot be null.');
+    }
+</text>
 }
 @EmptyLine
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, @(Model.ShouldGenerateXmlSerialization.ToString().ToLower()))
+      };
+    }
 @EmptyLine
     super(@(requiredParameters.Any(p => p.ModelType.IsPrimaryType(KnownPrimaryType.Credentials)) ? "credentials" : "undefined"), options);
     @EmptyLine
 @foreach (var property in Model.Properties.Where(p => p.DefaultValue != null))
 {
-    @:this.@(property.Name) = @(property.DefaultValue);
+<text>
+    this.@(property.Name) = @(property.DefaultValue);
+</text>
 }
 
-@if(!Model.IsCustomBaseUri)
+@if (!Model.IsCustomBaseUri)
 {
-    @:this.baseUri = baseUri as string;
+<text>
+    this.baseUri = baseUri as string;
 
-    @:if (!this.baseUri) {
-      @:this.baseUri = '@Model.BaseUrl';
-    @:}
+    if (!this.baseUri) {
+      this.baseUri = '@Model.BaseUrl';
+    }
+</text>
 }
 else
 {
-    @:this.baseUri = '@Model.BaseUrl';
+<text>
+    this.baseUri = '@Model.BaseUrl';
+</text>
 }
 
 @foreach (var param in requiredParameters)
 {
-  @:  this.@(param.Name) = @(param.Name);
+<text>
+    this.@(param.Name) = @(param.Name);
+</text>
 }
-  @EmptyLine
+@EmptyLine
     this.addUserAgentInfo(`${packageName}/${packageVersion}`);
-  @foreach (var property in optionalParameters)
-  {
-    @:if(options.@(property.Name) !== null && options.@(property.Name) !== undefined) {
-    @:  this.@(property.Name) = options.@(property.Name);
-    @:}
-  }
+@foreach (var property in optionalParameters)
+{
+<text>
+    if(options.@(property.Name) !== null && options.@(property.Name) !== undefined) {
+      this.@(property.Name) = options.@(property.Name);
+    }
+</text>
+}
 
-  @foreach (var methodGroup in Model.MethodGroupModels)
-  {
-    @:this.@(methodGroup.NameForProperty) = new operations.@(methodGroup.TypeName)(this);
-  }
+@foreach (var methodGroup in Model.MethodGroupModels)
+{
+<text>
+    this.@(methodGroup.NameForProperty) = new operations.@(methodGroup.TypeName)(this);
+</text>
+}
     this.serializer = new msRest.Serializer(Mappers, @(Model.ShouldGenerateXmlSerialization.ToString().ToLower()));
   }
 @foreach (var method in Model.MethodTemplateModels)
 {
-  @:// methods on the client.
-  @EmptyLine
-  @:@(Include(new MethodTemplate(), method))
+<text>
+  // methods on the client.
+@EmptyLine
+  @(Include(new MethodTemplate(), method))
+</text>
 }
 @foreach (var method in Model.MethodTemplateModels)
 {
-  @EmptyLine
-  @:@(Include(new MethodCallbackWrapperTemplate(), method))
+<text>
+@EmptyLine
+  @(Include(new MethodCallbackWrapperTemplate(), method))
+</text>
 }
 }
 @EmptyLine

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -289,21 +289,17 @@ class AzureCompositeModel extends msRestAzure.AzureServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.CatalogDictionaryOfArray;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -427,21 +423,17 @@ class AzureCompositeModel extends msRestAzure.AzureServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.CatalogArrayOfDictionary;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -72,7 +72,15 @@ class AzureCompositeModel extends msRestAzure.AzureServiceClient {
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 
@@ -289,22 +297,16 @@ class AzureCompositeModel extends msRestAzure.AzureServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.CatalogDictionaryOfArray;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.CatalogDictionaryOfArray;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -423,22 +425,16 @@ class AzureCompositeModel extends msRestAzure.AzureServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.CatalogArrayOfDictionary;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.CatalogArrayOfDictionary;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
@@ -183,21 +183,17 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ArrayWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -394,21 +390,17 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ArrayWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
@@ -183,22 +183,16 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ArrayWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ArrayWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -390,22 +384,16 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ArrayWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ArrayWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
@@ -177,22 +177,16 @@ export class BasicOperations {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Basic;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Basic;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
@@ -177,21 +177,17 @@ export class BasicOperations {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Basic;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
@@ -183,22 +183,16 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DictionaryWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DictionaryWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -390,22 +384,16 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DictionaryWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DictionaryWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
@@ -183,21 +183,17 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DictionaryWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -394,21 +390,17 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DictionaryWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
@@ -178,22 +178,16 @@ export class Inheritance {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Siamese;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Siamese;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
@@ -178,21 +178,17 @@ export class Inheritance {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Siamese;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
@@ -227,22 +227,16 @@ export class Polymorphicrecursive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Fish;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Fish;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
@@ -227,21 +227,17 @@ export class Polymorphicrecursive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Fish;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
@@ -207,21 +207,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Fish;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -412,21 +408,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Salmon;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -516,21 +508,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Salmon;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -662,21 +650,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Fish;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
@@ -207,22 +207,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Fish;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Fish;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -408,22 +402,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Salmon;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Salmon;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -508,22 +496,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Salmon;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Salmon;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -650,22 +632,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Fish;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Fish;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
@@ -175,21 +175,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.IntWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -378,21 +374,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.LongWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -581,21 +573,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.FloatWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -785,21 +773,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DoubleWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -988,21 +972,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.BooleanWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1191,21 +1171,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.StringWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1394,21 +1370,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DateWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1598,21 +1570,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DatetimeWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1802,21 +1770,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Datetimerfc1123Wrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2009,21 +1973,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DurationWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2216,21 +2176,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ByteWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
@@ -175,22 +175,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.IntWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.IntWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -374,22 +368,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.LongWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.LongWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -573,22 +561,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.FloatWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.FloatWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -773,22 +755,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DoubleWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DoubleWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -972,22 +948,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.BooleanWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.BooleanWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1171,22 +1141,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.StringWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StringWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1370,22 +1334,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DateWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DateWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1570,22 +1528,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DatetimeWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DatetimeWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1770,22 +1722,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Datetimerfc1123Wrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Datetimerfc1123Wrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1973,22 +1919,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DurationWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DurationWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2176,22 +2116,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ByteWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ByteWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
@@ -184,22 +184,16 @@ export class Readonlyproperty {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ReadonlyObj;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ReadonlyObj;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
@@ -184,21 +184,17 @@ export class Readonlyproperty {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ReadonlyObj;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
@@ -62,7 +62,15 @@ class AutoRestParameterGroupingTestService extends msRestAzure.AzureServiceClien
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
@@ -121,28 +121,22 @@ export class ParameterGrouping {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (body !== null && body !== undefined) {
-        httpRequest.unserializedBody = body;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'body',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'body');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = body;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'body',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "body",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
@@ -121,11 +121,10 @@ export class ParameterGrouping {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (body !== null && body !== undefined) {
+        httpRequest.unserializedBody = body;
         let requestModelMapper = {
           required: true,
           serializedName: 'body',
@@ -133,15 +132,12 @@ export class ParameterGrouping {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, body, 'body');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'body');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(body, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -59,7 +59,15 @@ class AutoRestReportServiceForAzure extends msRestAzure.AzureServiceClient {
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -59,7 +59,15 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 
@@ -133,36 +141,30 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceArray !== null && resourceArray !== undefined) {
-        httpRequest.unserializedBody = resourceArray;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'ResourceArray',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'ResourceElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Resource'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceArray');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceArray;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'ResourceArray',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'ResourceElementType',
+              type: {
+                name: 'Composite',
+                className: 'Resource'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceArray",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -359,36 +361,30 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceDictionary !== null && resourceDictionary !== undefined) {
-        httpRequest.unserializedBody = resourceDictionary;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'ResourceDictionary',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'FlattenedProductElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'FlattenedProduct'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceDictionary');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceDictionary;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'ResourceDictionary',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'FlattenedProductElementType',
+              type: {
+                name: 'Composite',
+                className: 'FlattenedProduct'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceDictionary",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -586,22 +582,16 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceComplexObject !== null && resourceComplexObject !== undefined) {
-        httpRequest.unserializedBody = resourceComplexObject;
-        let requestModelMapper = Mappers.ResourceCollection;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceComplexObject');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceComplexObject;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ResourceCollection;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceComplexObject",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -133,11 +133,10 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceArray !== null && resourceArray !== undefined) {
+        httpRequest.unserializedBody = resourceArray;
         let requestModelMapper = {
           required: false,
           serializedName: 'ResourceArray',
@@ -153,15 +152,12 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, resourceArray, 'resourceArray');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceArray');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceArray, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -363,11 +359,10 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceDictionary !== null && resourceDictionary !== undefined) {
+        httpRequest.unserializedBody = resourceDictionary;
         let requestModelMapper = {
           required: false,
           serializedName: 'ResourceDictionary',
@@ -383,15 +378,12 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, resourceDictionary, 'resourceDictionary');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceDictionary');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceDictionary, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -594,21 +586,17 @@ class AutoRestResourceFlatteningTestService extends msRestAzure.AzureServiceClie
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceComplexObject !== null && resourceComplexObject !== undefined) {
+        httpRequest.unserializedBody = resourceComplexObject;
         let requestModelMapper = Mappers.ResourceCollection;
-        requestModel = client.serializer.serialize(requestModelMapper, resourceComplexObject, 'resourceComplexObject');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceComplexObject');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceComplexObject, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
@@ -78,7 +78,15 @@ class AutoRestAzureSpecialParametersTestClient extends msRestAzure.AzureServiceC
       throw new Error('\'subscriptionId\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -64,7 +64,15 @@ class AutoRestParameterizedHostTestClient extends msRestAzure.AzureServiceClient
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/Head/autoRestHeadTestService.ts
+++ b/test/azure/generated/Head/autoRestHeadTestService.ts
@@ -62,7 +62,15 @@ class AutoRestHeadTestService extends msRestAzure.AzureServiceClient {
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
@@ -62,7 +62,15 @@ class AutoRestHeadExceptionTestService extends msRestAzure.AzureServiceClient {
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
@@ -65,7 +65,15 @@ class AutoRestLongRunningOperationTestService extends msRestAzure.AzureServiceCl
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/Lro/operations/lRORetrys.ts
+++ b/test/azure/generated/Lro/operations/lRORetrys.ts
@@ -359,22 +359,16 @@ export class LRORetrys {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -487,22 +481,16 @@ export class LRORetrys {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -886,22 +874,16 @@ export class LRORetrys {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -984,22 +966,16 @@ export class LRORetrys {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {

--- a/test/azure/generated/Lro/operations/lRORetrys.ts
+++ b/test/azure/generated/Lro/operations/lRORetrys.ts
@@ -359,21 +359,17 @@ export class LRORetrys {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -491,21 +487,17 @@ export class LRORetrys {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -894,21 +886,17 @@ export class LRORetrys {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -996,21 +984,17 @@ export class LRORetrys {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/Lro/operations/lROSADs.ts
+++ b/test/azure/generated/Lro/operations/lROSADs.ts
@@ -1084,22 +1084,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -1211,22 +1205,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -1338,22 +1326,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -1466,22 +1448,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1828,22 +1804,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -1924,22 +1894,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -2022,22 +1986,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -2119,22 +2077,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -2247,22 +2199,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2360,22 +2306,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2641,22 +2581,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -2739,22 +2673,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -2836,22 +2764,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 204) {
@@ -2949,22 +2871,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3062,22 +2978,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3427,22 +3337,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -3525,22 +3429,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -3623,22 +3521,16 @@ export class LROSADs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {

--- a/test/azure/generated/Lro/operations/lROSADs.ts
+++ b/test/azure/generated/Lro/operations/lROSADs.ts
@@ -1084,21 +1084,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1215,21 +1211,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1346,21 +1338,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1478,21 +1466,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1844,21 +1828,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1944,21 +1924,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2046,21 +2022,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2147,21 +2119,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2279,21 +2247,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2396,21 +2360,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2681,21 +2641,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2783,21 +2739,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2884,21 +2836,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3001,21 +2949,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3118,21 +3062,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3487,21 +3427,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3589,21 +3525,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3691,21 +3623,17 @@ export class LROSADs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -1642,21 +1642,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1758,21 +1754,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1875,21 +1867,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1992,21 +1980,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2124,21 +2108,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2241,21 +2221,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2373,21 +2349,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2490,21 +2462,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2607,21 +2575,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2724,21 +2688,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2841,21 +2801,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2958,21 +2914,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3075,21 +3027,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3190,21 +3138,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (sku !== null && sku !== undefined) {
+        httpRequest.unserializedBody = sku;
         let requestModelMapper = Mappers.Sku;
-        requestModel = client.serializer.serialize(requestModelMapper, sku, 'sku');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'sku');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(sku, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3305,21 +3249,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (sku !== null && sku !== undefined) {
+        httpRequest.unserializedBody = sku;
         let requestModelMapper = Mappers.Sku;
-        requestModel = client.serializer.serialize(requestModelMapper, sku, 'sku');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'sku');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(sku, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3433,21 +3373,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.SubProduct;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3561,21 +3497,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.SubProduct;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4934,21 +4866,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5035,21 +4963,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5152,21 +5076,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5269,21 +5189,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5386,21 +5302,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5488,21 +5400,17 @@ export class LROs {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -1642,22 +1642,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 204) {
@@ -1754,22 +1748,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1867,22 +1855,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -1980,22 +1962,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -2108,22 +2084,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2221,22 +2191,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -2349,22 +2313,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2462,22 +2420,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -2575,22 +2527,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2688,22 +2634,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2801,22 +2741,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2914,22 +2848,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3027,22 +2955,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -3138,22 +3060,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (sku !== null && sku !== undefined) {
-        httpRequest.unserializedBody = sku;
-        let requestModelMapper = Mappers.Sku;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'sku');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = sku;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Sku;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "sku",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -3249,22 +3165,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (sku !== null && sku !== undefined) {
-        httpRequest.unserializedBody = sku;
-        let requestModelMapper = Mappers.Sku;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'sku');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = sku;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Sku;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "sku",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -3373,22 +3283,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.SubProduct;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.SubProduct;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -3497,22 +3401,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.SubProduct;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.SubProduct;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -4866,22 +4764,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -4963,22 +4855,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -5076,22 +4962,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202 && statusCode !== 200) {
@@ -5189,22 +5069,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202 && statusCode !== 200) {
@@ -5302,22 +5176,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -5400,22 +5268,16 @@ export class LROs {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {

--- a/test/azure/generated/Lro/operations/lROsCustomHeader.ts
+++ b/test/azure/generated/Lro/operations/lROsCustomHeader.ts
@@ -250,21 +250,17 @@ export class LROsCustomHeader {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -369,21 +365,17 @@ export class LROsCustomHeader {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -502,21 +494,17 @@ export class LROsCustomHeader {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -606,21 +594,17 @@ export class LROsCustomHeader {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (product !== null && product !== undefined) {
+        httpRequest.unserializedBody = product;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, product, 'product');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(product, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/Lro/operations/lROsCustomHeader.ts
+++ b/test/azure/generated/Lro/operations/lROsCustomHeader.ts
@@ -250,22 +250,16 @@ export class LROsCustomHeader {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -365,22 +359,16 @@ export class LROsCustomHeader {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 201) {
@@ -494,22 +482,16 @@ export class LROsCustomHeader {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -594,22 +576,16 @@ export class LROsCustomHeader {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (product !== null && product !== undefined) {
-        httpRequest.unserializedBody = product;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'product');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = product;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "product",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {

--- a/test/azure/generated/Paging/autoRestPagingTestService.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestService.ts
@@ -62,7 +62,15 @@ class AutoRestPagingTestService extends msRestAzure.AzureServiceClient {
       throw new Error('\'credentials\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
+++ b/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
@@ -87,21 +87,17 @@ export class StorageAccounts {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (accountName !== null && accountName !== undefined) {
+        httpRequest.unserializedBody = accountName;
         let requestModelMapper = Mappers.StorageAccountCheckNameAvailabilityParameters;
-        requestModel = client.serializer.serialize(requestModelMapper, accountName, 'accountName');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'accountName');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(accountName, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -526,21 +522,17 @@ export class StorageAccounts {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (parameters !== null && parameters !== undefined) {
+        httpRequest.unserializedBody = parameters;
         let requestModelMapper = Mappers.StorageAccountUpdateParameters;
-        requestModel = client.serializer.serialize(requestModelMapper, parameters, 'parameters');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'parameters');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(parameters, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1016,21 +1008,17 @@ export class StorageAccounts {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (regenerateKeyParameter !== null && regenerateKeyParameter !== undefined) {
+        httpRequest.unserializedBody = regenerateKeyParameter;
         let requestModelMapper = Mappers.StorageAccountRegenerateKeyParameters;
-        requestModel = client.serializer.serialize(requestModelMapper, regenerateKeyParameter, 'regenerateKeyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'regenerateKeyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(regenerateKeyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1162,21 +1150,17 @@ export class StorageAccounts {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (parameters !== null && parameters !== undefined) {
+        httpRequest.unserializedBody = parameters;
         let requestModelMapper = Mappers.StorageAccountCreateParameters;
-        requestModel = client.serializer.serialize(requestModelMapper, parameters, 'parameters');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'parameters');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(parameters, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
+++ b/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
@@ -87,22 +87,16 @@ export class StorageAccounts {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (accountName !== null && accountName !== undefined) {
-        httpRequest.unserializedBody = accountName;
-        let requestModelMapper = Mappers.StorageAccountCheckNameAvailabilityParameters;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'accountName');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = accountName;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StorageAccountCheckNameAvailabilityParameters;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "accountName",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -522,22 +516,16 @@ export class StorageAccounts {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (parameters !== null && parameters !== undefined) {
-        httpRequest.unserializedBody = parameters;
-        let requestModelMapper = Mappers.StorageAccountUpdateParameters;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'parameters');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = parameters;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StorageAccountUpdateParameters;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "parameters",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1008,22 +996,16 @@ export class StorageAccounts {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (regenerateKeyParameter !== null && regenerateKeyParameter !== undefined) {
-        httpRequest.unserializedBody = regenerateKeyParameter;
-        let requestModelMapper = Mappers.StorageAccountRegenerateKeyParameters;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'regenerateKeyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = regenerateKeyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StorageAccountRegenerateKeyParameters;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "regenerateKeyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1150,22 +1132,16 @@ export class StorageAccounts {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (parameters !== null && parameters !== undefined) {
-        httpRequest.unserializedBody = parameters;
-        let requestModelMapper = Mappers.StorageAccountCreateParameters;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'parameters');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = parameters;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StorageAccountCreateParameters;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "parameters",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 202) {

--- a/test/azure/generated/StorageManagementClient/storageManagementClient.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClient.ts
@@ -72,7 +72,15 @@ class StorageManagementClient extends msRestAzure.AzureServiceClient {
       throw new Error('\'subscriptionId\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
@@ -71,7 +71,15 @@ class MicrosoftAzureTestUrl extends msRestAzure.AzureServiceClient {
       throw new Error('\'subscriptionId\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(credentials, options);
 

--- a/test/azure/lro.ts
+++ b/test/azure/lro.ts
@@ -9,24 +9,30 @@ import * as msRest from 'ms-rest-js';
 import * as msRestAzure from 'ms-rest-azure-js';
 
 import { AutoRestLongRunningOperationTestService, AutoRestLongRunningOperationTestServiceModels } from './generated/Lro/autoRestLongRunningOperationTestService';
+import * as Mappers from "./generated/Lro/models/mappers";
 
 var dummySubscriptionId = 'a878ae02-6106-429z-9397-58091ee45g98';
 var dummyToken = 'dummy12321343423';
 var credentials = new msRest.TokenCredentials(dummyToken);
 
-var clientOptions: msRestAzure.AzureServiceClientOptions = {};
+const serializer = new msRest.Serializer(Mappers, false);
+var clientOptions: msRestAzure.AzureServiceClientOptions = {
+  requestOptions: { jar: true } as any,
+  requestPolicyCreators: [
+    msRest.exponentialRetryPolicy(3, 0, 0, 0),
+    msRest.serializationPolicy(serializer)
+  ],
+  noRetryPolicy: true,
+  longRunningOperationRetryTimeout: 0
+};
 var baseUri = 'http://localhost:3000';
 
 describe('typescript', function () {
 
   describe('Swagger LRO Happy BAT', function () {
-    clientOptions.requestOptions = { jar: true } as any;
-    clientOptions.requestPolicyCreators = [msRest.exponentialRetryPolicy(3, 0, 0, 0)];
-    clientOptions.noRetryPolicy = true;
-    clientOptions.longRunningOperationRetryTimeout = 0;
-
     var testClient = new AutoRestLongRunningOperationTestService(credentials, baseUri, clientOptions);
     var product: AutoRestLongRunningOperationTestServiceModels.Product = { location: 'West US' };
+
     it('should work with Put201CreatingSucceeded200', function (done) {
       testClient.lROs.put201CreatingSucceeded200({ product: product }, function (error, result) {
         should.not.exist(error);
@@ -391,10 +397,6 @@ describe('typescript', function () {
   });
 
   describe('Swagger LRO Sad BAT', function () {
-    clientOptions.requestOptions = { jar: true } as any;
-    clientOptions.requestPolicyCreators = [msRest.exponentialRetryPolicy(3, 0, 0, 0)];
-    clientOptions.noRetryPolicy = true;
-
     var testClient = new AutoRestLongRunningOperationTestService(credentials, baseUri, clientOptions);
     testClient.longRunningOperationRetryTimeout = 0;
     var product = { location: 'West US' };

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATArrayService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -366,35 +366,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -573,35 +567,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'booleanElementType',
-                type: {
-                  name: 'Boolean'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'booleanElementType',
+              type: {
+                name: 'Boolean'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -976,35 +964,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1379,35 +1361,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1782,35 +1758,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2185,35 +2155,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2588,35 +2552,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2995,35 +2953,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3301,35 +3253,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'DateElementType',
-                type: {
-                  name: 'Date'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'DateElementType',
+              type: {
+                name: 'Date'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3707,35 +3653,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'DateElementType',
-                type: {
-                  name: 'DateTime'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'DateElementType',
+              type: {
+                name: 'DateTime'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -4113,35 +4053,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'DateElementType',
-                type: {
-                  name: 'DateTimeRfc1123'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'DateElementType',
+              type: {
+                name: 'DateTimeRfc1123'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -4320,35 +4254,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'TimeSpan'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'TimeSpan'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -4529,35 +4457,29 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'BufferElementType',
-                type: {
-                  name: 'ByteArray'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'BufferElementType',
+              type: {
+                name: 'ByteArray'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -5322,36 +5244,30 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'ProductElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Product'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'ProductElementType',
+              type: {
+                name: 'Composite',
+                className: 'Product'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -5963,42 +5879,36 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'ArrayElementType',
-                type: {
-                  name: 'Sequence',
-                  element: {
-                      required: false,
-                      serializedName: 'stringElementType',
-                      type: {
-                        name: 'String'
-                      }
-                  }
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'ArrayElementType',
+              type: {
+                name: 'Sequence',
+                element: {
+                    required: false,
+                    serializedName: 'stringElementType',
+                    type: {
+                      name: 'String'
+                    }
+                }
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -6616,42 +6526,36 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'ObjectElementType',
-                type: {
-                  name: 'Dictionary',
-                  value: {
-                      required: false,
-                      serializedName: 'stringElementType',
-                      type: {
-                        name: 'String'
-                      }
-                  }
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'ObjectElementType',
+              type: {
+                name: 'Dictionary',
+                value: {
+                    required: false,
+                    serializedName: 'stringElementType',
+                    type: {
+                      name: 'String'
+                    }
+                }
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -366,11 +366,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -385,15 +384,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -577,11 +573,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -596,15 +591,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -984,11 +976,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -1003,15 +994,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1391,11 +1379,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -1410,15 +1397,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1798,11 +1782,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -1817,15 +1800,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2205,11 +2185,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -2224,15 +2203,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2612,11 +2588,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -2631,15 +2606,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3023,11 +2995,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -3042,15 +3013,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3333,11 +3301,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -3352,15 +3319,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3743,11 +3707,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -3762,15 +3725,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4153,11 +4113,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -4172,15 +4131,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4364,11 +4320,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -4383,15 +4338,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4577,11 +4529,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -4596,15 +4547,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5374,11 +5322,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -5394,15 +5341,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -6019,11 +5963,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -6045,15 +5988,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -6676,11 +6616,10 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -6702,15 +6641,12 @@ export class ArrayModel {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
@@ -42,7 +42,15 @@ class AutoRestBoolTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -157,28 +157,22 @@ export class Bool {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (boolBody !== null && boolBody !== undefined) {
-        httpRequest.unserializedBody = boolBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'boolBody',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = boolBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'boolBody',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "boolBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -345,28 +339,22 @@ export class Bool {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (boolBody !== null && boolBody !== undefined) {
-        httpRequest.unserializedBody = boolBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'boolBody',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = boolBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'boolBody',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "boolBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -157,11 +157,10 @@ export class Bool {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (boolBody !== null && boolBody !== undefined) {
+        httpRequest.unserializedBody = boolBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'boolBody',
@@ -169,15 +168,12 @@ export class Bool {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, boolBody, 'boolBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(boolBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -349,11 +345,10 @@ export class Bool {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (boolBody !== null && boolBody !== undefined) {
+        httpRequest.unserializedBody = boolBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'boolBody',
@@ -361,15 +356,12 @@ export class Bool {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, boolBody, 'boolBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(boolBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATByteService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyByte/operations/byteModel.ts
+++ b/test/vanilla/generated/BodyByte/operations/byteModel.ts
@@ -340,11 +340,10 @@ export class ByteModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (byteBody !== null && byteBody !== undefined) {
+        httpRequest.unserializedBody = byteBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'byteBody',
@@ -352,15 +351,12 @@ export class ByteModel {
             name: 'ByteArray'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, byteBody, 'byteBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'byteBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(byteBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyByte/operations/byteModel.ts
+++ b/test/vanilla/generated/BodyByte/operations/byteModel.ts
@@ -340,28 +340,22 @@ export class ByteModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (byteBody !== null && byteBody !== undefined) {
-        httpRequest.unserializedBody = byteBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'byteBody',
-          type: {
-            name: 'ByteArray'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'byteBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = byteBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'byteBody',
+        type: {
+          name: 'ByteArray'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "byteBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
@@ -50,7 +50,15 @@ class AutoRestComplexTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
@@ -160,21 +160,17 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ArrayWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -348,21 +344,17 @@ export class ArrayModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ArrayWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
@@ -160,22 +160,16 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ArrayWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ArrayWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -344,22 +338,16 @@ export class ArrayModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ArrayWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ArrayWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
+++ b/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
@@ -153,22 +153,16 @@ export class BasicOperations {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Basic;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Basic;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
+++ b/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
@@ -153,21 +153,17 @@ export class BasicOperations {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Basic;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyComplex/operations/dictionary.ts
@@ -160,21 +160,17 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DictionaryWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -348,21 +344,17 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DictionaryWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyComplex/operations/dictionary.ts
@@ -160,22 +160,16 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DictionaryWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DictionaryWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -344,22 +338,16 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DictionaryWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DictionaryWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/inheritance.ts
+++ b/test/vanilla/generated/BodyComplex/operations/inheritance.ts
@@ -155,22 +155,16 @@ export class Inheritance {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Siamese;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Siamese;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/inheritance.ts
+++ b/test/vanilla/generated/BodyComplex/operations/inheritance.ts
@@ -155,21 +155,17 @@ export class Inheritance {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Siamese;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
@@ -204,22 +204,16 @@ export class Polymorphicrecursive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Fish;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Fish;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
@@ -204,21 +204,17 @@ export class Polymorphicrecursive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Fish;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
@@ -184,21 +184,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Fish;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -366,21 +362,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Salmon;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -461,21 +453,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Salmon;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -598,21 +586,17 @@ export class Polymorphism {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Fish;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
@@ -184,22 +184,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Fish;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Fish;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -362,22 +356,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Salmon;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Salmon;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -453,22 +441,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Salmon;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Salmon;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -586,22 +568,16 @@ export class Polymorphism {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Fish;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Fish;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/primitive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/primitive.ts
@@ -152,21 +152,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.IntWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -332,21 +328,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.LongWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -512,21 +504,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.FloatWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -693,21 +681,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DoubleWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -873,21 +857,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.BooleanWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1053,21 +1033,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.StringWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1233,21 +1209,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DateWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1414,21 +1386,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DatetimeWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1595,21 +1563,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.Datetimerfc1123Wrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1779,21 +1743,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.DurationWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1963,21 +1923,17 @@ export class Primitive {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ByteWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/primitive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/primitive.ts
@@ -152,22 +152,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.IntWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.IntWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -328,22 +322,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.LongWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.LongWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -504,22 +492,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.FloatWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.FloatWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -681,22 +663,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DoubleWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DoubleWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -857,22 +833,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.BooleanWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.BooleanWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1033,22 +1003,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.StringWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StringWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1209,22 +1173,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DateWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DateWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1386,22 +1344,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DatetimeWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DatetimeWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1563,22 +1515,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.Datetimerfc1123Wrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Datetimerfc1123Wrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1743,22 +1689,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.DurationWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.DurationWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1923,22 +1863,16 @@ export class Primitive {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ByteWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ByteWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
+++ b/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
@@ -161,21 +161,17 @@ export class Readonlyproperty {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (complexBody !== null && complexBody !== undefined) {
+        httpRequest.unserializedBody = complexBody;
         let requestModelMapper = Mappers.ReadonlyObj;
-        requestModel = client.serializer.serialize(requestModelMapper, complexBody, 'complexBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(complexBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
+++ b/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
@@ -161,22 +161,16 @@ export class Readonlyproperty {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (complexBody !== null && complexBody !== undefined) {
-        httpRequest.unserializedBody = complexBody;
-        let requestModelMapper = Mappers.ReadonlyObj;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'complexBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = complexBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ReadonlyObj;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "complexBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
@@ -42,7 +42,15 @@ class AutoRestDateTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyDate/operations/dateModel.ts
+++ b/test/vanilla/generated/BodyDate/operations/dateModel.ts
@@ -431,11 +431,10 @@ export class DateModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (dateBody !== null && dateBody !== undefined) {
+        httpRequest.unserializedBody = dateBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'dateBody',
@@ -443,15 +442,12 @@ export class DateModel {
             name: 'Date'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, dateBody, 'dateBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'dateBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(dateBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -624,11 +620,10 @@ export class DateModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (dateBody !== null && dateBody !== undefined) {
+        httpRequest.unserializedBody = dateBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'dateBody',
@@ -636,15 +631,12 @@ export class DateModel {
             name: 'Date'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, dateBody, 'dateBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'dateBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(dateBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyDate/operations/dateModel.ts
+++ b/test/vanilla/generated/BodyDate/operations/dateModel.ts
@@ -431,28 +431,22 @@ export class DateModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (dateBody !== null && dateBody !== undefined) {
-        httpRequest.unserializedBody = dateBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'dateBody',
-          type: {
-            name: 'Date'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'dateBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = dateBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'dateBody',
+        type: {
+          name: 'Date'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "dateBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -620,28 +614,22 @@ export class DateModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (dateBody !== null && dateBody !== undefined) {
-        httpRequest.unserializedBody = dateBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'dateBody',
-          type: {
-            name: 'Date'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'dateBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = dateBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'dateBody',
+        type: {
+          name: 'Date'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "dateBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -42,7 +42,15 @@ class AutoRestDateTimeTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyDateTime/operations/datetime.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/datetime.ts
@@ -431,28 +431,22 @@ export class Datetime {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -712,28 +706,22 @@ export class Datetime {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -995,28 +983,22 @@ export class Datetime {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1277,28 +1259,22 @@ export class Datetime {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1466,28 +1442,22 @@ export class Datetime {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1655,28 +1625,22 @@ export class Datetime {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyDateTime/operations/datetime.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/datetime.ts
@@ -431,11 +431,10 @@ export class Datetime {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -443,15 +442,12 @@ export class Datetime {
             name: 'DateTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -716,11 +712,10 @@ export class Datetime {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -728,15 +723,12 @@ export class Datetime {
             name: 'DateTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1003,11 +995,10 @@ export class Datetime {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -1015,15 +1006,12 @@ export class Datetime {
             name: 'DateTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1289,11 +1277,10 @@ export class Datetime {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -1301,15 +1288,12 @@ export class Datetime {
             name: 'DateTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1482,11 +1466,10 @@ export class Datetime {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -1494,15 +1477,12 @@ export class Datetime {
             name: 'DateTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1675,11 +1655,10 @@ export class Datetime {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -1687,15 +1666,12 @@ export class Datetime {
             name: 'DateTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -42,7 +42,15 @@ class AutoRestRFC1123DateTimeTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -431,28 +431,22 @@ export class Datetimerfc1123 {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTimeRfc1123'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTimeRfc1123'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -711,28 +705,22 @@ export class Datetimerfc1123 {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (datetimeBody !== null && datetimeBody !== undefined) {
-        httpRequest.unserializedBody = datetimeBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'datetimeBody',
-          type: {
-            name: 'DateTimeRfc1123'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = datetimeBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'datetimeBody',
+        type: {
+          name: 'DateTimeRfc1123'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "datetimeBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -431,11 +431,10 @@ export class Datetimerfc1123 {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -443,15 +442,12 @@ export class Datetimerfc1123 {
             name: 'DateTimeRfc1123'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -715,11 +711,10 @@ export class Datetimerfc1123 {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (datetimeBody !== null && datetimeBody !== undefined) {
+        httpRequest.unserializedBody = datetimeBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'datetimeBody',
@@ -727,15 +722,12 @@ export class Datetimerfc1123 {
             name: 'DateTimeRfc1123'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, datetimeBody, 'datetimeBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'datetimeBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(datetimeBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATdictionaryService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
@@ -268,11 +268,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -287,15 +286,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -871,11 +867,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -890,15 +885,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1278,11 +1270,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -1297,15 +1288,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1685,11 +1673,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -1704,15 +1691,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2092,11 +2076,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -2111,15 +2094,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2499,11 +2479,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -2518,15 +2497,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2906,11 +2882,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -2925,15 +2900,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3316,11 +3288,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -3335,15 +3306,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -3726,11 +3694,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -3745,15 +3712,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4137,11 +4101,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -4156,15 +4119,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4349,11 +4309,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -4368,15 +4327,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -4562,11 +4518,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -4581,15 +4536,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -5360,11 +5312,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -5380,15 +5331,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -6007,11 +5955,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -6033,15 +5980,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -6665,11 +6609,10 @@ export class Dictionary {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (arrayBody !== null && arrayBody !== undefined) {
+        httpRequest.unserializedBody = arrayBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'arrayBody',
@@ -6691,15 +6634,12 @@ export class Dictionary {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, arrayBody, 'arrayBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(arrayBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
@@ -268,35 +268,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -867,35 +861,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'booleanElementType',
-                type: {
-                  name: 'Boolean'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'booleanElementType',
+              type: {
+                name: 'Boolean'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1270,35 +1258,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1673,35 +1655,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2076,35 +2052,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2479,35 +2449,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'numberElementType',
-                type: {
-                  name: 'Number'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'numberElementType',
+              type: {
+                name: 'Number'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2882,35 +2846,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3288,35 +3246,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'DateElementType',
-                type: {
-                  name: 'Date'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'DateElementType',
+              type: {
+                name: 'Date'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -3694,35 +3646,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'DateElementType',
-                type: {
-                  name: 'DateTime'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'DateElementType',
+              type: {
+                name: 'DateTime'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -4101,35 +4047,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'DateElementType',
-                type: {
-                  name: 'DateTimeRfc1123'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'DateElementType',
+              type: {
+                name: 'DateTimeRfc1123'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -4309,35 +4249,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'TimeSpan'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'TimeSpan'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -4518,35 +4452,29 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'BufferElementType',
-                type: {
-                  name: 'ByteArray'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'BufferElementType',
+              type: {
+                name: 'ByteArray'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -5312,36 +5240,30 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'WidgetElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Widget'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'WidgetElementType',
+              type: {
+                name: 'Composite',
+                className: 'Widget'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -5955,42 +5877,36 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'ArrayElementType',
-                type: {
-                  name: 'Sequence',
-                  element: {
-                      required: false,
-                      serializedName: 'stringElementType',
-                      type: {
-                        name: 'String'
-                      }
-                  }
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'ArrayElementType',
+              type: {
+                name: 'Sequence',
+                element: {
+                    required: false,
+                    serializedName: 'stringElementType',
+                    type: {
+                      name: 'String'
+                    }
+                }
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -6609,42 +6525,36 @@ export class Dictionary {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (arrayBody !== null && arrayBody !== undefined) {
-        httpRequest.unserializedBody = arrayBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'arrayBody',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'ObjectElementType',
-                type: {
-                  name: 'Dictionary',
-                  value: {
-                      required: false,
-                      serializedName: 'stringElementType',
-                      type: {
-                        name: 'String'
-                      }
-                  }
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'arrayBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = arrayBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'arrayBody',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'ObjectElementType',
+              type: {
+                name: 'Dictionary',
+                value: {
+                    required: false,
+                    serializedName: 'stringElementType',
+                    type: {
+                      name: 'String'
+                    }
+                }
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "arrayBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
@@ -42,7 +42,15 @@ class AutoRestDurationTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyDuration/operations/duration.ts
+++ b/test/vanilla/generated/BodyDuration/operations/duration.ts
@@ -157,28 +157,22 @@ export class Duration {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (durationBody !== null && durationBody !== undefined) {
-        httpRequest.unserializedBody = durationBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'durationBody',
-          type: {
-            name: 'TimeSpan'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'durationBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = durationBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'durationBody',
+        type: {
+          name: 'TimeSpan'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "durationBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyDuration/operations/duration.ts
+++ b/test/vanilla/generated/BodyDuration/operations/duration.ts
@@ -157,11 +157,10 @@ export class Duration {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (durationBody !== null && durationBody !== undefined) {
+        httpRequest.unserializedBody = durationBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'durationBody',
@@ -169,15 +168,12 @@ export class Duration {
             name: 'TimeSpan'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, durationBody, 'durationBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'durationBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(durationBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATFileService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATFormDataService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyFormData/operations/formdata.ts
+++ b/test/vanilla/generated/BodyFormData/operations/formdata.ts
@@ -164,9 +164,8 @@ export class Formdata {
         }
       }
     }
-    // Serialize Request
-    let requestContent = fileContent;
-    httpRequest.body = requestContent;
+    // SerializedRequest
+    httpRequest.unserializedBody = fileContent;
     // Send Request
     httpRequest.rawResponse = true;
     let operationRes: msRest.HttpOperationResponse;

--- a/test/vanilla/generated/BodyFormData/operations/formdata.ts
+++ b/test/vanilla/generated/BodyFormData/operations/formdata.ts
@@ -164,8 +164,7 @@ export class Formdata {
         }
       }
     }
-    // SerializedRequest
-    httpRequest.unserializedBody = fileContent;
+    httpRequest.body = fileContent;
     // Send Request
     httpRequest.rawResponse = true;
     let operationRes: msRest.HttpOperationResponse;

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
@@ -42,7 +42,15 @@ class AutoRestIntegerTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyInteger/operations/intModel.ts
+++ b/test/vanilla/generated/BodyInteger/operations/intModel.ts
@@ -612,28 +612,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -709,28 +703,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -806,28 +794,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -903,28 +885,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1092,28 +1068,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'UnixTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'UnixTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyInteger/operations/intModel.ts
+++ b/test/vanilla/generated/BodyInteger/operations/intModel.ts
@@ -612,11 +612,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -624,15 +623,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -713,11 +709,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -725,15 +720,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -814,11 +806,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -826,15 +817,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -915,11 +903,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -927,15 +914,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1108,11 +1092,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -1120,15 +1103,12 @@ export class IntModel {
             name: 'UnixTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
@@ -42,7 +42,15 @@ class AutoRestNumberTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -430,28 +430,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -618,28 +612,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -806,28 +794,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -994,28 +976,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1182,28 +1158,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1370,28 +1340,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1558,28 +1522,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1746,28 +1704,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1934,28 +1886,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -2122,28 +2068,22 @@ export class Number {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (numberBody !== null && numberBody !== undefined) {
-        httpRequest.unserializedBody = numberBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'numberBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = numberBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'numberBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "numberBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -430,11 +430,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -442,15 +441,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -622,11 +618,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -634,15 +629,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -814,11 +806,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -826,15 +817,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1006,11 +994,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -1018,15 +1005,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1198,11 +1182,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -1210,15 +1193,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1390,11 +1370,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -1402,15 +1381,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1582,11 +1558,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -1594,15 +1569,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1774,11 +1746,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -1786,15 +1757,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1966,11 +1934,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -1978,15 +1945,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2158,11 +2122,10 @@ export class Number {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (numberBody !== null && numberBody !== undefined) {
+        httpRequest.unserializedBody = numberBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'numberBody',
@@ -2170,15 +2133,12 @@ export class Number {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, numberBody, 'numberBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'numberBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(numberBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
@@ -43,7 +43,15 @@ class AutoRestSwaggerBATService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/BodyString/operations/enumModel.ts
+++ b/test/vanilla/generated/BodyString/operations/enumModel.ts
@@ -167,29 +167,23 @@ export class EnumModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (stringBody !== null && stringBody !== undefined) {
-        httpRequest.unserializedBody = stringBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'stringBody',
-          type: {
-            name: 'Enum',
-            allowedValues: [ 'red color', 'green-color', 'blue_color' ]
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = stringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'stringBody',
+        type: {
+          name: 'Enum',
+          allowedValues: [ 'red color', 'green-color', 'blue_color' ]
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "stringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -365,29 +359,23 @@ export class EnumModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (enumStringBody !== null && enumStringBody !== undefined) {
-        httpRequest.unserializedBody = enumStringBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'enumStringBody',
-          type: {
-            name: 'Enum',
-            allowedValues: [ 'red color', 'green-color', 'blue_color' ]
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'enumStringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = enumStringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'enumStringBody',
+        type: {
+          name: 'Enum',
+          allowedValues: [ 'red color', 'green-color', 'blue_color' ]
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "enumStringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -557,22 +545,16 @@ export class EnumModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (enumStringBody !== null && enumStringBody !== undefined) {
-        httpRequest.unserializedBody = enumStringBody;
-        let requestModelMapper = Mappers.RefColorConstant;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'enumStringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = enumStringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.RefColorConstant;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "enumStringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyString/operations/enumModel.ts
+++ b/test/vanilla/generated/BodyString/operations/enumModel.ts
@@ -167,11 +167,10 @@ export class EnumModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (stringBody !== null && stringBody !== undefined) {
+        httpRequest.unserializedBody = stringBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'stringBody',
@@ -180,15 +179,12 @@ export class EnumModel {
             allowedValues: [ 'red color', 'green-color', 'blue_color' ]
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, stringBody, 'stringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(stringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -369,11 +365,10 @@ export class EnumModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (enumStringBody !== null && enumStringBody !== undefined) {
+        httpRequest.unserializedBody = enumStringBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'enumStringBody',
@@ -382,15 +377,12 @@ export class EnumModel {
             allowedValues: [ 'red color', 'green-color', 'blue_color' ]
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, enumStringBody, 'enumStringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'enumStringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(enumStringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -565,21 +557,17 @@ export class EnumModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (enumStringBody !== null && enumStringBody !== undefined) {
+        httpRequest.unserializedBody = enumStringBody;
         let requestModelMapper = Mappers.RefColorConstant;
-        requestModel = client.serializer.serialize(requestModelMapper, enumStringBody, 'enumStringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'enumStringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(enumStringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -157,28 +157,22 @@ export class String {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (stringBody !== null && stringBody !== undefined) {
-        httpRequest.unserializedBody = stringBody;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'stringBody',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = stringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'stringBody',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "stringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -345,28 +339,22 @@ export class String {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (stringBody !== null && stringBody !== undefined) {
-        httpRequest.unserializedBody = stringBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'stringBody',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = stringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'stringBody',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "stringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -536,28 +524,22 @@ export class String {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (stringBody !== null && stringBody !== undefined) {
-        httpRequest.unserializedBody = stringBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'stringBody',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = stringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'stringBody',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "stringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -729,28 +711,22 @@ export class String {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (stringBody !== null && stringBody !== undefined) {
-        httpRequest.unserializedBody = stringBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'stringBody',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = stringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'stringBody',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "stringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1099,28 +1075,22 @@ export class String {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (stringBody !== null && stringBody !== undefined) {
-        httpRequest.unserializedBody = stringBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'stringBody',
-          type: {
-            name: 'Base64Url'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = stringBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'stringBody',
+        type: {
+          name: 'Base64Url'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "stringBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -157,11 +157,10 @@ export class String {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (stringBody !== null && stringBody !== undefined) {
+        httpRequest.unserializedBody = stringBody;
         let requestModelMapper = {
           required: false,
           serializedName: 'stringBody',
@@ -169,15 +168,12 @@ export class String {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, stringBody, 'stringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(stringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -349,11 +345,10 @@ export class String {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (stringBody !== null && stringBody !== undefined) {
+        httpRequest.unserializedBody = stringBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'stringBody',
@@ -361,15 +356,12 @@ export class String {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, stringBody, 'stringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(stringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -544,11 +536,10 @@ export class String {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (stringBody !== null && stringBody !== undefined) {
+        httpRequest.unserializedBody = stringBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'stringBody',
@@ -556,15 +547,12 @@ export class String {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, stringBody, 'stringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(stringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -741,11 +729,10 @@ export class String {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (stringBody !== null && stringBody !== undefined) {
+        httpRequest.unserializedBody = stringBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'stringBody',
@@ -753,15 +740,12 @@ export class String {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, stringBody, 'stringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(stringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1115,11 +1099,10 @@ export class String {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (stringBody !== null && stringBody !== undefined) {
+        httpRequest.unserializedBody = stringBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'stringBody',
@@ -1127,15 +1110,12 @@ export class String {
             name: 'Base64Url'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, stringBody, 'stringBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'stringBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(stringBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -41,7 +41,15 @@ class ComplexModelClient extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 
@@ -218,22 +226,16 @@ class ComplexModelClient extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.CatalogDictionaryOfArray;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.CatalogDictionaryOfArray;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -342,22 +344,16 @@ class ComplexModelClient extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.CatalogArrayOfDictionary;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.CatalogArrayOfDictionary;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -218,21 +218,17 @@ class ComplexModelClient extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.CatalogDictionaryOfArray;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -346,21 +342,17 @@ class ComplexModelClient extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.CatalogArrayOfDictionary;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
@@ -43,7 +43,15 @@ class CompositeBoolInt extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -157,28 +157,22 @@ export class Bool {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (boolBody !== null && boolBody !== undefined) {
-        httpRequest.unserializedBody = boolBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'boolBody',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = boolBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'boolBody',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "boolBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -345,28 +339,22 @@ export class Bool {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (boolBody !== null && boolBody !== undefined) {
-        httpRequest.unserializedBody = boolBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'boolBody',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = boolBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'boolBody',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "boolBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -157,11 +157,10 @@ export class Bool {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (boolBody !== null && boolBody !== undefined) {
+        httpRequest.unserializedBody = boolBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'boolBody',
@@ -169,15 +168,12 @@ export class Bool {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, boolBody, 'boolBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(boolBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -349,11 +345,10 @@ export class Bool {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (boolBody !== null && boolBody !== undefined) {
+        httpRequest.unserializedBody = boolBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'boolBody',
@@ -361,15 +356,12 @@ export class Bool {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, boolBody, 'boolBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'boolBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(boolBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
@@ -612,28 +612,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -709,28 +703,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -806,28 +794,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -903,28 +885,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1092,28 +1068,22 @@ export class IntModel {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (intBody !== null && intBody !== undefined) {
-        httpRequest.unserializedBody = intBody;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'intBody',
-          type: {
-            name: 'UnixTime'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = intBody;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'intBody',
+        type: {
+          name: 'UnixTime'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "intBody",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
@@ -612,11 +612,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -624,15 +623,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -713,11 +709,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -725,15 +720,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -814,11 +806,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -826,15 +817,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -915,11 +903,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -927,15 +914,12 @@ export class IntModel {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1108,11 +1092,10 @@ export class IntModel {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (intBody !== null && intBody !== undefined) {
+        httpRequest.unserializedBody = intBody;
         let requestModelMapper = {
           required: true,
           serializedName: 'intBody',
@@ -1120,15 +1103,12 @@ export class IntModel {
             name: 'UnixTime'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, intBody, 'intBody');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'intBody');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(intBody, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -43,7 +43,15 @@ class AutoRestParameterizedHostTestClient extends msRest.ServiceClient {
    */
   constructor(options?: Models.AutoRestParameterizedHostTestClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
@@ -49,7 +49,15 @@ class AutoRestParameterizedCustomHostTestClient extends msRest.ServiceClient {
       throw new Error('\'subscriptionId\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATHeaderService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
@@ -48,7 +48,15 @@ class AutoRestHttpInfrastructureTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/Http/operations/httpClientFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpClientFailure.ts
@@ -231,28 +231,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -340,28 +334,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -449,28 +437,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -558,28 +540,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -913,28 +889,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1022,28 +992,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1131,28 +1095,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1240,28 +1198,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1349,28 +1301,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1704,28 +1650,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1813,28 +1753,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1922,28 +1856,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -2113,28 +2041,22 @@ export class HttpClientFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {

--- a/test/vanilla/generated/Http/operations/httpClientFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpClientFailure.ts
@@ -231,11 +231,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -243,15 +242,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -344,11 +340,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -356,15 +351,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -457,11 +449,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -469,15 +460,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -570,11 +558,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -582,15 +569,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -929,11 +913,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -941,15 +924,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1042,11 +1022,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1054,15 +1033,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1155,11 +1131,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1167,15 +1142,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1268,11 +1240,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1280,15 +1251,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1381,11 +1349,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1393,15 +1360,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1740,11 +1704,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1752,15 +1715,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1853,11 +1813,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1865,15 +1824,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1966,11 +1922,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1978,15 +1933,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2161,11 +2113,10 @@ export class HttpClientFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -2173,15 +2124,12 @@ export class HttpClientFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/Http/operations/httpRedirects.ts
+++ b/test/vanilla/generated/Http/operations/httpRedirects.ts
@@ -376,28 +376,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 301) {
@@ -614,28 +608,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 302) {
@@ -711,28 +699,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 303) {
@@ -947,28 +929,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 307) {
@@ -1043,28 +1019,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 307) {
@@ -1139,28 +1109,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 307) {
@@ -1235,28 +1199,22 @@ export class HttpRedirects {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200 && statusCode !== 307) {

--- a/test/vanilla/generated/Http/operations/httpRedirects.ts
+++ b/test/vanilla/generated/Http/operations/httpRedirects.ts
@@ -376,11 +376,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -388,15 +387,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -618,11 +614,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -630,15 +625,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -719,11 +711,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -731,15 +722,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -959,11 +947,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -971,15 +958,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1059,11 +1043,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1071,15 +1054,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1159,11 +1139,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1171,15 +1150,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1259,11 +1235,10 @@ export class HttpRedirects {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1271,15 +1246,12 @@ export class HttpRedirects {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/Http/operations/httpRetry.ts
+++ b/test/vanilla/generated/Http/operations/httpRetry.ts
@@ -136,28 +136,22 @@ export class HttpRetry {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -232,28 +226,22 @@ export class HttpRetry {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -398,28 +386,22 @@ export class HttpRetry {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -494,28 +476,22 @@ export class HttpRetry {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -590,28 +566,22 @@ export class HttpRetry {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -686,28 +656,22 @@ export class HttpRetry {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/Http/operations/httpRetry.ts
+++ b/test/vanilla/generated/Http/operations/httpRetry.ts
@@ -136,11 +136,10 @@ export class HttpRetry {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -148,15 +147,12 @@ export class HttpRetry {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -236,11 +232,10 @@ export class HttpRetry {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -248,15 +243,12 @@ export class HttpRetry {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -406,11 +398,10 @@ export class HttpRetry {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -418,15 +409,12 @@ export class HttpRetry {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -506,11 +494,10 @@ export class HttpRetry {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -518,15 +505,12 @@ export class HttpRetry {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -606,11 +590,10 @@ export class HttpRetry {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -618,15 +601,12 @@ export class HttpRetry {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -706,11 +686,10 @@ export class HttpRetry {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -718,15 +697,12 @@ export class HttpRetry {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/Http/operations/httpServerFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpServerFailure.ts
@@ -231,28 +231,22 @@ export class HttpServerFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -340,28 +334,22 @@ export class HttpServerFailure {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {

--- a/test/vanilla/generated/Http/operations/httpServerFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpServerFailure.ts
@@ -231,11 +231,10 @@ export class HttpServerFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -243,15 +242,12 @@ export class HttpServerFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -344,11 +340,10 @@ export class HttpServerFailure {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -356,15 +351,12 @@ export class HttpServerFailure {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/Http/operations/httpSuccess.ts
+++ b/test/vanilla/generated/Http/operations/httpSuccess.ts
@@ -227,28 +227,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -323,28 +317,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -419,28 +407,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -515,28 +497,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -611,28 +587,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -707,28 +677,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -803,28 +767,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -899,28 +857,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -995,28 +947,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -1091,28 +1037,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 202) {
@@ -1257,28 +1197,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 204) {
@@ -1353,28 +1287,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 204) {
@@ -1449,28 +1377,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 204) {
@@ -1545,28 +1467,22 @@ export class HttpSuccess {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (booleanValue !== null && booleanValue !== undefined) {
-        httpRequest.unserializedBody = booleanValue;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'booleanValue',
-          type: {
-            name: 'Boolean'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = booleanValue;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'booleanValue',
+        type: {
+          name: 'Boolean'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "DELETE"
+        httpMethod: "DELETE",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "booleanValue",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 204) {

--- a/test/vanilla/generated/Http/operations/httpSuccess.ts
+++ b/test/vanilla/generated/Http/operations/httpSuccess.ts
@@ -227,11 +227,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -239,15 +238,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -327,11 +323,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -339,15 +334,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -427,11 +419,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -439,15 +430,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -527,11 +515,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -539,15 +526,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -627,11 +611,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -639,15 +622,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -727,11 +707,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -739,15 +718,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -827,11 +803,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -839,15 +814,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -927,11 +899,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -939,15 +910,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1027,11 +995,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1039,15 +1006,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1127,11 +1091,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1139,15 +1102,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1297,11 +1257,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1309,15 +1268,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1397,11 +1353,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1409,15 +1364,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1497,11 +1449,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1509,15 +1460,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1597,11 +1545,10 @@ export class HttpSuccess {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (booleanValue !== null && booleanValue !== undefined) {
+        httpRequest.unserializedBody = booleanValue;
         let requestModelMapper = {
           required: false,
           serializedName: 'booleanValue',
@@ -1609,15 +1556,12 @@ export class HttpSuccess {
             name: 'Boolean'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, booleanValue, 'booleanValue');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'booleanValue');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(booleanValue, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -86,11 +86,10 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceArray !== null && resourceArray !== undefined) {
+        httpRequest.unserializedBody = resourceArray;
         let requestModelMapper = {
           required: false,
           serializedName: 'ResourceArray',
@@ -106,15 +105,12 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, resourceArray, 'resourceArray');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceArray');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceArray, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -289,11 +285,10 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceArray !== null && resourceArray !== undefined) {
+        httpRequest.unserializedBody = resourceArray;
         let requestModelMapper = {
           required: false,
           serializedName: 'ResourceArray',
@@ -309,15 +304,12 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, resourceArray, 'resourceArray');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceArray');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceArray, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -492,11 +484,10 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceDictionary !== null && resourceDictionary !== undefined) {
+        httpRequest.unserializedBody = resourceDictionary;
         let requestModelMapper = {
           required: false,
           serializedName: 'ResourceDictionary',
@@ -512,15 +503,12 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, resourceDictionary, 'resourceDictionary');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceDictionary');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceDictionary, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -695,21 +683,17 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (resourceComplexObject !== null && resourceComplexObject !== undefined) {
+        httpRequest.unserializedBody = resourceComplexObject;
         let requestModelMapper = Mappers.ResourceCollection;
-        requestModel = client.serializer.serialize(requestModelMapper, resourceComplexObject, 'resourceComplexObject');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceComplexObject');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(resourceComplexObject, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -869,21 +853,17 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (simpleBodyProduct !== null && simpleBodyProduct !== undefined) {
+        httpRequest.unserializedBody = simpleBodyProduct;
         let requestModelMapper = Mappers.SimpleProduct;
-        requestModel = client.serializer.serialize(requestModelMapper, simpleBodyProduct, 'simpleBodyProduct');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'simpleBodyProduct');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(simpleBodyProduct, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1015,21 +995,17 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (simpleBodyProduct !== null && simpleBodyProduct !== undefined) {
+        httpRequest.unserializedBody = simpleBodyProduct;
         let requestModelMapper = Mappers.SimpleProduct;
-        requestModel = client.serializer.serialize(requestModelMapper, simpleBodyProduct, 'simpleBodyProduct');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'simpleBodyProduct');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(simpleBodyProduct, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1190,21 +1166,17 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (simpleBodyProduct !== null && simpleBodyProduct !== undefined) {
+        httpRequest.unserializedBody = simpleBodyProduct;
         let requestModelMapper = Mappers.SimpleProduct;
-        requestModel = client.serializer.serialize(requestModelMapper, simpleBodyProduct, 'simpleBodyProduct');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'simpleBodyProduct');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(simpleBodyProduct, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -39,7 +39,15 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 
@@ -86,36 +94,30 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceArray !== null && resourceArray !== undefined) {
-        httpRequest.unserializedBody = resourceArray;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'ResourceArray',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'ResourceElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Resource'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceArray');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceArray;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'ResourceArray',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'ResourceElementType',
+              type: {
+                name: 'Composite',
+                className: 'Resource'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceArray",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -285,36 +287,30 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceArray !== null && resourceArray !== undefined) {
-        httpRequest.unserializedBody = resourceArray;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'ResourceArray',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'WrappedProductElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'WrappedProduct'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceArray');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceArray;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'ResourceArray',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'WrappedProductElementType',
+              type: {
+                name: 'Composite',
+                className: 'WrappedProduct'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceArray",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -484,36 +480,30 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceDictionary !== null && resourceDictionary !== undefined) {
-        httpRequest.unserializedBody = resourceDictionary;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'ResourceDictionary',
-          type: {
-            name: 'Dictionary',
-            value: {
-                required: false,
-                serializedName: 'FlattenedProductElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'FlattenedProduct'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceDictionary');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceDictionary;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'ResourceDictionary',
+        type: {
+          name: 'Dictionary',
+          value: {
+              required: false,
+              serializedName: 'FlattenedProductElementType',
+              type: {
+                name: 'Composite',
+                className: 'FlattenedProduct'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceDictionary",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -683,22 +673,16 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (resourceComplexObject !== null && resourceComplexObject !== undefined) {
-        httpRequest.unserializedBody = resourceComplexObject;
-        let requestModelMapper = Mappers.ResourceCollection;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'resourceComplexObject');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = resourceComplexObject;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ResourceCollection;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "resourceComplexObject",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -853,22 +837,16 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (simpleBodyProduct !== null && simpleBodyProduct !== undefined) {
-        httpRequest.unserializedBody = simpleBodyProduct;
-        let requestModelMapper = Mappers.SimpleProduct;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'simpleBodyProduct');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = simpleBodyProduct;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.SimpleProduct;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "simpleBodyProduct",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -995,22 +973,16 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (simpleBodyProduct !== null && simpleBodyProduct !== undefined) {
-        httpRequest.unserializedBody = simpleBodyProduct;
-        let requestModelMapper = Mappers.SimpleProduct;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'simpleBodyProduct');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = simpleBodyProduct;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.SimpleProduct;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "simpleBodyProduct",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1166,22 +1138,16 @@ class AutoRestResourceFlatteningTestService extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (simpleBodyProduct !== null && simpleBodyProduct !== undefined) {
-        httpRequest.unserializedBody = simpleBodyProduct;
-        let requestModelMapper = Mappers.SimpleProduct;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'simpleBodyProduct');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = simpleBodyProduct;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.SimpleProduct;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "simpleBodyProduct",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
@@ -42,7 +42,15 @@ class AutoRestParameterFlattening extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
@@ -95,21 +95,17 @@ export class AvailabilitySets {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (tags1 !== null && tags1 !== undefined) {
+        httpRequest.unserializedBody = tags1;
         let requestModelMapper = Mappers.AvailabilitySetUpdateParameters;
-        requestModel = client.serializer.serialize(requestModelMapper, tags1, 'tags1');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'tags1');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(tags1, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
@@ -95,22 +95,16 @@ export class AvailabilitySets {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (tags1 !== null && tags1 !== undefined) {
-        httpRequest.unserializedBody = tags1;
-        let requestModelMapper = Mappers.AvailabilitySetUpdateParameters;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'tags1');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = tags1;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.AvailabilitySetUpdateParameters;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PATCH"
+        httpMethod: "PATCH",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "tags1",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -39,7 +39,15 @@ class AutoRestReportService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
@@ -58,7 +58,15 @@ class AutoRestRequiredOptionalTestService extends msRest.ServiceClient {
       throw new Error('\'requiredGlobalQuery\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/RequiredOptional/operations/explicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/explicit.ts
@@ -68,11 +68,10 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: true,
           serializedName: 'bodyParameter',
@@ -80,15 +79,12 @@ export class Explicit {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -181,11 +177,10 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: false,
           serializedName: 'bodyParameter',
@@ -193,15 +188,12 @@ export class Explicit {
             name: 'Number'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -289,21 +281,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.IntWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -402,21 +390,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.IntOptionalWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -678,11 +662,10 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: true,
           serializedName: 'bodyParameter',
@@ -690,15 +673,12 @@ export class Explicit {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -791,11 +771,10 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: false,
           serializedName: 'bodyParameter',
@@ -803,15 +782,12 @@ export class Explicit {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -899,21 +875,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.StringWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1012,21 +984,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.StringOptionalWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1288,21 +1256,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1387,21 +1351,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1489,21 +1449,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.ClassWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1594,21 +1550,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.ClassOptionalWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1695,11 +1647,10 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: true,
           serializedName: 'bodyParameter',
@@ -1714,15 +1665,12 @@ export class Explicit {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1819,11 +1767,10 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: false,
           serializedName: 'bodyParameter',
@@ -1838,15 +1785,12 @@ export class Explicit {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1939,21 +1883,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.ArrayWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -2056,21 +1996,17 @@ export class Explicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = Mappers.ArrayOptionalWrapper;
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/RequiredOptional/operations/explicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/explicit.ts
@@ -68,28 +68,22 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -177,28 +171,22 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'Number'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'Number'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -281,22 +269,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.IntWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.IntWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -390,22 +372,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.IntOptionalWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.IntOptionalWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -662,28 +638,22 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -771,28 +741,22 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -875,22 +839,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.StringWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StringWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -984,22 +942,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.StringOptionalWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StringOptionalWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1256,22 +1208,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1351,22 +1297,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1449,22 +1389,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.ClassWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ClassWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1550,22 +1484,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.ClassOptionalWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ClassOptionalWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1647,35 +1575,29 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: true,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: true,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1767,35 +1689,29 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'stringElementType',
-                type: {
-                  name: 'String'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'stringElementType',
+              type: {
+                name: 'String'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -1883,22 +1799,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.ArrayWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ArrayWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode < 200 || statusCode >= 300) {
@@ -1996,22 +1906,16 @@ export class Explicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = Mappers.ArrayOptionalWrapper;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.ArrayOptionalWrapper;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/RequiredOptional/operations/implicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/implicit.ts
@@ -326,28 +326,22 @@ export class Implicit {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bodyParameter !== null && bodyParameter !== undefined) {
-        httpRequest.unserializedBody = bodyParameter;
-        let requestModelMapper = {
-          required: false,
-          serializedName: 'bodyParameter',
-          type: {
-            name: 'String'
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bodyParameter;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        required: false,
+        serializedName: 'bodyParameter',
+        type: {
+          name: 'String'
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bodyParameter",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/vanilla/generated/RequiredOptional/operations/implicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/implicit.ts
@@ -326,11 +326,10 @@ export class Implicit {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bodyParameter !== null && bodyParameter !== undefined) {
+        httpRequest.unserializedBody = bodyParameter;
         let requestModelMapper = {
           required: false,
           serializedName: 'bodyParameter',
@@ -338,15 +337,12 @@ export class Implicit {
             name: 'String'
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bodyParameter, 'bodyParameter');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bodyParameter');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bodyParameter, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/Url/autoRestUrlTestService.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestService.ts
@@ -53,7 +53,15 @@ class AutoRestUrlTestService extends msRest.ServiceClient {
       throw new Error('\'globalStringPath\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
@@ -42,7 +42,15 @@ class AutoRestUrlMutliCollectionFormatTestService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -306,21 +306,17 @@ class AutoRestValidationTest extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (body !== null && body !== undefined) {
+        httpRequest.unserializedBody = body;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, body, 'body');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'body');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(body, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -476,21 +472,17 @@ class AutoRestValidationTest extends msRest.ServiceClient {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (body !== null && body !== undefined) {
+        httpRequest.unserializedBody = body;
         let requestModelMapper = Mappers.Product;
-        requestModel = client.serializer.serialize(requestModelMapper, body, 'body');
-        requestContent = JSON.stringify(requestModel);
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'body');
+        httpRequest.body = JSON.stringify(httpRequest.body);
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(body, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -51,7 +51,15 @@ class AutoRestValidationTest extends msRest.ServiceClient {
       throw new Error('\'apiVersion\' cannot be null.');
     }
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, false)
+      };
+    }
 
     super(undefined, options);
 
@@ -306,22 +314,16 @@ class AutoRestValidationTest extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (body !== null && body !== undefined) {
-        httpRequest.unserializedBody = body;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'body');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = body;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "body",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {
@@ -472,22 +474,16 @@ class AutoRestValidationTest extends msRest.ServiceClient {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (body !== null && body !== undefined) {
-        httpRequest.unserializedBody = body;
-        let requestModelMapper = Mappers.Product;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'body');
-        httpRequest.body = JSON.stringify(httpRequest.body);
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = body;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Product;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "POST"
+        httpMethod: "POST",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "body",
+        isXML: false
       });
       let statusCode = operationRes.status;
       if (statusCode !== 200) {

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
@@ -42,7 +42,15 @@ class AutoRestSwaggerBATXMLService extends msRest.ServiceClient {
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 
-    if (!options) options = {};
+    if (!options) {
+      options = {};
+    }
+    if (!options.serializer) {
+      options = {
+        ...options,
+        serializer: new msRest.Serializer(Mappers, true)
+      };
+    }
 
     super(undefined, options);
 

--- a/test/xml/generated/Xml/operations/xml.ts
+++ b/test/xml/generated/Xml/operations/xml.ts
@@ -152,22 +152,16 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (slideshow !== null && slideshow !== undefined) {
-        httpRequest.unserializedBody = slideshow;
-        let requestModelMapper = Mappers.Slideshow;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'slideshow');
-        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'slideshow' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = slideshow;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Slideshow;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "slideshow",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -324,22 +318,16 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (wrappedLists !== null && wrappedLists !== undefined) {
-        httpRequest.unserializedBody = wrappedLists;
-        let requestModelMapper = Mappers.AppleBarrel;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'wrappedLists');
-        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'AppleBarrel' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = wrappedLists;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.AppleBarrel;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "wrappedLists",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -562,22 +550,16 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (slideshow !== null && slideshow !== undefined) {
-        httpRequest.unserializedBody = slideshow;
-        let requestModelMapper = Mappers.Slideshow;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'slideshow');
-        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'slideshow' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = slideshow;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Slideshow;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "slideshow",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -730,22 +712,16 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (appleBarrel !== null && appleBarrel !== undefined) {
-        httpRequest.unserializedBody = appleBarrel;
-        let requestModelMapper = Mappers.AppleBarrel;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'appleBarrel');
-        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'AppleBarrel' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = appleBarrel;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.AppleBarrel;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "appleBarrel",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -905,37 +881,31 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bananas !== null && bananas !== undefined) {
-        httpRequest.unserializedBody = bananas;
-        let requestModelMapper = {
-          xmlElementName: 'banana',
-          required: true,
-          serializedName: 'bananas',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'BananaElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Banana'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bananas');
-        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'banana'), { rootName: 'bananas' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bananas;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        xmlElementName: 'banana',
+        required: true,
+        serializedName: 'bananas',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'BananaElementType',
+              type: {
+                name: 'Composite',
+                className: 'Banana'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bananas",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -1095,37 +1065,31 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bananas !== null && bananas !== undefined) {
-        httpRequest.unserializedBody = bananas;
-        let requestModelMapper = {
-          xmlElementName: 'banana',
-          required: true,
-          serializedName: 'bananas',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'BananaElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Banana'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bananas');
-        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'banana'), { rootName: 'bananas' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bananas;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        xmlElementName: 'banana',
+        required: true,
+        serializedName: 'bananas',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'BananaElementType',
+              type: {
+                name: 'Composite',
+                className: 'Banana'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bananas",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -1285,37 +1249,31 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (bananas !== null && bananas !== undefined) {
-        httpRequest.unserializedBody = bananas;
-        let requestModelMapper = {
-          xmlElementName: 'banana',
-          required: true,
-          serializedName: 'bananas',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'BananaElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'Banana'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bananas');
-        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'banana'), { rootName: 'bananas' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = bananas;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        xmlElementName: 'banana',
+        required: true,
+        serializedName: 'bananas',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'BananaElementType',
+              type: {
+                name: 'Composite',
+                className: 'Banana'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "bananas",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -1468,22 +1426,16 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (banana !== null && banana !== undefined) {
-        httpRequest.unserializedBody = banana;
-        let requestModelMapper = Mappers.Banana;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'banana');
-        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'banana' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = banana;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.Banana;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "banana",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -1727,22 +1679,16 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (properties !== null && properties !== undefined) {
-        httpRequest.unserializedBody = properties;
-        let requestModelMapper = Mappers.StorageServiceProperties;
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'properties');
-        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'StorageServiceProperties' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = properties;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = Mappers.StorageServiceProperties;
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "properties",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {
@@ -1910,37 +1856,31 @@ export class Xml {
         }
       }
     }
-    // SerializedRequest
-    try {
-      if (properties !== null && properties !== undefined) {
-        httpRequest.unserializedBody = properties;
-        let requestModelMapper = {
-          xmlElementName: 'SignedIdentifiers',
-          required: true,
-          serializedName: 'properties',
-          type: {
-            name: 'Sequence',
-            element: {
-                required: false,
-                serializedName: 'SignedIdentifierElementType',
-                type: {
-                  name: 'Composite',
-                  className: 'SignedIdentifier'
-                }
-            }
-          }
-        };
-        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'properties');
-        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'SignedIdentifiers'), { rootName: 'SignedIdentifiers' });
-      }
-    } catch (error) {
-      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
-    }
+    httpRequest.body = properties;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
+      let requestModelMapper = {
+        xmlElementName: 'SignedIdentifiers',
+        required: true,
+        serializedName: 'properties',
+        type: {
+          name: 'Sequence',
+          element: {
+              required: false,
+              serializedName: 'SignedIdentifierElementType',
+              type: {
+                name: 'Composite',
+                className: 'SignedIdentifier'
+              }
+          }
+        }
+      };
       operationRes = await client.sendOperationRequest(httpRequest, {
-        httpMethod: "PUT"
+        httpMethod: "PUT",
+        requestBodyMapper: requestModelMapper,
+        requestBodyName: "properties",
+        isXML: true
       });
       let statusCode = operationRes.status;
       if (statusCode !== 201) {

--- a/test/xml/generated/Xml/operations/xml.ts
+++ b/test/xml/generated/Xml/operations/xml.ts
@@ -152,21 +152,17 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (slideshow !== null && slideshow !== undefined) {
+        httpRequest.unserializedBody = slideshow;
         let requestModelMapper = Mappers.Slideshow;
-        requestModel = client.serializer.serialize(requestModelMapper, slideshow, 'slideshow');
-        requestContent = msRest.stringifyXML(requestModel, { rootName: 'slideshow' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'slideshow');
+        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'slideshow' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(slideshow, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -328,21 +324,17 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (wrappedLists !== null && wrappedLists !== undefined) {
+        httpRequest.unserializedBody = wrappedLists;
         let requestModelMapper = Mappers.AppleBarrel;
-        requestModel = client.serializer.serialize(requestModelMapper, wrappedLists, 'wrappedLists');
-        requestContent = msRest.stringifyXML(requestModel, { rootName: 'AppleBarrel' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'wrappedLists');
+        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'AppleBarrel' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(wrappedLists, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -570,21 +562,17 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (slideshow !== null && slideshow !== undefined) {
+        httpRequest.unserializedBody = slideshow;
         let requestModelMapper = Mappers.Slideshow;
-        requestModel = client.serializer.serialize(requestModelMapper, slideshow, 'slideshow');
-        requestContent = msRest.stringifyXML(requestModel, { rootName: 'slideshow' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'slideshow');
+        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'slideshow' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(slideshow, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -742,21 +730,17 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (appleBarrel !== null && appleBarrel !== undefined) {
+        httpRequest.unserializedBody = appleBarrel;
         let requestModelMapper = Mappers.AppleBarrel;
-        requestModel = client.serializer.serialize(requestModelMapper, appleBarrel, 'appleBarrel');
-        requestContent = msRest.stringifyXML(requestModel, { rootName: 'AppleBarrel' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'appleBarrel');
+        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'AppleBarrel' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(appleBarrel, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -921,11 +905,10 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bananas !== null && bananas !== undefined) {
+        httpRequest.unserializedBody = bananas;
         let requestModelMapper = {
           xmlElementName: 'banana',
           required: true,
@@ -942,15 +925,12 @@ export class Xml {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bananas, 'bananas');
-        requestContent = msRest.stringifyXML(msRest.prepareXMLRootList(requestModel, 'banana'), { rootName: 'bananas' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bananas');
+        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'banana'), { rootName: 'bananas' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bananas, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1115,11 +1095,10 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bananas !== null && bananas !== undefined) {
+        httpRequest.unserializedBody = bananas;
         let requestModelMapper = {
           xmlElementName: 'banana',
           required: true,
@@ -1136,15 +1115,12 @@ export class Xml {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bananas, 'bananas');
-        requestContent = msRest.stringifyXML(msRest.prepareXMLRootList(requestModel, 'banana'), { rootName: 'bananas' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bananas');
+        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'banana'), { rootName: 'bananas' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bananas, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1309,11 +1285,10 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (bananas !== null && bananas !== undefined) {
+        httpRequest.unserializedBody = bananas;
         let requestModelMapper = {
           xmlElementName: 'banana',
           required: true,
@@ -1330,15 +1305,12 @@ export class Xml {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, bananas, 'bananas');
-        requestContent = msRest.stringifyXML(msRest.prepareXMLRootList(requestModel, 'banana'), { rootName: 'bananas' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'bananas');
+        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'banana'), { rootName: 'bananas' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(bananas, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1496,21 +1468,17 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (banana !== null && banana !== undefined) {
+        httpRequest.unserializedBody = banana;
         let requestModelMapper = Mappers.Banana;
-        requestModel = client.serializer.serialize(requestModelMapper, banana, 'banana');
-        requestContent = msRest.stringifyXML(requestModel, { rootName: 'banana' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'banana');
+        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'banana' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(banana, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1759,21 +1727,17 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (properties !== null && properties !== undefined) {
+        httpRequest.unserializedBody = properties;
         let requestModelMapper = Mappers.StorageServiceProperties;
-        requestModel = client.serializer.serialize(requestModelMapper, properties, 'properties');
-        requestContent = msRest.stringifyXML(requestModel, { rootName: 'StorageServiceProperties' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'properties');
+        httpRequest.body = msRest.stringifyXML(httpRequest.body, { rootName: 'StorageServiceProperties' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(properties, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {
@@ -1946,11 +1910,10 @@ export class Xml {
         }
       }
     }
-    // Serialize Request
-    let requestContent = null;
-    let requestModel = null;
+    // SerializedRequest
     try {
       if (properties !== null && properties !== undefined) {
+        httpRequest.unserializedBody = properties;
         let requestModelMapper = {
           xmlElementName: 'SignedIdentifiers',
           required: true,
@@ -1967,15 +1930,12 @@ export class Xml {
             }
           }
         };
-        requestModel = client.serializer.serialize(requestModelMapper, properties, 'properties');
-        requestContent = msRest.stringifyXML(msRest.prepareXMLRootList(requestModel, 'SignedIdentifiers'), { rootName: 'SignedIdentifiers' });
+        httpRequest.body = client.serializer.serialize(requestModelMapper, httpRequest.unserializedBody, 'properties');
+        httpRequest.body = msRest.stringifyXML(msRest.prepareXMLRootList(httpRequest.body, 'SignedIdentifiers'), { rootName: 'SignedIdentifiers' });
       }
     } catch (error) {
-      let serializationError = new Error(`Error "${error.message}" occurred in serializing the ` +
-          `payload - ${JSON.stringify(properties, null, 2)}.`);
-      return Promise.reject(serializationError);
+      return Promise.reject(new Error(`Error "${error.message}" occurred in serializing the payload - ${JSON.stringify(httpRequest.unserializedBody, null, 2)}.`));
     }
-    httpRequest.body = requestContent;
     // Send Request
     let operationRes: msRest.HttpOperationResponse;
     try {


### PR DESCRIPTION
This change only moves serialization for the request body into the serialization policy. The response body serialization will come in a later change.