### PR TITLE
Export context

### DIFF
--- a/src/DSL/TSBuilder.cs
+++ b/src/DSL/TSBuilder.cs
@@ -619,7 +619,7 @@ namespace AutoRest.TypeScript.DSL
 
         public void Export(Action<TSExport> exportAction)
         {
-            Text($"export {{");
+            Line($"export {{");
             Indent(() =>
             {
                 using (TSExport tsExport = new TSExport(this))
@@ -627,7 +627,15 @@ namespace AutoRest.TypeScript.DSL
                     exportAction.Invoke(tsExport);
                 }
             });
-            Text($"}};");
+            Line($"}};");
+        }
+
+        /// <summary>
+        /// Exports all the exports from the given module.
+        /// </summary>
+        public void ExportAll(string modulePath)
+        {
+            Line($"export * from \"{modulePath}\";");
         }
     }
 }

--- a/src/DSL/TSBuilder.cs
+++ b/src/DSL/TSBuilder.cs
@@ -616,5 +616,18 @@ namespace AutoRest.TypeScript.DSL
         {
             Line($"import {{ {string.Join(", ", importedTypeNames)} }} from \"{importSource}\";");
         }
+
+        public void Export(Action<TSExport> exportAction)
+        {
+            Text($"export {{");
+            Indent(() =>
+            {
+                using (TSExport tsExport = new TSExport(this))
+                {
+                    exportAction.Invoke(tsExport);
+                }
+            });
+            Text($"}};");
+        }
     }
 }

--- a/src/DSL/TSExport.cs
+++ b/src/DSL/TSExport.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+//
+
+using System;
+using System.Collections.Generic;
+
+namespace AutoRest.TypeScript.DSL
+{
+    /// <summary>
+    /// A TypeScript DSL representation for an ESM export block.
+    /// </summary>
+    public class TSExport : IDisposable
+    {
+        private readonly TSBuilder builder;
+        private string propertyBeingConstructed;
+        private State currentState = State.Start;
+
+        private enum State
+        {
+            Start,
+            Property
+        }
+
+        /// <summary>
+        /// Create a new export object.
+        /// </summary>
+        /// <param name="builder">The TSBuilder that this TSExport will emit to.</param>
+        public TSExport(TSBuilder builder)
+        {
+            this.builder = builder;
+        }
+
+        /// <summary>
+        /// Set the current state of this TSExport. Changing the state may add "\n" or ",\n".
+        /// </summary>
+        /// <param name="value"></param>
+        private void SetCurrentState(State value)
+        {
+            switch (currentState)
+            {
+                case State.Start:
+                    builder.Line();
+                    break;
+
+                case State.Property:
+                    builder.Line(",");
+                    break;
+
+                default:
+                    throw new Exception($"Unrecognized current state: {currentState}");
+            }
+
+            currentState = value;
+        }
+
+        /// <summary>
+        /// Mark the end of this TSExport. If the current state is not Start, then a newline will be added.
+        /// </summary>
+        public void Dispose()
+        {
+            if (currentState != State.Start)
+            {
+                builder.Line();
+            }
+        }
+
+        /// <summary>
+        /// Exports the provided name in this TSExport block.
+        /// </summary>
+        /// <param name="name">The name of the variable to export.</param>
+        public void Export(string name)
+        {
+            SetCurrentState(State.Property);
+            builder.Text(name);
+        }
+
+        /// <summary>
+        /// Exports the given name under the given alias in this TSExport block.
+        /// </summary>
+        /// <param name="name">The name of the variable to export.</param>
+        /// <param name="name">The alias to expose to consumers of this module.</param>
+        public void ExportAs(string name, string alias)
+        {
+            SetCurrentState(State.Property);
+            builder.Text($"{name} as {alias}");
+        }
+    }
+}

--- a/src/DSL/TSExport.cs
+++ b/src/DSL/TSExport.cs
@@ -13,7 +13,6 @@ namespace AutoRest.TypeScript.DSL
     public class TSExport : IDisposable
     {
         private readonly TSBuilder builder;
-        private string propertyBeingConstructed;
         private State currentState = State.Start;
 
         private enum State

--- a/src/azure/Templates/AzureMapperIndexTemplate.cshtml
+++ b/src/azure/Templates/AzureMapperIndexTemplate.cshtml
@@ -8,7 +8,7 @@
 @Header(" * ")
  */
 @EmptyLine
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 @if (Model.OrderedModelTemplateModels.Any())
 {
 @:import * as msRest from "ms-rest-js";

--- a/src/azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/azure/Templates/AzureServiceClientTemplate.cshtml
@@ -79,4 +79,4 @@ foreach (var methodGroup in Model.MethodGroupModels)
 @EmptyLine
 @(Model.GenerateOperationSpecDefinitions(EmptyLine))
 @EmptyLine
-export { @(Model.Name), Models as @(Model.ClientPrefix)Models, Mappers as @(Model.ClientPrefix)Mappers };
+@(Model.GenerateServiceClientExports())

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -565,5 +565,22 @@ namespace AutoRest.TypeScript.Model
 
             return builder.ToString();
         }
+
+        public string GenerateServiceClientExports()
+        {
+            TSBuilder builder = new TSBuilder();
+            builder.Export(exports =>
+            {
+                exports.Export(Name);
+                exports.Export(ContextName);
+                exports.ExportAs("Models", $"{ClientPrefix}Models");
+                exports.ExportAs("Mappers", $"{ClientPrefix}Mappers");
+                if (MethodGroupModels.Any())
+                {
+                    exports.ExportAs("operations", $"{ClientPrefix}Operations");
+                }
+            });
+            return builder.ToString();
+        }
     }
 }

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -575,11 +575,12 @@ namespace AutoRest.TypeScript.Model
                 exports.Export(ContextName);
                 exports.ExportAs("Models", $"{ClientPrefix}Models");
                 exports.ExportAs("Mappers", $"{ClientPrefix}Mappers");
-                if (MethodGroupModels.Any())
-                {
-                    exports.ExportAs("operations", $"{ClientPrefix}Operations");
-                }
             });
+
+            if (MethodGroupModels.Any())
+            {
+                builder.ExportAll("./operations");
+            }
             return builder.ToString();
         }
     }

--- a/src/vanilla/Templates/MethodGroupIndexTemplate.cshtml
+++ b/src/vanilla/Templates/MethodGroupIndexTemplate.cshtml
@@ -7,7 +7,5 @@
 @EmptyLine
 @foreach (var methodGroup in Model.MethodGroupModels)
 {
-@:import { @(methodGroup.TypeName) } from "./@(methodGroup.TypeName.ToCamelCase())";
+@:export * from "./@(methodGroup.TypeName.ToCamelCase())";
 }
-@EmptyLine
-export { @WrapComment("", Model.ExportMethodGroupNames()) };

--- a/src/vanilla/Templates/ServiceClientTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientTemplate.cshtml
@@ -82,4 +82,4 @@ foreach (var method in Model.MethodWrappableTemplateModels)
 @EmptyLine
 @(Model.GenerateOperationSpecDefinitions(EmptyLine))
 @EmptyLine
-export { @(Model.Name), Models as @(Model.ClientPrefix)Models, Mappers as @(Model.ClientPrefix)Mappers };
+@(Model.GenerateServiceClientExports())

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -337,6 +337,6 @@ export {
   AzureCompositeModel,
   AzureCompositeModelContext,
   Models as AzureCompositeModelModels,
-  Mappers as AzureCompositeModelMappers,
-  operations as AzureCompositeModelOperations
+  Mappers as AzureCompositeModelMappers
 };
+export * from "./operations";

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -333,4 +333,10 @@ const updateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AzureCompositeModel, Models as AzureCompositeModelModels, Mappers as AzureCompositeModelMappers };
+export {
+  AzureCompositeModel,
+  AzureCompositeModelContext,
+  Models as AzureCompositeModelModels,
+  Mappers as AzureCompositeModelMappers,
+  operations as AzureCompositeModelOperations
+};

