### PR TITLE
One serializer

### DIFF
--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -539,6 +539,11 @@ namespace AutoRest.TypeScript
             return "/" + constraintValue.Replace("/", "\\/") + "/";
         }
 
+        public static string CreateSerializerExpression(this CodeModel codeModel)
+        {
+            return $"new msRest.Serializer(Mappers{(codeModel.ShouldGenerateXmlSerialization == true ? ", true" : "")})";
+        }
+
         public static void ConstructParameterMapper(TSObject obj, ParameterTS parameter)
         {
             MethodTS.GenerateRequestParameter(obj, parameter, parameter.MethodTS.GetParameterTransformations());

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -453,6 +453,7 @@ namespace AutoRest.TypeScript.Model
                     }
                     else
                     {
+                        builder.ConstObjectVariable("serializer", ClientModelExtensions.CreateSerializerExpression(this));
                         addedFirstValue = true;
                     }
                     method.GenerateOperationSpecDefinition(builder);

--- a/src/vanilla/Model/MethodGroupTS.cs
+++ b/src/vanilla/Model/MethodGroupTS.cs
@@ -152,6 +152,7 @@ namespace AutoRest.TypeScript.Model
                     }
                     else
                     {
+                        builder.ConstObjectVariable("serializer", CodeModel.CreateSerializerExpression());
                         addedFirstValue = true;
                     }
                     method.GenerateOperationSpecDefinition(builder);

