### PR TITLE
Add TS_NODE_TYPE_CHECK environment variable before automated tests

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -7,6 +7,7 @@ Tasks "regeneration"
 Tasks "publishing"
 
 Install "child_process"
+Install "process"
 
 # ==============================================================================
 # Settings
@@ -22,10 +23,12 @@ task 'init', "" ,(done)->
   Fail "YOU MUST HAVE NODEJS VERSION GREATER THAN 7.10.0" if semver.lt( process.versions.node , "7.10.0" )
   done()
 
+task 'fetch_submodules',"", (done) ->
+  execute "git submodule update --init --recursive", done
+
 task 'install_common',"", (done) ->
   # global.verbose = true
   execute "npm install",{cwd:"#{basefolder}/autorest.common", silent:false }, done
-
 
 # Run language-specific tests:
 task 'test', '', ['test/generator-unit', 'test/typecheck', 'test/nodejs-unit'], (done) ->
@@ -39,7 +42,12 @@ task 'test/typecheck', 'type check generated code', [], (done) ->
   await execute "#{basefolder}/node_modules/.bin/tsc -p #{basefolder}/test/tsconfig.generated.json", defer _
   done();
 
-task 'test/nodejs-unit', 'run nodejs unit tests', [], (done) ->
+task 'set-tsnode-typecheck', 'set ts-node to type check mode', [], (done) ->
+  # This has to be set or else ts-node won't find const enum values.
+  process.env.TS_NODE_TYPE_CHECK = 'Y'
+  done()
+
+task 'test/nodejs-unit', 'run nodejs unit tests', ['set-tsnode-typecheck'], (done) ->
   await execute "#{basefolder}/node_modules/.bin/mocha --no-colors", defer _
   done();
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,11 @@
       "name": "Mocha Tests",
       "args": [],
       "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