--- a/test/azure/generated/AzureCompositeModelClient/models/mappers.ts
+++ b/test/azure/generated/AzureCompositeModelClient/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/AzureCompositeModelClient/operations/index.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/index.ts
@@ -8,15 +8,12 @@
  * regenerated.
  */
 
-import { BasicOperations } from "./basicOperations";
-import { Primitive } from "./primitive";
-import { ArrayModel } from "./arrayModel";
-import { Dictionary } from "./dictionary";
-import { Inheritance } from "./inheritance";
-import { Polymorphism } from "./polymorphism";
-import { Polymorphicrecursive } from "./polymorphicrecursive";
-import { Readonlyproperty } from "./readonlyproperty";
-import { Flattencomplex } from "./flattencomplex";
-
-export { BasicOperations, Primitive, ArrayModel, Dictionary, Inheritance, Polymorphism,
-Polymorphicrecursive, Readonlyproperty, Flattencomplex };
+export * from "./basicOperations";
+export * from "./primitive";
+export * from "./arrayModel";
+export * from "./dictionary";
+export * from "./inheritance";
+export * from "./polymorphism";
+export * from "./polymorphicrecursive";
+export * from "./readonlyproperty";
+export * from "./flattencomplex";

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
@@ -57,6 +57,6 @@ export {
   AutoRestParameterGroupingTestService,
   AutoRestParameterGroupingTestServiceContext,
   Models as AutoRestParameterGroupingTestServiceModels,
-  Mappers as AutoRestParameterGroupingTestServiceMappers,
-  operations as AutoRestParameterGroupingTestServiceOperations
+  Mappers as AutoRestParameterGroupingTestServiceMappers
 };
+export * from "./operations";

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
@@ -53,4 +53,10 @@ class AutoRestParameterGroupingTestService extends AutoRestParameterGroupingTest
 
 // Operation Specifications
 
-export { AutoRestParameterGroupingTestService, Models as AutoRestParameterGroupingTestServiceModels, Mappers as AutoRestParameterGroupingTestServiceMappers };
+export {
+  AutoRestParameterGroupingTestService,
+  AutoRestParameterGroupingTestServiceContext,
+  Models as AutoRestParameterGroupingTestServiceModels,
+  Mappers as AutoRestParameterGroupingTestServiceMappers,
+  operations as AutoRestParameterGroupingTestServiceOperations
+};

--- a/test/azure/generated/AzureParameterGrouping/models/mappers.ts
+++ b/test/azure/generated/AzureParameterGrouping/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/AzureParameterGrouping/operations/index.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { ParameterGrouping } from "./parameterGrouping";
-
-export { ParameterGrouping };
+export * from "./parameterGrouping";

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -121,4 +121,9 @@ const getReportOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AutoRestReportServiceForAzure, Models as AutoRestReportServiceForAzureModels, Mappers as AutoRestReportServiceForAzureMappers };
+export {
+  AutoRestReportServiceForAzure,
+  AutoRestReportServiceForAzureContext,
+  Models as AutoRestReportServiceForAzureModels,
+  Mappers as AutoRestReportServiceForAzureMappers
+};

--- a/test/azure/generated/AzureReport/models/mappers.ts
+++ b/test/azure/generated/AzureReport/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -468,4 +468,9 @@ const getResourceCollectionOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AutoRestResourceFlatteningTestService, Models as AutoRestResourceFlatteningTestServiceModels, Mappers as AutoRestResourceFlatteningTestServiceMappers };
+export {
+  AutoRestResourceFlatteningTestService,
+  AutoRestResourceFlatteningTestServiceContext,
+  Models as AutoRestResourceFlatteningTestServiceModels,
+  Mappers as AutoRestResourceFlatteningTestServiceMappers
+};

--- a/test/azure/generated/AzureResource/models/mappers.ts
+++ b/test/azure/generated/AzureResource/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
@@ -73,6 +73,6 @@ export {
   AutoRestAzureSpecialParametersTestClient,
   AutoRestAzureSpecialParametersTestClientContext,
   Models as AutoRestAzureSpecialParametersTestModels,
-  Mappers as AutoRestAzureSpecialParametersTestMappers,
-  operations as AutoRestAzureSpecialParametersTestOperations
+  Mappers as AutoRestAzureSpecialParametersTestMappers
 };
+export * from "./operations";

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
@@ -69,4 +69,10 @@ class AutoRestAzureSpecialParametersTestClient extends AutoRestAzureSpecialParam
 
 // Operation Specifications
 
-export { AutoRestAzureSpecialParametersTestClient, Models as AutoRestAzureSpecialParametersTestModels, Mappers as AutoRestAzureSpecialParametersTestMappers };
+export {
+  AutoRestAzureSpecialParametersTestClient,
+  AutoRestAzureSpecialParametersTestClientContext,
+  Models as AutoRestAzureSpecialParametersTestModels,
+  Mappers as AutoRestAzureSpecialParametersTestMappers,
+  operations as AutoRestAzureSpecialParametersTestOperations
+};

--- a/test/azure/generated/AzureSpecials/models/mappers.ts
+++ b/test/azure/generated/AzureSpecials/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/AzureSpecials/operations/index.ts
+++ b/test/azure/generated/AzureSpecials/operations/index.ts
@@ -8,14 +8,11 @@
  * regenerated.
  */
 
-import { XMsClientRequestId } from "./xMsClientRequestId";
-import { SubscriptionInCredentials } from "./subscriptionInCredentials";
-import { SubscriptionInMethod } from "./subscriptionInMethod";
-import { ApiVersionDefault } from "./apiVersionDefault";
-import { ApiVersionLocal } from "./apiVersionLocal";
-import { SkipUrlEncoding } from "./skipUrlEncoding";
-import { Odata } from "./odata";
-import { Header } from "./header";
-
-export { XMsClientRequestId, SubscriptionInCredentials, SubscriptionInMethod,
-ApiVersionDefault, ApiVersionLocal, SkipUrlEncoding, Odata, Header };
+export * from "./xMsClientRequestId";
+export * from "./subscriptionInCredentials";
+export * from "./subscriptionInMethod";
+export * from "./apiVersionDefault";
+export * from "./apiVersionLocal";
+export * from "./skipUrlEncoding";
+export * from "./odata";
+export * from "./header";

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -56,6 +56,6 @@ export {
   AutoRestParameterizedHostTestClient,
   AutoRestParameterizedHostTestClientContext,
   Models as AutoRestParameterizedHostTestModels,
-  Mappers as AutoRestParameterizedHostTestMappers,
-  operations as AutoRestParameterizedHostTestOperations
+  Mappers as AutoRestParameterizedHostTestMappers
 };
+export * from "./operations";

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -52,4 +52,10 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
 
 // Operation Specifications
 
-export { AutoRestParameterizedHostTestClient, Models as AutoRestParameterizedHostTestModels, Mappers as AutoRestParameterizedHostTestMappers };
+export {
+  AutoRestParameterizedHostTestClient,
+  AutoRestParameterizedHostTestClientContext,
+  Models as AutoRestParameterizedHostTestModels,
+  Mappers as AutoRestParameterizedHostTestMappers,
+  operations as AutoRestParameterizedHostTestOperations
+};

--- a/test/azure/generated/CustomBaseUri/models/mappers.ts
+++ b/test/azure/generated/CustomBaseUri/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/CustomBaseUri/operations/index.ts
+++ b/test/azure/generated/CustomBaseUri/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Paths } from "./paths";
-
-export { Paths };
+export * from "./paths";

