### PR TITLE
Add a build step that checks our scripts

### DIFF
--- a/.gulp/dotnet.iced
+++ b/.gulp/dotnet.iced
@@ -26,11 +26,17 @@ dotnet = (cmd) ->
 # ==============================================================================
 # Tasks
 
+task 'build/scripts', '', [], (done) ->
+  execute "tsc -p ./.scripts/", (code, stdout, stderr) ->
+    done()
 
-task 'build','dotnet',['restore', 'version-number'], (done) ->
+task 'build/generator','dotnet',['restore', 'version-number'], (done) ->
   execute "dotnet build -c #{configuration} #{solution} /nologo /clp:NoSummary /p:VersionPrefix=#{version}", (code, stdout, stderr) ->
     execute "dotnet publish -c #{configuration} #{sourceFolder} --output #{sourceFolder}/bin/netcoreapp2.0 /nologo /clp:NoSummary /p:VersionPrefix=#{version}", (code, stdout, stderr) ->
       done()
+
+task 'build', '', ['build/scripts', 'build/generator'], (done) ->
+  done()
 
 task 'clear-cache-on-force', '', (done)->
   if global.force 

--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -135,6 +135,7 @@ checkRegeneration = (taskName) ->
 task 'testci', '', [], (done) ->
   # VSTS can't handle regenerating after running browser tests
   await checkRegeneration "regenerate", defer _
+  await run "build", defer _
   await run "test", defer _
   done();
 

--- a/.scripts/tsconfig.json
+++ b/.scripts/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
I recently made some changes to dependencies.ts that broke @RikkiGibson's bundlesize.ts script. This PR makes it so that we run `tsc` against our .scripts folder so that doesn't happen again.