### PR TITLE
No structural equals

### DIFF
--- a/.scripts/bundlesize.js
+++ b/.scripts/bundlesize.js
@@ -10,49 +10,63 @@ const filesize = require("filesize");
 
 const { GitHubCiClient } = require("./github");
 const {
-    repo,
-    githubToken,
-    pr
+  repo,
+  githubToken,
+  pr
 } = require("@microsoft.azure/autorest.testserver/coverage/cli");
 
 const commentIndicatorBundlesize = "<!--AUTO-GENERATED TYPESCRIPT BUNDLESIZE COMMENT-->\n";
 
 async function getBundleSize() {
-    await exec(join(__dirname, "../node_modules/.bin/webpack -p"), { maxBuffer: 1024 * 1024 });
-    const status = await stat(join(__dirname, "../testBundle.js"));
-    return status.size;
+  await new Promise((resolve, reject) => {
+    cp.exec(join(__dirname, "../node_modules/.bin/webpack -p"), { maxBuffer: 1024 * 1024 }, (err, stdout, stderr) => {
+      if (stdout) {
+        console.log(stdout);
+      }
+      if (stderr) {
+        console.error(stderr);
+      }
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
+      }
+    });
+  });
+  const status = await stat(join(__dirname, "../testBundle.js"));
+  return status.size;
 }
 
 async function main(repo, pr, token) {
-    const ghClient = new GitHubCiClient(repo, token);
+  const ghClient = new GitHubCiClient(repo, token);
 
-    const prData = await ghClient.getPR(pr);
-    await exec("git reset --hard " + prData.base.sha, { maxBuffer: 1024 * 1024 });
-    const baseSize = await getBundleSize();
+  const prData = await ghClient.getPR(pr);
+  await exec("git reset --hard " + prData.base.sha, { maxBuffer: 1024 * 1024 });
+  const baseSize = await getBundleSize();
 
-    await exec("git reset --hard " + prData.head.sha, { maxBuffer: 1024 * 1024 });
-    const headSize = await getBundleSize();
+  await exec("git reset --hard " + prData.head.sha, { maxBuffer: 1024 * 1024 });
+  const headSize = await getBundleSize();
 
-    const change = (headSize / baseSize) - 1;
-    const percentChange = (Math.abs(change) * 100).toFixed(2) + '%';
+  const change = (headSize / baseSize) - 1;
+  const percentChange = (Math.abs(change) * 100).toFixed(2) + '%';
 
-    const comment = `${commentIndicatorBundlesize}
-# 🤖 AutoRest automatic bundle size check 🤖
-### Size ${change >= 0 ? "increased" : "decreased"} by ${percentChange} (${filesize(headSize-baseSize)})
-`
+  const comment = `${commentIndicatorBundlesize}
+  # 🤖 AutoRest automatic bundle size check 🤖
+  ### Size ${change >= 0 ? "increased" : "decreased"} by ${percentChange} (${filesize(headSize-baseSize)})
+  `
 
-    // try cleaning up previous auto-comments
-    try {
-        const comments = await ghClient.getCommentsWithIndicator(pr, commentIndicatorBundlesize);
-        for (const comment of comments) await ghClient.tryDeleteComment(comment.id);
-    } catch (_) { }
-    // send comment
-    await ghClient.createComment(pr, comment);
+  // try cleaning up previous auto-comments
+  try {
+    const comments = await ghClient.getCommentsWithIndicator(pr, commentIndicatorBundlesize);
+    for (const comment of comments) await ghClient.tryDeleteComment(comment.id);
+  } catch (_) { }
+  // send comment
+  await ghClient.createComment(pr, comment);
 }
 
 main(repo, pr, githubToken)
 .catch(err => {
-    console.error(err.message);
-    console.error(err.stack);
-    process.exit(1);
+  console.error(err.message);
+  console.error(err.stack);
+  process.exit(1);
 });

--- a/.scripts/bundlesize.js
+++ b/.scripts/bundlesize.js
@@ -26,11 +26,8 @@ async function getBundleSize() {
       if (stderr) {
         console.error(stderr);
       }
-      if (err) {
-        reject(err);
-      } else {
-        resolve();
-      }
+      // Even if webpack errors, we still just want to see what it put on disk
+      resolve();
     });
   });
   const status = await stat(join(__dirname, "../testBundle.js"));

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm install -g autorest
 This AutoRest extension generates TypeScript code that is compatible with:
 ```
 "ms-rest-azure-js": "~0.5.68",
-"ms-rest-js": "~0.9.248"
+"ms-rest-js": "~0.9.250"
 ```
 
 # Usage

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mocha-chrome": "^1.0.3",
     "moment": "~2.21.0",
     "ms-rest-azure-js": "~0.5.68",