--- a/test/azure/generated/Head/autoRestHeadTestService.ts
+++ b/test/azure/generated/Head/autoRestHeadTestService.ts
@@ -57,6 +57,6 @@ export {
   AutoRestHeadTestService,
   AutoRestHeadTestServiceContext,
   Models as AutoRestHeadTestServiceModels,
-  Mappers as AutoRestHeadTestServiceMappers,
-  operations as AutoRestHeadTestServiceOperations
+  Mappers as AutoRestHeadTestServiceMappers
 };
+export * from "./operations";

--- a/test/azure/generated/Head/autoRestHeadTestService.ts
+++ b/test/azure/generated/Head/autoRestHeadTestService.ts
@@ -53,4 +53,10 @@ class AutoRestHeadTestService extends AutoRestHeadTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestHeadTestService, Models as AutoRestHeadTestServiceModels, Mappers as AutoRestHeadTestServiceMappers };
+export {
+  AutoRestHeadTestService,
+  AutoRestHeadTestServiceContext,
+  Models as AutoRestHeadTestServiceModels,
+  Mappers as AutoRestHeadTestServiceMappers,
+  operations as AutoRestHeadTestServiceOperations
+};

--- a/test/azure/generated/Head/models/mappers.ts
+++ b/test/azure/generated/Head/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;

--- a/test/azure/generated/Head/operations/index.ts
+++ b/test/azure/generated/Head/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { HttpSuccess } from "./httpSuccess";
-
-export { HttpSuccess };
+export * from "./httpSuccess";

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
@@ -57,6 +57,6 @@ export {
   AutoRestHeadExceptionTestService,
   AutoRestHeadExceptionTestServiceContext,
   Models as AutoRestHeadExceptionTestServiceModels,
-  Mappers as AutoRestHeadExceptionTestServiceMappers,
-  operations as AutoRestHeadExceptionTestServiceOperations
+  Mappers as AutoRestHeadExceptionTestServiceMappers
 };
+export * from "./operations";

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
@@ -53,4 +53,10 @@ class AutoRestHeadExceptionTestService extends AutoRestHeadExceptionTestServiceC
 
 // Operation Specifications
 
-export { AutoRestHeadExceptionTestService, Models as AutoRestHeadExceptionTestServiceModels, Mappers as AutoRestHeadExceptionTestServiceMappers };
+export {
+  AutoRestHeadExceptionTestService,
+  AutoRestHeadExceptionTestServiceContext,
+  Models as AutoRestHeadExceptionTestServiceModels,
+  Mappers as AutoRestHeadExceptionTestServiceMappers,
+  operations as AutoRestHeadExceptionTestServiceOperations
+};

--- a/test/azure/generated/HeadExceptions/models/mappers.ts
+++ b/test/azure/generated/HeadExceptions/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 
 export const CloudError = CloudErrorMapper;
 export const BaseResource = BaseResourceMapper;

--- a/test/azure/generated/HeadExceptions/operations/index.ts
+++ b/test/azure/generated/HeadExceptions/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { HeadException } from "./headException";
-
-export { HeadException };
+export * from "./headException";

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
@@ -59,4 +59,10 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
 
 // Operation Specifications
 
-export { AutoRestLongRunningOperationTestService, Models as AutoRestLongRunningOperationTestServiceModels, Mappers as AutoRestLongRunningOperationTestServiceMappers };
+export {
+  AutoRestLongRunningOperationTestService,
+  AutoRestLongRunningOperationTestServiceContext,
+  Models as AutoRestLongRunningOperationTestServiceModels,
+  Mappers as AutoRestLongRunningOperationTestServiceMappers,
+  operations as AutoRestLongRunningOperationTestServiceOperations
+};

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
@@ -63,6 +63,6 @@ export {
   AutoRestLongRunningOperationTestService,
   AutoRestLongRunningOperationTestServiceContext,
   Models as AutoRestLongRunningOperationTestServiceModels,
-  Mappers as AutoRestLongRunningOperationTestServiceMappers,
-  operations as AutoRestLongRunningOperationTestServiceOperations
+  Mappers as AutoRestLongRunningOperationTestServiceMappers
 };
+export * from "./operations";

--- a/test/azure/generated/Lro/models/mappers.ts
+++ b/test/azure/generated/Lro/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/Lro/operations/index.ts
+++ b/test/azure/generated/Lro/operations/index.ts
@@ -8,9 +8,7 @@
  * regenerated.
  */
 
-import { LROs } from "./lROs";
-import { LRORetrys } from "./lRORetrys";
-import { LROSADs } from "./lROSADs";
-import { LROsCustomHeader } from "./lROsCustomHeader";
-
-export { LROs, LRORetrys, LROSADs, LROsCustomHeader };
+export * from "./lROs";
+export * from "./lRORetrys";
+export * from "./lROSADs";
+export * from "./lROsCustomHeader";

--- a/test/azure/generated/Paging/autoRestPagingTestService.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestService.ts
@@ -53,4 +53,10 @@ class AutoRestPagingTestService extends AutoRestPagingTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestPagingTestService, Models as AutoRestPagingTestServiceModels, Mappers as AutoRestPagingTestServiceMappers };
+export {
+  AutoRestPagingTestService,
+  AutoRestPagingTestServiceContext,
+  Models as AutoRestPagingTestServiceModels,
+  Mappers as AutoRestPagingTestServiceMappers,
+  operations as AutoRestPagingTestServiceOperations
+};

--- a/test/azure/generated/Paging/autoRestPagingTestService.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestService.ts
@@ -57,6 +57,6 @@ export {
   AutoRestPagingTestService,
   AutoRestPagingTestServiceContext,
   Models as AutoRestPagingTestServiceModels,
-  Mappers as AutoRestPagingTestServiceMappers,
-  operations as AutoRestPagingTestServiceOperations
+  Mappers as AutoRestPagingTestServiceMappers
 };
+export * from "./operations";

--- a/test/azure/generated/Paging/models/mappers.ts
+++ b/test/azure/generated/Paging/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/Paging/operations/index.ts
+++ b/test/azure/generated/Paging/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Paging } from "./paging";
-
-export { Paging };
+export * from "./paging";

--- a/test/azure/generated/StorageManagementClient/models/mappers.ts
+++ b/test/azure/generated/StorageManagementClient/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/StorageManagementClient/operations/index.ts
+++ b/test/azure/generated/StorageManagementClient/operations/index.ts
@@ -8,7 +8,5 @@
  * regenerated.
  */
 
-import { StorageAccounts } from "./storageAccounts";
-import { UsageOperations } from "./usageOperations";
-
-export { StorageAccounts, UsageOperations };
+export * from "./storageAccounts";
+export * from "./usageOperations";

--- a/test/azure/generated/StorageManagementClient/storageManagementClient.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClient.ts
@@ -61,6 +61,6 @@ export {
   StorageManagementClient,
   StorageManagementClientContext,
   Models as StorageManagementModels,
-  Mappers as StorageManagementMappers,
-  operations as StorageManagementOperations
+  Mappers as StorageManagementMappers
 };
+export * from "./operations";