-      "internalConsoleOptions": "openOnSessionStart"
+      "internalConsoleOptions": "openOnSessionStart",
+      "env": {
+        // This has to be set or else ts-node won't find const enum values.
+        "TS_NODE_TYPE_CHECK": "Y"
+      }
     },
     {
       "type": "node",

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -1525,6 +1525,54 @@ export class LROs {
 
 
   /**
+   * Long running post request, service returns a 202 to the initial request with
+   * both Location and Azure-Async header. Poll Azure-Async and it's success.
+   * Should NOT poll Location to get the final object if you support initial
+   * Autorest behavior.
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @returns {Promise} A promise is returned
+   *
+   * @resolve {HttpOperationResponse} - The deserialized result object.
+   *
+   * @reject {Error|ServiceError} - The error object.
+   */
+  async postDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse> {
+    let client = this.client;
+    // Send request
+    let initialResult: msRest.HttpOperationResponse;
+    try {
+      initialResult = await this.beginPostDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    let operationRes: msRest.HttpOperationResponse;
+    try {
+      operationRes = await client.getLongRunningOperationResult(initialResult, options);
+      let httpRequest = operationRes.request;
+
+      // Deserialize Response
+      let parsedResponse = operationRes.parsedBody as { [key: string]: any };
+      try {
+        if (parsedResponse !== null && parsedResponse !== undefined) {
+          const resultMapper = Mappers.Product;
+          operationRes.parsedBody = this.serializer.deserialize(resultMapper, parsedResponse, 'operationRes.parsedBody');
+        }
+      } catch (error) {
+        let deserializationError = new msRest.RestError(`Error ${error} occurred in deserializing the responseBody - ${operationRes.bodyAsText}`);
+        deserializationError.request = msRest.stripRequest(httpRequest);
+        deserializationError.response = msRest.stripResponse(operationRes);
+        return Promise.reject(deserializationError);
+      }
+  } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve(operationRes);
+  }
+
+
+  /**
    * Long running post request, service returns a 202 to the initial request,
    * with an entity that contains ProvisioningState=’Creating’. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
@@ -5027,6 +5075,100 @@ export class LROs {
   }
 
   /**
+   * Long running post request, service returns a 202 to the initial request with
+   * both Location and Azure-Async header. Poll Azure-Async and it's success.
+   * Should NOT poll Location to get the final object if you support initial
+   * Autorest behavior.
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @returns {Promise} A promise is returned
+   *
+   * @resolve {HttpOperationResponse} - The deserialized result object.
+   *
+   * @reject {Error|ServiceError} - The error object.
+   */
+  async beginPostDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<Models.Product>> {
+    let client = this.client;
+
+    // Create HTTP transport objects
+    const httpRequest = new WebResource();
+    let operationRes: msRest.HttpOperationResponse;
+    try {
+      const operationArguments: msRest.OperationArguments = msRest.createOperationArguments(
+        {
+          "this.client.acceptLanguage": this.client.acceptLanguage
+        },
+        options);
+      operationRes = await client.sendOperationRequest(
+        httpRequest,
+        operationArguments,
+        {
+          httpMethod: "POST",
+          baseUrl: this.client.baseUri,
+          path: "lro/LROPostDoubleHeadersFinalAzureHeaderGetDefault",
+          headerParameters: [
+            {
+              parameterPath: "this.client.acceptLanguage",
+              mapper: {
+                serializedName: "accept-language",
+                defaultValue: 'en-US',
+                type: {
+                  name: "String"
+                }
+              }
+            }
+          ],
+          serializer: this.serializer
+        });
+      let statusCode = operationRes.status;
+      if (statusCode !== 202) {
+        let error = new msRest.RestError(operationRes.bodyAsText as string);
+        error.statusCode = operationRes.status;
+        error.request = msRest.stripRequest(httpRequest);
+        error.response = msRest.stripResponse(operationRes);
+        let parsedErrorResponse = operationRes.parsedBody as { [key: string]: any };
+        try {
+          if (parsedErrorResponse) {
+            if (parsedErrorResponse.error) parsedErrorResponse = parsedErrorResponse.error;
+            if (parsedErrorResponse.code) error.code = parsedErrorResponse.code;
+            if (parsedErrorResponse.message) error.message = parsedErrorResponse.message;
+          }
+          if (parsedErrorResponse !== null && parsedErrorResponse !== undefined) {
+            const resultMapper = Mappers.CloudError;
+            error.body = this.serializer.deserialize(resultMapper, parsedErrorResponse, 'error.body');
+          }
+        } catch (defaultError) {
+          error.message = `Error "${defaultError.message}" occurred in deserializing the responseBody ` +
+                           `- "${operationRes.bodyAsText}" for the default response.`;
+          return Promise.reject(error);
+        }
+        return Promise.reject(error);
+      }
+      // Deserialize Response
+      if (statusCode === 202) {
+        let parsedResponse = operationRes.parsedBody as { [key: string]: any };
+        try {
+          if (parsedResponse !== null && parsedResponse !== undefined) {
+            const resultMapper = Mappers.Product;
+            operationRes.parsedBody = this.serializer.deserialize(resultMapper, parsedResponse, 'operationRes.parsedBody');
+          }
+        } catch (error) {
+          let deserializationError = new msRest.RestError(`Error ${error} occurred in deserializing the responseBody - ${operationRes.bodyAsText}`);
+          deserializationError.request = msRest.stripRequest(httpRequest);
+          deserializationError.response = msRest.stripResponse(operationRes);
+          return Promise.reject(deserializationError);
+        }
+      }
+
+    } catch(err) {
+      return Promise.reject(err);
+    }
+
+    return Promise.resolve(operationRes);
+  }
+
+  /**
    * Long running post request, service returns a 202 to the initial request,
    * with an entity that contains ProvisioningState=’Creating’. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
@@ -7011,6 +7153,54 @@ export class LROs {
   }
 
   /**
+   * Long running post request, service returns a 202 to the initial request with
+   * both Location and Azure-Async header. Poll Azure-Async and it's success.
+   * Should NOT poll Location to get the final object if you support initial
+   * Autorest behavior.
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @param {ServiceCallback} callback - The callback.
+   *
+   * @returns {ServiceCallback} callback(err, result, request, operationRes)
+   *
+   *                      {Error|ServiceError}  err        - The Error object if an error occurred, null otherwise.
+   *
+   *                      {Models.Product} [result]   - The deserialized result object if an error did not occur.
+   *                      See {@link Models.Product} for more information.
+   *
+   *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
+   *
+   *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
+   */
+  postDoubleHeadersFinalAzureHeaderGetDefault(): Promise<Models.Product>;
+  postDoubleHeadersFinalAzureHeaderGetDefault(options: msRest.RequestOptionsBase): Promise<Models.Product>;
+  postDoubleHeadersFinalAzureHeaderGetDefault(callback: msRest.ServiceCallback<Models.Product>): void;
+  postDoubleHeadersFinalAzureHeaderGetDefault(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Product>): void;
+  postDoubleHeadersFinalAzureHeaderGetDefault(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<Models.Product>): any {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    let cb = callback as msRest.ServiceCallback<Models.Product>;
+    if (!callback) {
+      return this.postDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
+        return Promise.resolve(operationRes.parsedBody as Models.Product);
+      }).catch((err: Error) => {
+        return Promise.reject(err);
+      });
+    } else {
+      msRest.promiseToCallback(this.postDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
+        if (err) {
+          return cb(err);
+        }
+        let result = data.parsedBody as Models.Product;
+        return cb(err, result, data.request, data);
+      });
+    }
+  }
+
+  /**
    * Long running post request, service returns a 202 to the initial request,
    * with an entity that contains ProvisioningState=’Creating’. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
@@ -8790,6 +8980,54 @@ export class LROs {
       });
     } else {
       msRest.promiseToCallback(this.beginPostDoubleHeadersFinalAzureHeaderGetWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
+        if (err) {
+          return cb(err);
+        }
+        let result = data.parsedBody as Models.Product;
+        return cb(err, result, data.request, data);
+      });
+    }
+  }
+
+  /**
+   * Long running post request, service returns a 202 to the initial request with
+   * both Location and Azure-Async header. Poll Azure-Async and it's success.
+   * Should NOT poll Location to get the final object if you support initial
+   * Autorest behavior.
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @param {ServiceCallback} callback - The callback.
+   *
+   * @returns {ServiceCallback} callback(err, result, request, operationRes)
+   *
+   *                      {Error|ServiceError}  err        - The Error object if an error occurred, null otherwise.
+   *
+   *                      {Models.Product} [result]   - The deserialized result object if an error did not occur.
+   *                      See {@link Models.Product} for more information.
+   *
+   *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
+   *
+   *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
+   */
+  beginPostDoubleHeadersFinalAzureHeaderGetDefault(): Promise<Models.Product>;
+  beginPostDoubleHeadersFinalAzureHeaderGetDefault(options: msRest.RequestOptionsBase): Promise<Models.Product>;
+  beginPostDoubleHeadersFinalAzureHeaderGetDefault(callback: msRest.ServiceCallback<Models.Product>): void;
+  beginPostDoubleHeadersFinalAzureHeaderGetDefault(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.Product>): void;
+  beginPostDoubleHeadersFinalAzureHeaderGetDefault(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<Models.Product>): any {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    let cb = callback as msRest.ServiceCallback<Models.Product>;
+    if (!callback) {
+      return this.beginPostDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
+        return Promise.resolve(operationRes.parsedBody as Models.Product);
+      }).catch((err: Error) => {
+        return Promise.reject(err);
+      });
+    } else {
+      msRest.promiseToCallback(this.beginPostDoubleHeadersFinalAzureHeaderGetDefaultWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
         if (err) {
           return cb(err);
         }


### PR DESCRIPTION
If we don't add this environment variable (TS_NODE_TYPE_CHECK = "Y"), then when ts-node runs our tests it won't find the const enum values (complains about not being able to find Csv on an undefined value). This problem can be fixed by setting the environment variable before running ts-node (as I've done in this PR), or to get rid of ts-node and just compile the typescript code using tsc. I figured everyone would prefer this route. The only problem is that now running "mocha" from the command line outside of gulp, npm, or vscode won't work unless you've previously set the TS_NODE_TYPE_CHECK environment variable.