### PR TITLE
Fix bundle size script

### DIFF
--- a/.scripts/bundlesize.ts
+++ b/.scripts/bundlesize.ts
@@ -1,14 +1,15 @@
-const { join } = require("path");
-const { promisify } = require("util");
-const cp = require("child_process");
+import { join } from "path";
+import { promisify } from "util";
+import cp = require("child_process");
+import fs = require("fs");
+import filesize = require("filesize");
+
 const exec = promisify(cp.exec);
-const fs = require("fs");
-const filesize = require("filesize");
-const dependencies = require("./dependencies");
 
 async function getBundleSize() {
   await new Promise((resolve) => {
-    const child = cp.spawn(join(__dirname, "../node_modules/.bin/webpack"), ['-p'], { maxBuffer: 1024 * 1024, stdio: 'inherit' });
+    const opts = { maxBuffer: 1024 * 1024, stdio: 'inherit' };
+    const child = cp.spawn(join(__dirname, "../node_modules/.bin/webpack"), ['-p'], opts);
     child.on('exit', () => resolve());
   });
   const status = fs.statSync(join(__dirname, "../testBundle.js"));
@@ -42,15 +43,15 @@ async function main() {
   let headSize = undefined;
 
   const branch = process.env.TRAVIS_BRANCH;
-  const prCommit = process.env.TRAVIS_PULL_REQUEST_SHA
+  const prCommit = process.env.TRAVIS_PULL_REQUEST_SHA;
 
   try {
     await execVerbose("git reset --hard " + branch);
-    dependencies.refreshNodeModules({ ignoreScripts: true });
+    await execVerbose("npm i");
     baseSize = await getBundleSize();
 
     await execVerbose("git reset --hard " + prCommit);
-    dependencies.refreshNodeModules({ ignoreScripts: true });
+    await execVerbose("npm i");
     headSize = await getBundleSize();
 
     const change = (headSize / baseSize) - 1;
@@ -65,6 +66,7 @@ async function main() {
     } else {
       outputErrorMessage(`Unrecognized error`, error);
     }
+    throw error;
   }
 }
 

--- a/.scripts/bundlesize.ts
+++ b/.scripts/bundlesize.ts
@@ -47,11 +47,11 @@ async function main() {
 
   try {
     await execVerbose("git reset --hard " + branch);
-    await execVerbose("npm i");
+    await execVerbose("npm i --ignore-scripts");
     baseSize = await getBundleSize();
 
     await execVerbose("git reset --hard " + prCommit);
-    await execVerbose("npm i");
+    await execVerbose("npm i --ignore-scripts");
     headSize = await getBundleSize();
 
     const change = (headSize / baseSize) - 1;


### PR DESCRIPTION
I found this silently broke when the dependencies script changed, probably because we didn't use the `import` syntax in TypeScript.

This should do the trick, and also succeed at reporting non-webpack errors. `npm i` should be sufficient in this environment as the branches being compared should not depend on any local versions of packages.