--- a/test/azure/generated/StorageManagementClient/storageManagementClient.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClient.ts
@@ -57,4 +57,10 @@ class StorageManagementClient extends StorageManagementClientContext {
 
 // Operation Specifications
 
-export { StorageManagementClient, Models as StorageManagementModels, Mappers as StorageManagementMappers };
+export {
+  StorageManagementClient,
+  StorageManagementClientContext,
+  Models as StorageManagementModels,
+  Mappers as StorageManagementMappers,
+  operations as StorageManagementOperations
+};

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
@@ -55,4 +55,10 @@ class MicrosoftAzureTestUrl extends MicrosoftAzureTestUrlContext {
 
 // Operation Specifications
 
-export { MicrosoftAzureTestUrl, Models as MicrosoftAzureTestUrlModels, Mappers as MicrosoftAzureTestUrlMappers };
+export {
+  MicrosoftAzureTestUrl,
+  MicrosoftAzureTestUrlContext,
+  Models as MicrosoftAzureTestUrlModels,
+  Mappers as MicrosoftAzureTestUrlMappers,
+  operations as MicrosoftAzureTestUrlOperations
+};

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
@@ -59,6 +59,6 @@ export {
   MicrosoftAzureTestUrl,
   MicrosoftAzureTestUrlContext,
   Models as MicrosoftAzureTestUrlModels,
-  Mappers as MicrosoftAzureTestUrlMappers,
-  operations as MicrosoftAzureTestUrlOperations
+  Mappers as MicrosoftAzureTestUrlMappers
 };
+export * from "./operations";

--- a/test/azure/generated/SubscriptionIdApiVersion/models/mappers.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azure/generated/SubscriptionIdApiVersion/operations/index.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Group } from "./group";
-
-export { Group };
+export * from "./group";

--- a/test/azuremetadata/generated/lib/autoRestLongRunningOperationTestService.ts
+++ b/test/azuremetadata/generated/lib/autoRestLongRunningOperationTestService.ts
@@ -59,4 +59,10 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
 
 // Operation Specifications
 
-export { AutoRestLongRunningOperationTestService, Models as AutoRestLongRunningOperationTestServiceModels, Mappers as AutoRestLongRunningOperationTestServiceMappers };
+export {
+  AutoRestLongRunningOperationTestService,
+  AutoRestLongRunningOperationTestServiceContext,
+  Models as AutoRestLongRunningOperationTestServiceModels,
+  Mappers as AutoRestLongRunningOperationTestServiceMappers,
+  operations as AutoRestLongRunningOperationTestServiceOperations
+};

--- a/test/azuremetadata/generated/lib/autoRestLongRunningOperationTestService.ts
+++ b/test/azuremetadata/generated/lib/autoRestLongRunningOperationTestService.ts
@@ -63,6 +63,6 @@ export {
   AutoRestLongRunningOperationTestService,
   AutoRestLongRunningOperationTestServiceContext,
   Models as AutoRestLongRunningOperationTestServiceModels,
-  Mappers as AutoRestLongRunningOperationTestServiceMappers,
-  operations as AutoRestLongRunningOperationTestServiceOperations
+  Mappers as AutoRestLongRunningOperationTestServiceMappers
 };
+export * from "./operations";

--- a/test/azuremetadata/generated/lib/models/mappers.ts
+++ b/test/azuremetadata/generated/lib/models/mappers.ts
@@ -8,7 +8,7 @@
  * regenerated.
  */
 
-import {CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
+import { CloudErrorMapper, BaseResourceMapper } from "ms-rest-azure-js";
 import * as msRest from "ms-rest-js";
 
 export const CloudError = CloudErrorMapper;

--- a/test/azuremetadata/generated/lib/operations/index.ts
+++ b/test/azuremetadata/generated/lib/operations/index.ts
@@ -8,9 +8,7 @@
  * regenerated.
  */
 
-import { LROs } from "./lROs";
-import { LRORetrys } from "./lRORetrys";
-import { LROSADs } from "./lROSADs";
-import { LROsCustomHeader } from "./lROsCustomHeader";
-
-export { LROs, LRORetrys, LROSADs, LROsCustomHeader };
+export * from "./lROs";
+export * from "./lRORetrys";
+export * from "./lROSADs";
+export * from "./lROsCustomHeader";

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
@@ -45,4 +45,10 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATService, Models as AutoRestSwaggerBATServiceModels, Mappers as AutoRestSwaggerBATServiceMappers };
+export {
+  AutoRestSwaggerBATService,
+  AutoRestSwaggerBATServiceContext,
+  Models as AutoRestSwaggerBATServiceModels,
+  Mappers as AutoRestSwaggerBATServiceMappers,
+  operations as AutoRestSwaggerBATServiceOperations
+};

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
@@ -49,6 +49,6 @@ export {
   AutoRestSwaggerBATService,
   AutoRestSwaggerBATServiceContext,
   Models as AutoRestSwaggerBATServiceModels,
-  Mappers as AutoRestSwaggerBATServiceMappers,
-  operations as AutoRestSwaggerBATServiceOperations
+  Mappers as AutoRestSwaggerBATServiceMappers
 };
+export * from "./operations";

--- a/test/enumunion/generated/BodyString/operations/index.ts
+++ b/test/enumunion/generated/BodyString/operations/index.ts
@@ -8,7 +8,5 @@
  * regenerated.
  */
 
-import { String } from "./string";
-import { EnumModel } from "./enumModel";
-
-export { String, EnumModel };
+export * from "./string";
+export * from "./enumModel";

--- a/test/metadata/generated/lib/autoRestComplexTestService.ts
+++ b/test/metadata/generated/lib/autoRestComplexTestService.ts
@@ -63,6 +63,6 @@ export {
   AutoRestComplexTestService,
   AutoRestComplexTestServiceContext,
   Models as AutoRestComplexTestServiceModels,
-  Mappers as AutoRestComplexTestServiceMappers,
-  operations as AutoRestComplexTestServiceOperations
+  Mappers as AutoRestComplexTestServiceMappers
 };
+export * from "./operations";

--- a/test/metadata/generated/lib/autoRestComplexTestService.ts
+++ b/test/metadata/generated/lib/autoRestComplexTestService.ts
@@ -59,4 +59,10 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestComplexTestService, Models as AutoRestComplexTestServiceModels, Mappers as AutoRestComplexTestServiceMappers };
+export {
+  AutoRestComplexTestService,
+  AutoRestComplexTestServiceContext,
+  Models as AutoRestComplexTestServiceModels,
+  Mappers as AutoRestComplexTestServiceMappers,
+  operations as AutoRestComplexTestServiceOperations
+};

--- a/test/metadata/generated/lib/operations/index.ts
+++ b/test/metadata/generated/lib/operations/index.ts
@@ -8,15 +8,12 @@
  * regenerated.
  */
 
-import { BasicOperations } from "./basicOperations";
-import { Primitive } from "./primitive";
-import { ArrayModel } from "./arrayModel";
-import { Dictionary } from "./dictionary";
-import { Inheritance } from "./inheritance";
-import { Polymorphism } from "./polymorphism";
-import { Polymorphicrecursive } from "./polymorphicrecursive";
-import { Readonlyproperty } from "./readonlyproperty";
-import { Flattencomplex } from "./flattencomplex";
-
-export { BasicOperations, Primitive, ArrayModel, Dictionary, Inheritance, Polymorphism,
-Polymorphicrecursive, Readonlyproperty, Flattencomplex };
+export * from "./basicOperations";
+export * from "./primitive";
+export * from "./arrayModel";
+export * from "./dictionary";
+export * from "./inheritance";
+export * from "./polymorphism";
+export * from "./polymorphicrecursive";
+export * from "./readonlyproperty";
+export * from "./flattencomplex";

--- a/test/no-body-methods/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/no-body-methods/generated/BodyString/autoRestSwaggerBATService.ts
@@ -45,4 +45,10 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATService, Models as AutoRestSwaggerBATServiceModels, Mappers as AutoRestSwaggerBATServiceMappers };
+export {
+  AutoRestSwaggerBATService,
+  AutoRestSwaggerBATServiceContext,
+  Models as AutoRestSwaggerBATServiceModels,
+  Mappers as AutoRestSwaggerBATServiceMappers,
+  operations as AutoRestSwaggerBATServiceOperations
+};

--- a/test/no-body-methods/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/no-body-methods/generated/BodyString/autoRestSwaggerBATService.ts
@@ -49,6 +49,6 @@ export {
   AutoRestSwaggerBATService,
   AutoRestSwaggerBATServiceContext,
   Models as AutoRestSwaggerBATServiceModels,
-  Mappers as AutoRestSwaggerBATServiceMappers,
-  operations as AutoRestSwaggerBATServiceOperations
+  Mappers as AutoRestSwaggerBATServiceMappers
 };
