### PR TITLE
Remove 'git clean -xdf' from metadata tests

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -64,14 +64,12 @@ task 'test/vanilla-metadata', '', [], (done) ->
   cwd = "#{basefolder}/test/metadata/generated"
   await execute "npm install", { cwd: cwd, silent: false }, defer _
   await execute "npm run build", { cwd: cwd, silent: false }, defer _
-  await execute "git clean -xdf", { cwd: cwd, silent: false }, defer _
   done()
 
 task 'test/azure-metadata', '', [], (done) ->
   cwd = "#{basefolder}/test/metadata/generated"
   await execute "npm install", {cwd: cwd, silent: false }, defer _
   await execute "npm run build", {cwd: cwd, silent: false }, defer _
-  await execute "git clean -xdf", { cwd: cwd, silent: false }, defer _
   done()
 
 task 'test/typecheck', 'type check generated code', [], (done) ->


### PR DESCRIPTION
I was consistently running into errors on a clean copy of the master branch whenever I ran `gulp test` with errors about webpack or other various problems. If I remove these two lines, all of the problems go away.