### PR TITLE
Remove leading dash from PackageJson.cshtml

### DIFF
--- a/src/vanilla/Templates/PackageJson.cshtml
+++ b/src/vanilla/Templates/PackageJson.cshtml
@@ -1,4 +1,4 @@
-﻿-@using System.Linq
+﻿@using System.Linq
 @using AutoRest.Core.Utilities;
 @using AutoRest.TypeScript.vanilla.Templates
 @inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>


### PR DESCRIPTION
Somehow I added a leading dash into this file by accident, and probably since it just looks like a line marker in a git diff it was overlooked. Let's fix it.