+export * from "./operations";

--- a/test/no-body-methods/generated/BodyString/operations/index.ts
+++ b/test/no-body-methods/generated/BodyString/operations/index.ts
@@ -8,7 +8,5 @@
  * regenerated.
  */
 
-import { String } from "./string";
-import { EnumModel } from "./enumModel";
-
-export { String, EnumModel };
+export * from "./string";
+export * from "./enumModel";

--- a/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
@@ -311,4 +311,9 @@ const postWithConstantInBodyOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AutoRestValidationTest, Models as AutoRestValidationTestModels, Mappers as AutoRestValidationTestMappers };
+export {
+  AutoRestValidationTest,
+  AutoRestValidationTestContext,
+  Models as AutoRestValidationTestModels,
+  Mappers as AutoRestValidationTestMappers
+};

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATArrayService,
   AutoRestSwaggerBATArrayServiceContext,
   Models as AutoRestSwaggerBATArrayServiceModels,
-  Mappers as AutoRestSwaggerBATArrayServiceMappers,
-  operations as AutoRestSwaggerBATArrayServiceOperations
+  Mappers as AutoRestSwaggerBATArrayServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATArrayService extends AutoRestSwaggerBATArrayServiceConte
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATArrayService, Models as AutoRestSwaggerBATArrayServiceModels, Mappers as AutoRestSwaggerBATArrayServiceMappers };
+export {
+  AutoRestSwaggerBATArrayService,
+  AutoRestSwaggerBATArrayServiceContext,
+  Models as AutoRestSwaggerBATArrayServiceModels,
+  Mappers as AutoRestSwaggerBATArrayServiceMappers,
+  operations as AutoRestSwaggerBATArrayServiceOperations
+};

--- a/test/vanilla/generated/BodyArray/operations/index.ts
+++ b/test/vanilla/generated/BodyArray/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { ArrayModel } from "./arrayModel";
-
-export { ArrayModel };
+export * from "./arrayModel";

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestBoolTestService,
   AutoRestBoolTestServiceContext,
   Models as AutoRestBoolTestServiceModels,
-  Mappers as AutoRestBoolTestServiceMappers,
-  operations as AutoRestBoolTestServiceOperations
+  Mappers as AutoRestBoolTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
@@ -43,4 +43,10 @@ class AutoRestBoolTestService extends AutoRestBoolTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestBoolTestService, Models as AutoRestBoolTestServiceModels, Mappers as AutoRestBoolTestServiceMappers };
+export {
+  AutoRestBoolTestService,
+  AutoRestBoolTestServiceContext,
+  Models as AutoRestBoolTestServiceModels,
+  Mappers as AutoRestBoolTestServiceMappers,
+  operations as AutoRestBoolTestServiceOperations
+};

--- a/test/vanilla/generated/BodyBoolean/operations/index.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Bool } from "./bool";
-
-export { Bool };
+export * from "./bool";

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATByteService,
   AutoRestSwaggerBATByteServiceContext,
   Models as AutoRestSwaggerBATByteServiceModels,
-  Mappers as AutoRestSwaggerBATByteServiceMappers,
-  operations as AutoRestSwaggerBATByteServiceOperations
+  Mappers as AutoRestSwaggerBATByteServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATByteService extends AutoRestSwaggerBATByteServiceContext
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATByteService, Models as AutoRestSwaggerBATByteServiceModels, Mappers as AutoRestSwaggerBATByteServiceMappers };
+export {
+  AutoRestSwaggerBATByteService,
+  AutoRestSwaggerBATByteServiceContext,
+  Models as AutoRestSwaggerBATByteServiceModels,
+  Mappers as AutoRestSwaggerBATByteServiceMappers,
+  operations as AutoRestSwaggerBATByteServiceOperations
+};

--- a/test/vanilla/generated/BodyByte/operations/index.ts
+++ b/test/vanilla/generated/BodyByte/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { ByteModel } from "./byteModel";
-
-export { ByteModel };
+export * from "./byteModel";

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
@@ -63,6 +63,6 @@ export {
   AutoRestComplexTestService,
   AutoRestComplexTestServiceContext,
   Models as AutoRestComplexTestServiceModels,
-  Mappers as AutoRestComplexTestServiceMappers,
-  operations as AutoRestComplexTestServiceOperations
+  Mappers as AutoRestComplexTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
@@ -59,4 +59,10 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestComplexTestService, Models as AutoRestComplexTestServiceModels, Mappers as AutoRestComplexTestServiceMappers };
+export {
+  AutoRestComplexTestService,
+  AutoRestComplexTestServiceContext,
+  Models as AutoRestComplexTestServiceModels,
+  Mappers as AutoRestComplexTestServiceMappers,
+  operations as AutoRestComplexTestServiceOperations
+};

--- a/test/vanilla/generated/BodyComplex/operations/index.ts
+++ b/test/vanilla/generated/BodyComplex/operations/index.ts
@@ -8,15 +8,12 @@
  * regenerated.
  */
 
-import { BasicOperations } from "./basicOperations";
-import { Primitive } from "./primitive";
-import { ArrayModel } from "./arrayModel";
-import { Dictionary } from "./dictionary";
-import { Inheritance } from "./inheritance";
-import { Polymorphism } from "./polymorphism";
-import { Polymorphicrecursive } from "./polymorphicrecursive";
-import { Readonlyproperty } from "./readonlyproperty";
-import { Flattencomplex } from "./flattencomplex";
-
-export { BasicOperations, Primitive, ArrayModel, Dictionary, Inheritance, Polymorphism,
-Polymorphicrecursive, Readonlyproperty, Flattencomplex };
+export * from "./basicOperations";
+export * from "./primitive";
+export * from "./arrayModel";
+export * from "./dictionary";
+export * from "./inheritance";
+export * from "./polymorphism";
+export * from "./polymorphicrecursive";
+export * from "./readonlyproperty";
+export * from "./flattencomplex";

--- a/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestDateTestService,
   AutoRestDateTestServiceContext,
   Models as AutoRestDateTestServiceModels,
-  Mappers as AutoRestDateTestServiceMappers,
-  operations as AutoRestDateTestServiceOperations
+  Mappers as AutoRestDateTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
@@ -43,4 +43,10 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestDateTestService, Models as AutoRestDateTestServiceModels, Mappers as AutoRestDateTestServiceMappers };
+export {
+  AutoRestDateTestService,
+  AutoRestDateTestServiceContext,
+  Models as AutoRestDateTestServiceModels,
+  Mappers as AutoRestDateTestServiceMappers,
+  operations as AutoRestDateTestServiceOperations
+};

--- a/test/vanilla/generated/BodyDate/operations/index.ts
+++ b/test/vanilla/generated/BodyDate/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { DateModel } from "./dateModel";
-
-export { DateModel };
+export * from "./dateModel";

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestDateTimeTestService,
   AutoRestDateTimeTestServiceContext,
   Models as AutoRestDateTimeTestServiceModels,
-  Mappers as AutoRestDateTimeTestServiceMappers,
-  operations as AutoRestDateTimeTestServiceOperations
+  Mappers as AutoRestDateTimeTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -43,4 +43,10 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestDateTimeTestService, Models as AutoRestDateTimeTestServiceModels, Mappers as AutoRestDateTimeTestServiceMappers };
+export {
+  AutoRestDateTimeTestService,
+  AutoRestDateTimeTestServiceContext,
+  Models as AutoRestDateTimeTestServiceModels,
+  Mappers as AutoRestDateTimeTestServiceMappers,
+  operations as AutoRestDateTimeTestServiceOperations
+};

--- a/test/vanilla/generated/BodyDateTime/operations/index.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Datetime } from "./datetime";
-
-export { Datetime };
+export * from "./datetime";

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestRFC1123DateTimeTestService,
   AutoRestRFC1123DateTimeTestServiceContext,
   Models as AutoRestRFC1123DateTimeTestServiceModels,
