### PR TITLE
Disable colors in CI output for mocha

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -31,7 +31,7 @@ task 'test/typecheck', 'type check generated code', [], (done) ->
   done();
 
 task 'test/nodejs-unit', 'run nodejs unit tests', [], (done) ->
-  await execute "#{basefolder}/node_modules/.bin/mocha", defer _
+  await execute "#{basefolder}/node_modules/.bin/mocha --no-colors", defer _
   done();
 
 task 'test/chrome-unit', 'run browser unit tests', [], (done) ->


### PR DESCRIPTION
VSTS puts in lots of noise characters instead of colors, so I'm turning mocha's colors off for CI.

Note I'm not adding this to `mocha.opts` because I still want a plain old `mocha` invocation to have colors.