### PR TITLE
Model enum as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ``` yaml
 use-extension:
-  "@microsoft.azure/autorest.modeler": "2.1.23"
+  "@microsoft.azure/autorest.modeler": "2.3.51"
 
 pipeline:
   typescript/modeler:

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ use-extension:
   "@microsoft.azure/autorest.modeler": "2.3.51"
 
 pipeline:
-  typescript/modeler:
-    input: swagger-document/identity
+  typescript/imodeler1:
+    input: openapi-document/identity
     output-artifact: code-model-v1
     scope: typescript
   typescript/commonmarker:
-    input: modeler
+    input: imodeler1
     output-artifact: code-model-v1
   typescript/cm/transform:
     input: commonmarker

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.typescript/blob/master/README.md",
   "devDependencies": {
+    "@microsoft.azure/autorest.modeler": "^2.3.51",
     "@microsoft.azure/autorest.testserver": "^2.5.19",
     "@types/assert": "0.0.31",
     "@types/express": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "homepage": "https://github.com/Azure/autorest.typescript/blob/master/README.md",
   "devDependencies": {
     "@microsoft.azure/autorest.modeler": "^2.3.51",
-    "@microsoft.azure/autorest.testserver": "^2.5.19",
+    "@microsoft.azure/autorest.testserver": "^2.5.22",
     "@types/assert": "0.0.31",
     "@types/express": "^4.11.1",
     "@types/fork-ts-checker-webpack-plugin": "^0.4.0",

--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -490,11 +490,14 @@ namespace AutoRest.TypeScript
             }
             else if (enumType != null)
             {
-                var enumName = enumType.Name.ToPascalCase();
-                tsType = "Models." + enumName;
-                if (inModelsModule || enumName.Contains('.'))
+                string enumName = enumType.DeclarationName;
+                if (inModelsModule || enumName.Contains('.') || enumName == "string")
                 {
                     tsType = enumName;
+                }
+                else
+                {
+                    tsType = "Models." + enumName.ToPascalCase();
                 }
             }
             else if (composite != null)

--- a/src/vanilla/Model/EnumTypeTS.cs
+++ b/src/vanilla/Model/EnumTypeTS.cs
@@ -8,6 +8,7 @@ namespace AutoRest.TypeScript.Model
 {
     public class EnumTypeTS : EnumType
     {
+        protected override string ModelAsStringType => "string";
         public string EnumName => CodeNamer.Instance.PascalCase(Name);
     }
 }

--- a/test/azure/generated/CustomBaseUri/operations/paths.ts
+++ b/test/azure/generated/CustomBaseUri/operations/paths.ts
@@ -83,6 +83,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       mapper: {
         required: true,
         serializedName: "accountName",
+        defaultValue: '',
         type: {
           name: "String"
         }

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -4720,10 +4720,10 @@ const beginDeleteNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
     }
   ],
   responses: {
-    204: {
+    202: {
       headersMapper: Mappers.LROsDeleteNoHeaderInRetryHeaders
     },
-    202: {
+    204: {
       headersMapper: Mappers.LROsDeleteNoHeaderInRetryHeaders
     },
     default: {
@@ -4749,10 +4749,10 @@ const beginDeleteAsyncNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
     }
   ],
   responses: {
-    204: {
+    202: {
       headersMapper: Mappers.LROsDeleteAsyncNoHeaderInRetryHeaders
     },
-    202: {
+    204: {
       headersMapper: Mappers.LROsDeleteAsyncNoHeaderInRetryHeaders
     },
     default: {
@@ -4882,10 +4882,10 @@ const beginPost200WithPayloadOperationSpec: msRest.OperationSpec = {
     }
   ],
   responses: {
-    202: {
+    200: {
       bodyMapper: Mappers.Sku
     },
-    200: {
+    202: {
       bodyMapper: Mappers.Sku
     },
     default: {
@@ -5066,11 +5066,11 @@ const beginPostAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
   },
   contentType: "application/json; charset=utf-8",
   responses: {
-    202: {
-      headersMapper: Mappers.LROsPostAsyncRetrySucceededHeaders
-    },
     200: {
       bodyMapper: Mappers.Product,
+      headersMapper: Mappers.LROsPostAsyncRetrySucceededHeaders
+    },
+    202: {
       headersMapper: Mappers.LROsPostAsyncRetrySucceededHeaders
     },
     default: {
@@ -5104,11 +5104,11 @@ const beginPostAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
   },
   contentType: "application/json; charset=utf-8",
   responses: {
-    202: {
-      headersMapper: Mappers.LROsPostAsyncNoRetrySucceededHeaders
-    },
     200: {
       bodyMapper: Mappers.Product,
+      headersMapper: Mappers.LROsPostAsyncNoRetrySucceededHeaders
+    },
+    202: {
       headersMapper: Mappers.LROsPostAsyncNoRetrySucceededHeaders
     },
     default: {

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
@@ -71,7 +71,7 @@ export class MicrosoftAzureTestUrlContext extends msRestAzure.AzureServiceClient
     this.longRunningOperationRetryTimeout = 30;
     this.baseUri = baseUri as string;
     if (!this.baseUri) {
-      this.baseUri = 'https://management.azure.com/';
+      this.baseUri = 'https://management.azure.com';
     }
     this.credentials = credentials;
     this.subscriptionId = subscriptionId;

--- a/test/vanilla/acceptanceTests.ts
+++ b/test/vanilla/acceptanceTests.ts
@@ -32,6 +32,7 @@ import { AutoRestParameterizedHostTestClient } from './generated/CustomBaseUri/a
 import { AutoRestParameterizedCustomHostTestClient } from './generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient';
 import { fail } from "assert";
 import { timeoutPromise } from '../util/util';
+import { FooEnum } from './generated/BodyArray/models';
 
 const readStreamToBuffer = async function (strm: NodeJS.ReadableStream): Promise<Buffer> {
   return new Promise<Buffer>((resolve, reject) => {
@@ -1088,6 +1089,20 @@ describe('typescript', function () {
               });
             });
           });
+        });
+
+        it('should get and put enum arrays', async function () {
+          const testArray = [FooEnum.Foo1, FooEnum.Foo2, FooEnum.Foo3];
+          const result = await testClient.arrayModel.getEnumValid();
+          assert.deepEqual(result, testArray);
+          await testClient.arrayModel.putEnumValid(testArray);
+        });
+
+        it('should get and put string enum arrays', async function () {
+          const testArray = ["foo1", "foo2", "foo3"];
+          const result = await testClient.arrayModel.getStringEnumValid();
+          assert.deepEqual(result, testArray);
+          await testClient.arrayModel.putStringEnumValid(testArray);
         });
 
         it('should get and put uuid arrays', function (done) {

--- a/test/vanilla/acceptanceTests.ts
+++ b/test/vanilla/acceptanceTests.ts
@@ -102,9 +102,9 @@ describe('typescript', function () {
       });
 
       it('should put valid boolean values', function (done) {
-        testClient.bool.putTrue(true, function (error, result) {
+        testClient.bool.putTrue(function (error) {
           should.not.exist(error);
-          testClient.bool.putFalse(false, function (error, result) {
+          testClient.bool.putFalse(function (error) {
             should.not.exist(error);
             done();
           });
@@ -219,9 +219,9 @@ describe('typescript', function () {
       });
 
       it('should put valid boolean values', function (done) {
-        testClient.bool.putTrue(true, function (error, result) {
+        testClient.bool.putTrue(function (error) {
           should.not.exist(error);
-          testClient.bool.putFalse(false, function (error, result) {
+          testClient.bool.putFalse(function (error) {
             should.not.exist(error);
             done();
           });
@@ -342,9 +342,9 @@ describe('typescript', function () {
       });
 
       it('should put big positive and negative double value', function (done) {
-        testClient.number.putBigDoublePositiveDecimal(99999999.99, function (error, result) {
+        testClient.number.putBigDoublePositiveDecimal(function (error) {
           should.not.exist(error);
-          testClient.number.putBigDoubleNegativeDecimal(-99999999.99, function (error, result) {
+          testClient.number.putBigDoubleNegativeDecimal(function (error) {
             should.not.exist(error);
             done();
           });
@@ -392,7 +392,7 @@ describe('typescript', function () {
       });
 
       it('should support valid empty string value', function (done) {
-        testClient.string.putEmpty(AutoRestSwaggerBATServiceModels.StringBody1.EmptyString, function (error, result) {
+        testClient.string.putEmpty(function (error) {
           should.not.exist(error);
           testClient.string.getEmpty(function (error, result) {
             result.should.equal('');
@@ -402,7 +402,7 @@ describe('typescript', function () {
       });
 
       it('should support valid MBC string value', function (done) {
-        testClient.string.putMbcs(AutoRestSwaggerBATServiceModels.StringBody2.啊齄丂狛狜隣郎隣兀﨩ˊーぁんァヶΑАЯаяāɡㄅㄩɑɡ䜣, function (error, result) {
+        testClient.string.putMbcs(function (error) {
           should.not.exist(error);
           testClient.string.getMbcs(function (error, result) {
             result.should.equal(AutoRestSwaggerBATServiceModels.GetMbcsOKResponse.啊齄丂狛狜隣郎隣兀﨩ˊーぁんァヶΑАЯаяāɡㄅㄩɑɡ䜣);
@@ -412,7 +412,7 @@ describe('typescript', function () {
       });
 
       it('should support whitespace string value', function (done) {
-        testClient.string.putWhitespace(AutoRestSwaggerBATServiceModels.StringBody3.Nowisthetimeforallgoodmentocometotheaidoftheircountry, function (error, result) {
+        testClient.string.putWhitespace(function (error) {
           should.not.exist(error);
           testClient.string.getWhitespace(function (error, result) {
             result.should.equal(AutoRestSwaggerBATServiceModels.GetWhitespaceOKResponse.Nowisthetimeforallgoodmentocometotheaidoftheircountry);

--- a/test/vanilla/generated/BodyArray/models/index.ts
+++ b/test/vanilla/generated/BodyArray/models/index.ts
@@ -39,3 +39,15 @@ export interface ErrorModel {
    */
   message?: string;
 }
+
+/**
+ * Defines values for FooEnum.
+ * Possible values include: 'foo1', 'foo2', 'foo3'
+ * @readonly
+ * @enum {string}
+ */
+export enum FooEnum {
+  Foo1 = 'foo1',
+  Foo2 = 'foo2',
+  Foo3 = 'foo3',
+}

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -551,15 +551,12 @@ export class ArrayModel {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  async getEnumValidWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<Models.FooEnum[]>> {
-
-    let operationRes: msRest.HttpOperationResponse;
-    try {
-      operationRes = await this.client.sendOperationRequest(msRest.createOperationArguments({}, options), getEnumValidOperationSpec);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-    return Promise.resolve(operationRes);
+  getEnumValidWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<Models.FooEnum[]>> {
+    return this.client.sendOperationRequest(
+      {
+        options
+      },
+      getEnumValidOperationSpec);
   }
 
   /**
@@ -575,21 +572,13 @@ export class ArrayModel {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  async putEnumValidWithHttpOperationResponse(arrayBody: Models.FooEnum[], options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
-
-    let operationRes: msRest.HttpOperationResponse;
-    try {
-      operationRes = await this.client.sendOperationRequest(
-        msRest.createOperationArguments(
-          {
-            arrayBody
-          },
-          options),
-        putEnumValidOperationSpec);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-    return Promise.resolve(operationRes);
+  putEnumValidWithHttpOperationResponse(arrayBody: Models.FooEnum[], options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+    return this.client.sendOperationRequest(
+      {
+        arrayBody,
+        options
+      },
+      putEnumValidOperationSpec);
   }
 
   /**
@@ -603,15 +592,12 @@ export class ArrayModel {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  async getStringEnumValidWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<string[]>> {
-
-    let operationRes: msRest.HttpOperationResponse;
-    try {
-      operationRes = await this.client.sendOperationRequest(msRest.createOperationArguments({}, options), getStringEnumValidOperationSpec);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-    return Promise.resolve(operationRes);
+  getStringEnumValidWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<string[]>> {
+    return this.client.sendOperationRequest(
+      {
+        options
+      },
+      getStringEnumValidOperationSpec);
   }
 
   /**
@@ -627,21 +613,13 @@ export class ArrayModel {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  async putStringEnumValidWithHttpOperationResponse(arrayBody: string[], options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
-
-    let operationRes: msRest.HttpOperationResponse;
-    try {
-      operationRes = await this.client.sendOperationRequest(
-        msRest.createOperationArguments(
-          {
-            arrayBody
-          },
-          options),
-        putStringEnumValidOperationSpec);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-    return Promise.resolve(operationRes);
+  putStringEnumValidWithHttpOperationResponse(arrayBody: string[], options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+    return this.client.sendOperationRequest(
+      {
+        arrayBody,
+        options
+      },
+      putStringEnumValidOperationSpec);
   }
 
   /**
@@ -2034,26 +2012,7 @@ export class ArrayModel {
   getEnumValid(callback: msRest.ServiceCallback<Models.FooEnum[]>): void;
   getEnumValid(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FooEnum[]>): void;
   getEnumValid(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<Models.FooEnum[]>): any {
-    if (!callback && typeof options === 'function') {
-      callback = options;
-      options = undefined;
-    }
-    let cb = callback as msRest.ServiceCallback<Models.FooEnum[]>;
-    if (!callback) {
-      return this.getEnumValidWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
-        return Promise.resolve(operationRes.parsedBody as Models.FooEnum[]);
-      }).catch((err: Error) => {
-        return Promise.reject(err);
-      });
-    } else {
-      msRest.promiseToCallback(this.getEnumValidWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
-        if (err) {
-          return cb(err);
-        }
-        let result = data.parsedBody as Models.FooEnum[];
-        return cb(err, result, data.request, data);
-      });
-    }
+    return msRest.responseToBody(this.getEnumValidWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -2077,26 +2036,7 @@ export class ArrayModel {
   putEnumValid(arrayBody: Models.FooEnum[], callback: msRest.ServiceCallback<void>): void;
   putEnumValid(arrayBody: Models.FooEnum[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
   putEnumValid(arrayBody: Models.FooEnum[], options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    if (!callback && typeof options === 'function') {
-      callback = options;
-      options = undefined;
-    }
-    let cb = callback as msRest.ServiceCallback<void>;
-    if (!callback) {
-      return this.putEnumValidWithHttpOperationResponse(arrayBody, options).then((operationRes: msRest.HttpOperationResponse) => {
-        return Promise.resolve(operationRes.parsedBody as void);
-      }).catch((err: Error) => {
-        return Promise.reject(err);
-      });
-    } else {
-      msRest.promiseToCallback(this.putEnumValidWithHttpOperationResponse(arrayBody, options))((err: Error, data: msRest.HttpOperationResponse) => {
-        if (err) {
-          return cb(err);
-        }
-        let result = data.parsedBody as void;
-        return cb(err, result, data.request, data);
-      });
-    }
+    return msRest.responseToBody(this.putEnumValidWithHttpOperationResponse.bind(this), arrayBody, options, callback);
   }
 
   /**
@@ -2118,26 +2058,7 @@ export class ArrayModel {
   getStringEnumValid(callback: msRest.ServiceCallback<string[]>): void;
   getStringEnumValid(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<string[]>): void;
   getStringEnumValid(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<string[]>): any {
-    if (!callback && typeof options === 'function') {
-      callback = options;
-      options = undefined;
-    }
-    let cb = callback as msRest.ServiceCallback<string[]>;
-    if (!callback) {
-      return this.getStringEnumValidWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
-        return Promise.resolve(operationRes.parsedBody as string[]);
-      }).catch((err: Error) => {
-        return Promise.reject(err);
-      });
-    } else {
-      msRest.promiseToCallback(this.getStringEnumValidWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
-        if (err) {
-          return cb(err);
-        }
-        let result = data.parsedBody as string[];
-        return cb(err, result, data.request, data);
-      });
-    }
+    return msRest.responseToBody(this.getStringEnumValidWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -2161,26 +2082,7 @@ export class ArrayModel {
   putStringEnumValid(arrayBody: string[], callback: msRest.ServiceCallback<void>): void;
   putStringEnumValid(arrayBody: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
   putStringEnumValid(arrayBody: string[], options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    if (!callback && typeof options === 'function') {
-      callback = options;
-      options = undefined;
-    }
-    let cb = callback as msRest.ServiceCallback<void>;
-    if (!callback) {
-      return this.putStringEnumValidWithHttpOperationResponse(arrayBody, options).then((operationRes: msRest.HttpOperationResponse) => {
-        return Promise.resolve(operationRes.parsedBody as void);
-      }).catch((err: Error) => {
-        return Promise.reject(err);
-      });
-    } else {
-      msRest.promiseToCallback(this.putStringEnumValidWithHttpOperationResponse(arrayBody, options))((err: Error, data: msRest.HttpOperationResponse) => {
-        if (err) {
-          return cb(err);
-        }
-        let result = data.parsedBody as void;
-        return cb(err, result, data.request, data);
-      });
-    }
+    return msRest.responseToBody(this.putStringEnumValidWithHttpOperationResponse.bind(this), arrayBody, options, callback);
   }
 
   /**

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -541,6 +541,110 @@ export class ArrayModel {
   }
 
   /**
+   * Get enum array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @returns {Promise} A promise is returned
+   *
+   * @resolve {HttpOperationResponse} The deserialized result object.
+   *
+   * @reject {Error|ServiceError} The error object.
+   */
+  async getEnumValidWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<Models.FooEnum[]>> {
+
+    let operationRes: msRest.HttpOperationResponse;
+    try {
+      operationRes = await this.client.sendOperationRequest(msRest.createOperationArguments({}, options), getEnumValidOperationSpec);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve(operationRes);
+  }
+
+  /**
+   * Set array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {FooEnum[]} arrayBody
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @returns {Promise} A promise is returned
+   *
+   * @resolve {HttpOperationResponse} The deserialized result object.
+   *
+   * @reject {Error|ServiceError} The error object.
+   */
+  async putEnumValidWithHttpOperationResponse(arrayBody: Models.FooEnum[], options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+
+    let operationRes: msRest.HttpOperationResponse;
+    try {
+      operationRes = await this.client.sendOperationRequest(
+        msRest.createOperationArguments(
+          {
+            arrayBody
+          },
+          options),
+        putEnumValidOperationSpec);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve(operationRes);
+  }
+
+  /**
+   * Get enum array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @returns {Promise} A promise is returned
+   *
+   * @resolve {HttpOperationResponse} The deserialized result object.
+   *
+   * @reject {Error|ServiceError} The error object.
+   */
+  async getStringEnumValidWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<string[]>> {
+
+    let operationRes: msRest.HttpOperationResponse;
+    try {
+      operationRes = await this.client.sendOperationRequest(msRest.createOperationArguments({}, options), getStringEnumValidOperationSpec);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve(operationRes);
+  }
+
+  /**
+   * Set array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {string[]} arrayBody
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @returns {Promise} A promise is returned
+   *
+   * @resolve {HttpOperationResponse} The deserialized result object.
+   *
+   * @reject {Error|ServiceError} The error object.
+   */
+  async putStringEnumValidWithHttpOperationResponse(arrayBody: string[], options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+
+    let operationRes: msRest.HttpOperationResponse;
+    try {
+      operationRes = await this.client.sendOperationRequest(
+        msRest.createOperationArguments(
+          {
+            arrayBody
+          },
+          options),
+        putStringEnumValidOperationSpec);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return Promise.resolve(operationRes);
+  }
+
+  /**
    * Get string array value ['foo', null, 'foo2']
    *
    * @param {RequestOptionsBase} [options] Optional Parameters.
@@ -1909,6 +2013,174 @@ export class ArrayModel {
   putStringValid(arrayBody: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
   putStringValid(arrayBody: string[], options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
     return msRest.responseToBody(this.putStringValidWithHttpOperationResponse.bind(this), arrayBody, options, callback);
+  }
+
+  /**
+   * Get enum array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @param {ServiceCallback} callback The callback.
+   *
+   * @returns {ServiceCallback} callback(err, result, request, operationRes)
+   *                      {Error|ServiceError}  err        - The Error object if an error occurred, null otherwise.
+   *                      {Models.FooEnum[]} [result]   - The deserialized result object if an error did not occur.
+   *
+   *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
+   *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
+   */
+  getEnumValid(): Promise<Models.FooEnum[]>;
+  getEnumValid(options: msRest.RequestOptionsBase): Promise<Models.FooEnum[]>;
+  getEnumValid(callback: msRest.ServiceCallback<Models.FooEnum[]>): void;
+  getEnumValid(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<Models.FooEnum[]>): void;
+  getEnumValid(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<Models.FooEnum[]>): any {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    let cb = callback as msRest.ServiceCallback<Models.FooEnum[]>;
+    if (!callback) {
+      return this.getEnumValidWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
+        return Promise.resolve(operationRes.parsedBody as Models.FooEnum[]);
+      }).catch((err: Error) => {
+        return Promise.reject(err);
+      });
+    } else {
+      msRest.promiseToCallback(this.getEnumValidWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
+        if (err) {
+          return cb(err);
+        }
+        let result = data.parsedBody as Models.FooEnum[];
+        return cb(err, result, data.request, data);
+      });
+    }
+  }
+
+  /**
+   * Set array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {FooEnum[]} arrayBody
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @param {ServiceCallback} callback The callback.
+   *
+   * @returns {ServiceCallback} callback(err, result, request, operationRes)
+   *                      {Error|ServiceError}  err        - The Error object if an error occurred, null otherwise.
+   *                      {void} [result]   - The deserialized result object if an error did not occur.
+   *
+   *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
+   *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
+   */
+  putEnumValid(arrayBody: Models.FooEnum[]): Promise<void>;
+  putEnumValid(arrayBody: Models.FooEnum[], options: msRest.RequestOptionsBase): Promise<void>;
+  putEnumValid(arrayBody: Models.FooEnum[], callback: msRest.ServiceCallback<void>): void;
+  putEnumValid(arrayBody: Models.FooEnum[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putEnumValid(arrayBody: Models.FooEnum[], options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    let cb = callback as msRest.ServiceCallback<void>;
+    if (!callback) {
+      return this.putEnumValidWithHttpOperationResponse(arrayBody, options).then((operationRes: msRest.HttpOperationResponse) => {
+        return Promise.resolve(operationRes.parsedBody as void);
+      }).catch((err: Error) => {
+        return Promise.reject(err);
+      });
+    } else {
+      msRest.promiseToCallback(this.putEnumValidWithHttpOperationResponse(arrayBody, options))((err: Error, data: msRest.HttpOperationResponse) => {
+        if (err) {
+          return cb(err);
+        }
+        let result = data.parsedBody as void;
+        return cb(err, result, data.request, data);
+      });
+    }
+  }
+
+  /**
+   * Get enum array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @param {ServiceCallback} callback The callback.
+   *
+   * @returns {ServiceCallback} callback(err, result, request, operationRes)
+   *                      {Error|ServiceError}  err        - The Error object if an error occurred, null otherwise.
+   *                      {string[]} [result]   - The deserialized result object if an error did not occur.
+   *
+   *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
+   *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
+   */
+  getStringEnumValid(): Promise<string[]>;
+  getStringEnumValid(options: msRest.RequestOptionsBase): Promise<string[]>;
+  getStringEnumValid(callback: msRest.ServiceCallback<string[]>): void;
+  getStringEnumValid(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<string[]>): void;
+  getStringEnumValid(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<string[]>): any {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    let cb = callback as msRest.ServiceCallback<string[]>;
+    if (!callback) {
+      return this.getStringEnumValidWithHttpOperationResponse(options).then((operationRes: msRest.HttpOperationResponse) => {
+        return Promise.resolve(operationRes.parsedBody as string[]);
+      }).catch((err: Error) => {
+        return Promise.reject(err);
+      });
+    } else {
+      msRest.promiseToCallback(this.getStringEnumValidWithHttpOperationResponse(options))((err: Error, data: msRest.HttpOperationResponse) => {
+        if (err) {
+          return cb(err);
+        }
+        let result = data.parsedBody as string[];
+        return cb(err, result, data.request, data);
+      });
+    }
+  }
+
+  /**
+   * Set array value ['foo1', 'foo2', 'foo3']
+   *
+   * @param {string[]} arrayBody
+   *
+   * @param {RequestOptionsBase} [options] Optional Parameters.
+   *
+   * @param {ServiceCallback} callback The callback.
+   *
+   * @returns {ServiceCallback} callback(err, result, request, operationRes)
+   *                      {Error|ServiceError}  err        - The Error object if an error occurred, null otherwise.
+   *                      {void} [result]   - The deserialized result object if an error did not occur.
+   *
+   *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
+   *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
+   */
+  putStringEnumValid(arrayBody: string[]): Promise<void>;
+  putStringEnumValid(arrayBody: string[], options: msRest.RequestOptionsBase): Promise<void>;
+  putStringEnumValid(arrayBody: string[], callback: msRest.ServiceCallback<void>): void;
+  putStringEnumValid(arrayBody: string[], options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putStringEnumValid(arrayBody: string[], options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
+    let cb = callback as msRest.ServiceCallback<void>;
+    if (!callback) {
+      return this.putStringEnumValidWithHttpOperationResponse(arrayBody, options).then((operationRes: msRest.HttpOperationResponse) => {
+        return Promise.resolve(operationRes.parsedBody as void);
+      }).catch((err: Error) => {
+        return Promise.reject(err);
+      });
+    } else {
+      msRest.promiseToCallback(this.putStringEnumValidWithHttpOperationResponse(arrayBody, options))((err: Error, data: msRest.HttpOperationResponse) => {
+        if (err) {
+          return cb(err);
+        }
+        let result = data.parsedBody as void;
+        return cb(err, result, data.request, data);
+      });
+    }
   }
 
   /**
@@ -3459,6 +3731,124 @@ const getStringValidOperationSpec: msRest.OperationSpec = {
 const putStringValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "array/prim/string/foo1.foo2.foo3",
+  requestBody: {
+    parameterPath: "arrayBody",
+    mapper: {
+      required: true,
+      serializedName: "arrayBody",
+      type: {
+        name: "Sequence",
+        element: {
+          serializedName: "stringElementType",
+          type: {
+            name: "String"
+          }
+        }
+      }
+    }
+  },
+  contentType: "application/json; charset=utf-8",
+  responses: {
+    200: {},
+    default: {
+      bodyMapper: Mappers.ErrorModel
+    }
+  },
+  serializer: new msRest.Serializer(Mappers)
+};
+
+const getEnumValidOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "array/prim/enum/foo1.foo2.foo3",
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            serializedName: "FooEnumElementType",
+            type: {
+              name: "Enum",
+              allowedValues: [
+                "foo1",
+                "foo2",
+                "foo3"
+              ]
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.ErrorModel
+    }
+  },
+  serializer: new msRest.Serializer(Mappers)
+};
+
+const putEnumValidOperationSpec: msRest.OperationSpec = {
+  httpMethod: "PUT",
+  path: "array/prim/enum/foo1.foo2.foo3",
+  requestBody: {
+    parameterPath: "arrayBody",
+    mapper: {
+      required: true,
+      serializedName: "arrayBody",
+      type: {
+        name: "Sequence",
+        element: {
+          serializedName: "FooEnumElementType",
+          type: {
+            name: "Enum",
+            allowedValues: [
+              "foo1",
+              "foo2",
+              "foo3"
+            ]
+          }
+        }
+      }
+    }
+  },
+  contentType: "application/json; charset=utf-8",
+  responses: {
+    200: {},
+    default: {
+      bodyMapper: Mappers.ErrorModel
+    }
+  },
+  serializer: new msRest.Serializer(Mappers)
+};
+
+const getStringEnumValidOperationSpec: msRest.OperationSpec = {
+  httpMethod: "GET",
+  path: "array/prim/string-enum/foo1.foo2.foo3",
+  responses: {
+    200: {
+      bodyMapper: {
+        serializedName: "parsedResponse",
+        type: {
+          name: "Sequence",
+          element: {
+            serializedName: "stringElementType",
+            type: {
+              name: "String"
+            }
+          }
+        }
+      }
+    },
+    default: {
+      bodyMapper: Mappers.ErrorModel
+    }
+  },
+  serializer: new msRest.Serializer(Mappers)
+};
+
+const putStringEnumValidOperationSpec: msRest.OperationSpec = {
+  httpMethod: "PUT",
+  path: "array/prim/string-enum/foo1.foo2.foo3",
   requestBody: {
     parameterPath: "arrayBody",
     mapper: {

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -46,8 +46,6 @@ export class Bool {
   /**
    * Set Boolean value true
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -56,10 +54,9 @@ export class Bool {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putTrueWithHttpOperationResponse(boolBody: boolean, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putTrueWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        boolBody,
         options
       },
       putTrueOperationSpec);
@@ -87,8 +84,6 @@ export class Bool {
   /**
    * Set Boolean value false
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -97,10 +92,9 @@ export class Bool {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putFalseWithHttpOperationResponse(boolBody: boolean, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putFalseWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        boolBody,
         options
       },
       putFalseOperationSpec);
@@ -169,8 +163,6 @@ export class Bool {
   /**
    * Set Boolean value true
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -182,12 +174,12 @@ export class Bool {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putTrue(boolBody: boolean): Promise<void>;
-  putTrue(boolBody: boolean, options: msRest.RequestOptionsBase): Promise<void>;
-  putTrue(boolBody: boolean, callback: msRest.ServiceCallback<void>): void;
-  putTrue(boolBody: boolean, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putTrue(boolBody: boolean, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putTrueWithHttpOperationResponse.bind(this), boolBody, options, callback);
+  putTrue(): Promise<void>;
+  putTrue(options: msRest.RequestOptionsBase): Promise<void>;
+  putTrue(callback: msRest.ServiceCallback<void>): void;
+  putTrue(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putTrue(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putTrueWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -215,8 +207,6 @@ export class Bool {
   /**
    * Set Boolean value false
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -228,12 +218,12 @@ export class Bool {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putFalse(boolBody: boolean): Promise<void>;
-  putFalse(boolBody: boolean, options: msRest.RequestOptionsBase): Promise<void>;
-  putFalse(boolBody: boolean, callback: msRest.ServiceCallback<void>): void;
-  putFalse(boolBody: boolean, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putFalse(boolBody: boolean, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putFalseWithHttpOperationResponse.bind(this), boolBody, options, callback);
+  putFalse(): Promise<void>;
+  putFalse(options: msRest.RequestOptionsBase): Promise<void>;
+  putFalse(callback: msRest.ServiceCallback<void>): void;
+  putFalse(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putFalse(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putFalseWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -309,7 +299,9 @@ const putTrueOperationSpec: msRest.OperationSpec = {
     parameterPath: "boolBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "boolBody",
+      defaultValue: true,
       type: {
         name: "Boolean"
       }
@@ -351,7 +343,9 @@ const putFalseOperationSpec: msRest.OperationSpec = {
     parameterPath: "boolBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "boolBody",
+      defaultValue: false,
       type: {
         name: "Boolean"
       }

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -185,8 +185,6 @@ export class Number {
   /**
    * Put big double value 99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -195,10 +193,9 @@ export class Number {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putBigDoublePositiveDecimalWithHttpOperationResponse(numberBody: number, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putBigDoublePositiveDecimalWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        numberBody,
         options
       },
       putBigDoublePositiveDecimalOperationSpec);
@@ -226,8 +223,6 @@ export class Number {
   /**
    * Put big double value -99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -236,10 +231,9 @@ export class Number {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putBigDoubleNegativeDecimalWithHttpOperationResponse(numberBody: number, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putBigDoubleNegativeDecimalWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        numberBody,
         options
       },
       putBigDoubleNegativeDecimalOperationSpec);
@@ -308,8 +302,6 @@ export class Number {
   /**
    * Put big decimal value 99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -318,10 +310,9 @@ export class Number {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putBigDecimalPositiveDecimalWithHttpOperationResponse(numberBody: number, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putBigDecimalPositiveDecimalWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        numberBody,
         options
       },
       putBigDecimalPositiveDecimalOperationSpec);
@@ -349,8 +340,6 @@ export class Number {
   /**
    * Put big decimal value -99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -359,10 +348,9 @@ export class Number {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putBigDecimalNegativeDecimalWithHttpOperationResponse(numberBody: number, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putBigDecimalNegativeDecimalWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        numberBody,
         options
       },
       putBigDecimalNegativeDecimalOperationSpec);
@@ -693,8 +681,6 @@ export class Number {
   /**
    * Put big double value 99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -706,12 +692,12 @@ export class Number {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putBigDoublePositiveDecimal(numberBody: number): Promise<void>;
-  putBigDoublePositiveDecimal(numberBody: number, options: msRest.RequestOptionsBase): Promise<void>;
-  putBigDoublePositiveDecimal(numberBody: number, callback: msRest.ServiceCallback<void>): void;
-  putBigDoublePositiveDecimal(numberBody: number, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putBigDoublePositiveDecimal(numberBody: number, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putBigDoublePositiveDecimalWithHttpOperationResponse.bind(this), numberBody, options, callback);
+  putBigDoublePositiveDecimal(): Promise<void>;
+  putBigDoublePositiveDecimal(options: msRest.RequestOptionsBase): Promise<void>;
+  putBigDoublePositiveDecimal(callback: msRest.ServiceCallback<void>): void;
+  putBigDoublePositiveDecimal(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putBigDoublePositiveDecimal(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putBigDoublePositiveDecimalWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -739,8 +725,6 @@ export class Number {
   /**
    * Put big double value -99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -752,12 +736,12 @@ export class Number {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putBigDoubleNegativeDecimal(numberBody: number): Promise<void>;
-  putBigDoubleNegativeDecimal(numberBody: number, options: msRest.RequestOptionsBase): Promise<void>;
-  putBigDoubleNegativeDecimal(numberBody: number, callback: msRest.ServiceCallback<void>): void;
-  putBigDoubleNegativeDecimal(numberBody: number, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putBigDoubleNegativeDecimal(numberBody: number, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putBigDoubleNegativeDecimalWithHttpOperationResponse.bind(this), numberBody, options, callback);
+  putBigDoubleNegativeDecimal(): Promise<void>;
+  putBigDoubleNegativeDecimal(options: msRest.RequestOptionsBase): Promise<void>;
+  putBigDoubleNegativeDecimal(callback: msRest.ServiceCallback<void>): void;
+  putBigDoubleNegativeDecimal(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putBigDoubleNegativeDecimal(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putBigDoubleNegativeDecimalWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -831,8 +815,6 @@ export class Number {
   /**
    * Put big decimal value 99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -844,12 +826,12 @@ export class Number {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putBigDecimalPositiveDecimal(numberBody: number): Promise<void>;
-  putBigDecimalPositiveDecimal(numberBody: number, options: msRest.RequestOptionsBase): Promise<void>;
-  putBigDecimalPositiveDecimal(numberBody: number, callback: msRest.ServiceCallback<void>): void;
-  putBigDecimalPositiveDecimal(numberBody: number, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putBigDecimalPositiveDecimal(numberBody: number, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putBigDecimalPositiveDecimalWithHttpOperationResponse.bind(this), numberBody, options, callback);
+  putBigDecimalPositiveDecimal(): Promise<void>;
+  putBigDecimalPositiveDecimal(options: msRest.RequestOptionsBase): Promise<void>;
+  putBigDecimalPositiveDecimal(callback: msRest.ServiceCallback<void>): void;
+  putBigDecimalPositiveDecimal(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putBigDecimalPositiveDecimal(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putBigDecimalPositiveDecimalWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -877,8 +859,6 @@ export class Number {
   /**
    * Put big decimal value -99999999.99
    *
-   * @param {number} numberBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -890,12 +870,12 @@ export class Number {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putBigDecimalNegativeDecimal(numberBody: number): Promise<void>;
-  putBigDecimalNegativeDecimal(numberBody: number, options: msRest.RequestOptionsBase): Promise<void>;
-  putBigDecimalNegativeDecimal(numberBody: number, callback: msRest.ServiceCallback<void>): void;
-  putBigDecimalNegativeDecimal(numberBody: number, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putBigDecimalNegativeDecimal(numberBody: number, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putBigDecimalNegativeDecimalWithHttpOperationResponse.bind(this), numberBody, options, callback);
+  putBigDecimalNegativeDecimal(): Promise<void>;
+  putBigDecimalNegativeDecimal(options: msRest.RequestOptionsBase): Promise<void>;
+  putBigDecimalNegativeDecimal(callback: msRest.ServiceCallback<void>): void;
+  putBigDecimalNegativeDecimal(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putBigDecimalNegativeDecimal(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putBigDecimalNegativeDecimalWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -1228,7 +1208,9 @@ const putBigDoublePositiveDecimalOperationSpec: msRest.OperationSpec = {
     parameterPath: "numberBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "numberBody",
+      defaultValue: 99999999.99,
       type: {
         name: "Number"
       }
@@ -1270,7 +1252,9 @@ const putBigDoubleNegativeDecimalOperationSpec: msRest.OperationSpec = {
     parameterPath: "numberBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "numberBody",
+      defaultValue: -99999999.99,
       type: {
         name: "Number"
       }
@@ -1354,7 +1338,9 @@ const putBigDecimalPositiveDecimalOperationSpec: msRest.OperationSpec = {
     parameterPath: "numberBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "numberBody",
+      defaultValue: 99999999.99,
       type: {
         name: "Number"
       }
@@ -1396,7 +1382,9 @@ const putBigDecimalNegativeDecimalOperationSpec: msRest.OperationSpec = {
     parameterPath: "numberBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "numberBody",
+      defaultValue: -99999999.99,
       type: {
         name: "Number"
       }

--- a/test/vanilla/generated/BodyString/models/index.ts
+++ b/test/vanilla/generated/BodyString/models/index.ts
@@ -122,21 +122,6 @@ export enum GetEmptyOKResponse {
 }
 
 /**
- * Defines values for StringBody1.
- * Possible values include: ''
- * There could be more values for this enum apart from the ones defined here.If
- * you want to set a value that is not from the known values then you can do
- * the following:
- * let param: StringBody1 =
- * <StringBody1>"someUnknownValueThatWillStillBeValid";
- * @readonly
- * @enum {string}
- */
-export enum StringBody1 {
-  EmptyString = '',
-}
-
-/**
  * Defines values for GetMbcsOKResponse.
  * Possible values include:
  * '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
@@ -153,22 +138,6 @@ export enum GetMbcsOKResponse {
 }
 
 /**
- * Defines values for StringBody2.
- * Possible values include:
- * '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
- * There could be more values for this enum apart from the ones defined here.If
- * you want to set a value that is not from the known values then you can do
- * the following:
- * let param: StringBody2 =
- * <StringBody2>"someUnknownValueThatWillStillBeValid";
- * @readonly
- * @enum {string}
- */
-export enum StringBody2 {
-  啊齄丂狛狜隣郎隣兀﨩ˊーぁんァヶΑАЯаяāɡㄅㄩɑɡ䜣 = '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€',
-}
-
-/**
  * Defines values for GetWhitespaceOKResponse.
  * Possible values include: '    Now is the time for all good men to come to
  * the aid of their country    '
@@ -181,21 +150,5 @@ export enum StringBody2 {
  * @enum {string}
  */
 export enum GetWhitespaceOKResponse {
-  Nowisthetimeforallgoodmentocometotheaidoftheircountry = '    Now is the time for all good men to come to the aid of their country    ',
-}
-
-/**
- * Defines values for StringBody3.
- * Possible values include: '    Now is the time for all good men to come to
- * the aid of their country    '
- * There could be more values for this enum apart from the ones defined here.If
- * you want to set a value that is not from the known values then you can do
- * the following:
- * let param: StringBody3 =
- * <StringBody3>"someUnknownValueThatWillStillBeValid";
- * @readonly
- * @enum {string}
- */
-export enum StringBody3 {
   Nowisthetimeforallgoodmentocometotheaidoftheircountry = '    Now is the time for all good men to come to the aid of their country    ',
 }

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -85,8 +85,6 @@ export class String {
   /**
    * Set string value empty ''
    *
-   * @param {StringBody1} stringBody Possible values include: ''
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -95,10 +93,9 @@ export class String {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putEmptyWithHttpOperationResponse(stringBody: Models.StringBody1, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putEmptyWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        stringBody,
         options
       },
       putEmptyOperationSpec);
@@ -126,9 +123,6 @@ export class String {
   /**
    * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    *
-   * @param {StringBody2} stringBody Possible values include:
-   * '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -137,10 +131,9 @@ export class String {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putMbcsWithHttpOperationResponse(stringBody: Models.StringBody2, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putMbcsWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        stringBody,
         options
       },
       putMbcsOperationSpec);
@@ -170,9 +163,6 @@ export class String {
    * Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for
    * all good men to come to the aid of their country<tab><space><space>'
    *
-   * @param {StringBody3} stringBody Possible values include: '    Now is the time for all good men
-   * to come to the aid of their country    '
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -181,10 +171,9 @@ export class String {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putWhitespaceWithHttpOperationResponse(stringBody: Models.StringBody3, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putWhitespaceWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        stringBody,
         options
       },
       putWhitespaceOperationSpec);
@@ -357,8 +346,6 @@ export class String {
   /**
    * Set string value empty ''
    *
-   * @param {StringBody1} stringBody Possible values include: ''
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -370,12 +357,12 @@ export class String {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putEmpty(stringBody: Models.StringBody1): Promise<void>;
-  putEmpty(stringBody: Models.StringBody1, options: msRest.RequestOptionsBase): Promise<void>;
-  putEmpty(stringBody: Models.StringBody1, callback: msRest.ServiceCallback<void>): void;
-  putEmpty(stringBody: Models.StringBody1, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putEmpty(stringBody: Models.StringBody1, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putEmptyWithHttpOperationResponse.bind(this), stringBody, options, callback);
+  putEmpty(): Promise<void>;
+  putEmpty(options: msRest.RequestOptionsBase): Promise<void>;
+  putEmpty(callback: msRest.ServiceCallback<void>): void;
+  putEmpty(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putEmpty(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putEmptyWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -403,9 +390,6 @@ export class String {
   /**
    * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    *
-   * @param {StringBody2} stringBody Possible values include:
-   * '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -417,12 +401,12 @@ export class String {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putMbcs(stringBody: Models.StringBody2): Promise<void>;
-  putMbcs(stringBody: Models.StringBody2, options: msRest.RequestOptionsBase): Promise<void>;
-  putMbcs(stringBody: Models.StringBody2, callback: msRest.ServiceCallback<void>): void;
-  putMbcs(stringBody: Models.StringBody2, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putMbcs(stringBody: Models.StringBody2, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putMbcsWithHttpOperationResponse.bind(this), stringBody, options, callback);
+  putMbcs(): Promise<void>;
+  putMbcs(options: msRest.RequestOptionsBase): Promise<void>;
+  putMbcs(callback: msRest.ServiceCallback<void>): void;
+  putMbcs(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putMbcs(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putMbcsWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -452,9 +436,6 @@ export class String {
    * Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for
    * all good men to come to the aid of their country<tab><space><space>'
    *
-   * @param {StringBody3} stringBody Possible values include: '    Now is the time for all good men
-   * to come to the aid of their country    '
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -466,12 +447,12 @@ export class String {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putWhitespace(stringBody: Models.StringBody3): Promise<void>;
-  putWhitespace(stringBody: Models.StringBody3, options: msRest.RequestOptionsBase): Promise<void>;
-  putWhitespace(stringBody: Models.StringBody3, callback: msRest.ServiceCallback<void>): void;
-  putWhitespace(stringBody: Models.StringBody3, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putWhitespace(stringBody: Models.StringBody3, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putWhitespaceWithHttpOperationResponse.bind(this), stringBody, options, callback);
+  putWhitespace(): Promise<void>;
+  putWhitespace(options: msRest.RequestOptionsBase): Promise<void>;
+  putWhitespace(callback: msRest.ServiceCallback<void>): void;
+  putWhitespace(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putWhitespace(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putWhitespaceWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -659,7 +640,9 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
     parameterPath: "stringBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "stringBody",
+      defaultValue: '',
       type: {
         name: "String"
       }
@@ -701,7 +684,9 @@ const putMbcsOperationSpec: msRest.OperationSpec = {
     parameterPath: "stringBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "stringBody",
+      defaultValue: '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€',
       type: {
         name: "String"
       }
@@ -743,7 +728,9 @@ const putWhitespaceOperationSpec: msRest.OperationSpec = {
     parameterPath: "stringBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "stringBody",
+      defaultValue: '    Now is the time for all good men to come to the aid of their country    ',
       type: {
         name: "String"
       }

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -46,8 +46,6 @@ export class Bool {
   /**
    * Set Boolean value true
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -56,10 +54,9 @@ export class Bool {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putTrueWithHttpOperationResponse(boolBody: boolean, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putTrueWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        boolBody,
         options
       },
       putTrueOperationSpec);
@@ -87,8 +84,6 @@ export class Bool {
   /**
    * Set Boolean value false
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
@@ -97,10 +92,9 @@ export class Bool {
    *
    * @reject {Error|ServiceError} The error object.
    */
-  putFalseWithHttpOperationResponse(boolBody: boolean, options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
+  putFalseWithHttpOperationResponse(options?: msRest.RequestOptionsBase): Promise<msRest.HttpOperationResponse<void>> {
     return this.client.sendOperationRequest(
       {
-        boolBody,
         options
       },
       putFalseOperationSpec);
@@ -169,8 +163,6 @@ export class Bool {
   /**
    * Set Boolean value true
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -182,12 +174,12 @@ export class Bool {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putTrue(boolBody: boolean): Promise<void>;
-  putTrue(boolBody: boolean, options: msRest.RequestOptionsBase): Promise<void>;
-  putTrue(boolBody: boolean, callback: msRest.ServiceCallback<void>): void;
-  putTrue(boolBody: boolean, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putTrue(boolBody: boolean, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putTrueWithHttpOperationResponse.bind(this), boolBody, options, callback);
+  putTrue(): Promise<void>;
+  putTrue(options: msRest.RequestOptionsBase): Promise<void>;
+  putTrue(callback: msRest.ServiceCallback<void>): void;
+  putTrue(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putTrue(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putTrueWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -215,8 +207,6 @@ export class Bool {
   /**
    * Set Boolean value false
    *
-   * @param {boolean} boolBody
-   *
    * @param {RequestOptionsBase} [options] Optional Parameters.
    *
    * @param {ServiceCallback} callback The callback.
@@ -228,12 +218,12 @@ export class Bool {
    *                      {WebResource} [request]  - The HTTP Request object if an error did not occur.
    *                      {HttpOperationResponse} [response] - The HTTP Response stream if an error did not occur.
    */
-  putFalse(boolBody: boolean): Promise<void>;
-  putFalse(boolBody: boolean, options: msRest.RequestOptionsBase): Promise<void>;
-  putFalse(boolBody: boolean, callback: msRest.ServiceCallback<void>): void;
-  putFalse(boolBody: boolean, options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
-  putFalse(boolBody: boolean, options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
-    return msRest.responseToBody(this.putFalseWithHttpOperationResponse.bind(this), boolBody, options, callback);
+  putFalse(): Promise<void>;
+  putFalse(options: msRest.RequestOptionsBase): Promise<void>;
+  putFalse(callback: msRest.ServiceCallback<void>): void;
+  putFalse(options: msRest.RequestOptionsBase, callback: msRest.ServiceCallback<void>): void;
+  putFalse(options?: msRest.RequestOptionsBase, callback?: msRest.ServiceCallback<void>): any {
+    return msRest.responseToBody(this.putFalseWithHttpOperationResponse.bind(this), options, callback);
   }
 
   /**
@@ -309,7 +299,9 @@ const putTrueOperationSpec: msRest.OperationSpec = {
     parameterPath: "boolBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "boolBody",
+      defaultValue: true,
       type: {
         name: "Boolean"
       }
@@ -351,7 +343,9 @@ const putFalseOperationSpec: msRest.OperationSpec = {
     parameterPath: "boolBody",
     mapper: {
       required: true,
+      isConstant: true,
       serializedName: "boolBody",
+      defaultValue: false,
       type: {
         name: "Boolean"
       }

--- a/test/vanilla/generated/CustomBaseUri/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUri/operations/paths.ts
@@ -83,6 +83,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       mapper: {
         required: true,
         serializedName: "accountName",
+        defaultValue: '',
         type: {
           name: "String"
         }

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
@@ -94,6 +94,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       mapper: {
         required: true,
         serializedName: "vault",
+        defaultValue: '',
         type: {
           name: "String"
         }
@@ -105,6 +106,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       mapper: {
         required: true,
         serializedName: "secret",
+        defaultValue: '',
         type: {
           name: "String"
         }


### PR DESCRIPTION
Fixes #88 

It's not clear whether updating the modeler helped fix the problem, but I'm doing it anyway as we might as well benefit from whatever other fixes happened along the way.

The key was really in overriding ModelAsStringType and using DeclarationName to reference the model type.