-  Mappers as AutoRestRFC1123DateTimeTestServiceMappers,
-  operations as AutoRestRFC1123DateTimeTestServiceOperations
+  Mappers as AutoRestRFC1123DateTimeTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -43,4 +43,10 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
 
 // Operation Specifications
 
-export { AutoRestRFC1123DateTimeTestService, Models as AutoRestRFC1123DateTimeTestServiceModels, Mappers as AutoRestRFC1123DateTimeTestServiceMappers };
+export {
+  AutoRestRFC1123DateTimeTestService,
+  AutoRestRFC1123DateTimeTestServiceContext,
+  Models as AutoRestRFC1123DateTimeTestServiceModels,
+  Mappers as AutoRestRFC1123DateTimeTestServiceMappers,
+  operations as AutoRestRFC1123DateTimeTestServiceOperations
+};

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/index.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Datetimerfc1123 } from "./datetimerfc1123";
-
-export { Datetimerfc1123 };
+export * from "./datetimerfc1123";

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATdictionaryService,
   AutoRestSwaggerBATdictionaryServiceContext,
   Models as AutoRestSwaggerBATdictionaryServiceModels,
-  Mappers as AutoRestSwaggerBATdictionaryServiceMappers,
-  operations as AutoRestSwaggerBATdictionaryServiceOperations
+  Mappers as AutoRestSwaggerBATdictionaryServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATdictionaryService extends AutoRestSwaggerBATdictionarySe
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATdictionaryService, Models as AutoRestSwaggerBATdictionaryServiceModels, Mappers as AutoRestSwaggerBATdictionaryServiceMappers };
+export {
+  AutoRestSwaggerBATdictionaryService,
+  AutoRestSwaggerBATdictionaryServiceContext,
+  Models as AutoRestSwaggerBATdictionaryServiceModels,
+  Mappers as AutoRestSwaggerBATdictionaryServiceMappers,
+  operations as AutoRestSwaggerBATdictionaryServiceOperations
+};

--- a/test/vanilla/generated/BodyDictionary/operations/index.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Dictionary } from "./dictionary";
-
-export { Dictionary };
+export * from "./dictionary";

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
@@ -43,4 +43,10 @@ class AutoRestDurationTestService extends AutoRestDurationTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestDurationTestService, Models as AutoRestDurationTestServiceModels, Mappers as AutoRestDurationTestServiceMappers };
+export {
+  AutoRestDurationTestService,
+  AutoRestDurationTestServiceContext,
+  Models as AutoRestDurationTestServiceModels,
+  Mappers as AutoRestDurationTestServiceMappers,
+  operations as AutoRestDurationTestServiceOperations
+};

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestDurationTestService,
   AutoRestDurationTestServiceContext,
   Models as AutoRestDurationTestServiceModels,
-  Mappers as AutoRestDurationTestServiceMappers,
-  operations as AutoRestDurationTestServiceOperations
+  Mappers as AutoRestDurationTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyDuration/operations/index.ts
+++ b/test/vanilla/generated/BodyDuration/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Duration } from "./duration";
-
-export { Duration };
+export * from "./duration";

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATFileService,
   AutoRestSwaggerBATFileServiceContext,
   Models as AutoRestSwaggerBATFileServiceModels,
-  Mappers as AutoRestSwaggerBATFileServiceMappers,
-  operations as AutoRestSwaggerBATFileServiceOperations
+  Mappers as AutoRestSwaggerBATFileServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATFileService extends AutoRestSwaggerBATFileServiceContext
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATFileService, Models as AutoRestSwaggerBATFileServiceModels, Mappers as AutoRestSwaggerBATFileServiceMappers };
+export {
+  AutoRestSwaggerBATFileService,
+  AutoRestSwaggerBATFileServiceContext,
+  Models as AutoRestSwaggerBATFileServiceModels,
+  Mappers as AutoRestSwaggerBATFileServiceMappers,
+  operations as AutoRestSwaggerBATFileServiceOperations
+};

--- a/test/vanilla/generated/BodyFile/operations/index.ts
+++ b/test/vanilla/generated/BodyFile/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Files } from "./files";
-
-export { Files };
+export * from "./files";

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATFormDataService,
   AutoRestSwaggerBATFormDataServiceContext,
   Models as AutoRestSwaggerBATFormDataServiceModels,
-  Mappers as AutoRestSwaggerBATFormDataServiceMappers,
-  operations as AutoRestSwaggerBATFormDataServiceOperations
+  Mappers as AutoRestSwaggerBATFormDataServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATFormDataService extends AutoRestSwaggerBATFormDataServic
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATFormDataService, Models as AutoRestSwaggerBATFormDataServiceModels, Mappers as AutoRestSwaggerBATFormDataServiceMappers };
+export {
+  AutoRestSwaggerBATFormDataService,
+  AutoRestSwaggerBATFormDataServiceContext,
+  Models as AutoRestSwaggerBATFormDataServiceModels,
+  Mappers as AutoRestSwaggerBATFormDataServiceMappers,
+  operations as AutoRestSwaggerBATFormDataServiceOperations
+};

--- a/test/vanilla/generated/BodyFormData/operations/index.ts
+++ b/test/vanilla/generated/BodyFormData/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Formdata } from "./formdata";
-
-export { Formdata };
+export * from "./formdata";

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
@@ -43,4 +43,10 @@ class AutoRestIntegerTestService extends AutoRestIntegerTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestIntegerTestService, Models as AutoRestIntegerTestServiceModels, Mappers as AutoRestIntegerTestServiceMappers };
+export {
+  AutoRestIntegerTestService,
+  AutoRestIntegerTestServiceContext,
+  Models as AutoRestIntegerTestServiceModels,
+  Mappers as AutoRestIntegerTestServiceMappers,
+  operations as AutoRestIntegerTestServiceOperations
+};

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestIntegerTestService,
   AutoRestIntegerTestServiceContext,
   Models as AutoRestIntegerTestServiceModels,
-  Mappers as AutoRestIntegerTestServiceMappers,
-  operations as AutoRestIntegerTestServiceOperations
+  Mappers as AutoRestIntegerTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyInteger/operations/index.ts
+++ b/test/vanilla/generated/BodyInteger/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { IntModel } from "./intModel";
-
-export { IntModel };
+export * from "./intModel";

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
@@ -43,4 +43,10 @@ class AutoRestNumberTestService extends AutoRestNumberTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestNumberTestService, Models as AutoRestNumberTestServiceModels, Mappers as AutoRestNumberTestServiceMappers };
+export {
+  AutoRestNumberTestService,
+  AutoRestNumberTestServiceContext,
+  Models as AutoRestNumberTestServiceModels,
+  Mappers as AutoRestNumberTestServiceMappers,
+  operations as AutoRestNumberTestServiceOperations
+};

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestNumberTestService,
   AutoRestNumberTestServiceContext,
   Models as AutoRestNumberTestServiceModels,