--- a/src/vanilla/Model/MethodTS.cs
+++ b/src/vanilla/Model/MethodTS.cs
@@ -314,7 +314,7 @@ namespace AutoRest.TypeScript.Model
             {
                 ifBlock.Try(tryBlock =>
                 {
-                    tryBlock.ConstObjectVariable("serializer", CreateSerializerExpression());
+                    tryBlock.ConstObjectVariable("serializer", CodeModel.CreateSerializerExpression());
                     tryBlock.Text($"{valueReference} = ");
                     tryBlock.FunctionCall("serializer.deserialize", argumentList =>
                     {
@@ -629,7 +629,7 @@ namespace AutoRest.TypeScript.Model
                 operationSpec.BooleanProperty("isXML", true);
             }
 
-            operationSpec.TextProperty("serializer", CreateSerializerExpression());
+            operationSpec.TextProperty("serializer", "serializer");
         }
 
         private static void AddSkipEncodingProperty(TSObject parameterObject, Parameter parameter)
@@ -746,11 +746,6 @@ namespace AutoRest.TypeScript.Model
         private string GetOperationSpecVariableName()
         {
             return Name.ToCamelCase() + "OperationSpec";
-        }
-
-        public string CreateSerializerExpression()
-        {
-            return $"new msRest.Serializer(Mappers{(CodeModel.ShouldGenerateXmlSerialization == true ? ", true" : "")})";
         }
 
         public static bool IsInOptionsParameter(Parameter parameter)

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -236,6 +236,7 @@ class AzureCompositeModel extends AzureCompositeModelContext {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis",
@@ -257,7 +258,7 @@ const listOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const createOperationSpec: msRest.OperationSpec = {
@@ -294,7 +295,7 @@ const createOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const updateOperationSpec: msRest.OperationSpec = {
@@ -331,7 +332,7 @@ const updateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { AzureCompositeModel, Models as AzureCompositeModelModels, Mappers as AzureCompositeModelMappers };

--- a/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
@@ -234,6 +234,7 @@ export class ArrayModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/array/valid",
@@ -248,7 +249,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -276,7 +277,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -293,7 +294,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -321,7 +322,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -338,5 +339,5 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
@@ -280,6 +280,7 @@ export class BasicOperations {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/basic/valid",
@@ -294,7 +295,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -320,7 +321,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -337,7 +338,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -354,7 +355,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullOperationSpec: msRest.OperationSpec = {
@@ -371,7 +372,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -388,5 +389,5 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
@@ -275,6 +275,7 @@ export class Dictionary {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/dictionary/typed/valid",
@@ -289,7 +290,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -317,7 +318,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -334,7 +335,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -362,7 +363,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullOperationSpec: msRest.OperationSpec = {
@@ -379,7 +380,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -396,5 +397,5 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
@@ -66,6 +66,7 @@ export class Flattencomplex {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/flatten/valid",
@@ -80,5 +81,5 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
@@ -120,6 +120,7 @@ export class Inheritance {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/inheritance/valid",
@@ -134,7 +135,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -157,5 +158,5 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
@@ -220,6 +220,7 @@ export class Polymorphicrecursive {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/polymorphicrecursive/valid",
@@ -234,7 +235,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -257,5 +258,5 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
@@ -417,6 +417,7 @@ export class Polymorphism {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/polymorphism/valid",
@@ -431,7 +432,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -454,7 +455,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplicatedOperationSpec: msRest.OperationSpec = {
@@ -471,7 +472,7 @@ const getComplicatedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putComplicatedOperationSpec: msRest.OperationSpec = {
@@ -494,7 +495,7 @@ const putComplicatedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMissingDiscriminatorOperationSpec: msRest.OperationSpec = {
@@ -519,7 +520,7 @@ const putMissingDiscriminatorOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidMissingRequiredOperationSpec: msRest.OperationSpec = {
@@ -542,5 +543,5 @@ const putValidMissingRequiredOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
@@ -982,6 +982,7 @@ export class Primitive {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getIntOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/primitive/integer",
@@ -996,7 +997,7 @@ const getIntOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putIntOperationSpec: msRest.OperationSpec = {
@@ -1019,7 +1020,7 @@ const putIntOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongOperationSpec: msRest.OperationSpec = {
@@ -1036,7 +1037,7 @@ const getLongOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLongOperationSpec: msRest.OperationSpec = {
@@ -1059,7 +1060,7 @@ const putLongOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatOperationSpec: msRest.OperationSpec = {
@@ -1076,7 +1077,7 @@ const getFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putFloatOperationSpec: msRest.OperationSpec = {
@@ -1099,7 +1100,7 @@ const putFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleOperationSpec: msRest.OperationSpec = {
@@ -1116,7 +1117,7 @@ const getDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDoubleOperationSpec: msRest.OperationSpec = {
@@ -1139,7 +1140,7 @@ const putDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBoolOperationSpec: msRest.OperationSpec = {
@@ -1156,7 +1157,7 @@ const getBoolOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBoolOperationSpec: msRest.OperationSpec = {
@@ -1179,7 +1180,7 @@ const putBoolOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringOperationSpec: msRest.OperationSpec = {
@@ -1196,7 +1197,7 @@ const getStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putStringOperationSpec: msRest.OperationSpec = {
@@ -1219,7 +1220,7 @@ const putStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateOperationSpec: msRest.OperationSpec = {
@@ -1236,7 +1237,7 @@ const getDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateOperationSpec: msRest.OperationSpec = {
@@ -1259,7 +1260,7 @@ const putDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1276,7 +1277,7 @@ const getDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1299,7 +1300,7 @@ const putDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
@@ -1316,7 +1317,7 @@ const getDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
@@ -1339,7 +1340,7 @@ const putDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDurationOperationSpec: msRest.OperationSpec = {
@@ -1356,7 +1357,7 @@ const getDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDurationOperationSpec: msRest.OperationSpec = {
@@ -1384,7 +1385,7 @@ const putDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getByteOperationSpec: msRest.OperationSpec = {
@@ -1401,7 +1402,7 @@ const getByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putByteOperationSpec: msRest.OperationSpec = {
@@ -1429,5 +1430,5 @@ const putByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
@@ -111,6 +111,7 @@ export class Readonlyproperty {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/readonlyproperty/valid",
@@ -125,7 +126,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -153,5 +154,5 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
@@ -202,6 +202,7 @@ export class ParameterGrouping {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const postRequiredOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "parameterGrouping/postRequired/{path}",
@@ -235,7 +236,7 @@ const postRequiredOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalOperationSpec: msRest.OperationSpec = {
@@ -254,7 +255,7 @@ const postOptionalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postMultiParamGroupsOperationSpec: msRest.OperationSpec = {
@@ -275,7 +276,7 @@ const postMultiParamGroupsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postSharedParameterGroupObjectOperationSpec: msRest.OperationSpec = {
@@ -294,5 +295,5 @@ const postSharedParameterGroupObjectOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -90,6 +90,7 @@ class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getReportOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "report/azure",
@@ -118,7 +119,7 @@ const getReportOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { AutoRestReportServiceForAzure, Models as AutoRestReportServiceForAzureModels, Mappers as AutoRestReportServiceForAzureMappers };

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -306,6 +306,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const putArrayOperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "azure/resource-flatten/array",
@@ -338,7 +339,7 @@ const putArrayOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayOperationSpec: msRest.OperationSpec = {
@@ -367,7 +368,7 @@ const getArrayOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDictionaryOperationSpec: msRest.OperationSpec = {
@@ -402,7 +403,7 @@ const putDictionaryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryOperationSpec: msRest.OperationSpec = {
@@ -431,7 +432,7 @@ const getDictionaryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putResourceCollectionOperationSpec: msRest.OperationSpec = {
@@ -454,7 +455,7 @@ const putResourceCollectionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getResourceCollectionOperationSpec: msRest.OperationSpec = {
@@ -471,7 +472,7 @@ const getResourceCollectionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { AutoRestResourceFlatteningTestService, Models as AutoRestResourceFlatteningTestServiceModels, Mappers as AutoRestResourceFlatteningTestServiceMappers };

--- a/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
@@ -192,6 +192,7 @@ export class ApiVersionDefault {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getMethodGlobalValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "azurespecials/apiVersion/method/string/none/query/global/2015-07-01-preview",
@@ -207,7 +208,7 @@ const getMethodGlobalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMethodGlobalNotProvidedValidOperationSpec: msRest.OperationSpec = {
@@ -225,7 +226,7 @@ const getMethodGlobalNotProvidedValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getPathGlobalValidOperationSpec: msRest.OperationSpec = {
@@ -243,7 +244,7 @@ const getPathGlobalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSwaggerGlobalValidOperationSpec: msRest.OperationSpec = {
@@ -261,5 +262,5 @@ const getSwaggerGlobalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
@@ -193,6 +193,7 @@ export class ApiVersionLocal {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getMethodLocalValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "azurespecials/apiVersion/method/string/none/query/local/2.0",
@@ -208,7 +209,7 @@ const getMethodLocalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMethodLocalNullOperationSpec: msRest.OperationSpec = {
@@ -226,7 +227,7 @@ const getMethodLocalNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getPathLocalValidOperationSpec: msRest.OperationSpec = {
@@ -244,7 +245,7 @@ const getPathLocalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSwaggerLocalValidOperationSpec: msRest.OperationSpec = {
@@ -262,5 +263,5 @@ const getSwaggerLocalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/header.ts
+++ b/test/azure/generated/AzureSpecials/operations/header.ts
@@ -176,6 +176,7 @@ export class Header {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const customNamedRequestIdOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "azurespecials/customNamedRequestId",
@@ -191,7 +192,7 @@ const customNamedRequestIdOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const customNamedRequestIdParamGroupingOperationSpec: msRest.OperationSpec = {
@@ -209,7 +210,7 @@ const customNamedRequestIdParamGroupingOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const customNamedRequestIdHeadOperationSpec: msRest.OperationSpec = {
@@ -230,5 +231,5 @@ const customNamedRequestIdHeadOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/odata.ts
+++ b/test/azure/generated/AzureSpecials/operations/odata.ts
@@ -70,6 +70,7 @@ export class Odata {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getWithFilterOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "azurespecials/odata/filter",
@@ -87,5 +88,5 @@ const getWithFilterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
+++ b/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
@@ -336,6 +336,7 @@ export class SkipUrlEncoding {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getMethodPathValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "azurespecials/skipUrlEncoding/method/path/valid/{unencodedPathParam}",
@@ -351,7 +352,7 @@ const getMethodPathValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getPathPathValidOperationSpec: msRest.OperationSpec = {
@@ -369,7 +370,7 @@ const getPathPathValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSwaggerPathValidOperationSpec: msRest.OperationSpec = {
@@ -387,7 +388,7 @@ const getSwaggerPathValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMethodQueryValidOperationSpec: msRest.OperationSpec = {
@@ -405,7 +406,7 @@ const getMethodQueryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMethodQueryNullOperationSpec: msRest.OperationSpec = {
@@ -423,7 +424,7 @@ const getMethodQueryNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getPathQueryValidOperationSpec: msRest.OperationSpec = {
@@ -441,7 +442,7 @@ const getPathQueryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSwaggerQueryValidOperationSpec: msRest.OperationSpec = {
@@ -459,5 +460,5 @@ const getSwaggerQueryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
@@ -243,6 +243,7 @@ export class SubscriptionInCredentials {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const postMethodGlobalValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "azurespecials/subscriptionId/method/string/none/path/global/1234-5678-9012-3456/{subscriptionId}",
@@ -258,7 +259,7 @@ const postMethodGlobalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postMethodGlobalNullOperationSpec: msRest.OperationSpec = {
@@ -276,7 +277,7 @@ const postMethodGlobalNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postMethodGlobalNotProvidedValidOperationSpec: msRest.OperationSpec = {
@@ -297,7 +298,7 @@ const postMethodGlobalNotProvidedValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postPathGlobalValidOperationSpec: msRest.OperationSpec = {
@@ -315,7 +316,7 @@ const postPathGlobalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postSwaggerGlobalValidOperationSpec: msRest.OperationSpec = {
@@ -333,5 +334,5 @@ const postSwaggerGlobalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
@@ -228,6 +228,7 @@ export class SubscriptionInMethod {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const postMethodLocalValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "azurespecials/subscriptionId/method/string/none/path/local/1234-5678-9012-3456/{subscriptionId}",
@@ -243,7 +244,7 @@ const postMethodLocalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postMethodLocalNullOperationSpec: msRest.OperationSpec = {
@@ -261,7 +262,7 @@ const postMethodLocalNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postPathLocalValidOperationSpec: msRest.OperationSpec = {
@@ -279,7 +280,7 @@ const postPathLocalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postSwaggerLocalValidOperationSpec: msRest.OperationSpec = {
@@ -297,5 +298,5 @@ const postSwaggerLocalValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
+++ b/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
@@ -121,6 +121,7 @@ export class XMsClientRequestId {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "azurespecials/overwrite/x-ms-client-request-id/method/",
@@ -133,7 +134,7 @@ const getOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramGetOperationSpec: msRest.OperationSpec = {
@@ -149,5 +150,5 @@ const paramGetOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/CustomBaseUri/operations/paths.ts
+++ b/test/azure/generated/CustomBaseUri/operations/paths.ts
@@ -74,6 +74,7 @@ export class Paths {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getEmptyOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "customuri",
@@ -90,5 +91,5 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/Head/operations/httpSuccess.ts
+++ b/test/azure/generated/Head/operations/httpSuccess.ts
@@ -166,6 +166,7 @@ export class HttpSuccess {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head200OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/success/200",
@@ -179,7 +180,7 @@ const head200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head204OperationSpec: msRest.OperationSpec = {
@@ -195,7 +196,7 @@ const head204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head404OperationSpec: msRest.OperationSpec = {
@@ -211,5 +212,5 @@ const head404OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/HeadExceptions/operations/headException.ts
+++ b/test/azure/generated/HeadExceptions/operations/headException.ts
@@ -151,6 +151,7 @@ export class HeadException {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head200OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/success/200",
@@ -163,7 +164,7 @@ const head200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head204OperationSpec: msRest.OperationSpec = {
@@ -178,7 +179,7 @@ const head204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head404OperationSpec: msRest.OperationSpec = {
@@ -193,5 +194,5 @@ const head404OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/Lro/operations/lRORetrys.ts
+++ b/test/azure/generated/Lro/operations/lRORetrys.ts
@@ -711,6 +711,7 @@ export class LRORetrys {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const beginPut201CreatingSucceeded200OperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "lro/retryerror/put/201/creating/succeeded/200",
@@ -736,7 +737,7 @@ const beginPut201CreatingSucceeded200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRelativeRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -762,7 +763,7 @@ const beginPutAsyncRelativeRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteProvisioning202Accepted200SucceededOperationSpec: msRest.OperationSpec = {
@@ -784,7 +785,7 @@ const beginDeleteProvisioning202Accepted200SucceededOperationSpec: msRest.Operat
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete202Retry200OperationSpec: msRest.OperationSpec = {
@@ -801,7 +802,7 @@ const beginDelete202Retry200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRelativeRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -818,7 +819,7 @@ const beginDeleteAsyncRelativeRetrySucceededOperationSpec: msRest.OperationSpec 
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202Retry200OperationSpec: msRest.OperationSpec = {
@@ -843,7 +844,7 @@ const beginPost202Retry200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRelativeRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -868,5 +869,5 @@ const beginPostAsyncRelativeRetrySucceededOperationSpec: msRest.OperationSpec = 
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/Lro/operations/lROSADs.ts
+++ b/test/azure/generated/Lro/operations/lROSADs.ts
@@ -2499,6 +2499,7 @@ export class LROSADs {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const beginPutNonRetry400OperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "lro/nonretryerror/put/400",
@@ -2524,7 +2525,7 @@ const beginPutNonRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutNonRetry201Creating400OperationSpec: msRest.OperationSpec = {
@@ -2552,7 +2553,7 @@ const beginPutNonRetry201Creating400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutNonRetry201Creating400InvalidJsonOperationSpec: msRest.OperationSpec = {
@@ -2580,7 +2581,7 @@ const beginPutNonRetry201Creating400InvalidJsonOperationSpec: msRest.OperationSp
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRelativeRetry400OperationSpec: msRest.OperationSpec = {
@@ -2606,7 +2607,7 @@ const beginPutAsyncRelativeRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteNonRetry400OperationSpec: msRest.OperationSpec = {
@@ -2623,7 +2624,7 @@ const beginDeleteNonRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete202NonRetry400OperationSpec: msRest.OperationSpec = {
@@ -2640,7 +2641,7 @@ const beginDelete202NonRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRelativeRetry400OperationSpec: msRest.OperationSpec = {
@@ -2657,7 +2658,7 @@ const beginDeleteAsyncRelativeRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostNonRetry400OperationSpec: msRest.OperationSpec = {
@@ -2682,7 +2683,7 @@ const beginPostNonRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202NonRetry400OperationSpec: msRest.OperationSpec = {
@@ -2707,7 +2708,7 @@ const beginPost202NonRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRelativeRetry400OperationSpec: msRest.OperationSpec = {
@@ -2732,7 +2733,7 @@ const beginPostAsyncRelativeRetry400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutError201NoProvisioningStatePayloadOperationSpec: msRest.OperationSpec = {
@@ -2760,7 +2761,7 @@ const beginPutError201NoProvisioningStatePayloadOperationSpec: msRest.OperationS
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRelativeRetryNoStatusOperationSpec: msRest.OperationSpec = {
@@ -2786,7 +2787,7 @@ const beginPutAsyncRelativeRetryNoStatusOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRelativeRetryNoStatusPayloadOperationSpec: msRest.OperationSpec = {
@@ -2812,7 +2813,7 @@ const beginPutAsyncRelativeRetryNoStatusPayloadOperationSpec: msRest.OperationSp
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete204SucceededOperationSpec: msRest.OperationSpec = {
@@ -2827,7 +2828,7 @@ const beginDelete204SucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRelativeRetryNoStatusOperationSpec: msRest.OperationSpec = {
@@ -2844,7 +2845,7 @@ const beginDeleteAsyncRelativeRetryNoStatusOperationSpec: msRest.OperationSpec =
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202NoLocationOperationSpec: msRest.OperationSpec = {
@@ -2869,7 +2870,7 @@ const beginPost202NoLocationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRelativeRetryNoPayloadOperationSpec: msRest.OperationSpec = {
@@ -2894,7 +2895,7 @@ const beginPostAsyncRelativeRetryNoPayloadOperationSpec: msRest.OperationSpec = 
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut200InvalidJsonOperationSpec: msRest.OperationSpec = {
@@ -2920,7 +2921,7 @@ const beginPut200InvalidJsonOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRelativeRetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
@@ -2946,7 +2947,7 @@ const beginPutAsyncRelativeRetryInvalidHeaderOperationSpec: msRest.OperationSpec
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRelativeRetryInvalidJsonPollingOperationSpec: msRest.OperationSpec = {
@@ -2972,7 +2973,7 @@ const beginPutAsyncRelativeRetryInvalidJsonPollingOperationSpec: msRest.Operatio
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete202RetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
@@ -2989,7 +2990,7 @@ const beginDelete202RetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRelativeRetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
@@ -3006,7 +3007,7 @@ const beginDeleteAsyncRelativeRetryInvalidHeaderOperationSpec: msRest.OperationS
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRelativeRetryInvalidJsonPollingOperationSpec: msRest.OperationSpec = {
@@ -3023,7 +3024,7 @@ const beginDeleteAsyncRelativeRetryInvalidJsonPollingOperationSpec: msRest.Opera
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202RetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
@@ -3048,7 +3049,7 @@ const beginPost202RetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRelativeRetryInvalidHeaderOperationSpec: msRest.OperationSpec = {
@@ -3073,7 +3074,7 @@ const beginPostAsyncRelativeRetryInvalidHeaderOperationSpec: msRest.OperationSpe
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRelativeRetryInvalidJsonPollingOperationSpec: msRest.OperationSpec = {
@@ -3098,5 +3099,5 @@ const beginPostAsyncRelativeRetryInvalidJsonPollingOperationSpec: msRest.Operati
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -3933,6 +3933,7 @@ export class LROs {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const beginPut200SucceededOperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "lro/put/200/succeeded",
@@ -3956,7 +3957,7 @@ const beginPut200SucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut200SucceededNoStateOperationSpec: msRest.OperationSpec = {
@@ -3981,7 +3982,7 @@ const beginPut200SucceededNoStateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut202Retry200OperationSpec: msRest.OperationSpec = {
@@ -4006,7 +4007,7 @@ const beginPut202Retry200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut201CreatingSucceeded200OperationSpec: msRest.OperationSpec = {
@@ -4034,7 +4035,7 @@ const beginPut201CreatingSucceeded200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut200UpdatingSucceeded204OperationSpec: msRest.OperationSpec = {
@@ -4059,7 +4060,7 @@ const beginPut200UpdatingSucceeded204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut201CreatingFailed200OperationSpec: msRest.OperationSpec = {
@@ -4087,7 +4088,7 @@ const beginPut201CreatingFailed200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut200Acceptedcanceled200OperationSpec: msRest.OperationSpec = {
@@ -4112,7 +4113,7 @@ const beginPut200Acceptedcanceled200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
@@ -4138,7 +4139,7 @@ const beginPutNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -4164,7 +4165,7 @@ const beginPutAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -4190,7 +4191,7 @@ const beginPutAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncRetryFailedOperationSpec: msRest.OperationSpec = {
@@ -4216,7 +4217,7 @@ const beginPutAsyncRetryFailedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncNoRetrycanceledOperationSpec: msRest.OperationSpec = {
@@ -4242,7 +4243,7 @@ const beginPutAsyncNoRetrycanceledOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
@@ -4268,7 +4269,7 @@ const beginPutAsyncNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutNonResourceOperationSpec: msRest.OperationSpec = {
@@ -4293,7 +4294,7 @@ const beginPutNonResourceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncNonResourceOperationSpec: msRest.OperationSpec = {
@@ -4318,7 +4319,7 @@ const beginPutAsyncNonResourceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutSubResourceOperationSpec: msRest.OperationSpec = {
@@ -4345,7 +4346,7 @@ const beginPutSubResourceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPutAsyncSubResourceOperationSpec: msRest.OperationSpec = {
@@ -4372,7 +4373,7 @@ const beginPutAsyncSubResourceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteProvisioning202Accepted200SucceededOperationSpec: msRest.OperationSpec = {
@@ -4394,7 +4395,7 @@ const beginDeleteProvisioning202Accepted200SucceededOperationSpec: msRest.Operat
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteProvisioning202DeletingFailed200OperationSpec: msRest.OperationSpec = {
@@ -4416,7 +4417,7 @@ const beginDeleteProvisioning202DeletingFailed200OperationSpec: msRest.Operation
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteProvisioning202Deletingcanceled200OperationSpec: msRest.OperationSpec = {
@@ -4438,7 +4439,7 @@ const beginDeleteProvisioning202Deletingcanceled200OperationSpec: msRest.Operati
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete204SucceededOperationSpec: msRest.OperationSpec = {
@@ -4453,7 +4454,7 @@ const beginDelete204SucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete202Retry200OperationSpec: msRest.OperationSpec = {
@@ -4474,7 +4475,7 @@ const beginDelete202Retry200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDelete202NoRetry204OperationSpec: msRest.OperationSpec = {
@@ -4495,7 +4496,7 @@ const beginDelete202NoRetry204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
@@ -4515,7 +4516,7 @@ const beginDeleteNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
@@ -4535,7 +4536,7 @@ const beginDeleteAsyncNoHeaderInRetryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -4552,7 +4553,7 @@ const beginDeleteAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -4569,7 +4570,7 @@ const beginDeleteAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRetryFailedOperationSpec: msRest.OperationSpec = {
@@ -4586,7 +4587,7 @@ const beginDeleteAsyncRetryFailedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginDeleteAsyncRetrycanceledOperationSpec: msRest.OperationSpec = {
@@ -4603,7 +4604,7 @@ const beginDeleteAsyncRetrycanceledOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost200WithPayloadOperationSpec: msRest.OperationSpec = {
@@ -4623,7 +4624,7 @@ const beginPost200WithPayloadOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202Retry200OperationSpec: msRest.OperationSpec = {
@@ -4648,7 +4649,7 @@ const beginPost202Retry200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202NoRetry204OperationSpec: msRest.OperationSpec = {
@@ -4674,7 +4675,7 @@ const beginPost202NoRetry204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostDoubleHeadersFinalLocationGetOperationSpec: msRest.OperationSpec = {
@@ -4691,7 +4692,7 @@ const beginPostDoubleHeadersFinalLocationGetOperationSpec: msRest.OperationSpec 
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostDoubleHeadersFinalAzureHeaderGetOperationSpec: msRest.OperationSpec = {
@@ -4708,7 +4709,7 @@ const beginPostDoubleHeadersFinalAzureHeaderGetOperationSpec: msRest.OperationSp
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostDoubleHeadersFinalAzureHeaderGetDefaultOperationSpec: msRest.OperationSpec = {
@@ -4725,7 +4726,7 @@ const beginPostDoubleHeadersFinalAzureHeaderGetDefaultOperationSpec: msRest.Oper
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -4754,7 +4755,7 @@ const beginPostAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -4783,7 +4784,7 @@ const beginPostAsyncNoRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRetryFailedOperationSpec: msRest.OperationSpec = {
@@ -4808,7 +4809,7 @@ const beginPostAsyncRetryFailedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRetrycanceledOperationSpec: msRest.OperationSpec = {
@@ -4833,5 +4834,5 @@ const beginPostAsyncRetrycanceledOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/Lro/operations/lROsCustomHeader.ts
+++ b/test/azure/generated/Lro/operations/lROsCustomHeader.ts
@@ -445,6 +445,7 @@ export class LROsCustomHeader {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const beginPutAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "lro/customheader/putasync/retry/succeeded",
@@ -468,7 +469,7 @@ const beginPutAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPut201CreatingSucceeded200OperationSpec: msRest.OperationSpec = {
@@ -496,7 +497,7 @@ const beginPut201CreatingSucceeded200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPost202Retry200OperationSpec: msRest.OperationSpec = {
@@ -521,7 +522,7 @@ const beginPost202Retry200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginPostAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
@@ -546,5 +547,5 @@ const beginPostAsyncRetrySucceededOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/Paging/operations/paging.ts
+++ b/test/azure/generated/Paging/operations/paging.ts
@@ -1236,6 +1236,7 @@ export class Paging {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getSinglePagesOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "paging/single",
@@ -1250,7 +1251,7 @@ const getSinglePagesOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesOperationSpec: msRest.OperationSpec = {
@@ -1270,7 +1271,7 @@ const getMultiplePagesOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOdataMultiplePagesOperationSpec: msRest.OperationSpec = {
@@ -1290,7 +1291,7 @@ const getOdataMultiplePagesOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesWithOffsetOperationSpec: msRest.OperationSpec = {
@@ -1313,7 +1314,7 @@ const getMultiplePagesWithOffsetOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesRetryFirstOperationSpec: msRest.OperationSpec = {
@@ -1330,7 +1331,7 @@ const getMultiplePagesRetryFirstOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesRetrySecondOperationSpec: msRest.OperationSpec = {
@@ -1347,7 +1348,7 @@ const getMultiplePagesRetrySecondOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSinglePagesFailureOperationSpec: msRest.OperationSpec = {
@@ -1364,7 +1365,7 @@ const getSinglePagesFailureOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesFailureOperationSpec: msRest.OperationSpec = {
@@ -1381,7 +1382,7 @@ const getMultiplePagesFailureOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesFailureUriOperationSpec: msRest.OperationSpec = {
@@ -1398,7 +1399,7 @@ const getMultiplePagesFailureUriOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesFragmentNextLinkOperationSpec: msRest.OperationSpec = {
@@ -1421,7 +1422,7 @@ const getMultiplePagesFragmentNextLinkOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesFragmentWithGroupingNextLinkOperationSpec: msRest.OperationSpec = {
@@ -1444,7 +1445,7 @@ const getMultiplePagesFragmentWithGroupingNextLinkOperationSpec: msRest.Operatio
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const nextFragmentOperationSpec: msRest.OperationSpec = {
@@ -1468,7 +1469,7 @@ const nextFragmentOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const nextFragmentWithGroupingOperationSpec: msRest.OperationSpec = {
@@ -1492,7 +1493,7 @@ const nextFragmentWithGroupingOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginGetMultiplePagesLROOperationSpec: msRest.OperationSpec = {
@@ -1512,7 +1513,7 @@ const beginGetMultiplePagesLROOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSinglePagesNextOperationSpec: msRest.OperationSpec = {
@@ -1533,7 +1534,7 @@ const getSinglePagesNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesNextOperationSpec: msRest.OperationSpec = {
@@ -1557,7 +1558,7 @@ const getMultiplePagesNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOdataMultiplePagesNextOperationSpec: msRest.OperationSpec = {
@@ -1581,7 +1582,7 @@ const getOdataMultiplePagesNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesWithOffsetNextOperationSpec: msRest.OperationSpec = {
@@ -1605,7 +1606,7 @@ const getMultiplePagesWithOffsetNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesRetryFirstNextOperationSpec: msRest.OperationSpec = {
@@ -1626,7 +1627,7 @@ const getMultiplePagesRetryFirstNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesRetrySecondNextOperationSpec: msRest.OperationSpec = {
@@ -1647,7 +1648,7 @@ const getMultiplePagesRetrySecondNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSinglePagesFailureNextOperationSpec: msRest.OperationSpec = {
@@ -1668,7 +1669,7 @@ const getSinglePagesFailureNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesFailureNextOperationSpec: msRest.OperationSpec = {
@@ -1689,7 +1690,7 @@ const getMultiplePagesFailureNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMultiplePagesFailureUriNextOperationSpec: msRest.OperationSpec = {
@@ -1710,7 +1711,7 @@ const getMultiplePagesFailureUriNextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginGetMultiplePagesLRONextOperationSpec: msRest.OperationSpec = {
@@ -1734,5 +1735,5 @@ const beginGetMultiplePagesLRONextOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
+++ b/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
@@ -613,6 +613,7 @@ export class StorageAccounts {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const checkNameAvailabilityOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability",
@@ -641,7 +642,7 @@ const checkNameAvailabilityOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const deleteMethodOperationSpec: msRest.OperationSpec = {
@@ -665,7 +666,7 @@ const deleteMethodOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getPropertiesOperationSpec: msRest.OperationSpec = {
@@ -690,7 +691,7 @@ const getPropertiesOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const updateOperationSpec: msRest.OperationSpec = {
@@ -723,7 +724,7 @@ const updateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const listKeysOperationSpec: msRest.OperationSpec = {
@@ -748,7 +749,7 @@ const listKeysOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const listOperationSpec: msRest.OperationSpec = {
@@ -771,7 +772,7 @@ const listOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const listByResourceGroupOperationSpec: msRest.OperationSpec = {
@@ -795,7 +796,7 @@ const listByResourceGroupOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const regenerateKeyOperationSpec: msRest.OperationSpec = {
@@ -833,7 +834,7 @@ const regenerateKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const beginCreateOperationSpec: msRest.OperationSpec = {
@@ -867,5 +868,5 @@ const beginCreateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
+++ b/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
@@ -70,6 +70,7 @@ export class UsageOperations {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages",
@@ -90,5 +91,5 @@ const listOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.CloudError
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
@@ -75,6 +75,7 @@ export class Group {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getSampleResourceGroupOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}",
@@ -96,5 +97,5 @@ const getSampleResourceGroupOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/enumunion/generated/BodyString/operations/enumModel.ts
+++ b/test/enumunion/generated/BodyString/operations/enumModel.ts
@@ -284,6 +284,7 @@ export class EnumModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNotExpandableOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "string/enum/notExpandable",
@@ -305,7 +306,7 @@ const getNotExpandableOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putNotExpandableOperationSpec: msRest.OperationSpec = {
@@ -333,7 +334,7 @@ const putNotExpandableOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getReferencedOperationSpec: msRest.OperationSpec = {
@@ -357,7 +358,7 @@ const getReferencedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putReferencedOperationSpec: msRest.OperationSpec = {
@@ -385,7 +386,7 @@ const putReferencedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getReferencedConstantOperationSpec: msRest.OperationSpec = {
@@ -399,7 +400,7 @@ const getReferencedConstantOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putReferencedConstantOperationSpec: msRest.OperationSpec = {
@@ -424,5 +425,5 @@ const putReferencedConstantOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/enumunion/generated/BodyString/operations/string.ts
+++ b/test/enumunion/generated/BodyString/operations/string.ts
@@ -570,6 +570,7 @@ export class String {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "string/null",
@@ -586,7 +587,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putNullOperationSpec: msRest.OperationSpec = {
@@ -611,7 +612,7 @@ const putNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -630,7 +631,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -655,7 +656,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMbcsOperationSpec: msRest.OperationSpec = {
@@ -674,7 +675,7 @@ const getMbcsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMbcsOperationSpec: msRest.OperationSpec = {
@@ -699,7 +700,7 @@ const putMbcsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getWhitespaceOperationSpec: msRest.OperationSpec = {
@@ -718,7 +719,7 @@ const getWhitespaceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putWhitespaceOperationSpec: msRest.OperationSpec = {
@@ -743,7 +744,7 @@ const putWhitespaceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -762,7 +763,7 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBase64EncodedOperationSpec: msRest.OperationSpec = {
@@ -781,7 +782,7 @@ const getBase64EncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -800,7 +801,7 @@ const getBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -823,7 +824,7 @@ const putBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -842,5 +843,5 @@ const getNullBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -2981,6 +2981,7 @@ export class ArrayModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "array/null",
@@ -3003,7 +3004,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -3028,7 +3029,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -3053,7 +3054,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -3082,7 +3083,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanTfftOperationSpec: msRest.OperationSpec = {
@@ -3107,7 +3108,7 @@ const getBooleanTfftOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBooleanTfftOperationSpec: msRest.OperationSpec = {
@@ -3136,7 +3137,7 @@ const putBooleanTfftOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3161,7 +3162,7 @@ const getBooleanInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3186,7 +3187,7 @@ const getBooleanInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntegerValidOperationSpec: msRest.OperationSpec = {
@@ -3211,7 +3212,7 @@ const getIntegerValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putIntegerValidOperationSpec: msRest.OperationSpec = {
@@ -3240,7 +3241,7 @@ const putIntegerValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3265,7 +3266,7 @@ const getIntInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3290,7 +3291,7 @@ const getIntInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongValidOperationSpec: msRest.OperationSpec = {
@@ -3315,7 +3316,7 @@ const getLongValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLongValidOperationSpec: msRest.OperationSpec = {
@@ -3344,7 +3345,7 @@ const putLongValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3369,7 +3370,7 @@ const getLongInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3394,7 +3395,7 @@ const getLongInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatValidOperationSpec: msRest.OperationSpec = {
@@ -3419,7 +3420,7 @@ const getFloatValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putFloatValidOperationSpec: msRest.OperationSpec = {
@@ -3448,7 +3449,7 @@ const putFloatValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3473,7 +3474,7 @@ const getFloatInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3498,7 +3499,7 @@ const getFloatInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleValidOperationSpec: msRest.OperationSpec = {
@@ -3523,7 +3524,7 @@ const getDoubleValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDoubleValidOperationSpec: msRest.OperationSpec = {
@@ -3552,7 +3553,7 @@ const putDoubleValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3577,7 +3578,7 @@ const getDoubleInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3602,7 +3603,7 @@ const getDoubleInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringValidOperationSpec: msRest.OperationSpec = {
@@ -3627,7 +3628,7 @@ const getStringValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putStringValidOperationSpec: msRest.OperationSpec = {
@@ -3656,7 +3657,7 @@ const putStringValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEnumValidOperationSpec: msRest.OperationSpec = {
@@ -3686,7 +3687,7 @@ const getEnumValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEnumValidOperationSpec: msRest.OperationSpec = {
@@ -3720,7 +3721,7 @@ const putEnumValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringEnumValidOperationSpec: msRest.OperationSpec = {
@@ -3745,7 +3746,7 @@ const getStringEnumValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putStringEnumValidOperationSpec: msRest.OperationSpec = {
@@ -3774,7 +3775,7 @@ const putStringEnumValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringWithNullOperationSpec: msRest.OperationSpec = {
@@ -3799,7 +3800,7 @@ const getStringWithNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringWithInvalidOperationSpec: msRest.OperationSpec = {
@@ -3824,7 +3825,7 @@ const getStringWithInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUuidValidOperationSpec: msRest.OperationSpec = {
@@ -3849,7 +3850,7 @@ const getUuidValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUuidValidOperationSpec: msRest.OperationSpec = {
@@ -3878,7 +3879,7 @@ const putUuidValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUuidInvalidCharsOperationSpec: msRest.OperationSpec = {
@@ -3903,7 +3904,7 @@ const getUuidInvalidCharsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateValidOperationSpec: msRest.OperationSpec = {
@@ -3928,7 +3929,7 @@ const getDateValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateValidOperationSpec: msRest.OperationSpec = {
@@ -3957,7 +3958,7 @@ const putDateValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3982,7 +3983,7 @@ const getDateInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateInvalidCharsOperationSpec: msRest.OperationSpec = {
@@ -4007,7 +4008,7 @@ const getDateInvalidCharsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeValidOperationSpec: msRest.OperationSpec = {
@@ -4032,7 +4033,7 @@ const getDateTimeValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeValidOperationSpec: msRest.OperationSpec = {
@@ -4061,7 +4062,7 @@ const putDateTimeValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -4086,7 +4087,7 @@ const getDateTimeInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeInvalidCharsOperationSpec: msRest.OperationSpec = {
@@ -4111,7 +4112,7 @@ const getDateTimeInvalidCharsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
@@ -4136,7 +4137,7 @@ const getDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
@@ -4165,7 +4166,7 @@ const putDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDurationValidOperationSpec: msRest.OperationSpec = {
@@ -4190,7 +4191,7 @@ const getDurationValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDurationValidOperationSpec: msRest.OperationSpec = {
@@ -4219,7 +4220,7 @@ const putDurationValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getByteValidOperationSpec: msRest.OperationSpec = {
@@ -4244,7 +4245,7 @@ const getByteValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putByteValidOperationSpec: msRest.OperationSpec = {
@@ -4273,7 +4274,7 @@ const putByteValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getByteInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -4298,7 +4299,7 @@ const getByteInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBase64UrlOperationSpec: msRest.OperationSpec = {
@@ -4323,7 +4324,7 @@ const getBase64UrlOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexNullOperationSpec: msRest.OperationSpec = {
@@ -4349,7 +4350,7 @@ const getComplexNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexEmptyOperationSpec: msRest.OperationSpec = {
@@ -4375,7 +4376,7 @@ const getComplexEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexItemNullOperationSpec: msRest.OperationSpec = {
@@ -4401,7 +4402,7 @@ const getComplexItemNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexItemEmptyOperationSpec: msRest.OperationSpec = {
@@ -4427,7 +4428,7 @@ const getComplexItemEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexValidOperationSpec: msRest.OperationSpec = {
@@ -4453,7 +4454,7 @@ const getComplexValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putComplexValidOperationSpec: msRest.OperationSpec = {
@@ -4483,7 +4484,7 @@ const putComplexValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayNullOperationSpec: msRest.OperationSpec = {
@@ -4514,7 +4515,7 @@ const getArrayNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayEmptyOperationSpec: msRest.OperationSpec = {
@@ -4545,7 +4546,7 @@ const getArrayEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayItemNullOperationSpec: msRest.OperationSpec = {
@@ -4576,7 +4577,7 @@ const getArrayItemNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayItemEmptyOperationSpec: msRest.OperationSpec = {
@@ -4607,7 +4608,7 @@ const getArrayItemEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayValidOperationSpec: msRest.OperationSpec = {
@@ -4638,7 +4639,7 @@ const getArrayValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putArrayValidOperationSpec: msRest.OperationSpec = {
@@ -4673,7 +4674,7 @@ const putArrayValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryNullOperationSpec: msRest.OperationSpec = {
@@ -4704,7 +4705,7 @@ const getDictionaryNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryEmptyOperationSpec: msRest.OperationSpec = {
@@ -4735,7 +4736,7 @@ const getDictionaryEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryItemNullOperationSpec: msRest.OperationSpec = {
@@ -4766,7 +4767,7 @@ const getDictionaryItemNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryItemEmptyOperationSpec: msRest.OperationSpec = {
@@ -4797,7 +4798,7 @@ const getDictionaryItemEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryValidOperationSpec: msRest.OperationSpec = {
@@ -4828,7 +4829,7 @@ const getDictionaryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDictionaryValidOperationSpec: msRest.OperationSpec = {
@@ -4863,5 +4864,5 @@ const putDictionaryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -273,6 +273,7 @@ export class Bool {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getTrueOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "bool/true",
@@ -289,7 +290,7 @@ const getTrueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putTrueOperationSpec: msRest.OperationSpec = {
@@ -314,7 +315,7 @@ const putTrueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFalseOperationSpec: msRest.OperationSpec = {
@@ -333,7 +334,7 @@ const getFalseOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putFalseOperationSpec: msRest.OperationSpec = {
@@ -358,7 +359,7 @@ const putFalseOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullOperationSpec: msRest.OperationSpec = {
@@ -377,7 +378,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -396,5 +397,5 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyByte/operations/byteModel.ts
+++ b/test/vanilla/generated/BodyByte/operations/byteModel.ts
@@ -239,6 +239,7 @@ export class ByteModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "byte/null",
@@ -255,7 +256,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -274,7 +275,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNonAsciiOperationSpec: msRest.OperationSpec = {
@@ -293,7 +294,7 @@ const getNonAsciiOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putNonAsciiOperationSpec: msRest.OperationSpec = {
@@ -316,7 +317,7 @@ const putNonAsciiOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -335,5 +336,5 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
@@ -233,6 +233,7 @@ export class ArrayModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/array/valid",
@@ -244,7 +245,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -269,7 +270,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -283,7 +284,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -308,7 +309,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -322,5 +323,5 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
+++ b/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
@@ -280,6 +280,7 @@ export class BasicOperations {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/basic/valid",
@@ -291,7 +292,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -314,7 +315,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -328,7 +329,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -342,7 +343,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullOperationSpec: msRest.OperationSpec = {
@@ -356,7 +357,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -370,5 +371,5 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyComplex/operations/dictionary.ts
@@ -274,6 +274,7 @@ export class Dictionary {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/dictionary/typed/valid",
@@ -285,7 +286,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -310,7 +311,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -324,7 +325,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -349,7 +350,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullOperationSpec: msRest.OperationSpec = {
@@ -363,7 +364,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -377,5 +378,5 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
+++ b/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
@@ -65,6 +65,7 @@ export class Flattencomplex {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/flatten/valid",
@@ -74,5 +75,5 @@ const getValidOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/inheritance.ts
+++ b/test/vanilla/generated/BodyComplex/operations/inheritance.ts
@@ -119,6 +119,7 @@ export class Inheritance {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/inheritance/valid",
@@ -130,7 +131,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -150,5 +151,5 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
@@ -219,6 +219,7 @@ export class Polymorphicrecursive {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/polymorphicrecursive/valid",
@@ -230,7 +231,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -250,5 +251,5 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
@@ -416,6 +416,7 @@ export class Polymorphism {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/polymorphism/valid",
@@ -427,7 +428,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -447,7 +448,7 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplicatedOperationSpec: msRest.OperationSpec = {
@@ -461,7 +462,7 @@ const getComplicatedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putComplicatedOperationSpec: msRest.OperationSpec = {
@@ -481,7 +482,7 @@ const putComplicatedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMissingDiscriminatorOperationSpec: msRest.OperationSpec = {
@@ -503,7 +504,7 @@ const putMissingDiscriminatorOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidMissingRequiredOperationSpec: msRest.OperationSpec = {
@@ -523,5 +524,5 @@ const putValidMissingRequiredOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/primitive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/primitive.ts
@@ -981,6 +981,7 @@ export class Primitive {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getIntOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/primitive/integer",
@@ -992,7 +993,7 @@ const getIntOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putIntOperationSpec: msRest.OperationSpec = {
@@ -1012,7 +1013,7 @@ const putIntOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongOperationSpec: msRest.OperationSpec = {
@@ -1026,7 +1027,7 @@ const getLongOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLongOperationSpec: msRest.OperationSpec = {
@@ -1046,7 +1047,7 @@ const putLongOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatOperationSpec: msRest.OperationSpec = {
@@ -1060,7 +1061,7 @@ const getFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putFloatOperationSpec: msRest.OperationSpec = {
@@ -1080,7 +1081,7 @@ const putFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleOperationSpec: msRest.OperationSpec = {
@@ -1094,7 +1095,7 @@ const getDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDoubleOperationSpec: msRest.OperationSpec = {
@@ -1114,7 +1115,7 @@ const putDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBoolOperationSpec: msRest.OperationSpec = {
@@ -1128,7 +1129,7 @@ const getBoolOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBoolOperationSpec: msRest.OperationSpec = {
@@ -1148,7 +1149,7 @@ const putBoolOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringOperationSpec: msRest.OperationSpec = {
@@ -1162,7 +1163,7 @@ const getStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putStringOperationSpec: msRest.OperationSpec = {
@@ -1182,7 +1183,7 @@ const putStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateOperationSpec: msRest.OperationSpec = {
@@ -1196,7 +1197,7 @@ const getDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateOperationSpec: msRest.OperationSpec = {
@@ -1216,7 +1217,7 @@ const putDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1230,7 +1231,7 @@ const getDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1250,7 +1251,7 @@ const putDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
@@ -1264,7 +1265,7 @@ const getDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
@@ -1284,7 +1285,7 @@ const putDateTimeRfc1123OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDurationOperationSpec: msRest.OperationSpec = {
@@ -1298,7 +1299,7 @@ const getDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDurationOperationSpec: msRest.OperationSpec = {
@@ -1323,7 +1324,7 @@ const putDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getByteOperationSpec: msRest.OperationSpec = {
@@ -1337,7 +1338,7 @@ const getByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putByteOperationSpec: msRest.OperationSpec = {
@@ -1362,5 +1363,5 @@ const putByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
+++ b/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
@@ -110,6 +110,7 @@ export class Readonlyproperty {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "complex/readonlyproperty/valid",
@@ -121,7 +122,7 @@ const getValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putValidOperationSpec: msRest.OperationSpec = {
@@ -146,5 +147,5 @@ const putValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyDate/operations/dateModel.ts
+++ b/test/vanilla/generated/BodyDate/operations/dateModel.ts
@@ -365,6 +365,7 @@ export class DateModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "date/null",
@@ -381,7 +382,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidDateOperationSpec: msRest.OperationSpec = {
@@ -400,7 +401,7 @@ const getInvalidDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowDateOperationSpec: msRest.OperationSpec = {
@@ -419,7 +420,7 @@ const getOverflowDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowDateOperationSpec: msRest.OperationSpec = {
@@ -438,7 +439,7 @@ const getUnderflowDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMaxDateOperationSpec: msRest.OperationSpec = {
@@ -461,7 +462,7 @@ const putMaxDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMaxDateOperationSpec: msRest.OperationSpec = {
@@ -480,7 +481,7 @@ const getMaxDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMinDateOperationSpec: msRest.OperationSpec = {
@@ -503,7 +504,7 @@ const putMinDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMinDateOperationSpec: msRest.OperationSpec = {
@@ -522,5 +523,5 @@ const getMinDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyDateTime/operations/datetime.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/datetime.ts
@@ -836,6 +836,7 @@ export class Datetime {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "datetime/null",
@@ -852,7 +853,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -871,7 +872,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowOperationSpec: msRest.OperationSpec = {
@@ -890,7 +891,7 @@ const getOverflowOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowOperationSpec: msRest.OperationSpec = {
@@ -909,7 +910,7 @@ const getUnderflowOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUtcMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -932,7 +933,7 @@ const putUtcMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUtcLowercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -951,7 +952,7 @@ const getUtcLowercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUtcUppercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -970,7 +971,7 @@ const getUtcUppercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLocalPositiveOffsetMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -993,7 +994,7 @@ const putLocalPositiveOffsetMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalPositiveOffsetLowercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1012,7 +1013,7 @@ const getLocalPositiveOffsetLowercaseMaxDateTimeOperationSpec: msRest.OperationS
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalPositiveOffsetUppercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1031,7 +1032,7 @@ const getLocalPositiveOffsetUppercaseMaxDateTimeOperationSpec: msRest.OperationS
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLocalNegativeOffsetMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1054,7 +1055,7 @@ const putLocalNegativeOffsetMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalNegativeOffsetUppercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1073,7 +1074,7 @@ const getLocalNegativeOffsetUppercaseMaxDateTimeOperationSpec: msRest.OperationS
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalNegativeOffsetLowercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1092,7 +1093,7 @@ const getLocalNegativeOffsetLowercaseMaxDateTimeOperationSpec: msRest.OperationS
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1115,7 +1116,7 @@ const putUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1134,7 +1135,7 @@ const getUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLocalPositiveOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1157,7 +1158,7 @@ const putLocalPositiveOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalPositiveOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1176,7 +1177,7 @@ const getLocalPositiveOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLocalNegativeOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1199,7 +1200,7 @@ const putLocalNegativeOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalNegativeOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -1218,5 +1219,5 @@ const getLocalNegativeOffsetMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -406,6 +406,7 @@ export class Datetimerfc1123 {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "datetimerfc1123/null",
@@ -422,7 +423,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -441,7 +442,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowOperationSpec: msRest.OperationSpec = {
@@ -460,7 +461,7 @@ const getOverflowOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowOperationSpec: msRest.OperationSpec = {
@@ -479,7 +480,7 @@ const getUnderflowOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUtcMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -502,7 +503,7 @@ const putUtcMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUtcLowercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -521,7 +522,7 @@ const getUtcLowercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUtcUppercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
@@ -540,7 +541,7 @@ const getUtcUppercaseMaxDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -563,7 +564,7 @@ const putUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
@@ -582,5 +583,5 @@ const getUtcMinDateTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
@@ -2806,6 +2806,7 @@ export class Dictionary {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "dictionary/null",
@@ -2828,7 +2829,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -2853,7 +2854,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -2882,7 +2883,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullValueOperationSpec: msRest.OperationSpec = {
@@ -2907,7 +2908,7 @@ const getNullValueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullKeyOperationSpec: msRest.OperationSpec = {
@@ -2932,7 +2933,7 @@ const getNullKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyStringKeyOperationSpec: msRest.OperationSpec = {
@@ -2957,7 +2958,7 @@ const getEmptyStringKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -2982,7 +2983,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanTfftOperationSpec: msRest.OperationSpec = {
@@ -3007,7 +3008,7 @@ const getBooleanTfftOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBooleanTfftOperationSpec: msRest.OperationSpec = {
@@ -3036,7 +3037,7 @@ const putBooleanTfftOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3061,7 +3062,7 @@ const getBooleanInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3086,7 +3087,7 @@ const getBooleanInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntegerValidOperationSpec: msRest.OperationSpec = {
@@ -3111,7 +3112,7 @@ const getIntegerValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putIntegerValidOperationSpec: msRest.OperationSpec = {
@@ -3140,7 +3141,7 @@ const putIntegerValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3165,7 +3166,7 @@ const getIntInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3190,7 +3191,7 @@ const getIntInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongValidOperationSpec: msRest.OperationSpec = {
@@ -3215,7 +3216,7 @@ const getLongValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putLongValidOperationSpec: msRest.OperationSpec = {
@@ -3244,7 +3245,7 @@ const putLongValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3269,7 +3270,7 @@ const getLongInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3294,7 +3295,7 @@ const getLongInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatValidOperationSpec: msRest.OperationSpec = {
@@ -3319,7 +3320,7 @@ const getFloatValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putFloatValidOperationSpec: msRest.OperationSpec = {
@@ -3348,7 +3349,7 @@ const putFloatValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3373,7 +3374,7 @@ const getFloatInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFloatInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3398,7 +3399,7 @@ const getFloatInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleValidOperationSpec: msRest.OperationSpec = {
@@ -3423,7 +3424,7 @@ const getDoubleValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDoubleValidOperationSpec: msRest.OperationSpec = {
@@ -3452,7 +3453,7 @@ const putDoubleValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3477,7 +3478,7 @@ const getDoubleInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDoubleInvalidStringOperationSpec: msRest.OperationSpec = {
@@ -3502,7 +3503,7 @@ const getDoubleInvalidStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringValidOperationSpec: msRest.OperationSpec = {
@@ -3527,7 +3528,7 @@ const getStringValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putStringValidOperationSpec: msRest.OperationSpec = {
@@ -3556,7 +3557,7 @@ const putStringValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringWithNullOperationSpec: msRest.OperationSpec = {
@@ -3581,7 +3582,7 @@ const getStringWithNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getStringWithInvalidOperationSpec: msRest.OperationSpec = {
@@ -3606,7 +3607,7 @@ const getStringWithInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateValidOperationSpec: msRest.OperationSpec = {
@@ -3631,7 +3632,7 @@ const getDateValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateValidOperationSpec: msRest.OperationSpec = {
@@ -3660,7 +3661,7 @@ const putDateValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3685,7 +3686,7 @@ const getDateInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateInvalidCharsOperationSpec: msRest.OperationSpec = {
@@ -3710,7 +3711,7 @@ const getDateInvalidCharsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeValidOperationSpec: msRest.OperationSpec = {
@@ -3735,7 +3736,7 @@ const getDateTimeValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeValidOperationSpec: msRest.OperationSpec = {
@@ -3764,7 +3765,7 @@ const putDateTimeValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -3789,7 +3790,7 @@ const getDateTimeInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeInvalidCharsOperationSpec: msRest.OperationSpec = {
@@ -3814,7 +3815,7 @@ const getDateTimeInvalidCharsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
@@ -3839,7 +3840,7 @@ const getDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
@@ -3868,7 +3869,7 @@ const putDateTimeRfc1123ValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDurationValidOperationSpec: msRest.OperationSpec = {
@@ -3893,7 +3894,7 @@ const getDurationValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDurationValidOperationSpec: msRest.OperationSpec = {
@@ -3922,7 +3923,7 @@ const putDurationValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getByteValidOperationSpec: msRest.OperationSpec = {
@@ -3947,7 +3948,7 @@ const getByteValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putByteValidOperationSpec: msRest.OperationSpec = {
@@ -3976,7 +3977,7 @@ const putByteValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getByteInvalidNullOperationSpec: msRest.OperationSpec = {
@@ -4001,7 +4002,7 @@ const getByteInvalidNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBase64UrlOperationSpec: msRest.OperationSpec = {
@@ -4026,7 +4027,7 @@ const getBase64UrlOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexNullOperationSpec: msRest.OperationSpec = {
@@ -4052,7 +4053,7 @@ const getComplexNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexEmptyOperationSpec: msRest.OperationSpec = {
@@ -4078,7 +4079,7 @@ const getComplexEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexItemNullOperationSpec: msRest.OperationSpec = {
@@ -4104,7 +4105,7 @@ const getComplexItemNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexItemEmptyOperationSpec: msRest.OperationSpec = {
@@ -4130,7 +4131,7 @@ const getComplexItemEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getComplexValidOperationSpec: msRest.OperationSpec = {
@@ -4156,7 +4157,7 @@ const getComplexValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putComplexValidOperationSpec: msRest.OperationSpec = {
@@ -4186,7 +4187,7 @@ const putComplexValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayNullOperationSpec: msRest.OperationSpec = {
@@ -4217,7 +4218,7 @@ const getArrayNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayEmptyOperationSpec: msRest.OperationSpec = {
@@ -4248,7 +4249,7 @@ const getArrayEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayItemNullOperationSpec: msRest.OperationSpec = {
@@ -4279,7 +4280,7 @@ const getArrayItemNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayItemEmptyOperationSpec: msRest.OperationSpec = {
@@ -4310,7 +4311,7 @@ const getArrayItemEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayValidOperationSpec: msRest.OperationSpec = {
@@ -4341,7 +4342,7 @@ const getArrayValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putArrayValidOperationSpec: msRest.OperationSpec = {
@@ -4376,7 +4377,7 @@ const putArrayValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryNullOperationSpec: msRest.OperationSpec = {
@@ -4407,7 +4408,7 @@ const getDictionaryNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryEmptyOperationSpec: msRest.OperationSpec = {
@@ -4438,7 +4439,7 @@ const getDictionaryEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryItemNullOperationSpec: msRest.OperationSpec = {
@@ -4469,7 +4470,7 @@ const getDictionaryItemNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryItemEmptyOperationSpec: msRest.OperationSpec = {
@@ -4500,7 +4501,7 @@ const getDictionaryItemEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryValidOperationSpec: msRest.OperationSpec = {
@@ -4531,7 +4532,7 @@ const getDictionaryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDictionaryValidOperationSpec: msRest.OperationSpec = {
@@ -4566,5 +4567,5 @@ const putDictionaryValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyDuration/operations/duration.ts
+++ b/test/vanilla/generated/BodyDuration/operations/duration.ts
@@ -196,6 +196,7 @@ export class Duration {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "duration/null",
@@ -212,7 +213,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putPositiveDurationOperationSpec: msRest.OperationSpec = {
@@ -235,7 +236,7 @@ const putPositiveDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getPositiveDurationOperationSpec: msRest.OperationSpec = {
@@ -254,7 +255,7 @@ const getPositiveDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -273,5 +274,5 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyFile/operations/files.ts
+++ b/test/vanilla/generated/BodyFile/operations/files.ts
@@ -84,6 +84,7 @@ export class Files {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getFileOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "files/stream/nonempty",
@@ -100,7 +101,7 @@ const getFileOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFileLargeOperationSpec: msRest.OperationSpec = {
@@ -119,7 +120,7 @@ const getFileLargeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyFileOperationSpec: msRest.OperationSpec = {
@@ -138,5 +139,5 @@ const getEmptyFileOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyFormData/operations/formdata.ts
+++ b/test/vanilla/generated/BodyFormData/operations/formdata.ts
@@ -75,6 +75,7 @@ export class Formdata {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const uploadFileOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "formdata/stream/uploadfile",
@@ -96,7 +97,7 @@ const uploadFileOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const uploadFileViaBodyOperationSpec: msRest.OperationSpec = {
@@ -126,5 +127,5 @@ const uploadFileViaBodyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyInteger/operations/intModel.ts
+++ b/test/vanilla/generated/BodyInteger/operations/intModel.ts
@@ -626,6 +626,7 @@ export class IntModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "int/null",
@@ -642,7 +643,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -661,7 +662,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowInt32OperationSpec: msRest.OperationSpec = {
@@ -680,7 +681,7 @@ const getOverflowInt32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowInt32OperationSpec: msRest.OperationSpec = {
@@ -699,7 +700,7 @@ const getUnderflowInt32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowInt64OperationSpec: msRest.OperationSpec = {
@@ -718,7 +719,7 @@ const getOverflowInt64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowInt64OperationSpec: msRest.OperationSpec = {
@@ -737,7 +738,7 @@ const getUnderflowInt64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMax32OperationSpec: msRest.OperationSpec = {
@@ -760,7 +761,7 @@ const putMax32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMax64OperationSpec: msRest.OperationSpec = {
@@ -783,7 +784,7 @@ const putMax64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMin32OperationSpec: msRest.OperationSpec = {
@@ -806,7 +807,7 @@ const putMin32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMin64OperationSpec: msRest.OperationSpec = {
@@ -829,7 +830,7 @@ const putMin64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnixTimeOperationSpec: msRest.OperationSpec = {
@@ -848,7 +849,7 @@ const getUnixTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUnixTimeDateOperationSpec: msRest.OperationSpec = {
@@ -871,7 +872,7 @@ const putUnixTimeDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidUnixTimeOperationSpec: msRest.OperationSpec = {
@@ -890,7 +891,7 @@ const getInvalidUnixTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullUnixTimeOperationSpec: msRest.OperationSpec = {
@@ -909,5 +910,5 @@ const getNullUnixTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -1041,6 +1041,7 @@ export class Number {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "number/null",
@@ -1057,7 +1058,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidFloatOperationSpec: msRest.OperationSpec = {
@@ -1076,7 +1077,7 @@ const getInvalidFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidDoubleOperationSpec: msRest.OperationSpec = {
@@ -1095,7 +1096,7 @@ const getInvalidDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidDecimalOperationSpec: msRest.OperationSpec = {
@@ -1114,7 +1115,7 @@ const getInvalidDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigFloatOperationSpec: msRest.OperationSpec = {
@@ -1137,7 +1138,7 @@ const putBigFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigFloatOperationSpec: msRest.OperationSpec = {
@@ -1156,7 +1157,7 @@ const getBigFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigDoubleOperationSpec: msRest.OperationSpec = {
@@ -1179,7 +1180,7 @@ const putBigDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigDoubleOperationSpec: msRest.OperationSpec = {
@@ -1198,7 +1199,7 @@ const getBigDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigDoublePositiveDecimalOperationSpec: msRest.OperationSpec = {
@@ -1223,7 +1224,7 @@ const putBigDoublePositiveDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigDoublePositiveDecimalOperationSpec: msRest.OperationSpec = {
@@ -1242,7 +1243,7 @@ const getBigDoublePositiveDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigDoubleNegativeDecimalOperationSpec: msRest.OperationSpec = {
@@ -1267,7 +1268,7 @@ const putBigDoubleNegativeDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigDoubleNegativeDecimalOperationSpec: msRest.OperationSpec = {
@@ -1286,7 +1287,7 @@ const getBigDoubleNegativeDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigDecimalOperationSpec: msRest.OperationSpec = {
@@ -1309,7 +1310,7 @@ const putBigDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigDecimalOperationSpec: msRest.OperationSpec = {
@@ -1328,7 +1329,7 @@ const getBigDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigDecimalPositiveDecimalOperationSpec: msRest.OperationSpec = {
@@ -1353,7 +1354,7 @@ const putBigDecimalPositiveDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigDecimalPositiveDecimalOperationSpec: msRest.OperationSpec = {
@@ -1372,7 +1373,7 @@ const getBigDecimalPositiveDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBigDecimalNegativeDecimalOperationSpec: msRest.OperationSpec = {
@@ -1397,7 +1398,7 @@ const putBigDecimalNegativeDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBigDecimalNegativeDecimalOperationSpec: msRest.OperationSpec = {
@@ -1416,7 +1417,7 @@ const getBigDecimalNegativeDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putSmallFloatOperationSpec: msRest.OperationSpec = {
@@ -1439,7 +1440,7 @@ const putSmallFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSmallFloatOperationSpec: msRest.OperationSpec = {
@@ -1458,7 +1459,7 @@ const getSmallFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putSmallDoubleOperationSpec: msRest.OperationSpec = {
@@ -1481,7 +1482,7 @@ const putSmallDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSmallDoubleOperationSpec: msRest.OperationSpec = {
@@ -1500,7 +1501,7 @@ const getSmallDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putSmallDecimalOperationSpec: msRest.OperationSpec = {
@@ -1523,7 +1524,7 @@ const putSmallDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getSmallDecimalOperationSpec: msRest.OperationSpec = {
@@ -1542,5 +1543,5 @@ const getSmallDecimalOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyString/operations/enumModel.ts
+++ b/test/vanilla/generated/BodyString/operations/enumModel.ts
@@ -284,6 +284,7 @@ export class EnumModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNotExpandableOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "string/enum/notExpandable",
@@ -305,7 +306,7 @@ const getNotExpandableOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putNotExpandableOperationSpec: msRest.OperationSpec = {
@@ -333,7 +334,7 @@ const putNotExpandableOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getReferencedOperationSpec: msRest.OperationSpec = {
@@ -357,7 +358,7 @@ const getReferencedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putReferencedOperationSpec: msRest.OperationSpec = {
@@ -385,7 +386,7 @@ const putReferencedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getReferencedConstantOperationSpec: msRest.OperationSpec = {
@@ -399,7 +400,7 @@ const getReferencedConstantOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putReferencedConstantOperationSpec: msRest.OperationSpec = {
@@ -424,5 +425,5 @@ const putReferencedConstantOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -570,6 +570,7 @@ export class String {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "string/null",
@@ -586,7 +587,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putNullOperationSpec: msRest.OperationSpec = {
@@ -611,7 +612,7 @@ const putNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getEmptyOperationSpec: msRest.OperationSpec = {
@@ -630,7 +631,7 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putEmptyOperationSpec: msRest.OperationSpec = {
@@ -655,7 +656,7 @@ const putEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getMbcsOperationSpec: msRest.OperationSpec = {
@@ -674,7 +675,7 @@ const getMbcsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMbcsOperationSpec: msRest.OperationSpec = {
@@ -699,7 +700,7 @@ const putMbcsOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getWhitespaceOperationSpec: msRest.OperationSpec = {
@@ -718,7 +719,7 @@ const getWhitespaceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putWhitespaceOperationSpec: msRest.OperationSpec = {
@@ -743,7 +744,7 @@ const putWhitespaceOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNotProvidedOperationSpec: msRest.OperationSpec = {
@@ -762,7 +763,7 @@ const getNotProvidedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBase64EncodedOperationSpec: msRest.OperationSpec = {
@@ -781,7 +782,7 @@ const getBase64EncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -800,7 +801,7 @@ const getBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -823,7 +824,7 @@ const putBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -842,5 +843,5 @@ const getNullBase64UrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -205,6 +205,7 @@ class ComplexModelClient extends ComplexModelClientContext {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const listOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/Microsoft.Cache/Redis",
@@ -223,7 +224,7 @@ const listOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const createOperationSpec: msRest.OperationSpec = {
@@ -257,7 +258,7 @@ const createOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const updateOperationSpec: msRest.OperationSpec = {
@@ -291,7 +292,7 @@ const updateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { ComplexModelClient, Models as ComplexModelModels, Mappers as ComplexModelMappers };

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -273,6 +273,7 @@ export class Bool {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getTrueOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "bool/true",
@@ -289,7 +290,7 @@ const getTrueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putTrueOperationSpec: msRest.OperationSpec = {
@@ -314,7 +315,7 @@ const putTrueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getFalseOperationSpec: msRest.OperationSpec = {
@@ -333,7 +334,7 @@ const getFalseOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putFalseOperationSpec: msRest.OperationSpec = {
@@ -358,7 +359,7 @@ const putFalseOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullOperationSpec: msRest.OperationSpec = {
@@ -377,7 +378,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -396,5 +397,5 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
@@ -626,6 +626,7 @@ export class IntModel {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "int/null",
@@ -642,7 +643,7 @@ const getNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidOperationSpec: msRest.OperationSpec = {
@@ -661,7 +662,7 @@ const getInvalidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowInt32OperationSpec: msRest.OperationSpec = {
@@ -680,7 +681,7 @@ const getOverflowInt32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowInt32OperationSpec: msRest.OperationSpec = {
@@ -699,7 +700,7 @@ const getUnderflowInt32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOverflowInt64OperationSpec: msRest.OperationSpec = {
@@ -718,7 +719,7 @@ const getOverflowInt64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnderflowInt64OperationSpec: msRest.OperationSpec = {
@@ -737,7 +738,7 @@ const getUnderflowInt64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMax32OperationSpec: msRest.OperationSpec = {
@@ -760,7 +761,7 @@ const putMax32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMax64OperationSpec: msRest.OperationSpec = {
@@ -783,7 +784,7 @@ const putMax64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMin32OperationSpec: msRest.OperationSpec = {
@@ -806,7 +807,7 @@ const putMin32OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putMin64OperationSpec: msRest.OperationSpec = {
@@ -829,7 +830,7 @@ const putMin64OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getUnixTimeOperationSpec: msRest.OperationSpec = {
@@ -848,7 +849,7 @@ const getUnixTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putUnixTimeDateOperationSpec: msRest.OperationSpec = {
@@ -871,7 +872,7 @@ const putUnixTimeDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getInvalidUnixTimeOperationSpec: msRest.OperationSpec = {
@@ -890,7 +891,7 @@ const getInvalidUnixTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNullUnixTimeOperationSpec: msRest.OperationSpec = {
@@ -909,5 +910,5 @@ const getNullUnixTimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/CustomBaseUri/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUri/operations/paths.ts
@@ -74,6 +74,7 @@ export class Paths {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getEmptyOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "customuri",
@@ -87,5 +88,5 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
@@ -85,6 +85,7 @@ export class Paths {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getEmptyOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "customuri/{subscriptionId}/{keyName}",
@@ -104,5 +105,5 @@ const getEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Header/operations/header.ts
+++ b/test/vanilla/generated/Header/operations/header.ts
@@ -1441,6 +1441,7 @@ export class Header {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const paramExistingKeyOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "header/param/existingkey",
@@ -1453,7 +1454,7 @@ const paramExistingKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseExistingKeyOperationSpec: msRest.OperationSpec = {
@@ -1467,7 +1468,7 @@ const responseExistingKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramProtectedKeyOperationSpec: msRest.OperationSpec = {
@@ -1482,7 +1483,7 @@ const paramProtectedKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseProtectedKeyOperationSpec: msRest.OperationSpec = {
@@ -1496,7 +1497,7 @@ const responseProtectedKeyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramIntegerOperationSpec: msRest.OperationSpec = {
@@ -1512,7 +1513,7 @@ const paramIntegerOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseIntegerOperationSpec: msRest.OperationSpec = {
@@ -1529,7 +1530,7 @@ const responseIntegerOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramLongOperationSpec: msRest.OperationSpec = {
@@ -1545,7 +1546,7 @@ const paramLongOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseLongOperationSpec: msRest.OperationSpec = {
@@ -1562,7 +1563,7 @@ const responseLongOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramFloatOperationSpec: msRest.OperationSpec = {
@@ -1578,7 +1579,7 @@ const paramFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseFloatOperationSpec: msRest.OperationSpec = {
@@ -1595,7 +1596,7 @@ const responseFloatOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramDoubleOperationSpec: msRest.OperationSpec = {
@@ -1611,7 +1612,7 @@ const paramDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseDoubleOperationSpec: msRest.OperationSpec = {
@@ -1628,7 +1629,7 @@ const responseDoubleOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramBoolOperationSpec: msRest.OperationSpec = {
@@ -1644,7 +1645,7 @@ const paramBoolOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseBoolOperationSpec: msRest.OperationSpec = {
@@ -1661,7 +1662,7 @@ const responseBoolOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramStringOperationSpec: msRest.OperationSpec = {
@@ -1677,7 +1678,7 @@ const paramStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseStringOperationSpec: msRest.OperationSpec = {
@@ -1694,7 +1695,7 @@ const responseStringOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramDateOperationSpec: msRest.OperationSpec = {
@@ -1710,7 +1711,7 @@ const paramDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseDateOperationSpec: msRest.OperationSpec = {
@@ -1727,7 +1728,7 @@ const responseDateOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramDatetimeOperationSpec: msRest.OperationSpec = {
@@ -1743,7 +1744,7 @@ const paramDatetimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseDatetimeOperationSpec: msRest.OperationSpec = {
@@ -1760,7 +1761,7 @@ const responseDatetimeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramDatetimeRfc1123OperationSpec: msRest.OperationSpec = {
@@ -1776,7 +1777,7 @@ const paramDatetimeRfc1123OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseDatetimeRfc1123OperationSpec: msRest.OperationSpec = {
@@ -1793,7 +1794,7 @@ const responseDatetimeRfc1123OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramDurationOperationSpec: msRest.OperationSpec = {
@@ -1809,7 +1810,7 @@ const paramDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseDurationOperationSpec: msRest.OperationSpec = {
@@ -1826,7 +1827,7 @@ const responseDurationOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramByteOperationSpec: msRest.OperationSpec = {
@@ -1842,7 +1843,7 @@ const paramByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseByteOperationSpec: msRest.OperationSpec = {
@@ -1859,7 +1860,7 @@ const responseByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const paramEnumOperationSpec: msRest.OperationSpec = {
@@ -1875,7 +1876,7 @@ const paramEnumOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const responseEnumOperationSpec: msRest.OperationSpec = {
@@ -1892,7 +1893,7 @@ const responseEnumOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const customRequestIdOperationSpec: msRest.OperationSpec = {
@@ -1904,5 +1905,5 @@ const customRequestIdOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/httpClientFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpClientFailure.ts
@@ -971,6 +971,7 @@ export class HttpClientFailure {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head400OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/failure/client/400",
@@ -979,7 +980,7 @@ const head400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get400OperationSpec: msRest.OperationSpec = {
@@ -990,7 +991,7 @@ const get400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put400OperationSpec: msRest.OperationSpec = {
@@ -1014,7 +1015,7 @@ const put400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch400OperationSpec: msRest.OperationSpec = {
@@ -1038,7 +1039,7 @@ const patch400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post400OperationSpec: msRest.OperationSpec = {
@@ -1062,7 +1063,7 @@ const post400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete400OperationSpec: msRest.OperationSpec = {
@@ -1086,7 +1087,7 @@ const delete400OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head401OperationSpec: msRest.OperationSpec = {
@@ -1097,7 +1098,7 @@ const head401OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get402OperationSpec: msRest.OperationSpec = {
@@ -1108,7 +1109,7 @@ const get402OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get403OperationSpec: msRest.OperationSpec = {
@@ -1119,7 +1120,7 @@ const get403OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put404OperationSpec: msRest.OperationSpec = {
@@ -1143,7 +1144,7 @@ const put404OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch405OperationSpec: msRest.OperationSpec = {
@@ -1167,7 +1168,7 @@ const patch405OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post406OperationSpec: msRest.OperationSpec = {
@@ -1191,7 +1192,7 @@ const post406OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete407OperationSpec: msRest.OperationSpec = {
@@ -1215,7 +1216,7 @@ const delete407OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put409OperationSpec: msRest.OperationSpec = {
@@ -1239,7 +1240,7 @@ const put409OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head410OperationSpec: msRest.OperationSpec = {
@@ -1250,7 +1251,7 @@ const head410OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get411OperationSpec: msRest.OperationSpec = {
@@ -1261,7 +1262,7 @@ const get411OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get412OperationSpec: msRest.OperationSpec = {
@@ -1272,7 +1273,7 @@ const get412OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put413OperationSpec: msRest.OperationSpec = {
@@ -1296,7 +1297,7 @@ const put413OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch414OperationSpec: msRest.OperationSpec = {
@@ -1320,7 +1321,7 @@ const patch414OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post415OperationSpec: msRest.OperationSpec = {
@@ -1344,7 +1345,7 @@ const post415OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get416OperationSpec: msRest.OperationSpec = {
@@ -1355,7 +1356,7 @@ const get416OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete417OperationSpec: msRest.OperationSpec = {
@@ -1379,7 +1380,7 @@ const delete417OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head429OperationSpec: msRest.OperationSpec = {
@@ -1390,5 +1391,5 @@ const head429OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/httpFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpFailure.ts
@@ -150,6 +150,7 @@ export class HttpFailure {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getEmptyErrorOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "http/failure/emptybody/error",
@@ -166,7 +167,7 @@ const getEmptyErrorOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNoModelErrorOperationSpec: msRest.OperationSpec = {
@@ -183,7 +184,7 @@ const getNoModelErrorOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNoModelEmptyOperationSpec: msRest.OperationSpec = {
@@ -200,5 +201,5 @@ const getNoModelEmptyOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/httpRedirects.ts
+++ b/test/vanilla/generated/Http/operations/httpRedirects.ts
@@ -649,6 +649,7 @@ export class HttpRedirects {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head300OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/redirect/300",
@@ -663,7 +664,7 @@ const head300OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get300OperationSpec: msRest.OperationSpec = {
@@ -692,7 +693,7 @@ const get300OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head301OperationSpec: msRest.OperationSpec = {
@@ -709,7 +710,7 @@ const head301OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get301OperationSpec: msRest.OperationSpec = {
@@ -726,7 +727,7 @@ const get301OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put301OperationSpec: msRest.OperationSpec = {
@@ -753,7 +754,7 @@ const put301OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head302OperationSpec: msRest.OperationSpec = {
@@ -770,7 +771,7 @@ const head302OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get302OperationSpec: msRest.OperationSpec = {
@@ -787,7 +788,7 @@ const get302OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch302OperationSpec: msRest.OperationSpec = {
@@ -814,7 +815,7 @@ const patch302OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post303OperationSpec: msRest.OperationSpec = {
@@ -844,7 +845,7 @@ const post303OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head307OperationSpec: msRest.OperationSpec = {
@@ -861,7 +862,7 @@ const head307OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get307OperationSpec: msRest.OperationSpec = {
@@ -878,7 +879,7 @@ const get307OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put307OperationSpec: msRest.OperationSpec = {
@@ -908,7 +909,7 @@ const put307OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch307OperationSpec: msRest.OperationSpec = {
@@ -938,7 +939,7 @@ const patch307OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post307OperationSpec: msRest.OperationSpec = {
@@ -968,7 +969,7 @@ const post307OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete307OperationSpec: msRest.OperationSpec = {
@@ -998,5 +999,5 @@ const delete307OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/httpRetry.ts
+++ b/test/vanilla/generated/Http/operations/httpRetry.ts
@@ -356,6 +356,7 @@ export class HttpRetry {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head408OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/retry/408",
@@ -365,7 +366,7 @@ const head408OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put500OperationSpec: msRest.OperationSpec = {
@@ -390,7 +391,7 @@ const put500OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch500OperationSpec: msRest.OperationSpec = {
@@ -415,7 +416,7 @@ const patch500OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get502OperationSpec: msRest.OperationSpec = {
@@ -427,7 +428,7 @@ const get502OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post503OperationSpec: msRest.OperationSpec = {
@@ -452,7 +453,7 @@ const post503OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete503OperationSpec: msRest.OperationSpec = {
@@ -477,7 +478,7 @@ const delete503OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put504OperationSpec: msRest.OperationSpec = {
@@ -502,7 +503,7 @@ const put504OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch504OperationSpec: msRest.OperationSpec = {
@@ -527,5 +528,5 @@ const patch504OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/httpServerFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpServerFailure.ts
@@ -192,6 +192,7 @@ export class HttpServerFailure {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head501OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/failure/server/501",
@@ -200,7 +201,7 @@ const head501OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get501OperationSpec: msRest.OperationSpec = {
@@ -211,7 +212,7 @@ const get501OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post505OperationSpec: msRest.OperationSpec = {
@@ -235,7 +236,7 @@ const post505OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete505OperationSpec: msRest.OperationSpec = {
@@ -259,5 +260,5 @@ const delete505OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/httpSuccess.ts
+++ b/test/vanilla/generated/Http/operations/httpSuccess.ts
@@ -766,6 +766,7 @@ export class HttpSuccess {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const head200OperationSpec: msRest.OperationSpec = {
   httpMethod: "HEAD",
   path: "http/success/200",
@@ -775,7 +776,7 @@ const head200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200OperationSpec: msRest.OperationSpec = {
@@ -794,7 +795,7 @@ const get200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put200OperationSpec: msRest.OperationSpec = {
@@ -819,7 +820,7 @@ const put200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch200OperationSpec: msRest.OperationSpec = {
@@ -844,7 +845,7 @@ const patch200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post200OperationSpec: msRest.OperationSpec = {
@@ -869,7 +870,7 @@ const post200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete200OperationSpec: msRest.OperationSpec = {
@@ -894,7 +895,7 @@ const delete200OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put201OperationSpec: msRest.OperationSpec = {
@@ -919,7 +920,7 @@ const put201OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post201OperationSpec: msRest.OperationSpec = {
@@ -944,7 +945,7 @@ const post201OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put202OperationSpec: msRest.OperationSpec = {
@@ -969,7 +970,7 @@ const put202OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch202OperationSpec: msRest.OperationSpec = {
@@ -994,7 +995,7 @@ const patch202OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post202OperationSpec: msRest.OperationSpec = {
@@ -1019,7 +1020,7 @@ const post202OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete202OperationSpec: msRest.OperationSpec = {
@@ -1044,7 +1045,7 @@ const delete202OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head204OperationSpec: msRest.OperationSpec = {
@@ -1056,7 +1057,7 @@ const head204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const put204OperationSpec: msRest.OperationSpec = {
@@ -1081,7 +1082,7 @@ const put204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const patch204OperationSpec: msRest.OperationSpec = {
@@ -1106,7 +1107,7 @@ const patch204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const post204OperationSpec: msRest.OperationSpec = {
@@ -1131,7 +1132,7 @@ const post204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const delete204OperationSpec: msRest.OperationSpec = {
@@ -1156,7 +1157,7 @@ const delete204OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const head404OperationSpec: msRest.OperationSpec = {
@@ -1169,5 +1170,5 @@ const head404OperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Http/operations/multipleResponses.ts
+++ b/test/vanilla/generated/Http/operations/multipleResponses.ts
@@ -1424,6 +1424,7 @@ export class MultipleResponses {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const get200Model204NoModelDefaultError200ValidOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "http/payloads/200/A/204/none/default/Error/response/200/valid",
@@ -1436,7 +1437,7 @@ const get200Model204NoModelDefaultError200ValidOperationSpec: msRest.OperationSp
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model204NoModelDefaultError204ValidOperationSpec: msRest.OperationSpec = {
@@ -1451,7 +1452,7 @@ const get200Model204NoModelDefaultError204ValidOperationSpec: msRest.OperationSp
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model204NoModelDefaultError201InvalidOperationSpec: msRest.OperationSpec = {
@@ -1466,7 +1467,7 @@ const get200Model204NoModelDefaultError201InvalidOperationSpec: msRest.Operation
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model204NoModelDefaultError202NoneOperationSpec: msRest.OperationSpec = {
@@ -1481,7 +1482,7 @@ const get200Model204NoModelDefaultError202NoneOperationSpec: msRest.OperationSpe
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model204NoModelDefaultError400ValidOperationSpec: msRest.OperationSpec = {
@@ -1496,7 +1497,7 @@ const get200Model204NoModelDefaultError400ValidOperationSpec: msRest.OperationSp
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model201ModelDefaultError200ValidOperationSpec: msRest.OperationSpec = {
@@ -1513,7 +1514,7 @@ const get200Model201ModelDefaultError200ValidOperationSpec: msRest.OperationSpec
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model201ModelDefaultError201ValidOperationSpec: msRest.OperationSpec = {
@@ -1530,7 +1531,7 @@ const get200Model201ModelDefaultError201ValidOperationSpec: msRest.OperationSpec
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200Model201ModelDefaultError400ValidOperationSpec: msRest.OperationSpec = {
@@ -1547,7 +1548,7 @@ const get200Model201ModelDefaultError400ValidOperationSpec: msRest.OperationSpec
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA201ModelC404ModelDDefaultError200ValidOperationSpec: msRest.OperationSpec = {
@@ -1567,7 +1568,7 @@ const get200ModelA201ModelC404ModelDDefaultError200ValidOperationSpec: msRest.Op
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA201ModelC404ModelDDefaultError201ValidOperationSpec: msRest.OperationSpec = {
@@ -1587,7 +1588,7 @@ const get200ModelA201ModelC404ModelDDefaultError201ValidOperationSpec: msRest.Op
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA201ModelC404ModelDDefaultError404ValidOperationSpec: msRest.OperationSpec = {
@@ -1607,7 +1608,7 @@ const get200ModelA201ModelC404ModelDDefaultError404ValidOperationSpec: msRest.Op
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA201ModelC404ModelDDefaultError400ValidOperationSpec: msRest.OperationSpec = {
@@ -1627,7 +1628,7 @@ const get200ModelA201ModelC404ModelDDefaultError400ValidOperationSpec: msRest.Op
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultError202NoneOperationSpec: msRest.OperationSpec = {
@@ -1640,7 +1641,7 @@ const get202None204NoneDefaultError202NoneOperationSpec: msRest.OperationSpec = 
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultError204NoneOperationSpec: msRest.OperationSpec = {
@@ -1653,7 +1654,7 @@ const get202None204NoneDefaultError204NoneOperationSpec: msRest.OperationSpec = 
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultError400ValidOperationSpec: msRest.OperationSpec = {
@@ -1666,7 +1667,7 @@ const get202None204NoneDefaultError400ValidOperationSpec: msRest.OperationSpec =
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultNone202InvalidOperationSpec: msRest.OperationSpec = {
@@ -1677,7 +1678,7 @@ const get202None204NoneDefaultNone202InvalidOperationSpec: msRest.OperationSpec 
     204: {},
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultNone204NoneOperationSpec: msRest.OperationSpec = {
@@ -1688,7 +1689,7 @@ const get202None204NoneDefaultNone204NoneOperationSpec: msRest.OperationSpec = {
     204: {},
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultNone400NoneOperationSpec: msRest.OperationSpec = {
@@ -1699,7 +1700,7 @@ const get202None204NoneDefaultNone400NoneOperationSpec: msRest.OperationSpec = {
     204: {},
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get202None204NoneDefaultNone400InvalidOperationSpec: msRest.OperationSpec = {
@@ -1710,7 +1711,7 @@ const get202None204NoneDefaultNone400InvalidOperationSpec: msRest.OperationSpec 
     204: {},
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultModelA200ValidOperationSpec: msRest.OperationSpec = {
@@ -1721,7 +1722,7 @@ const getDefaultModelA200ValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.A
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultModelA200NoneOperationSpec: msRest.OperationSpec = {
@@ -1732,7 +1733,7 @@ const getDefaultModelA200NoneOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.A
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultModelA400ValidOperationSpec: msRest.OperationSpec = {
@@ -1743,7 +1744,7 @@ const getDefaultModelA400ValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.A
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultModelA400NoneOperationSpec: msRest.OperationSpec = {
@@ -1754,7 +1755,7 @@ const getDefaultModelA400NoneOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.A
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultNone200InvalidOperationSpec: msRest.OperationSpec = {
@@ -1763,7 +1764,7 @@ const getDefaultNone200InvalidOperationSpec: msRest.OperationSpec = {
   responses: {
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultNone200NoneOperationSpec: msRest.OperationSpec = {
@@ -1772,7 +1773,7 @@ const getDefaultNone200NoneOperationSpec: msRest.OperationSpec = {
   responses: {
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultNone400InvalidOperationSpec: msRest.OperationSpec = {
@@ -1781,7 +1782,7 @@ const getDefaultNone400InvalidOperationSpec: msRest.OperationSpec = {
   responses: {
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDefaultNone400NoneOperationSpec: msRest.OperationSpec = {
@@ -1790,7 +1791,7 @@ const getDefaultNone400NoneOperationSpec: msRest.OperationSpec = {
   responses: {
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA200NoneOperationSpec: msRest.OperationSpec = {
@@ -1802,7 +1803,7 @@ const get200ModelA200NoneOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA200ValidOperationSpec: msRest.OperationSpec = {
@@ -1814,7 +1815,7 @@ const get200ModelA200ValidOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA200InvalidOperationSpec: msRest.OperationSpec = {
@@ -1826,7 +1827,7 @@ const get200ModelA200InvalidOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA400NoneOperationSpec: msRest.OperationSpec = {
@@ -1838,7 +1839,7 @@ const get200ModelA400NoneOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA400ValidOperationSpec: msRest.OperationSpec = {
@@ -1850,7 +1851,7 @@ const get200ModelA400ValidOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA400InvalidOperationSpec: msRest.OperationSpec = {
@@ -1862,7 +1863,7 @@ const get200ModelA400InvalidOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const get200ModelA202ValidOperationSpec: msRest.OperationSpec = {
@@ -1874,5 +1875,5 @@ const get200ModelA202ValidOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -535,6 +535,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const putArrayOperationSpec: msRest.OperationSpec = {
   httpMethod: "PUT",
   path: "model-flatten/array",
@@ -564,7 +565,7 @@ const putArrayOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getArrayOperationSpec: msRest.OperationSpec = {
@@ -590,7 +591,7 @@ const getArrayOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putWrappedArrayOperationSpec: msRest.OperationSpec = {
@@ -622,7 +623,7 @@ const putWrappedArrayOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getWrappedArrayOperationSpec: msRest.OperationSpec = {
@@ -648,7 +649,7 @@ const getWrappedArrayOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putDictionaryOperationSpec: msRest.OperationSpec = {
@@ -680,7 +681,7 @@ const putDictionaryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getDictionaryOperationSpec: msRest.OperationSpec = {
@@ -706,7 +707,7 @@ const getDictionaryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putResourceCollectionOperationSpec: msRest.OperationSpec = {
@@ -726,7 +727,7 @@ const putResourceCollectionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getResourceCollectionOperationSpec: msRest.OperationSpec = {
@@ -740,7 +741,7 @@ const getResourceCollectionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putSimpleProductOperationSpec: msRest.OperationSpec = {
@@ -762,7 +763,7 @@ const putSimpleProductOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postFlattenedSimpleProductOperationSpec: msRest.OperationSpec = {
@@ -796,7 +797,7 @@ const postFlattenedSimpleProductOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putSimpleProductWithGroupingOperationSpec: msRest.OperationSpec = {
@@ -839,7 +840,7 @@ const putSimpleProductWithGroupingOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { AutoRestResourceFlatteningTestService, Models as AutoRestResourceFlatteningTestServiceModels, Mappers as AutoRestResourceFlatteningTestServiceMappers };

--- a/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
@@ -86,6 +86,7 @@ export class AvailabilitySets {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const updateOperationSpec: msRest.OperationSpec = {
   httpMethod: "PATCH",
   path: "parameterFlattening/{resourceGroupName}/{availabilitySetName}",
@@ -107,5 +108,5 @@ const updateOperationSpec: msRest.OperationSpec = {
     200: {},
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -80,6 +80,7 @@ class AutoRestReportService extends AutoRestReportServiceContext {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getReportOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "report",
@@ -105,7 +106,7 @@ const getReportOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { AutoRestReportService, Models as AutoRestReportServiceModels, Mappers as AutoRestReportServiceMappers };

--- a/test/vanilla/generated/RequiredOptional/operations/explicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/explicit.ts
@@ -1008,6 +1008,7 @@ export class Explicit {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const postRequiredIntegerParameterOperationSpec: msRest.OperationSpec = {
   httpMethod: "POST",
   path: "reqopt/requied/integer/parameter",
@@ -1027,7 +1028,7 @@ const postRequiredIntegerParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalIntegerParameterOperationSpec: msRest.OperationSpec = {
@@ -1052,7 +1053,7 @@ const postOptionalIntegerParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredIntegerPropertyOperationSpec: msRest.OperationSpec = {
@@ -1073,7 +1074,7 @@ const postRequiredIntegerPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalIntegerPropertyOperationSpec: msRest.OperationSpec = {
@@ -1095,7 +1096,7 @@ const postOptionalIntegerPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredIntegerHeaderOperationSpec: msRest.OperationSpec = {
@@ -1109,7 +1110,7 @@ const postRequiredIntegerHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalIntegerHeaderOperationSpec: msRest.OperationSpec = {
@@ -1124,7 +1125,7 @@ const postOptionalIntegerHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredStringParameterOperationSpec: msRest.OperationSpec = {
@@ -1146,7 +1147,7 @@ const postRequiredStringParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalStringParameterOperationSpec: msRest.OperationSpec = {
@@ -1171,7 +1172,7 @@ const postOptionalStringParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredStringPropertyOperationSpec: msRest.OperationSpec = {
@@ -1192,7 +1193,7 @@ const postRequiredStringPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalStringPropertyOperationSpec: msRest.OperationSpec = {
@@ -1214,7 +1215,7 @@ const postOptionalStringPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredStringHeaderOperationSpec: msRest.OperationSpec = {
@@ -1228,7 +1229,7 @@ const postRequiredStringHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalStringHeaderOperationSpec: msRest.OperationSpec = {
@@ -1243,7 +1244,7 @@ const postOptionalStringHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredClassParameterOperationSpec: msRest.OperationSpec = {
@@ -1262,7 +1263,7 @@ const postRequiredClassParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalClassParameterOperationSpec: msRest.OperationSpec = {
@@ -1282,7 +1283,7 @@ const postOptionalClassParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredClassPropertyOperationSpec: msRest.OperationSpec = {
@@ -1303,7 +1304,7 @@ const postRequiredClassPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalClassPropertyOperationSpec: msRest.OperationSpec = {
@@ -1325,7 +1326,7 @@ const postOptionalClassPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredArrayParameterOperationSpec: msRest.OperationSpec = {
@@ -1353,7 +1354,7 @@ const postRequiredArrayParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalArrayParameterOperationSpec: msRest.OperationSpec = {
@@ -1384,7 +1385,7 @@ const postOptionalArrayParameterOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredArrayPropertyOperationSpec: msRest.OperationSpec = {
@@ -1405,7 +1406,7 @@ const postRequiredArrayPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalArrayPropertyOperationSpec: msRest.OperationSpec = {
@@ -1427,7 +1428,7 @@ const postOptionalArrayPropertyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postRequiredArrayHeaderOperationSpec: msRest.OperationSpec = {
@@ -1441,7 +1442,7 @@ const postRequiredArrayHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postOptionalArrayHeaderOperationSpec: msRest.OperationSpec = {
@@ -1456,5 +1457,5 @@ const postOptionalArrayHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/RequiredOptional/operations/implicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/implicit.ts
@@ -321,6 +321,7 @@ export class Implicit {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getRequiredPathOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "reqopt/implicit/required/path/{pathParameter}",
@@ -332,7 +333,7 @@ const getRequiredPathOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putOptionalQueryOperationSpec: msRest.OperationSpec = {
@@ -347,7 +348,7 @@ const putOptionalQueryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putOptionalHeaderOperationSpec: msRest.OperationSpec = {
@@ -362,7 +363,7 @@ const putOptionalHeaderOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const putOptionalBodyOperationSpec: msRest.OperationSpec = {
@@ -387,7 +388,7 @@ const putOptionalBodyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getRequiredGlobalPathOperationSpec: msRest.OperationSpec = {
@@ -401,7 +402,7 @@ const getRequiredGlobalPathOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getRequiredGlobalQueryOperationSpec: msRest.OperationSpec = {
@@ -415,7 +416,7 @@ const getRequiredGlobalQueryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getOptionalGlobalQueryOperationSpec: msRest.OperationSpec = {
@@ -429,5 +430,5 @@ const getOptionalGlobalQueryOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Url/operations/pathItems.ts
+++ b/test/vanilla/generated/Url/operations/pathItems.ts
@@ -249,6 +249,7 @@ export class PathItems {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getAllWithValuesOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery",
@@ -268,7 +269,7 @@ const getAllWithValuesOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getGlobalQueryNullOperationSpec: msRest.OperationSpec = {
@@ -290,7 +291,7 @@ const getGlobalQueryNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getGlobalAndLocalQueryNullOperationSpec: msRest.OperationSpec = {
@@ -312,7 +313,7 @@ const getGlobalAndLocalQueryNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLocalPathItemQueryNullOperationSpec: msRest.OperationSpec = {
@@ -334,5 +335,5 @@ const getLocalPathItemQueryNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Url/operations/paths.ts
+++ b/test/vanilla/generated/Url/operations/paths.ts
@@ -1155,6 +1155,7 @@ export class Paths {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getBooleanTrueOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "paths/bool/true/{boolPath}",
@@ -1167,7 +1168,7 @@ const getBooleanTrueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanFalseOperationSpec: msRest.OperationSpec = {
@@ -1182,7 +1183,7 @@ const getBooleanFalseOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntOneMillionOperationSpec: msRest.OperationSpec = {
@@ -1197,7 +1198,7 @@ const getIntOneMillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntNegativeOneMillionOperationSpec: msRest.OperationSpec = {
@@ -1212,7 +1213,7 @@ const getIntNegativeOneMillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getTenBillionOperationSpec: msRest.OperationSpec = {
@@ -1227,7 +1228,7 @@ const getTenBillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNegativeTenBillionOperationSpec: msRest.OperationSpec = {
@@ -1242,7 +1243,7 @@ const getNegativeTenBillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const floatScientificPositiveOperationSpec: msRest.OperationSpec = {
@@ -1257,7 +1258,7 @@ const floatScientificPositiveOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const floatScientificNegativeOperationSpec: msRest.OperationSpec = {
@@ -1272,7 +1273,7 @@ const floatScientificNegativeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const doubleDecimalPositiveOperationSpec: msRest.OperationSpec = {
@@ -1287,7 +1288,7 @@ const doubleDecimalPositiveOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const doubleDecimalNegativeOperationSpec: msRest.OperationSpec = {
@@ -1302,7 +1303,7 @@ const doubleDecimalNegativeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringUnicodeOperationSpec: msRest.OperationSpec = {
@@ -1317,7 +1318,7 @@ const stringUnicodeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringUrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -1332,7 +1333,7 @@ const stringUrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringEmptyOperationSpec: msRest.OperationSpec = {
@@ -1347,7 +1348,7 @@ const stringEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringNullOperationSpec: msRest.OperationSpec = {
@@ -1362,7 +1363,7 @@ const stringNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const enumValidOperationSpec: msRest.OperationSpec = {
@@ -1377,7 +1378,7 @@ const enumValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const enumNullOperationSpec: msRest.OperationSpec = {
@@ -1392,7 +1393,7 @@ const enumNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const byteMultiByteOperationSpec: msRest.OperationSpec = {
@@ -1407,7 +1408,7 @@ const byteMultiByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const byteEmptyOperationSpec: msRest.OperationSpec = {
@@ -1422,7 +1423,7 @@ const byteEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const byteNullOperationSpec: msRest.OperationSpec = {
@@ -1437,7 +1438,7 @@ const byteNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateValidOperationSpec: msRest.OperationSpec = {
@@ -1452,7 +1453,7 @@ const dateValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateNullOperationSpec: msRest.OperationSpec = {
@@ -1467,7 +1468,7 @@ const dateNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateTimeValidOperationSpec: msRest.OperationSpec = {
@@ -1482,7 +1483,7 @@ const dateTimeValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateTimeNullOperationSpec: msRest.OperationSpec = {
@@ -1497,7 +1498,7 @@ const dateTimeNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const base64UrlOperationSpec: msRest.OperationSpec = {
@@ -1512,7 +1513,7 @@ const base64UrlOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayCsvInPathOperationSpec: msRest.OperationSpec = {
@@ -1527,7 +1528,7 @@ const arrayCsvInPathOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const unixTimeUrlOperationSpec: msRest.OperationSpec = {
@@ -1542,5 +1543,5 @@ const unixTimeUrlOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Url/operations/queries.ts
+++ b/test/vanilla/generated/Url/operations/queries.ts
@@ -1431,6 +1431,7 @@ export class Queries {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const getBooleanTrueOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "queries/bool/true",
@@ -1443,7 +1444,7 @@ const getBooleanTrueOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanFalseOperationSpec: msRest.OperationSpec = {
@@ -1458,7 +1459,7 @@ const getBooleanFalseOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getBooleanNullOperationSpec: msRest.OperationSpec = {
@@ -1473,7 +1474,7 @@ const getBooleanNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntOneMillionOperationSpec: msRest.OperationSpec = {
@@ -1488,7 +1489,7 @@ const getIntOneMillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntNegativeOneMillionOperationSpec: msRest.OperationSpec = {
@@ -1503,7 +1504,7 @@ const getIntNegativeOneMillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getIntNullOperationSpec: msRest.OperationSpec = {
@@ -1518,7 +1519,7 @@ const getIntNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getTenBillionOperationSpec: msRest.OperationSpec = {
@@ -1533,7 +1534,7 @@ const getTenBillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getNegativeTenBillionOperationSpec: msRest.OperationSpec = {
@@ -1548,7 +1549,7 @@ const getNegativeTenBillionOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getLongNullOperationSpec: msRest.OperationSpec = {
@@ -1563,7 +1564,7 @@ const getLongNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const floatScientificPositiveOperationSpec: msRest.OperationSpec = {
@@ -1578,7 +1579,7 @@ const floatScientificPositiveOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const floatScientificNegativeOperationSpec: msRest.OperationSpec = {
@@ -1593,7 +1594,7 @@ const floatScientificNegativeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const floatNullOperationSpec: msRest.OperationSpec = {
@@ -1608,7 +1609,7 @@ const floatNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const doubleDecimalPositiveOperationSpec: msRest.OperationSpec = {
@@ -1623,7 +1624,7 @@ const doubleDecimalPositiveOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const doubleDecimalNegativeOperationSpec: msRest.OperationSpec = {
@@ -1638,7 +1639,7 @@ const doubleDecimalNegativeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const doubleNullOperationSpec: msRest.OperationSpec = {
@@ -1653,7 +1654,7 @@ const doubleNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringUnicodeOperationSpec: msRest.OperationSpec = {
@@ -1668,7 +1669,7 @@ const stringUnicodeOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringUrlEncodedOperationSpec: msRest.OperationSpec = {
@@ -1683,7 +1684,7 @@ const stringUrlEncodedOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringEmptyOperationSpec: msRest.OperationSpec = {
@@ -1698,7 +1699,7 @@ const stringEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const stringNullOperationSpec: msRest.OperationSpec = {
@@ -1713,7 +1714,7 @@ const stringNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const enumValidOperationSpec: msRest.OperationSpec = {
@@ -1728,7 +1729,7 @@ const enumValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const enumNullOperationSpec: msRest.OperationSpec = {
@@ -1743,7 +1744,7 @@ const enumNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const byteMultiByteOperationSpec: msRest.OperationSpec = {
@@ -1758,7 +1759,7 @@ const byteMultiByteOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const byteEmptyOperationSpec: msRest.OperationSpec = {
@@ -1773,7 +1774,7 @@ const byteEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const byteNullOperationSpec: msRest.OperationSpec = {
@@ -1788,7 +1789,7 @@ const byteNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateValidOperationSpec: msRest.OperationSpec = {
@@ -1803,7 +1804,7 @@ const dateValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateNullOperationSpec: msRest.OperationSpec = {
@@ -1818,7 +1819,7 @@ const dateNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateTimeValidOperationSpec: msRest.OperationSpec = {
@@ -1833,7 +1834,7 @@ const dateTimeValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const dateTimeNullOperationSpec: msRest.OperationSpec = {
@@ -1848,7 +1849,7 @@ const dateTimeNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringCsvValidOperationSpec: msRest.OperationSpec = {
@@ -1863,7 +1864,7 @@ const arrayStringCsvValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringCsvNullOperationSpec: msRest.OperationSpec = {
@@ -1878,7 +1879,7 @@ const arrayStringCsvNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringCsvEmptyOperationSpec: msRest.OperationSpec = {
@@ -1893,7 +1894,7 @@ const arrayStringCsvEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringSsvValidOperationSpec: msRest.OperationSpec = {
@@ -1908,7 +1909,7 @@ const arrayStringSsvValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringTsvValidOperationSpec: msRest.OperationSpec = {
@@ -1923,7 +1924,7 @@ const arrayStringTsvValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringPipesValidOperationSpec: msRest.OperationSpec = {
@@ -1938,5 +1939,5 @@ const arrayStringPipesValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
@@ -154,6 +154,7 @@ export class Queries {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const arrayStringMultiNullOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "queries/array/multi/string/null",
@@ -166,7 +167,7 @@ const arrayStringMultiNullOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringMultiEmptyOperationSpec: msRest.OperationSpec = {
@@ -181,7 +182,7 @@ const arrayStringMultiEmptyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const arrayStringMultiValidOperationSpec: msRest.OperationSpec = {
@@ -196,5 +197,5 @@ const arrayStringMultiValidOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -224,6 +224,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers);
 const validationOfMethodParametersOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "fakepath/{subscriptionId}/{resourceGroupName}/{id}",
@@ -243,7 +244,7 @@ const validationOfMethodParametersOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const validationOfBodyOperationSpec: msRest.OperationSpec = {
@@ -273,7 +274,7 @@ const validationOfBodyOperationSpec: msRest.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const getWithConstantInPathOperationSpec: msRest.OperationSpec = {
@@ -286,7 +287,7 @@ const getWithConstantInPathOperationSpec: msRest.OperationSpec = {
     200: {},
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 const postWithConstantInBodyOperationSpec: msRest.OperationSpec = {
@@ -309,7 +310,7 @@ const postWithConstantInBodyOperationSpec: msRest.OperationSpec = {
     },
     default: {}
   },
-  serializer: new msRest.Serializer(Mappers)
+  serializer
 };
 
 export { AutoRestValidationTest, Models as AutoRestValidationTestModels, Mappers as AutoRestValidationTestMappers };

--- a/test/xml/generated/Xml/operations/xml.ts
+++ b/test/xml/generated/Xml/operations/xml.ts
@@ -1196,6 +1196,7 @@ export class Xml {
 }
 
 // Operation Specifications
+const serializer = new msRest.Serializer(Mappers, true);
 const getComplexTypeRefNoMetaOperationSpec: msRest.OperationSpec = {
   httpMethod: "GET",
   path: "xml/complex-type-ref-no-meta",
@@ -1206,7 +1207,7 @@ const getComplexTypeRefNoMetaOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putComplexTypeRefNoMetaOperationSpec: msRest.OperationSpec = {
@@ -1225,7 +1226,7 @@ const putComplexTypeRefNoMetaOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getComplexTypeRefWithMetaOperationSpec: msRest.OperationSpec = {
@@ -1238,7 +1239,7 @@ const getComplexTypeRefWithMetaOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putComplexTypeRefWithMetaOperationSpec: msRest.OperationSpec = {
@@ -1257,7 +1258,7 @@ const putComplexTypeRefWithMetaOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getSimpleOperationSpec: msRest.OperationSpec = {
@@ -1272,7 +1273,7 @@ const getSimpleOperationSpec: msRest.OperationSpec = {
     }
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putSimpleOperationSpec: msRest.OperationSpec = {
@@ -1293,7 +1294,7 @@ const putSimpleOperationSpec: msRest.OperationSpec = {
     }
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getWrappedListsOperationSpec: msRest.OperationSpec = {
@@ -1306,7 +1307,7 @@ const getWrappedListsOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putWrappedListsOperationSpec: msRest.OperationSpec = {
@@ -1327,7 +1328,7 @@ const putWrappedListsOperationSpec: msRest.OperationSpec = {
     }
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getHeadersOperationSpec: msRest.OperationSpec = {
@@ -1340,7 +1341,7 @@ const getHeadersOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getEmptyListOperationSpec: msRest.OperationSpec = {
@@ -1353,7 +1354,7 @@ const getEmptyListOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putEmptyListOperationSpec: msRest.OperationSpec = {
@@ -1372,7 +1373,7 @@ const putEmptyListOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getEmptyWrappedListsOperationSpec: msRest.OperationSpec = {
@@ -1385,7 +1386,7 @@ const getEmptyWrappedListsOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putEmptyWrappedListsOperationSpec: msRest.OperationSpec = {
@@ -1404,7 +1405,7 @@ const putEmptyWrappedListsOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getRootListOperationSpec: msRest.OperationSpec = {
@@ -1430,7 +1431,7 @@ const getRootListOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putRootListOperationSpec: msRest.OperationSpec = {
@@ -1460,7 +1461,7 @@ const putRootListOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getRootListSingleItemOperationSpec: msRest.OperationSpec = {
@@ -1486,7 +1487,7 @@ const getRootListSingleItemOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putRootListSingleItemOperationSpec: msRest.OperationSpec = {
@@ -1516,7 +1517,7 @@ const putRootListSingleItemOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getEmptyRootListOperationSpec: msRest.OperationSpec = {
@@ -1542,7 +1543,7 @@ const getEmptyRootListOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putEmptyRootListOperationSpec: msRest.OperationSpec = {
@@ -1572,7 +1573,7 @@ const putEmptyRootListOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getEmptyChildElementOperationSpec: msRest.OperationSpec = {
@@ -1585,7 +1586,7 @@ const getEmptyChildElementOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putEmptyChildElementOperationSpec: msRest.OperationSpec = {
@@ -1604,7 +1605,7 @@ const putEmptyChildElementOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const listContainersOperationSpec: msRest.OperationSpec = {
@@ -1620,7 +1621,7 @@ const listContainersOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getServicePropertiesOperationSpec: msRest.OperationSpec = {
@@ -1637,7 +1638,7 @@ const getServicePropertiesOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putServicePropertiesOperationSpec: msRest.OperationSpec = {
@@ -1660,7 +1661,7 @@ const putServicePropertiesOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const getAclsOperationSpec: msRest.OperationSpec = {
@@ -1690,7 +1691,7 @@ const getAclsOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const putAclsOperationSpec: msRest.OperationSpec = {
@@ -1725,7 +1726,7 @@ const putAclsOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };
 
 const listBlobsOperationSpec: msRest.OperationSpec = {
@@ -1742,5 +1743,5 @@ const listBlobsOperationSpec: msRest.OperationSpec = {
     default: {}
   },
   isXML: true,
-  serializer: new msRest.Serializer(Mappers, true)
+  serializer
 };


### PR DESCRIPTION
Reduces redundancy and overhead a bit by sharing one serializer instance between operation specs in the same module.