### PR TITLE
Don't collect types within an error type

### DIFF
--- a/src/vanilla/Model/MethodGroupTS.cs
+++ b/src/vanilla/Model/MethodGroupTS.cs
@@ -55,7 +55,11 @@ namespace AutoRest.TypeScript.Model
                     }
                     if (method.DefaultResponse != null)
                     {
-                        CollectReferencedModelNames(modelNames, method.DefaultResponse.Body);
+                        // We don't want to collect types contained within the error type
+                        if (method.DefaultResponse.Body is CompositeType)
+                        {
+                            modelNames.Add(method.DefaultResponse.Body.Name);
+                        }
                         CollectReferencedModelNames(modelNames, method.DefaultResponse.Headers);
                     }
                 }

--- a/test/vanilla/acceptanceTests.ts
+++ b/test/vanilla/acceptanceTests.ts
@@ -1980,6 +1980,9 @@ describe('typescript', function () {
               ev.loadedBytes.should.be.a.Number;
             }
           });
+          if (response.blobBody) {
+            await response.blobBody();
+          }
           assert(uploadNotified);
           assert(downloadNotified);
         });
@@ -2353,6 +2356,9 @@ describe('typescript', function () {
         });
       });
       it('should work for all http redirect status codes with different verbs', function (done) {
+        // For whatever reason, Chrome's redirect caching seems to break this.
+        // Be sure to run tests either with inspector open/cache disabled, or in a fresh incognito window.
+        this.timeout(2000);
         testClient.httpRedirects.head300(function (error, result, request, response) {
           should.not.exist(error);
           response.status.should.equal(200);


### PR DESCRIPTION
Fixes #178.

Would like to dive in a little and investigate why the original code resulted in a CloudErrorBody but not the code which generates all mappers using essentially `CodeModel.ModelTypes.Concat(CodeModel.HeaderTypes)`. After we confirm working behavior in some of the main ARM services, we may wish to just merge this as it will prevent our Portal users from needing to manually modify the generated code.