-    "ms-rest-js": "~0.9.248",
+    "ms-rest-js": "~0.9.250",
     "run-sequence": "*",
     "should": "5.2.0",
     "shx": "^0.2.2",

--- a/src/azure/TransformerTSa.cs
+++ b/src/azure/TransformerTSa.cs
@@ -27,7 +27,7 @@ namespace AutoRest.TypeScript.Azure
                 throw new InvalidCastException("Code Model is not a TypeScript Azure code model.");
             }
 
-            // MethodNames are normalized explicitly to provide a consitent method name while 
+            // MethodNames are normalized explicitly to provide a consitent method name while
             // generating cloned methods for long running operations with reserved words. For
             // example - beginDeleteMethod() insteadof beginDelete() as delete is a reserved word.
             // Namer.NormalizeMethodNames(serviceClient);
@@ -88,7 +88,7 @@ namespace AutoRest.TypeScript.Azure
                         compositType.Extensions[AzureExtensions.PageableExtension] = true;
                         var pageTemplateModel = new PageCompositeTypeTSa(nextLinkName, itemName).LoadFrom(compositType);
                         // var pageTemplateModel = new PageTemplateModel(compositType, serviceClient, nextLinkName, itemName);
-                        if (!codeModel.PageTemplateModels.Any(ptm => ptm.StructurallyEquals(pageTemplateModel)))
+                        if (!codeModel.PageTemplateModels.Any(ptm => ptm.Name == pageTemplateModel.Name))
                         {
                             codeModel.PageTemplateModels.Add(pageTemplateModel);
                         }

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -329,7 +329,7 @@ namespace AutoRest.TypeScript.Model
 
         public virtual string PackageDependencies()
         {
-            return "\"ms-rest-js\": \"~0.9.248\"";
+            return "\"ms-rest-js\": \"~0.9.250\"";
         }
 
         public virtual Method GetSampleMethod()

--- a/test/azure/lro.ts
+++ b/test/azure/lro.ts
@@ -4,7 +4,6 @@
 'use strict';
 
 import * as should from 'should';
-import * as assert from 'assert';
 import * as msRest from 'ms-rest-js';
 import * as msRestAzure from 'ms-rest-azure-js';
 

--- a/test/azure/lro.ts
+++ b/test/azure/lro.ts
@@ -9,18 +9,15 @@ import * as msRest from 'ms-rest-js';
 import * as msRestAzure from 'ms-rest-azure-js';
 
 import { AutoRestLongRunningOperationTestService, AutoRestLongRunningOperationTestServiceModels } from './generated/Lro/autoRestLongRunningOperationTestService';
-import * as Mappers from "./generated/Lro/models/mappers";
 
-var dummySubscriptionId = 'a878ae02-6106-429z-9397-58091ee45g98';
 var dummyToken = 'dummy12321343423';
 var credentials = new msRest.TokenCredentials(dummyToken);
 
-const serializer = new msRest.Serializer(Mappers, false);
 var clientOptions: msRestAzure.AzureServiceClientOptions = {
   requestOptions: { jar: true } as any,
   requestPolicyCreators: [
     msRest.exponentialRetryPolicy(3, 0, 0, 0),
-    msRest.serializationPolicy(serializer)
+    msRest.serializationPolicy()
   ],
   noRetryPolicy: true,
   longRunningOperationRetryTimeout: 0

--- a/test/vanilla/acceptanceTests.ts
+++ b/test/vanilla/acceptanceTests.ts
@@ -2284,15 +2284,12 @@ describe('typescript', function () {
     });
     describe('Http infrastructure Client', function () {
       const serializer = new msRest.Serializer(AutoRestHttpInfrastructureTestServiceMappers);
-      var testOptions: msRest.ServiceClientOptions = {
-        ...clientOptions,
-        serializer: serializer
-      };
+      var testOptions: msRest.ServiceClientOptions = { ...clientOptions };
       //testOptions.requestOptions = { jar: true };
       testOptions.requestPolicyCreators = [
         msRest.redirectPolicy(),
         msRest.exponentialRetryPolicy(3, 0, 0, 0),
-        msRest.serializationPolicy(serializer)
+        msRest.serializationPolicy()
       ];
       testOptions.noRetryPolicy = true;
       var testClient = new AutoRestHttpInfrastructureTestService(baseUri, testOptions);


### PR DESCRIPTION
This fixes a pathological behavior in the azure-arm generator where generating a network client would take 7+ minutes due to insane amounts of JSON serialization/comparision through IModelType.StructurallyEquals. Now it takes about 1 minute on my PC.

While I was at it I fixed the bundlesize check and fixed some build errors in the tests related to recent ms-rest-js changes.

Fixes #159