### PR TITLE
Import helpers

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "through2-parallel": "^0.1.3",
     "ts-loader": "^4.1.0",
     "ts-node": "^5.0.1",
+    "tslib": "^1.9.2",
     "tslint": "^5.10.0",
     "typescript": "^2.8.1",
     "underscore": "^1.8.3",

--- a/src/vanilla/Templates/PackageJson.cshtml
+++ b/src/vanilla/Templates/PackageJson.cshtml
@@ -1,4 +1,4 @@
-﻿@using System.Linq
+﻿-@using System.Linq
 @using AutoRest.Core.Utilities;
 @using AutoRest.TypeScript.vanilla.Templates
 @inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>
@@ -16,6 +16,7 @@
   "types": "./typings/lib/@(Model.Name.ToCamelCase()).d.ts",
   "devDependencies": {
     "ts-loader": "^2.3.7",
+    "tslib": "^1.9.2",
     "tslint": "^5.7.0",
     "typescript": "^2.5.2",
     "webpack": "^3.6.0",

--- a/src/vanilla/Templates/TsConfig.cshtml
+++ b/src/vanilla/Templates/TsConfig.cshtml
@@ -21,6 +21,7 @@
     "outDir": "./dist/lib",
     "declaration": true,
     "declarationDir": "./typings/lib",
+    "importHelpers": true,
     "lib": [ "dom", "dom.iterable", "es5", "es6", "es7", "esnext", "esnext.asynciterable", "es2015.iterable"]
   },
   "compileOnSave": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "sourceMap": true,
     "importHelpers": true,
-    "target": "es2017",
+    "target": "es6",
     "lib": [
       "dom",
       "es2015"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "sourceMap": true,
+    "importHelpers": true,
     "target": "es2017",
     "lib": [
       "dom",


### PR DESCRIPTION
- Adds importHelpers: true to the base tsconfig. We don't ship this to users, so it doesn't really matter as much.
- Adds importHelpers: true to tsconfig.json template and tslib to package.json template. This will affect how the user's code bundles. In the ARM network client it seemed to make a pretty negligible difference (0.5% of a 800~ KB bundle). Perhaps the generated code doesn't make as use of as many language features that require helpers to be generated by tsc?
- Changes the target of the base tsconfig.json to es6 to match our tsconfig.json template. What target should we really have here?