-  Mappers as AutoRestNumberTestServiceMappers,
-  operations as AutoRestNumberTestServiceOperations
+  Mappers as AutoRestNumberTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyNumber/operations/index.ts
+++ b/test/vanilla/generated/BodyNumber/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Number } from "./number";
-
-export { Number };
+export * from "./number";

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
@@ -45,4 +45,10 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATService, Models as AutoRestSwaggerBATServiceModels, Mappers as AutoRestSwaggerBATServiceMappers };
+export {
+  AutoRestSwaggerBATService,
+  AutoRestSwaggerBATServiceContext,
+  Models as AutoRestSwaggerBATServiceModels,
+  Mappers as AutoRestSwaggerBATServiceMappers,
+  operations as AutoRestSwaggerBATServiceOperations
+};

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
@@ -49,6 +49,6 @@ export {
   AutoRestSwaggerBATService,
   AutoRestSwaggerBATServiceContext,
   Models as AutoRestSwaggerBATServiceModels,
-  Mappers as AutoRestSwaggerBATServiceMappers,
-  operations as AutoRestSwaggerBATServiceOperations
+  Mappers as AutoRestSwaggerBATServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/BodyString/operations/index.ts
+++ b/test/vanilla/generated/BodyString/operations/index.ts
@@ -8,7 +8,5 @@
  * regenerated.
  */
 
-import { String } from "./string";
-import { EnumModel } from "./enumModel";
-
-export { String, EnumModel };
+export * from "./string";
+export * from "./enumModel";

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -293,4 +293,9 @@ const updateOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { ComplexModelClient, Models as ComplexModelModels, Mappers as ComplexModelMappers };
+export {
+  ComplexModelClient,
+  ComplexModelClientContext,
+  Models as ComplexModelModels,
+  Mappers as ComplexModelMappers
+};

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
@@ -45,4 +45,10 @@ class CompositeBoolInt extends CompositeBoolIntContext {
 
 // Operation Specifications
 
-export { CompositeBoolInt, Models as CompositeBoolIntModels, Mappers as CompositeBoolIntMappers };
+export {
+  CompositeBoolInt,
+  CompositeBoolIntContext,
+  Models as CompositeBoolIntModels,
+  Mappers as CompositeBoolIntMappers,
+  operations as CompositeBoolIntOperations
+};

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
@@ -49,6 +49,6 @@ export {
   CompositeBoolInt,
   CompositeBoolIntContext,
   Models as CompositeBoolIntModels,
-  Mappers as CompositeBoolIntMappers,
-  operations as CompositeBoolIntOperations
+  Mappers as CompositeBoolIntMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/index.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/index.ts
@@ -8,7 +8,5 @@
  * regenerated.
  */
 
-import { Bool } from "./bool";
-import { IntModel } from "./intModel";
-
-export { Bool, IntModel };
+export * from "./bool";
+export * from "./intModel";

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -46,6 +46,6 @@ export {
   AutoRestParameterizedHostTestClient,
   AutoRestParameterizedHostTestClientContext,
   Models as AutoRestParameterizedHostTestModels,
-  Mappers as AutoRestParameterizedHostTestMappers,
-  operations as AutoRestParameterizedHostTestOperations
+  Mappers as AutoRestParameterizedHostTestMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -42,4 +42,10 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
 
 // Operation Specifications
 
-export { AutoRestParameterizedHostTestClient, Models as AutoRestParameterizedHostTestModels, Mappers as AutoRestParameterizedHostTestMappers };
+export {
+  AutoRestParameterizedHostTestClient,
+  AutoRestParameterizedHostTestClientContext,
+  Models as AutoRestParameterizedHostTestModels,
+  Mappers as AutoRestParameterizedHostTestMappers,
+  operations as AutoRestParameterizedHostTestOperations
+};

--- a/test/vanilla/generated/CustomBaseUri/operations/index.ts
+++ b/test/vanilla/generated/CustomBaseUri/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Paths } from "./paths";
-
-export { Paths };
+export * from "./paths";

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
@@ -42,4 +42,10 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
 
 // Operation Specifications
 
-export { AutoRestParameterizedCustomHostTestClient, Models as AutoRestParameterizedCustomHostTestModels, Mappers as AutoRestParameterizedCustomHostTestMappers };
+export {
+  AutoRestParameterizedCustomHostTestClient,
+  AutoRestParameterizedCustomHostTestClientContext,
+  Models as AutoRestParameterizedCustomHostTestModels,
+  Mappers as AutoRestParameterizedCustomHostTestMappers,
+  operations as AutoRestParameterizedCustomHostTestOperations
+};

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
@@ -46,6 +46,6 @@ export {
   AutoRestParameterizedCustomHostTestClient,
   AutoRestParameterizedCustomHostTestClientContext,
   Models as AutoRestParameterizedCustomHostTestModels,
-  Mappers as AutoRestParameterizedCustomHostTestMappers,
-  operations as AutoRestParameterizedCustomHostTestOperations
+  Mappers as AutoRestParameterizedCustomHostTestMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/operations/index.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Paths } from "./paths";
-
-export { Paths };
+export * from "./paths";

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATHeaderService,
   AutoRestSwaggerBATHeaderServiceContext,
   Models as AutoRestSwaggerBATHeaderServiceModels,
-  Mappers as AutoRestSwaggerBATHeaderServiceMappers,
-  operations as AutoRestSwaggerBATHeaderServiceOperations
+  Mappers as AutoRestSwaggerBATHeaderServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATHeaderService, Models as AutoRestSwaggerBATHeaderServiceModels, Mappers as AutoRestSwaggerBATHeaderServiceMappers };
+export {
+  AutoRestSwaggerBATHeaderService,
+  AutoRestSwaggerBATHeaderServiceContext,
+  Models as AutoRestSwaggerBATHeaderServiceModels,
+  Mappers as AutoRestSwaggerBATHeaderServiceMappers,
+  operations as AutoRestSwaggerBATHeaderServiceOperations
+};

--- a/test/vanilla/generated/Header/operations/index.ts
+++ b/test/vanilla/generated/Header/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Header } from "./header";
-
-export { Header };
+export * from "./header";

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
@@ -55,4 +55,10 @@ class AutoRestHttpInfrastructureTestService extends AutoRestHttpInfrastructureTe
 
 // Operation Specifications
 
-export { AutoRestHttpInfrastructureTestService, Models as AutoRestHttpInfrastructureTestServiceModels, Mappers as AutoRestHttpInfrastructureTestServiceMappers };
+export {
+  AutoRestHttpInfrastructureTestService,
+  AutoRestHttpInfrastructureTestServiceContext,
+  Models as AutoRestHttpInfrastructureTestServiceModels,
+  Mappers as AutoRestHttpInfrastructureTestServiceMappers,
+  operations as AutoRestHttpInfrastructureTestServiceOperations
+};

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
@@ -59,6 +59,6 @@ export {
   AutoRestHttpInfrastructureTestService,
   AutoRestHttpInfrastructureTestServiceContext,
   Models as AutoRestHttpInfrastructureTestServiceModels,
-  Mappers as AutoRestHttpInfrastructureTestServiceMappers,
-  operations as AutoRestHttpInfrastructureTestServiceOperations
+  Mappers as AutoRestHttpInfrastructureTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/Http/operations/index.ts
+++ b/test/vanilla/generated/Http/operations/index.ts
@@ -8,13 +8,10 @@
  * regenerated.
  */
 
-import { HttpFailure } from "./httpFailure";
-import { HttpSuccess } from "./httpSuccess";
-import { HttpRedirects } from "./httpRedirects";
-import { HttpClientFailure } from "./httpClientFailure";
-import { HttpServerFailure } from "./httpServerFailure";
-import { HttpRetry } from "./httpRetry";
-import { MultipleResponses } from "./multipleResponses";
-
-export { HttpFailure, HttpSuccess, HttpRedirects, HttpClientFailure, HttpServerFailure,
-HttpRetry, MultipleResponses };
+export * from "./httpFailure";
+export * from "./httpSuccess";
+export * from "./httpRedirects";
+export * from "./httpClientFailure";
+export * from "./httpServerFailure";
+export * from "./httpRetry";
+export * from "./multipleResponses";

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -830,4 +830,9 @@ const putSimpleProductWithGroupingOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AutoRestResourceFlatteningTestService, Models as AutoRestResourceFlatteningTestServiceModels, Mappers as AutoRestResourceFlatteningTestServiceMappers };
+export {
+  AutoRestResourceFlatteningTestService,
+  AutoRestResourceFlatteningTestServiceContext,
+  Models as AutoRestResourceFlatteningTestServiceModels,
+  Mappers as AutoRestResourceFlatteningTestServiceMappers
+};

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
@@ -43,4 +43,10 @@ class AutoRestParameterFlattening extends AutoRestParameterFlatteningContext {
 
 // Operation Specifications
 
-export { AutoRestParameterFlattening, Models as AutoRestParameterFlatteningModels, Mappers as AutoRestParameterFlatteningMappers };
+export {
+  AutoRestParameterFlattening,
+  AutoRestParameterFlatteningContext,
+  Models as AutoRestParameterFlatteningModels,
+  Mappers as AutoRestParameterFlatteningMappers,
+  operations as AutoRestParameterFlatteningOperations
+};

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
@@ -47,6 +47,6 @@ export {
   AutoRestParameterFlattening,
   AutoRestParameterFlatteningContext,
   Models as AutoRestParameterFlatteningModels,
-  Mappers as AutoRestParameterFlatteningMappers,
-  operations as AutoRestParameterFlatteningOperations
+  Mappers as AutoRestParameterFlatteningMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/ParameterFlattening/operations/index.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { AvailabilitySets } from "./availabilitySets";
-
-export { AvailabilitySets };
+export * from "./availabilitySets";

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -108,4 +108,9 @@ const getReportOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AutoRestReportService, Models as AutoRestReportServiceModels, Mappers as AutoRestReportServiceMappers };
+export {
+  AutoRestReportService,
+  AutoRestReportServiceContext,
+  Models as AutoRestReportServiceModels,
+  Mappers as AutoRestReportServiceMappers
+};

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
@@ -46,4 +46,10 @@ class AutoRestRequiredOptionalTestService extends AutoRestRequiredOptionalTestSe
 
 // Operation Specifications
 
-export { AutoRestRequiredOptionalTestService, Models as AutoRestRequiredOptionalTestServiceModels, Mappers as AutoRestRequiredOptionalTestServiceMappers };
+export {
+  AutoRestRequiredOptionalTestService,
+  AutoRestRequiredOptionalTestServiceContext,
+  Models as AutoRestRequiredOptionalTestServiceModels,
+  Mappers as AutoRestRequiredOptionalTestServiceMappers,
+  operations as AutoRestRequiredOptionalTestServiceOperations
+};

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
@@ -50,6 +50,6 @@ export {
   AutoRestRequiredOptionalTestService,
   AutoRestRequiredOptionalTestServiceContext,
   Models as AutoRestRequiredOptionalTestServiceModels,
-  Mappers as AutoRestRequiredOptionalTestServiceMappers,
-  operations as AutoRestRequiredOptionalTestServiceOperations
+  Mappers as AutoRestRequiredOptionalTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/RequiredOptional/operations/index.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/index.ts
@@ -8,7 +8,5 @@
  * regenerated.
  */
 
-import { Implicit } from "./implicit";
-import { Explicit } from "./explicit";
-
-export { Implicit, Explicit };
+export * from "./implicit";
+export * from "./explicit";

--- a/test/vanilla/generated/Url/autoRestUrlTestService.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestService.ts
@@ -48,4 +48,10 @@ class AutoRestUrlTestService extends AutoRestUrlTestServiceContext {
 
 // Operation Specifications
 
-export { AutoRestUrlTestService, Models as AutoRestUrlTestServiceModels, Mappers as AutoRestUrlTestServiceMappers };
+export {
+  AutoRestUrlTestService,
+  AutoRestUrlTestServiceContext,
+  Models as AutoRestUrlTestServiceModels,
+  Mappers as AutoRestUrlTestServiceMappers,
+  operations as AutoRestUrlTestServiceOperations
+};

--- a/test/vanilla/generated/Url/autoRestUrlTestService.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestService.ts
@@ -52,6 +52,6 @@ export {
   AutoRestUrlTestService,
   AutoRestUrlTestServiceContext,
   Models as AutoRestUrlTestServiceModels,
-  Mappers as AutoRestUrlTestServiceMappers,
-  operations as AutoRestUrlTestServiceOperations
+  Mappers as AutoRestUrlTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/Url/operations/index.ts
+++ b/test/vanilla/generated/Url/operations/index.ts
@@ -8,8 +8,6 @@
  * regenerated.
  */
 
-import { Paths } from "./paths";
-import { Queries } from "./queries";
-import { PathItems } from "./pathItems";
-
-export { Paths, Queries, PathItems };
+export * from "./paths";
+export * from "./queries";
+export * from "./pathItems";

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
@@ -43,4 +43,10 @@ class AutoRestUrlMutliCollectionFormatTestService extends AutoRestUrlMutliCollec
 
 // Operation Specifications
 
-export { AutoRestUrlMutliCollectionFormatTestService, Models as AutoRestUrlMutliCollectionFormatTestServiceModels, Mappers as AutoRestUrlMutliCollectionFormatTestServiceMappers };
+export {
+  AutoRestUrlMutliCollectionFormatTestService,
+  AutoRestUrlMutliCollectionFormatTestServiceContext,
+  Models as AutoRestUrlMutliCollectionFormatTestServiceModels,
+  Mappers as AutoRestUrlMutliCollectionFormatTestServiceMappers,
+  operations as AutoRestUrlMutliCollectionFormatTestServiceOperations
+};

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestUrlMutliCollectionFormatTestService,
   AutoRestUrlMutliCollectionFormatTestServiceContext,
   Models as AutoRestUrlMutliCollectionFormatTestServiceModels,
-  Mappers as AutoRestUrlMutliCollectionFormatTestServiceMappers,
-  operations as AutoRestUrlMutliCollectionFormatTestServiceOperations
+  Mappers as AutoRestUrlMutliCollectionFormatTestServiceMappers
 };
+export * from "./operations";

--- a/test/vanilla/generated/UrlMultiCollectionFormat/operations/index.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Queries } from "./queries";
-
-export { Queries };
+export * from "./queries";

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -311,4 +311,9 @@ const postWithConstantInBodyOperationSpec: msRest.OperationSpec = {
   serializer
 };
 
-export { AutoRestValidationTest, Models as AutoRestValidationTestModels, Mappers as AutoRestValidationTestMappers };
+export {
+  AutoRestValidationTest,
+  AutoRestValidationTestContext,
+  Models as AutoRestValidationTestModels,
+  Mappers as AutoRestValidationTestMappers
+};

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
@@ -47,6 +47,6 @@ export {
   AutoRestSwaggerBATXMLService,
   AutoRestSwaggerBATXMLServiceContext,
   Models as AutoRestSwaggerBATXMLServiceModels,
-  Mappers as AutoRestSwaggerBATXMLServiceMappers,
-  operations as AutoRestSwaggerBATXMLServiceOperations
+  Mappers as AutoRestSwaggerBATXMLServiceMappers
 };
+export * from "./operations";

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
@@ -43,4 +43,10 @@ class AutoRestSwaggerBATXMLService extends AutoRestSwaggerBATXMLServiceContext {
 
 // Operation Specifications
 
-export { AutoRestSwaggerBATXMLService, Models as AutoRestSwaggerBATXMLServiceModels, Mappers as AutoRestSwaggerBATXMLServiceMappers };
+export {
+  AutoRestSwaggerBATXMLService,
+  AutoRestSwaggerBATXMLServiceContext,
+  Models as AutoRestSwaggerBATXMLServiceModels,
+  Mappers as AutoRestSwaggerBATXMLServiceMappers,
+  operations as AutoRestSwaggerBATXMLServiceOperations
+};

--- a/test/xml/generated/Xml/operations/index.ts
+++ b/test/xml/generated/Xml/operations/index.ts
@@ -8,6 +8,4 @@
  * regenerated.
  */
 
-import { Xml } from "./xml";
-
-export { Xml };
+export * from "./xml";


### PR DESCRIPTION
Exports the context and operations directly in the client class so that the context pattern can be used from an external module.