### PR TITLE
Paging fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha-chrome": "^1.0.3",
     "moment": "~2.21.0",
     "ms-rest-azure-js": "~0.16.156",
-    "ms-rest-js": "~0.21.404",
+    "ms-rest-js": "~0.21.408",
     "run-sequence": "*",
     "should": "5.2.0",
     "shx": "^0.2.2",

--- a/src/vanilla/Model/MethodTS.cs
+++ b/src/vanilla/Model/MethodTS.cs
@@ -766,19 +766,18 @@ namespace AutoRest.TypeScript.Model
                 {
                     type.NamedType($"Array<{sequenceBody.ElementType.TSType(inModelsModule: true)}>");
                 }
+                else if (ReturnType.Body is CompositeTypeTS compositeBody)
+                {
+                    type.NamedType(compositeBody.TSType(inModelsModule: true));
+                }
+
+                if (ReturnType.Headers != null)
+                {
+                    type.NamedType(ReturnType.Headers.TSType(inModelsModule: true));
+                }
 
                 type.ObjectType(iface =>
                 {
-                    if (ReturnType.Headers != null)
-                    {
-                        foreach (var property in ((CompositeTypeTS)ReturnType.Headers).Properties)
-                        {
-                            iface.DocumentationComment(property.Documentation);
-                            // hard-coding response headers non-optional because Swagger itself can't specify whether or not they're required.
-                            iface.Property(property.Name, property.ModelType.TSType(inModelsModule: true), optional: false);
-                        }
-                    }
-
                     if (HasStreamResponseType())
                     {
                         iface.DocumentationComment(
@@ -797,19 +796,7 @@ namespace AutoRest.TypeScript.Model
 
                         iface.Property("readableStreamBody", "NodeJS.ReadableStream", optional: true);
                     }
-                    else if (ReturnType.Body is CompositeTypeTS compositeBody)
-                    {
-                        foreach (var property in compositeBody.ComposedProperties.Distinct(PropertyNameComparer.Instance))
-                        {
-                            iface.DocumentationComment(property.Documentation);
-                            iface.Property(
-                                property.Name,
-                                property.ModelType.TSType(inModelsModule: true),
-                                optional: !property.IsRequired,
-                                readOnly: property.IsReadOnly);
-                        }
-                    }
-                    else if (ReturnType.Body != null && !(ReturnType.Body is SequenceTypeTS || ReturnType.Body is DictionaryTypeTS))
+                    else if (ReturnType.Body != null && !(ReturnType.Body is CompositeTypeTS || ReturnType.Body is SequenceTypeTS || ReturnType.Body is DictionaryTypeTS))
                     {
                         iface.DocumentationComment("The parsed response body.");
                         iface.Property(primitiveHttpBodyPropertyName, ReturnType.Body.TSType(inModelsModule: true));

--- a/test/azure/generated/AzureCompositeModelClient/models/index.ts
+++ b/test/azure/generated/AzureCompositeModelClient/models/index.ts
@@ -857,11 +857,7 @@ export enum MyKind {
 /**
  * Contains response data for the list operation.
  */
-export type ListResponse = {
-  /**
-   * Array of products
-   */
-  productArray?: Product[];
+export type ListResponse = CatalogArray & {
   /**
    * The underlying HTTP response.
    */
@@ -880,11 +876,7 @@ export type ListResponse = {
 /**
  * Contains response data for the create operation.
  */
-export type CreateResponse = {
-  /**
-   * Dictionary of products
-   */
-  productDictionary?: { [propertyName: string]: Product };
+export type CreateResponse = CatalogDictionary & {
   /**
    * The underlying HTTP response.
    */
@@ -903,11 +895,7 @@ export type CreateResponse = {
 /**
  * Contains response data for the update operation.
  */
-export type UpdateResponse = {
-  /**
-   * Array of products
-   */
-  productArray?: Product[];
+export type UpdateResponse = CatalogArray & {
   /**
    * The underlying HTTP response.
    */
@@ -926,20 +914,7 @@ export type UpdateResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type BasicGetValidResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetValidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -958,20 +933,7 @@ export type BasicGetValidResponse = {
 /**
  * Contains response data for the getInvalid operation.
  */
-export type BasicGetInvalidResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetInvalidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -990,20 +952,7 @@ export type BasicGetInvalidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type BasicGetEmptyResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetEmptyResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -1022,20 +971,7 @@ export type BasicGetEmptyResponse = {
 /**
  * Contains response data for the getNull operation.
  */
-export type BasicGetNullResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetNullResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -1054,20 +990,7 @@ export type BasicGetNullResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type BasicGetNotProvidedResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetNotProvidedResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -1086,9 +1009,7 @@ export type BasicGetNotProvidedResponse = {
 /**
  * Contains response data for the getInt operation.
  */
-export type PrimitiveGetIntResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetIntResponse = IntWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1107,9 +1028,7 @@ export type PrimitiveGetIntResponse = {
 /**
  * Contains response data for the getLong operation.
  */
-export type PrimitiveGetLongResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetLongResponse = LongWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1128,9 +1047,7 @@ export type PrimitiveGetLongResponse = {
 /**
  * Contains response data for the getFloat operation.
  */
-export type PrimitiveGetFloatResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetFloatResponse = FloatWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1149,9 +1066,7 @@ export type PrimitiveGetFloatResponse = {
 /**
  * Contains response data for the getDouble operation.
  */
-export type PrimitiveGetDoubleResponse = {
-  field1?: number;
-  field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose?: number;
+export type PrimitiveGetDoubleResponse = DoubleWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1170,9 +1085,7 @@ export type PrimitiveGetDoubleResponse = {
 /**
  * Contains response data for the getBool operation.
  */
-export type PrimitiveGetBoolResponse = {
-  fieldTrue?: boolean;
-  fieldFalse?: boolean;
+export type PrimitiveGetBoolResponse = BooleanWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1191,10 +1104,7 @@ export type PrimitiveGetBoolResponse = {
 /**
  * Contains response data for the getString operation.
  */
-export type PrimitiveGetStringResponse = {
-  field?: string;
-  empty?: string;
-  nullProperty?: string;
+export type PrimitiveGetStringResponse = StringWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1213,9 +1123,7 @@ export type PrimitiveGetStringResponse = {
 /**
  * Contains response data for the getDate operation.
  */
-export type PrimitiveGetDateResponse = {
-  field?: Date;
-  leap?: Date;
+export type PrimitiveGetDateResponse = DateWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1234,9 +1142,7 @@ export type PrimitiveGetDateResponse = {
 /**
  * Contains response data for the getDateTime operation.
  */
-export type PrimitiveGetDateTimeResponse = {
-  field?: Date;
-  now?: Date;
+export type PrimitiveGetDateTimeResponse = DatetimeWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1255,9 +1161,7 @@ export type PrimitiveGetDateTimeResponse = {
 /**
  * Contains response data for the getDateTimeRfc1123 operation.
  */
-export type PrimitiveGetDateTimeRfc1123Response = {
-  field?: Date;
-  now?: Date;
+export type PrimitiveGetDateTimeRfc1123Response = Datetimerfc1123Wrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1276,8 +1180,7 @@ export type PrimitiveGetDateTimeRfc1123Response = {
 /**
  * Contains response data for the getDuration operation.
  */
-export type PrimitiveGetDurationResponse = {
-  field?: string;
+export type PrimitiveGetDurationResponse = DurationWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1296,8 +1199,7 @@ export type PrimitiveGetDurationResponse = {
 /**
  * Contains response data for the getByte operation.
  */
-export type PrimitiveGetByteResponse = {
-  field?: Uint8Array;
+export type PrimitiveGetByteResponse = ByteWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1316,8 +1218,7 @@ export type PrimitiveGetByteResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type ArrayModelGetValidResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetValidResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1336,8 +1237,7 @@ export type ArrayModelGetValidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type ArrayModelGetEmptyResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetEmptyResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1356,8 +1256,7 @@ export type ArrayModelGetEmptyResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type ArrayModelGetNotProvidedResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetNotProvidedResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1376,8 +1275,7 @@ export type ArrayModelGetNotProvidedResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type DictionaryGetValidResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetValidResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1396,8 +1294,7 @@ export type DictionaryGetValidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type DictionaryGetEmptyResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetEmptyResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1416,8 +1313,7 @@ export type DictionaryGetEmptyResponse = {
 /**
  * Contains response data for the getNull operation.
  */
-export type DictionaryGetNullResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetNullResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1436,8 +1332,7 @@ export type DictionaryGetNullResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type DictionaryGetNotProvidedResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetNotProvidedResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1456,12 +1351,7 @@ export type DictionaryGetNotProvidedResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type InheritanceGetValidResponse = {
-  id?: number;
-  name?: string;
-  color?: string;
-  hates?: Dog[];
-  breed?: string;
+export type InheritanceGetValidResponse = Siamese & {
   /**
    * The underlying HTTP response.
    */
@@ -1480,14 +1370,7 @@ export type InheritanceGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type PolymorphismGetValidResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
+export type PolymorphismGetValidResponse = FishUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1506,16 +1389,7 @@ export type PolymorphismGetValidResponse = {
 /**
  * Contains response data for the getComplicated operation.
  */
-export type PolymorphismGetComplicatedResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
-  location?: string;
-  iswild?: boolean;
+export type PolymorphismGetComplicatedResponse = SalmonUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1534,16 +1408,7 @@ export type PolymorphismGetComplicatedResponse = {
 /**
  * Contains response data for the putMissingDiscriminator operation.
  */
-export type PolymorphismPutMissingDiscriminatorResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
-  location?: string;
-  iswild?: boolean;
+export type PolymorphismPutMissingDiscriminatorResponse = SalmonUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1562,14 +1427,7 @@ export type PolymorphismPutMissingDiscriminatorResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type PolymorphicrecursiveGetValidResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
+export type PolymorphicrecursiveGetValidResponse = FishUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1588,12 +1446,7 @@ export type PolymorphicrecursiveGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type ReadonlypropertyGetValidResponse = {
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  size?: number;
+export type ReadonlypropertyGetValidResponse = ReadonlyObj & {
   /**
    * The underlying HTTP response.
    */
@@ -1612,13 +1465,7 @@ export type ReadonlypropertyGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type FlattencomplexGetValidResponse = {
-  propB1?: string;
-  /**
-   * Polymorphic Discriminator
-   */
-  kind: string;
-  propBH1?: string;
+export type FlattencomplexGetValidResponse = MyBaseTypeUnion & {
   /**
    * The underlying HTTP response.
    */

--- a/test/azure/generated/AzureResource/models/index.ts
+++ b/test/azure/generated/AzureResource/models/index.ts
@@ -196,10 +196,7 @@ export type GetDictionaryResponse = {
 /**
  * Contains response data for the getResourceCollection operation.
  */
-export type GetResourceCollectionResponse = {
-  productresource?: FlattenedProduct;
-  arrayofresources?: FlattenedProduct[];
-  dictionaryofresources?: { [propertyName: string]: FlattenedProduct };
+export type GetResourceCollectionResponse = ResourceCollection & {
   /**
    * The underlying HTTP response.
    */

--- a/test/azure/generated/AzureSpecials/models/index.ts
+++ b/test/azure/generated/AzureSpecials/models/index.ts
@@ -152,11 +152,7 @@ export interface HeaderCustomNamedRequestIdHeadHeaders {
 /**
  * Contains response data for the customNamedRequestId operation.
  */
-export type HeaderCustomNamedRequestIdResponse = {
-  /**
-   * Gets the foo-request-id.
-   */
-  fooRequestId: string;
+export type HeaderCustomNamedRequestIdResponse = HeaderCustomNamedRequestIdHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -171,11 +167,7 @@ export type HeaderCustomNamedRequestIdResponse = {
 /**
  * Contains response data for the customNamedRequestIdParamGrouping operation.
  */
-export type HeaderCustomNamedRequestIdParamGroupingResponse = {
-  /**
-   * Gets the foo-request-id.
-   */
-  fooRequestId: string;
+export type HeaderCustomNamedRequestIdParamGroupingResponse = HeaderCustomNamedRequestIdParamGroupingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -190,11 +182,7 @@ export type HeaderCustomNamedRequestIdParamGroupingResponse = {
 /**
  * Contains response data for the customNamedRequestIdHead operation.
  */
-export type HeaderCustomNamedRequestIdHeadResponse = {
-  /**
-   * Gets the foo-request-id.
-   */
-  fooRequestId: string;
+export type HeaderCustomNamedRequestIdHeadResponse = HeaderCustomNamedRequestIdHeadHeaders & {
   /**
    * The parsed response body.
    */

--- a/test/azure/generated/Lro/models/index.ts
+++ b/test/azure/generated/Lro/models/index.ts
@@ -2718,34 +2718,7 @@ export enum Status {
 /**
  * Contains response data for the put200Succeeded operation.
  */
-export type LROsPut200SucceededResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200SucceededResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2764,34 +2737,7 @@ export type LROsPut200SucceededResponse = {
 /**
  * Contains response data for the put200SucceededNoState operation.
  */
-export type LROsPut200SucceededNoStateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200SucceededNoStateResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2810,34 +2756,7 @@ export type LROsPut200SucceededNoStateResponse = {
 /**
  * Contains response data for the put202Retry200 operation.
  */
-export type LROsPut202Retry200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut202Retry200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2856,34 +2775,7 @@ export type LROsPut202Retry200Response = {
 /**
  * Contains response data for the put201CreatingSucceeded200 operation.
  */
-export type LROsPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2902,34 +2794,7 @@ export type LROsPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the put200UpdatingSucceeded204 operation.
  */
-export type LROsPut200UpdatingSucceeded204Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200UpdatingSucceeded204Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2948,34 +2813,7 @@ export type LROsPut200UpdatingSucceeded204Response = {
 /**
  * Contains response data for the put201CreatingFailed200 operation.
  */
-export type LROsPut201CreatingFailed200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut201CreatingFailed200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2994,34 +2832,7 @@ export type LROsPut201CreatingFailed200Response = {
 /**
  * Contains response data for the put200Acceptedcanceled200 operation.
  */
-export type LROsPut200Acceptedcanceled200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200Acceptedcanceled200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -3040,39 +2851,7 @@ export type LROsPut200Acceptedcanceled200Response = {
 /**
  * Contains response data for the putNoHeaderInRetry operation.
  */
-export type LROsPutNoHeaderInRetryResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noheader/202/200/operationResults
-   */
-  locationHeader: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutNoHeaderInRetryResponse = Product & LROsPutNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3095,48 +2874,7 @@ export type LROsPutNoHeaderInRetryResponse = {
 /**
  * Contains response data for the putAsyncRetrySucceeded operation.
  */
-export type LROsPutAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncRetrySucceededResponse = Product & LROsPutAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3159,44 +2897,7 @@ export type LROsPutAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the putAsyncNoRetrySucceeded operation.
  */
-export type LROsPutAsyncNoRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncNoRetrySucceededResponse = Product & LROsPutAsyncNoRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3219,48 +2920,7 @@ export type LROsPutAsyncNoRetrySucceededResponse = {
 /**
  * Contains response data for the putAsyncRetryFailed operation.
  */
-export type LROsPutAsyncRetryFailedResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncRetryFailedResponse = Product & LROsPutAsyncRetryFailedHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3283,44 +2943,7 @@ export type LROsPutAsyncRetryFailedResponse = {
 /**
  * Contains response data for the putAsyncNoRetrycanceled operation.
  */
-export type LROsPutAsyncNoRetrycanceledResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/canceled/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/canceled/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncNoRetrycanceledResponse = Product & LROsPutAsyncNoRetrycanceledHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3343,35 +2966,7 @@ export type LROsPutAsyncNoRetrycanceledResponse = {
 /**
  * Contains response data for the putAsyncNoHeaderInRetry operation.
  */
-export type LROsPutAsyncNoHeaderInRetryResponse = {
-  azureAsyncOperation: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncNoHeaderInRetryResponse = Product & LROsPutAsyncNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3394,9 +2989,7 @@ export type LROsPutAsyncNoHeaderInRetryResponse = {
 /**
  * Contains response data for the putNonResource operation.
  */
-export type LROsPutNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsPutNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -3415,9 +3008,7 @@ export type LROsPutNonResourceResponse = {
 /**
  * Contains response data for the putAsyncNonResource operation.
  */
-export type LROsPutAsyncNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsPutAsyncNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -3436,19 +3027,7 @@ export type LROsPutAsyncNonResourceResponse = {
 /**
  * Contains response data for the putSubResource operation.
  */
-export type LROsPutSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsPutSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -3467,19 +3046,7 @@ export type LROsPutSubResourceResponse = {
 /**
  * Contains response data for the putAsyncSubResource operation.
  */
-export type LROsPutAsyncSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsPutAsyncSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -3499,43 +3066,7 @@ export type LROsPutAsyncSubResourceResponse = {
  * Contains response data for the deleteProvisioning202Accepted200Succeeded
  * operation.
  */
-export type LROsDeleteProvisioning202Accepted200SucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/delete/provisioning/202/accepted/200/succeeded
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDeleteProvisioning202Accepted200SucceededResponse = Product & LROsDeleteProvisioning202Accepted200SucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3559,43 +3090,7 @@ export type LROsDeleteProvisioning202Accepted200SucceededResponse = {
  * Contains response data for the deleteProvisioning202DeletingFailed200
  * operation.
  */
-export type LROsDeleteProvisioning202DeletingFailed200Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/delete/provisioning/202/deleting/200/failed
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDeleteProvisioning202DeletingFailed200Response = Product & LROsDeleteProvisioning202DeletingFailed200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3619,43 +3114,7 @@ export type LROsDeleteProvisioning202DeletingFailed200Response = {
  * Contains response data for the deleteProvisioning202Deletingcanceled200
  * operation.
  */
-export type LROsDeleteProvisioning202Deletingcanceled200Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/delete/provisioning/202/deleting/200/canceled
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDeleteProvisioning202Deletingcanceled200Response = Product & LROsDeleteProvisioning202Deletingcanceled200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3678,42 +3137,7 @@ export type LROsDeleteProvisioning202Deletingcanceled200Response = {
 /**
  * Contains response data for the delete202Retry200 operation.
  */
-export type LROsDelete202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/delete/202/retry/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDelete202Retry200Response = Product & LROsDelete202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3736,42 +3160,7 @@ export type LROsDelete202Retry200Response = {
 /**
  * Contains response data for the delete202NoRetry204 operation.
  */
-export type LROsDelete202NoRetry204Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/delete/202/noretry/204
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDelete202NoRetry204Response = Product & LROsDelete202NoRetry204Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3794,11 +3183,7 @@ export type LROsDelete202NoRetry204Response = {
 /**
  * Contains response data for the deleteNoHeaderInRetry operation.
  */
-export type LROsDeleteNoHeaderInRetryResponse = {
-  /**
-   * Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults
-   */
-  location: string;
+export type LROsDeleteNoHeaderInRetryResponse = LROsDeleteNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3813,11 +3198,7 @@ export type LROsDeleteNoHeaderInRetryResponse = {
 /**
  * Contains response data for the deleteAsyncNoHeaderInRetry operation.
  */
-export type LROsDeleteAsyncNoHeaderInRetryResponse = {
-  /**
-   * Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults
-   */
-  location: string;
+export type LROsDeleteAsyncNoHeaderInRetryResponse = LROsDeleteAsyncNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3832,21 +3213,7 @@ export type LROsDeleteAsyncNoHeaderInRetryResponse = {
 /**
  * Contains response data for the deleteAsyncRetrySucceeded operation.
  */
-export type LROsDeleteAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncRetrySucceededResponse = LROsDeleteAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3861,21 +3228,7 @@ export type LROsDeleteAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the deleteAsyncNoRetrySucceeded operation.
  */
-export type LROsDeleteAsyncNoRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/noretry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/noretry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncNoRetrySucceededResponse = LROsDeleteAsyncNoRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3890,21 +3243,7 @@ export type LROsDeleteAsyncNoRetrySucceededResponse = {
 /**
  * Contains response data for the deleteAsyncRetryFailed operation.
  */
-export type LROsDeleteAsyncRetryFailedResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/failed/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncRetryFailedResponse = LROsDeleteAsyncRetryFailedHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3919,21 +3258,7 @@ export type LROsDeleteAsyncRetryFailedResponse = {
 /**
  * Contains response data for the deleteAsyncRetrycanceled operation.
  */
-export type LROsDeleteAsyncRetrycanceledResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/canceled/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/canceled/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncRetrycanceledResponse = LROsDeleteAsyncRetrycanceledHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3948,9 +3273,7 @@ export type LROsDeleteAsyncRetrycanceledResponse = {
 /**
  * Contains response data for the post200WithPayload operation.
  */
-export type LROsPost200WithPayloadResponse = {
-  name?: string;
-  id?: string;
+export type LROsPost200WithPayloadResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -3969,15 +3292,7 @@ export type LROsPost200WithPayloadResponse = {
 /**
  * Contains response data for the post202Retry200 operation.
  */
-export type LROsPost202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsPost202Retry200Response = LROsPost202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3992,42 +3307,7 @@ export type LROsPost202Retry200Response = {
 /**
  * Contains response data for the post202NoRetry204 operation.
  */
-export type LROsPost202NoRetry204Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/post/202/noretry/204
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPost202NoRetry204Response = Product & LROsPost202NoRetry204Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -4050,34 +3330,7 @@ export type LROsPost202NoRetry204Response = {
 /**
  * Contains response data for the postDoubleHeadersFinalLocationGet operation.
  */
-export type LROsPostDoubleHeadersFinalLocationGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostDoubleHeadersFinalLocationGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4097,34 +3350,7 @@ export type LROsPostDoubleHeadersFinalLocationGetResponse = {
  * Contains response data for the postDoubleHeadersFinalAzureHeaderGet
  * operation.
  */
-export type LROsPostDoubleHeadersFinalAzureHeaderGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostDoubleHeadersFinalAzureHeaderGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4144,34 +3370,7 @@ export type LROsPostDoubleHeadersFinalAzureHeaderGetResponse = {
  * Contains response data for the postDoubleHeadersFinalAzureHeaderGetDefault
  * operation.
  */
-export type LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4190,48 +3389,7 @@ export type LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
 /**
  * Contains response data for the postAsyncRetrySucceeded operation.
  */
-export type LROsPostAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostAsyncRetrySucceededResponse = Product & LROsPostAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4254,48 +3412,7 @@ export type LROsPostAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the postAsyncNoRetrySucceeded operation.
  */
-export type LROsPostAsyncNoRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostAsyncNoRetrySucceededResponse = Product & LROsPostAsyncNoRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4318,21 +3435,7 @@ export type LROsPostAsyncNoRetrySucceededResponse = {
 /**
  * Contains response data for the postAsyncRetryFailed operation.
  */
-export type LROsPostAsyncRetryFailedResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsPostAsyncRetryFailedResponse = LROsPostAsyncRetryFailedHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4347,21 +3450,7 @@ export type LROsPostAsyncRetryFailedResponse = {
 /**
  * Contains response data for the postAsyncRetrycanceled operation.
  */
-export type LROsPostAsyncRetrycanceledResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/canceled/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/canceled/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsPostAsyncRetrycanceledResponse = LROsPostAsyncRetrycanceledHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4376,34 +3465,7 @@ export type LROsPostAsyncRetrycanceledResponse = {
 /**
  * Contains response data for the beginPut200Succeeded operation.
  */
-export type LROsBeginPut200SucceededResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200SucceededResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4422,34 +3484,7 @@ export type LROsBeginPut200SucceededResponse = {
 /**
  * Contains response data for the beginPut200SucceededNoState operation.
  */
-export type LROsBeginPut200SucceededNoStateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200SucceededNoStateResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4468,34 +3503,7 @@ export type LROsBeginPut200SucceededNoStateResponse = {
 /**
  * Contains response data for the beginPut202Retry200 operation.
  */
-export type LROsBeginPut202Retry200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut202Retry200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4514,34 +3522,7 @@ export type LROsBeginPut202Retry200Response = {
 /**
  * Contains response data for the beginPut201CreatingSucceeded200 operation.
  */
-export type LROsBeginPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4560,34 +3541,7 @@ export type LROsBeginPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the beginPut200UpdatingSucceeded204 operation.
  */
-export type LROsBeginPut200UpdatingSucceeded204Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200UpdatingSucceeded204Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4606,34 +3560,7 @@ export type LROsBeginPut200UpdatingSucceeded204Response = {
 /**
  * Contains response data for the beginPut201CreatingFailed200 operation.
  */
-export type LROsBeginPut201CreatingFailed200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut201CreatingFailed200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4652,34 +3579,7 @@ export type LROsBeginPut201CreatingFailed200Response = {
 /**
  * Contains response data for the beginPut200Acceptedcanceled200 operation.
  */
-export type LROsBeginPut200Acceptedcanceled200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200Acceptedcanceled200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4698,9 +3598,7 @@ export type LROsBeginPut200Acceptedcanceled200Response = {
 /**
  * Contains response data for the beginPutNonResource operation.
  */
-export type LROsBeginPutNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsBeginPutNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -4719,9 +3617,7 @@ export type LROsBeginPutNonResourceResponse = {
 /**
  * Contains response data for the beginPutAsyncNonResource operation.
  */
-export type LROsBeginPutAsyncNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsBeginPutAsyncNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -4740,19 +3636,7 @@ export type LROsBeginPutAsyncNonResourceResponse = {
 /**
  * Contains response data for the beginPutSubResource operation.
  */
-export type LROsBeginPutSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsBeginPutSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -4771,19 +3655,7 @@ export type LROsBeginPutSubResourceResponse = {
 /**
  * Contains response data for the beginPutAsyncSubResource operation.
  */
-export type LROsBeginPutAsyncSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsBeginPutAsyncSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -4802,9 +3674,7 @@ export type LROsBeginPutAsyncSubResourceResponse = {
 /**
  * Contains response data for the beginPost200WithPayload operation.
  */
-export type LROsBeginPost200WithPayloadResponse = {
-  name?: string;
-  id?: string;
+export type LROsBeginPost200WithPayloadResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -4824,34 +3694,7 @@ export type LROsBeginPost200WithPayloadResponse = {
  * Contains response data for the beginPostDoubleHeadersFinalLocationGet
  * operation.
  */
-export type LROsBeginPostDoubleHeadersFinalLocationGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPostDoubleHeadersFinalLocationGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4871,34 +3714,7 @@ export type LROsBeginPostDoubleHeadersFinalLocationGetResponse = {
  * Contains response data for the beginPostDoubleHeadersFinalAzureHeaderGet
  * operation.
  */
-export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4918,34 +3734,7 @@ export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetResponse = {
  * Contains response data for the
  * beginPostDoubleHeadersFinalAzureHeaderGetDefault operation.
  */
-export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4964,34 +3753,7 @@ export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
 /**
  * Contains response data for the put201CreatingSucceeded200 operation.
  */
-export type LRORetrysPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5010,48 +3772,7 @@ export type LRORetrysPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the putAsyncRelativeRetrySucceeded operation.
  */
-export type LRORetrysPutAsyncRelativeRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysPutAsyncRelativeRetrySucceededResponse = Product & LRORetrysPutAsyncRelativeRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5075,43 +3796,7 @@ export type LRORetrysPutAsyncRelativeRetrySucceededResponse = {
  * Contains response data for the deleteProvisioning202Accepted200Succeeded
  * operation.
  */
-export type LRORetrysDeleteProvisioning202Accepted200SucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/delete/provisioning/202/accepted/200/succeeded
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysDeleteProvisioning202Accepted200SucceededResponse = Product & LRORetrysDeleteProvisioning202Accepted200SucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5134,15 +3819,7 @@ export type LRORetrysDeleteProvisioning202Accepted200SucceededResponse = {
 /**
  * Contains response data for the delete202Retry200 operation.
  */
-export type LRORetrysDelete202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysDelete202Retry200Response = LRORetrysDelete202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5157,21 +3834,7 @@ export type LRORetrysDelete202Retry200Response = {
 /**
  * Contains response data for the deleteAsyncRelativeRetrySucceeded operation.
  */
-export type LRORetrysDeleteAsyncRelativeRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/deleteasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/deleteasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysDeleteAsyncRelativeRetrySucceededResponse = LRORetrysDeleteAsyncRelativeRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5186,15 +3849,7 @@ export type LRORetrysDeleteAsyncRelativeRetrySucceededResponse = {
 /**
  * Contains response data for the post202Retry200 operation.
  */
-export type LRORetrysPost202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysPost202Retry200Response = LRORetrysPost202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5209,21 +3864,7 @@ export type LRORetrysPost202Retry200Response = {
 /**
  * Contains response data for the postAsyncRelativeRetrySucceeded operation.
  */
-export type LRORetrysPostAsyncRelativeRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysPostAsyncRelativeRetrySucceededResponse = LRORetrysPostAsyncRelativeRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5238,34 +3879,7 @@ export type LRORetrysPostAsyncRelativeRetrySucceededResponse = {
 /**
  * Contains response data for the beginPut201CreatingSucceeded200 operation.
  */
-export type LRORetrysBeginPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysBeginPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5284,34 +3898,7 @@ export type LRORetrysBeginPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the putNonRetry400 operation.
  */
-export type LROSADsPutNonRetry400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutNonRetry400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5330,34 +3917,7 @@ export type LROSADsPutNonRetry400Response = {
 /**
  * Contains response data for the putNonRetry201Creating400 operation.
  */
-export type LROSADsPutNonRetry201Creating400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutNonRetry201Creating400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5377,34 +3937,7 @@ export type LROSADsPutNonRetry201Creating400Response = {
  * Contains response data for the putNonRetry201Creating400InvalidJson
  * operation.
  */
-export type LROSADsPutNonRetry201Creating400InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutNonRetry201Creating400InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5423,48 +3956,7 @@ export type LROSADsPutNonRetry201Creating400InvalidJsonResponse = {
 /**
  * Contains response data for the putAsyncRelativeRetry400 operation.
  */
-export type LROSADsPutAsyncRelativeRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetry400Response = Product & LROSADsPutAsyncRelativeRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5487,15 +3979,7 @@ export type LROSADsPutAsyncRelativeRetry400Response = {
 /**
  * Contains response data for the deleteNonRetry400 operation.
  */
-export type LROSADsDeleteNonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteNonRetry400Response = LROSADsDeleteNonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5510,15 +3994,7 @@ export type LROSADsDeleteNonRetry400Response = {
 /**
  * Contains response data for the delete202NonRetry400 operation.
  */
-export type LROSADsDelete202NonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDelete202NonRetry400Response = LROSADsDelete202NonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5533,21 +4009,7 @@ export type LROSADsDelete202NonRetry400Response = {
 /**
  * Contains response data for the deleteAsyncRelativeRetry400 operation.
  */
-export type LROSADsDeleteAsyncRelativeRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/deleteasync/retry/operationResults/400
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/deleteasync/retry/operationResults/400
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetry400Response = LROSADsDeleteAsyncRelativeRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5562,15 +4024,7 @@ export type LROSADsDeleteAsyncRelativeRetry400Response = {
 /**
  * Contains response data for the postNonRetry400 operation.
  */
-export type LROSADsPostNonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostNonRetry400Response = LROSADsPostNonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5585,15 +4039,7 @@ export type LROSADsPostNonRetry400Response = {
 /**
  * Contains response data for the post202NonRetry400 operation.
  */
-export type LROSADsPost202NonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPost202NonRetry400Response = LROSADsPost202NonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5608,21 +4054,7 @@ export type LROSADsPost202NonRetry400Response = {
 /**
  * Contains response data for the postAsyncRelativeRetry400 operation.
  */
-export type LROSADsPostAsyncRelativeRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetry400Response = LROSADsPostAsyncRelativeRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5638,34 +4070,7 @@ export type LROSADsPostAsyncRelativeRetry400Response = {
  * Contains response data for the putError201NoProvisioningStatePayload
  * operation.
  */
-export type LROSADsPutError201NoProvisioningStatePayloadResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutError201NoProvisioningStatePayloadResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5684,48 +4089,7 @@ export type LROSADsPutError201NoProvisioningStatePayloadResponse = {
 /**
  * Contains response data for the putAsyncRelativeRetryNoStatus operation.
  */
-export type LROSADsPutAsyncRelativeRetryNoStatusResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryNoStatusResponse = Product & LROSADsPutAsyncRelativeRetryNoStatusHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5749,48 +4113,7 @@ export type LROSADsPutAsyncRelativeRetryNoStatusResponse = {
  * Contains response data for the putAsyncRelativeRetryNoStatusPayload
  * operation.
  */
-export type LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse = Product & LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5813,21 +4136,7 @@ export type LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse = {
 /**
  * Contains response data for the deleteAsyncRelativeRetryNoStatus operation.
  */
-export type LROSADsDeleteAsyncRelativeRetryNoStatusResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetryNoStatusResponse = LROSADsDeleteAsyncRelativeRetryNoStatusHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5842,15 +4151,7 @@ export type LROSADsDeleteAsyncRelativeRetryNoStatusResponse = {
 /**
  * Contains response data for the post202NoLocation operation.
  */
-export type LROSADsPost202NoLocationResponse = {
-  /**
-   * Location to poll for result status: will not be set
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPost202NoLocationResponse = LROSADsPost202NoLocationHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5865,21 +4166,7 @@ export type LROSADsPost202NoLocationResponse = {
 /**
  * Contains response data for the postAsyncRelativeRetryNoPayload operation.
  */
-export type LROSADsPostAsyncRelativeRetryNoPayloadResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/putasync/retry/failed/operationResults/nopayload
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/putasync/retry/failed/operationResults/nopayload
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetryNoPayloadResponse = LROSADsPostAsyncRelativeRetryNoPayloadHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5894,34 +4181,7 @@ export type LROSADsPostAsyncRelativeRetryNoPayloadResponse = {
 /**
  * Contains response data for the put200InvalidJson operation.
  */
-export type LROSADsPut200InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPut200InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5940,48 +4200,7 @@ export type LROSADsPut200InvalidJsonResponse = {
 /**
  * Contains response data for the putAsyncRelativeRetryInvalidHeader operation.
  */
-export type LROSADsPutAsyncRelativeRetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryInvalidHeaderResponse = Product & LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6005,48 +4224,7 @@ export type LROSADsPutAsyncRelativeRetryInvalidHeaderResponse = {
  * Contains response data for the putAsyncRelativeRetryInvalidJsonPolling
  * operation.
  */
-export type LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse = Product & LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6069,15 +4247,7 @@ export type LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse = {
 /**
  * Contains response data for the delete202RetryInvalidHeader operation.
  */
-export type LROSADsDelete202RetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsDelete202RetryInvalidHeaderResponse = LROSADsDelete202RetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6093,19 +4263,7 @@ export type LROSADsDelete202RetryInvalidHeaderResponse = {
  * Contains response data for the deleteAsyncRelativeRetryInvalidHeader
  * operation.
  */
-export type LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse = LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6121,21 +4279,7 @@ export type LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse = {
  * Contains response data for the deleteAsyncRelativeRetryInvalidJsonPolling
  * operation.
  */
-export type LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse = LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6150,15 +4294,7 @@ export type LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse = {
 /**
  * Contains response data for the post202RetryInvalidHeader operation.
  */
-export type LROSADsPost202RetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsPost202RetryInvalidHeaderResponse = LROSADsPost202RetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6174,19 +4310,7 @@ export type LROSADsPost202RetryInvalidHeaderResponse = {
  * Contains response data for the postAsyncRelativeRetryInvalidHeader
  * operation.
  */
-export type LROSADsPostAsyncRelativeRetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to foo
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetryInvalidHeaderResponse = LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6202,21 +4326,7 @@ export type LROSADsPostAsyncRelativeRetryInvalidHeaderResponse = {
  * Contains response data for the postAsyncRelativeRetryInvalidJsonPolling
  * operation.
  */
-export type LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse = LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6231,34 +4341,7 @@ export type LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse = {
 /**
  * Contains response data for the beginPutNonRetry400 operation.
  */
-export type LROSADsBeginPutNonRetry400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutNonRetry400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6277,34 +4360,7 @@ export type LROSADsBeginPutNonRetry400Response = {
 /**
  * Contains response data for the beginPutNonRetry201Creating400 operation.
  */
-export type LROSADsBeginPutNonRetry201Creating400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutNonRetry201Creating400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6324,34 +4380,7 @@ export type LROSADsBeginPutNonRetry201Creating400Response = {
  * Contains response data for the beginPutNonRetry201Creating400InvalidJson
  * operation.
  */
-export type LROSADsBeginPutNonRetry201Creating400InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutNonRetry201Creating400InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6371,34 +4400,7 @@ export type LROSADsBeginPutNonRetry201Creating400InvalidJsonResponse = {
  * Contains response data for the beginPutError201NoProvisioningStatePayload
  * operation.
  */
-export type LROSADsBeginPutError201NoProvisioningStatePayloadResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutError201NoProvisioningStatePayloadResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6417,34 +4419,7 @@ export type LROSADsBeginPutError201NoProvisioningStatePayloadResponse = {
 /**
  * Contains response data for the beginPut200InvalidJson operation.
  */
-export type LROSADsBeginPut200InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPut200InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6463,48 +4438,7 @@ export type LROSADsBeginPut200InvalidJsonResponse = {
 /**
  * Contains response data for the putAsyncRetrySucceeded operation.
  */
-export type LROsCustomHeaderPutAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsCustomHeaderPutAsyncRetrySucceededResponse = Product & LROsCustomHeaderPutAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6527,34 +4461,7 @@ export type LROsCustomHeaderPutAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the put201CreatingSucceeded200 operation.
  */
-export type LROsCustomHeaderPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsCustomHeaderPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6573,15 +4480,7 @@ export type LROsCustomHeaderPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the post202Retry200 operation.
  */
-export type LROsCustomHeaderPost202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/customheader/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsCustomHeaderPost202Retry200Response = LROsCustomHeaderPost202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -6596,21 +4495,7 @@ export type LROsCustomHeaderPost202Retry200Response = {
 /**
  * Contains response data for the postAsyncRetrySucceeded operation.
  */
-export type LROsCustomHeaderPostAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsCustomHeaderPostAsyncRetrySucceededResponse = LROsCustomHeaderPostAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6625,34 +4510,7 @@ export type LROsCustomHeaderPostAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the beginPut201CreatingSucceeded200 operation.
  */
-export type LROsCustomHeaderBeginPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsCustomHeaderBeginPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */

--- a/test/azure/generated/Paging/models/index.ts
+++ b/test/azure/generated/Paging/models/index.ts
@@ -417,9 +417,7 @@ export enum Status {
 /**
  * Contains response data for the getSinglePages operation.
  */
-export type PagingGetSinglePagesResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetSinglePagesResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -438,9 +436,7 @@ export type PagingGetSinglePagesResponse = {
 /**
  * Contains response data for the getMultiplePages operation.
  */
-export type PagingGetMultiplePagesResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -459,9 +455,7 @@ export type PagingGetMultiplePagesResponse = {
 /**
  * Contains response data for the getOdataMultiplePages operation.
  */
-export type PagingGetOdataMultiplePagesResponse = {
-  values?: Product[];
-  odatanextLink?: string;
+export type PagingGetOdataMultiplePagesResponse = OdataProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -480,9 +474,7 @@ export type PagingGetOdataMultiplePagesResponse = {
 /**
  * Contains response data for the getMultiplePagesWithOffset operation.
  */
-export type PagingGetMultiplePagesWithOffsetResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesWithOffsetResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -501,9 +493,7 @@ export type PagingGetMultiplePagesWithOffsetResponse = {
 /**
  * Contains response data for the getMultiplePagesRetryFirst operation.
  */
-export type PagingGetMultiplePagesRetryFirstResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesRetryFirstResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -522,9 +512,7 @@ export type PagingGetMultiplePagesRetryFirstResponse = {
 /**
  * Contains response data for the getMultiplePagesRetrySecond operation.
  */
-export type PagingGetMultiplePagesRetrySecondResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesRetrySecondResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -543,9 +531,7 @@ export type PagingGetMultiplePagesRetrySecondResponse = {
 /**
  * Contains response data for the getSinglePagesFailure operation.
  */
-export type PagingGetSinglePagesFailureResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetSinglePagesFailureResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -564,9 +550,7 @@ export type PagingGetSinglePagesFailureResponse = {
 /**
  * Contains response data for the getMultiplePagesFailure operation.
  */
-export type PagingGetMultiplePagesFailureResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesFailureResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -585,9 +569,7 @@ export type PagingGetMultiplePagesFailureResponse = {
 /**
  * Contains response data for the getMultiplePagesFailureUri operation.
  */
-export type PagingGetMultiplePagesFailureUriResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesFailureUriResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -606,9 +588,7 @@ export type PagingGetMultiplePagesFailureUriResponse = {
 /**
  * Contains response data for the getMultiplePagesFragmentNextLink operation.
  */
-export type PagingGetMultiplePagesFragmentNextLinkResponse = {
-  values?: Product[];
-  odatanextLink?: string;
+export type PagingGetMultiplePagesFragmentNextLinkResponse = OdataProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -628,9 +608,7 @@ export type PagingGetMultiplePagesFragmentNextLinkResponse = {
  * Contains response data for the getMultiplePagesFragmentWithGroupingNextLink
  * operation.
  */
-export type PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse = {
-  values?: Product[];
-  odatanextLink?: string;
+export type PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse = OdataProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -649,9 +627,7 @@ export type PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse = {
 /**
  * Contains response data for the getMultiplePagesLRO operation.
  */
-export type PagingGetMultiplePagesLROResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesLROResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -670,9 +646,7 @@ export type PagingGetMultiplePagesLROResponse = {
 /**
  * Contains response data for the nextFragment operation.
  */
-export type PagingNextFragmentResponse = {
-  values?: Product[];
-  odatanextLink?: string;
+export type PagingNextFragmentResponse = OdataProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -691,9 +665,7 @@ export type PagingNextFragmentResponse = {
 /**
  * Contains response data for the nextFragmentWithGrouping operation.
  */
-export type PagingNextFragmentWithGroupingResponse = {
-  values?: Product[];
-  odatanextLink?: string;
+export type PagingNextFragmentWithGroupingResponse = OdataProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -712,9 +684,7 @@ export type PagingNextFragmentWithGroupingResponse = {
 /**
  * Contains response data for the beginGetMultiplePagesLRO operation.
  */
-export type PagingBeginGetMultiplePagesLROResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingBeginGetMultiplePagesLROResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -733,9 +703,7 @@ export type PagingBeginGetMultiplePagesLROResponse = {
 /**
  * Contains response data for the getSinglePagesNext operation.
  */
-export type PagingGetSinglePagesNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetSinglePagesNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -754,9 +722,7 @@ export type PagingGetSinglePagesNextResponse = {
 /**
  * Contains response data for the getMultiplePagesNext operation.
  */
-export type PagingGetMultiplePagesNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -775,9 +741,7 @@ export type PagingGetMultiplePagesNextResponse = {
 /**
  * Contains response data for the getOdataMultiplePagesNext operation.
  */
-export type PagingGetOdataMultiplePagesNextResponse = {
-  values?: Product[];
-  odatanextLink?: string;
+export type PagingGetOdataMultiplePagesNextResponse = OdataProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -796,9 +760,7 @@ export type PagingGetOdataMultiplePagesNextResponse = {
 /**
  * Contains response data for the getMultiplePagesWithOffsetNext operation.
  */
-export type PagingGetMultiplePagesWithOffsetNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesWithOffsetNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -817,9 +779,7 @@ export type PagingGetMultiplePagesWithOffsetNextResponse = {
 /**
  * Contains response data for the getMultiplePagesRetryFirstNext operation.
  */
-export type PagingGetMultiplePagesRetryFirstNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesRetryFirstNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -838,9 +798,7 @@ export type PagingGetMultiplePagesRetryFirstNextResponse = {
 /**
  * Contains response data for the getMultiplePagesRetrySecondNext operation.
  */
-export type PagingGetMultiplePagesRetrySecondNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesRetrySecondNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -859,9 +817,7 @@ export type PagingGetMultiplePagesRetrySecondNextResponse = {
 /**
  * Contains response data for the getSinglePagesFailureNext operation.
  */
-export type PagingGetSinglePagesFailureNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetSinglePagesFailureNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -880,9 +836,7 @@ export type PagingGetSinglePagesFailureNextResponse = {
 /**
  * Contains response data for the getMultiplePagesFailureNext operation.
  */
-export type PagingGetMultiplePagesFailureNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesFailureNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -901,9 +855,7 @@ export type PagingGetMultiplePagesFailureNextResponse = {
 /**
  * Contains response data for the getMultiplePagesFailureUriNext operation.
  */
-export type PagingGetMultiplePagesFailureUriNextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesFailureUriNextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -922,9 +874,7 @@ export type PagingGetMultiplePagesFailureUriNextResponse = {
 /**
  * Contains response data for the getMultiplePagesLRONext operation.
  */
-export type PagingGetMultiplePagesLRONextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingGetMultiplePagesLRONextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */
@@ -943,9 +893,7 @@ export type PagingGetMultiplePagesLRONextResponse = {
 /**
  * Contains response data for the beginGetMultiplePagesLRONext operation.
  */
-export type PagingBeginGetMultiplePagesLRONextResponse = {
-  values?: Product[];
-  nextLink?: string;
+export type PagingBeginGetMultiplePagesLRONextResponse = ProductResult & {
   /**
    * The underlying HTTP response.
    */

--- a/test/azure/generated/StorageManagementClient/models/index.ts
+++ b/test/azure/generated/StorageManagementClient/models/index.ts
@@ -498,22 +498,7 @@ export enum UsageUnit {
 /**
  * Contains response data for the checkNameAvailability operation.
  */
-export type StorageAccountsCheckNameAvailabilityResponse = {
-  /**
-   * Gets a boolean value that indicates whether the name is available for you to use. If true, the
-   * name is available. If false, the name has already been taken or invalid and cannot be used.
-   */
-  nameAvailable?: boolean;
-  /**
-   * Gets the reason that a storage account name could not be used. The Reason element is only
-   * returned if NameAvailable is false. Possible values include: 'AccountNameInvalid',
-   * 'AlreadyExists'
-   */
-  reason?: Reason;
-  /**
-   * Gets an error message explaining the Reason value in more detail.
-   */
-  message?: string;
+export type StorageAccountsCheckNameAvailabilityResponse = CheckNameAvailabilityResult & {
   /**
    * The underlying HTTP response.
    */
@@ -532,85 +517,7 @@ export type StorageAccountsCheckNameAvailabilityResponse = {
 /**
  * Contains response data for the create operation.
  */
-export type StorageAccountsCreateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  /**
-   * Resource type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  /**
-   * Resource location
-   */
-  location: string;
-  /**
-   * Resource tags
-   */
-  tags?: { [propertyName: string]: string };
-  /**
-   * Gets the status of the storage account at the time the operation was called. Possible values
-   * include: 'Creating', 'ResolvingDNS', 'Succeeded'
-   */
-  provisioningState?: ProvisioningState;
-  /**
-   * Gets the type of the storage account. Possible values include: 'Standard_LRS', 'Standard_ZRS',
-   * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
-   */
-  accountType?: AccountType;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table
-   * object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.
-   */
-  primaryEndpoints?: Endpoints;
-  /**
-   * Gets the location of the primary for the storage account.
-   */
-  primaryLocation?: string;
-  /**
-   * Gets the status indicating whether the primary location of the storage account is available or
-   * unavailable. Possible values include: 'Available', 'Unavailable'
-   */
-  statusOfPrimary?: AccountStatus;
-  /**
-   * Gets the timestamp of the most recent instance of a failover to the secondary location. Only
-   * the most recent timestamp is retained. This element is not returned if there has never been a
-   * failover instance. Only available if the accountType is StandardGRS or StandardRAGRS.
-   */
-  lastGeoFailoverTime?: Date;
-  /**
-   * Gets the location of the geo replicated secondary for the storage account. Only available if
-   * the accountType is StandardGRS or StandardRAGRS.
-   */
-  secondaryLocation?: string;
-  /**
-   * Gets the status indicating whether the secondary location of the storage account is available
-   * or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS. Possible
-   * values include: 'Available', 'Unavailable'
-   */
-  statusOfSecondary?: AccountStatus;
-  /**
-   * Gets the creation date and time of the storage account in UTC.
-   */
-  creationTime?: Date;
-  /**
-   * Gets the user assigned custom domain assigned to this storage account.
-   */
-  customDomain?: CustomDomain;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table object
-   * from the secondary location of the storage account. Only available if the accountType is
-   * StandardRAGRS.
-   */
-  secondaryEndpoints?: Endpoints;
+export type StorageAccountsCreateResponse = StorageAccount & {
   /**
    * The underlying HTTP response.
    */
@@ -629,85 +536,7 @@ export type StorageAccountsCreateResponse = {
 /**
  * Contains response data for the getProperties operation.
  */
-export type StorageAccountsGetPropertiesResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  /**
-   * Resource type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  /**
-   * Resource location
-   */
-  location: string;
-  /**
-   * Resource tags
-   */
-  tags?: { [propertyName: string]: string };
-  /**
-   * Gets the status of the storage account at the time the operation was called. Possible values
-   * include: 'Creating', 'ResolvingDNS', 'Succeeded'
-   */
-  provisioningState?: ProvisioningState;
-  /**
-   * Gets the type of the storage account. Possible values include: 'Standard_LRS', 'Standard_ZRS',
-   * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
-   */
-  accountType?: AccountType;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table
-   * object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.
-   */
-  primaryEndpoints?: Endpoints;
-  /**
-   * Gets the location of the primary for the storage account.
-   */
-  primaryLocation?: string;
-  /**
-   * Gets the status indicating whether the primary location of the storage account is available or
-   * unavailable. Possible values include: 'Available', 'Unavailable'
-   */
-  statusOfPrimary?: AccountStatus;
-  /**
-   * Gets the timestamp of the most recent instance of a failover to the secondary location. Only
-   * the most recent timestamp is retained. This element is not returned if there has never been a
-   * failover instance. Only available if the accountType is StandardGRS or StandardRAGRS.
-   */
-  lastGeoFailoverTime?: Date;
-  /**
-   * Gets the location of the geo replicated secondary for the storage account. Only available if
-   * the accountType is StandardGRS or StandardRAGRS.
-   */
-  secondaryLocation?: string;
-  /**
-   * Gets the status indicating whether the secondary location of the storage account is available
-   * or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS. Possible
-   * values include: 'Available', 'Unavailable'
-   */
-  statusOfSecondary?: AccountStatus;
-  /**
-   * Gets the creation date and time of the storage account in UTC.
-   */
-  creationTime?: Date;
-  /**
-   * Gets the user assigned custom domain assigned to this storage account.
-   */
-  customDomain?: CustomDomain;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table object
-   * from the secondary location of the storage account. Only available if the accountType is
-   * StandardRAGRS.
-   */
-  secondaryEndpoints?: Endpoints;
+export type StorageAccountsGetPropertiesResponse = StorageAccount & {
   /**
    * The underlying HTTP response.
    */
@@ -726,85 +555,7 @@ export type StorageAccountsGetPropertiesResponse = {
 /**
  * Contains response data for the update operation.
  */
-export type StorageAccountsUpdateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  /**
-   * Resource type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  /**
-   * Resource location
-   */
-  location: string;
-  /**
-   * Resource tags
-   */
-  tags?: { [propertyName: string]: string };
-  /**
-   * Gets the status of the storage account at the time the operation was called. Possible values
-   * include: 'Creating', 'ResolvingDNS', 'Succeeded'
-   */
-  provisioningState?: ProvisioningState;
-  /**
-   * Gets the type of the storage account. Possible values include: 'Standard_LRS', 'Standard_ZRS',
-   * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
-   */
-  accountType?: AccountType;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table
-   * object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.
-   */
-  primaryEndpoints?: Endpoints;
-  /**
-   * Gets the location of the primary for the storage account.
-   */
-  primaryLocation?: string;
-  /**
-   * Gets the status indicating whether the primary location of the storage account is available or
-   * unavailable. Possible values include: 'Available', 'Unavailable'
-   */
-  statusOfPrimary?: AccountStatus;
-  /**
-   * Gets the timestamp of the most recent instance of a failover to the secondary location. Only
-   * the most recent timestamp is retained. This element is not returned if there has never been a
-   * failover instance. Only available if the accountType is StandardGRS or StandardRAGRS.
-   */
-  lastGeoFailoverTime?: Date;
-  /**
-   * Gets the location of the geo replicated secondary for the storage account. Only available if
-   * the accountType is StandardGRS or StandardRAGRS.
-   */
-  secondaryLocation?: string;
-  /**
-   * Gets the status indicating whether the secondary location of the storage account is available
-   * or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS. Possible
-   * values include: 'Available', 'Unavailable'
-   */
-  statusOfSecondary?: AccountStatus;
-  /**
-   * Gets the creation date and time of the storage account in UTC.
-   */
-  creationTime?: Date;
-  /**
-   * Gets the user assigned custom domain assigned to this storage account.
-   */
-  customDomain?: CustomDomain;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table object
-   * from the secondary location of the storage account. Only available if the accountType is
-   * StandardRAGRS.
-   */
-  secondaryEndpoints?: Endpoints;
+export type StorageAccountsUpdateResponse = StorageAccount & {
   /**
    * The underlying HTTP response.
    */
@@ -823,15 +574,7 @@ export type StorageAccountsUpdateResponse = {
 /**
  * Contains response data for the listKeys operation.
  */
-export type StorageAccountsListKeysResponse = {
-  /**
-   * Gets the value of key 1.
-   */
-  key1?: string;
-  /**
-   * Gets the value of key 2.
-   */
-  key2?: string;
+export type StorageAccountsListKeysResponse = StorageAccountKeys & {
   /**
    * The underlying HTTP response.
    */
@@ -850,16 +593,7 @@ export type StorageAccountsListKeysResponse = {
 /**
  * Contains response data for the list operation.
  */
-export type StorageAccountsListResponse = {
-  /**
-   * Gets the list of storage accounts and their properties.
-   */
-  value?: StorageAccount[];
-  /**
-   * Gets the link to the next set of results. Currently this will always be empty as the API does
-   * not support pagination.
-   */
-  nextLink?: string;
+export type StorageAccountsListResponse = StorageAccountListResult & {
   /**
    * The underlying HTTP response.
    */
@@ -878,16 +612,7 @@ export type StorageAccountsListResponse = {
 /**
  * Contains response data for the listByResourceGroup operation.
  */
-export type StorageAccountsListByResourceGroupResponse = {
-  /**
-   * Gets the list of storage accounts and their properties.
-   */
-  value?: StorageAccount[];
-  /**
-   * Gets the link to the next set of results. Currently this will always be empty as the API does
-   * not support pagination.
-   */
-  nextLink?: string;
+export type StorageAccountsListByResourceGroupResponse = StorageAccountListResult & {
   /**
    * The underlying HTTP response.
    */
@@ -906,15 +631,7 @@ export type StorageAccountsListByResourceGroupResponse = {
 /**
  * Contains response data for the regenerateKey operation.
  */
-export type StorageAccountsRegenerateKeyResponse = {
-  /**
-   * Gets the value of key 1.
-   */
-  key1?: string;
-  /**
-   * Gets the value of key 2.
-   */
-  key2?: string;
+export type StorageAccountsRegenerateKeyResponse = StorageAccountKeys & {
   /**
    * The underlying HTTP response.
    */
@@ -933,85 +650,7 @@ export type StorageAccountsRegenerateKeyResponse = {
 /**
  * Contains response data for the beginCreate operation.
  */
-export type StorageAccountsBeginCreateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  /**
-   * Resource type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  /**
-   * Resource location
-   */
-  location: string;
-  /**
-   * Resource tags
-   */
-  tags?: { [propertyName: string]: string };
-  /**
-   * Gets the status of the storage account at the time the operation was called. Possible values
-   * include: 'Creating', 'ResolvingDNS', 'Succeeded'
-   */
-  provisioningState?: ProvisioningState;
-  /**
-   * Gets the type of the storage account. Possible values include: 'Standard_LRS', 'Standard_ZRS',
-   * 'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
-   */
-  accountType?: AccountType;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table
-   * object.Note that StandardZRS and PremiumLRS accounts only return the blob endpoint.
-   */
-  primaryEndpoints?: Endpoints;
-  /**
-   * Gets the location of the primary for the storage account.
-   */
-  primaryLocation?: string;
-  /**
-   * Gets the status indicating whether the primary location of the storage account is available or
-   * unavailable. Possible values include: 'Available', 'Unavailable'
-   */
-  statusOfPrimary?: AccountStatus;
-  /**
-   * Gets the timestamp of the most recent instance of a failover to the secondary location. Only
-   * the most recent timestamp is retained. This element is not returned if there has never been a
-   * failover instance. Only available if the accountType is StandardGRS or StandardRAGRS.
-   */
-  lastGeoFailoverTime?: Date;
-  /**
-   * Gets the location of the geo replicated secondary for the storage account. Only available if
-   * the accountType is StandardGRS or StandardRAGRS.
-   */
-  secondaryLocation?: string;
-  /**
-   * Gets the status indicating whether the secondary location of the storage account is available
-   * or unavailable. Only available if the accountType is StandardGRS or StandardRAGRS. Possible
-   * values include: 'Available', 'Unavailable'
-   */
-  statusOfSecondary?: AccountStatus;
-  /**
-   * Gets the creation date and time of the storage account in UTC.
-   */
-  creationTime?: Date;
-  /**
-   * Gets the user assigned custom domain assigned to this storage account.
-   */
-  customDomain?: CustomDomain;
-  /**
-   * Gets the URLs that are used to perform a retrieval of a public blob, queue or table object
-   * from the secondary location of the storage account. Only available if the accountType is
-   * StandardRAGRS.
-   */
-  secondaryEndpoints?: Endpoints;
+export type StorageAccountsBeginCreateResponse = StorageAccount & {
   /**
    * The underlying HTTP response.
    */
@@ -1030,11 +669,7 @@ export type StorageAccountsBeginCreateResponse = {
 /**
  * Contains response data for the list operation.
  */
-export type UsageListResponse = {
-  /**
-   * Gets or sets the list Storage Resource Usages.
-   */
-  value?: Usage[];
+export type UsageListResponse = UsageListResult & {
   /**
    * The underlying HTTP response.
    */

--- a/test/azure/generated/SubscriptionIdApiVersion/models/index.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/models/index.ts
@@ -48,15 +48,7 @@ export interface ErrorModel {
 /**
  * Contains response data for the getSampleResourceGroup operation.
  */
-export type GroupGetSampleResourceGroupResponse = {
-  /**
-   * resource group name 'testgroup101'
-   */
-  name?: string;
-  /**
-   * resource group location 'West US'
-   */
-  location?: string;
+export type GroupGetSampleResourceGroupResponse = SampleResourceGroup & {
   /**
    * The underlying HTTP response.
    */

--- a/test/azure/paging.ts
+++ b/test/azure/paging.ts
@@ -4,11 +4,13 @@
 'use strict';
 
 import * as should from 'should';
+import * as assert from 'assert';
 import * as msAssert from "../util/msAssert";
 import * as msRest from 'ms-rest-js';
 import * as msRestAzure from 'ms-rest-azure-js';
 
 import { AutoRestPagingTestService } from './generated/Paging/autoRestPagingTestService';
+import { PagingGetMultiplePagesResponse } from './generated/Paging/models';
 
 var dummySubscriptionId = 'a878ae02-6106-429z-9397-58091ee45g98';
 var dummyToken = 'dummy12321343423';
@@ -29,12 +31,19 @@ describe('typescript', function () {
       clientOptions.noRetryPolicy = true;
       var testClient = new AutoRestPagingTestService(credentials, baseUri, clientOptions);
 
-      it('should get single pages', function (done) {
-        testClient.paging.getSinglePages(function (error, result) {
-          should.not.exist(error);
-          should.not.exist(result.nextLink);
-          done();
-        });
+      it('should get single pages', async function () {
+        const result = await testClient.paging.getSinglePages();
+        should.not.exist(result.nextLink);
+        assert.deepEqual(result.slice(), [{ properties: { id: 1, name: "Product" } }]);
+      });
+
+      it('should get multiple pages using promises', async function () {
+        let result = await testClient.paging.getMultiplePages({ clientRequestId: 'client-id' });
+        for (let i = 1; i < 10; i++) {
+          should.exist(result.nextLink);
+          result = await testClient.paging.getMultiplePagesNext(result.nextLink, { clientRequestId: 'client-id' });
+        }
+        should.not.exist(result.nextLink);
       });
 
       it('should get multiple pages', function (done) {

--- a/test/azuremetadata/generated/lib/models/index.ts
+++ b/test/azuremetadata/generated/lib/models/index.ts
@@ -2718,34 +2718,7 @@ export enum Status {
 /**
  * Contains response data for the put200Succeeded operation.
  */
-export type LROsPut200SucceededResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200SucceededResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2764,34 +2737,7 @@ export type LROsPut200SucceededResponse = {
 /**
  * Contains response data for the put200SucceededNoState operation.
  */
-export type LROsPut200SucceededNoStateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200SucceededNoStateResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2810,34 +2756,7 @@ export type LROsPut200SucceededNoStateResponse = {
 /**
  * Contains response data for the put202Retry200 operation.
  */
-export type LROsPut202Retry200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut202Retry200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2856,34 +2775,7 @@ export type LROsPut202Retry200Response = {
 /**
  * Contains response data for the put201CreatingSucceeded200 operation.
  */
-export type LROsPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2902,34 +2794,7 @@ export type LROsPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the put200UpdatingSucceeded204 operation.
  */
-export type LROsPut200UpdatingSucceeded204Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200UpdatingSucceeded204Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2948,34 +2813,7 @@ export type LROsPut200UpdatingSucceeded204Response = {
 /**
  * Contains response data for the put201CreatingFailed200 operation.
  */
-export type LROsPut201CreatingFailed200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut201CreatingFailed200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -2994,34 +2832,7 @@ export type LROsPut201CreatingFailed200Response = {
 /**
  * Contains response data for the put200Acceptedcanceled200 operation.
  */
-export type LROsPut200Acceptedcanceled200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPut200Acceptedcanceled200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -3040,39 +2851,7 @@ export type LROsPut200Acceptedcanceled200Response = {
 /**
  * Contains response data for the putNoHeaderInRetry operation.
  */
-export type LROsPutNoHeaderInRetryResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noheader/202/200/operationResults
-   */
-  locationHeader: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutNoHeaderInRetryResponse = Product & LROsPutNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3095,48 +2874,7 @@ export type LROsPutNoHeaderInRetryResponse = {
 /**
  * Contains response data for the putAsyncRetrySucceeded operation.
  */
-export type LROsPutAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncRetrySucceededResponse = Product & LROsPutAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3159,44 +2897,7 @@ export type LROsPutAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the putAsyncNoRetrySucceeded operation.
  */
-export type LROsPutAsyncNoRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncNoRetrySucceededResponse = Product & LROsPutAsyncNoRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3219,48 +2920,7 @@ export type LROsPutAsyncNoRetrySucceededResponse = {
 /**
  * Contains response data for the putAsyncRetryFailed operation.
  */
-export type LROsPutAsyncRetryFailedResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncRetryFailedResponse = Product & LROsPutAsyncRetryFailedHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3283,44 +2943,7 @@ export type LROsPutAsyncRetryFailedResponse = {
 /**
  * Contains response data for the putAsyncNoRetrycanceled operation.
  */
-export type LROsPutAsyncNoRetrycanceledResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/canceled/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/noretry/canceled/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncNoRetrycanceledResponse = Product & LROsPutAsyncNoRetrycanceledHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3343,35 +2966,7 @@ export type LROsPutAsyncNoRetrycanceledResponse = {
 /**
  * Contains response data for the putAsyncNoHeaderInRetry operation.
  */
-export type LROsPutAsyncNoHeaderInRetryResponse = {
-  azureAsyncOperation: string;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPutAsyncNoHeaderInRetryResponse = Product & LROsPutAsyncNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3394,9 +2989,7 @@ export type LROsPutAsyncNoHeaderInRetryResponse = {
 /**
  * Contains response data for the putNonResource operation.
  */
-export type LROsPutNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsPutNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -3415,9 +3008,7 @@ export type LROsPutNonResourceResponse = {
 /**
  * Contains response data for the putAsyncNonResource operation.
  */
-export type LROsPutAsyncNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsPutAsyncNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -3436,19 +3027,7 @@ export type LROsPutAsyncNonResourceResponse = {
 /**
  * Contains response data for the putSubResource operation.
  */
-export type LROsPutSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsPutSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -3467,19 +3046,7 @@ export type LROsPutSubResourceResponse = {
 /**
  * Contains response data for the putAsyncSubResource operation.
  */
-export type LROsPutAsyncSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsPutAsyncSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -3499,43 +3066,7 @@ export type LROsPutAsyncSubResourceResponse = {
  * Contains response data for the deleteProvisioning202Accepted200Succeeded
  * operation.
  */
-export type LROsDeleteProvisioning202Accepted200SucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/delete/provisioning/202/accepted/200/succeeded
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDeleteProvisioning202Accepted200SucceededResponse = Product & LROsDeleteProvisioning202Accepted200SucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3559,43 +3090,7 @@ export type LROsDeleteProvisioning202Accepted200SucceededResponse = {
  * Contains response data for the deleteProvisioning202DeletingFailed200
  * operation.
  */
-export type LROsDeleteProvisioning202DeletingFailed200Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/delete/provisioning/202/deleting/200/failed
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDeleteProvisioning202DeletingFailed200Response = Product & LROsDeleteProvisioning202DeletingFailed200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3619,43 +3114,7 @@ export type LROsDeleteProvisioning202DeletingFailed200Response = {
  * Contains response data for the deleteProvisioning202Deletingcanceled200
  * operation.
  */
-export type LROsDeleteProvisioning202Deletingcanceled200Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/delete/provisioning/202/deleting/200/canceled
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDeleteProvisioning202Deletingcanceled200Response = Product & LROsDeleteProvisioning202Deletingcanceled200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3678,42 +3137,7 @@ export type LROsDeleteProvisioning202Deletingcanceled200Response = {
 /**
  * Contains response data for the delete202Retry200 operation.
  */
-export type LROsDelete202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/delete/202/retry/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDelete202Retry200Response = Product & LROsDelete202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3736,42 +3160,7 @@ export type LROsDelete202Retry200Response = {
 /**
  * Contains response data for the delete202NoRetry204 operation.
  */
-export type LROsDelete202NoRetry204Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/delete/202/noretry/204
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsDelete202NoRetry204Response = Product & LROsDelete202NoRetry204Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3794,11 +3183,7 @@ export type LROsDelete202NoRetry204Response = {
 /**
  * Contains response data for the deleteNoHeaderInRetry operation.
  */
-export type LROsDeleteNoHeaderInRetryResponse = {
-  /**
-   * Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults
-   */
-  location: string;
+export type LROsDeleteNoHeaderInRetryResponse = LROsDeleteNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3813,11 +3198,7 @@ export type LROsDeleteNoHeaderInRetryResponse = {
 /**
  * Contains response data for the deleteAsyncNoHeaderInRetry operation.
  */
-export type LROsDeleteAsyncNoHeaderInRetryResponse = {
-  /**
-   * Location to poll for result status: will be set to /lro/put/noheader/202/204/operationresults
-   */
-  location: string;
+export type LROsDeleteAsyncNoHeaderInRetryResponse = LROsDeleteAsyncNoHeaderInRetryHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3832,21 +3213,7 @@ export type LROsDeleteAsyncNoHeaderInRetryResponse = {
 /**
  * Contains response data for the deleteAsyncRetrySucceeded operation.
  */
-export type LROsDeleteAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncRetrySucceededResponse = LROsDeleteAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3861,21 +3228,7 @@ export type LROsDeleteAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the deleteAsyncNoRetrySucceeded operation.
  */
-export type LROsDeleteAsyncNoRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/noretry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/noretry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncNoRetrySucceededResponse = LROsDeleteAsyncNoRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3890,21 +3243,7 @@ export type LROsDeleteAsyncNoRetrySucceededResponse = {
 /**
  * Contains response data for the deleteAsyncRetryFailed operation.
  */
-export type LROsDeleteAsyncRetryFailedResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/failed/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncRetryFailedResponse = LROsDeleteAsyncRetryFailedHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3919,21 +3258,7 @@ export type LROsDeleteAsyncRetryFailedResponse = {
 /**
  * Contains response data for the deleteAsyncRetrycanceled operation.
  */
-export type LROsDeleteAsyncRetrycanceledResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/canceled/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/canceled/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsDeleteAsyncRetrycanceledResponse = LROsDeleteAsyncRetrycanceledHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -3948,9 +3273,7 @@ export type LROsDeleteAsyncRetrycanceledResponse = {
 /**
  * Contains response data for the post200WithPayload operation.
  */
-export type LROsPost200WithPayloadResponse = {
-  name?: string;
-  id?: string;
+export type LROsPost200WithPayloadResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -3969,15 +3292,7 @@ export type LROsPost200WithPayloadResponse = {
 /**
  * Contains response data for the post202Retry200 operation.
  */
-export type LROsPost202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsPost202Retry200Response = LROsPost202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -3992,42 +3307,7 @@ export type LROsPost202Retry200Response = {
 /**
  * Contains response data for the post202NoRetry204 operation.
  */
-export type LROsPost202NoRetry204Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/post/202/noretry/204
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPost202NoRetry204Response = Product & LROsPost202NoRetry204Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -4050,34 +3330,7 @@ export type LROsPost202NoRetry204Response = {
 /**
  * Contains response data for the postDoubleHeadersFinalLocationGet operation.
  */
-export type LROsPostDoubleHeadersFinalLocationGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostDoubleHeadersFinalLocationGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4097,34 +3350,7 @@ export type LROsPostDoubleHeadersFinalLocationGetResponse = {
  * Contains response data for the postDoubleHeadersFinalAzureHeaderGet
  * operation.
  */
-export type LROsPostDoubleHeadersFinalAzureHeaderGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostDoubleHeadersFinalAzureHeaderGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4144,34 +3370,7 @@ export type LROsPostDoubleHeadersFinalAzureHeaderGetResponse = {
  * Contains response data for the postDoubleHeadersFinalAzureHeaderGetDefault
  * operation.
  */
-export type LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4190,48 +3389,7 @@ export type LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
 /**
  * Contains response data for the postAsyncRetrySucceeded operation.
  */
-export type LROsPostAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostAsyncRetrySucceededResponse = Product & LROsPostAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4254,48 +3412,7 @@ export type LROsPostAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the postAsyncNoRetrySucceeded operation.
  */
-export type LROsPostAsyncNoRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsPostAsyncNoRetrySucceededResponse = Product & LROsPostAsyncNoRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4318,21 +3435,7 @@ export type LROsPostAsyncNoRetrySucceededResponse = {
 /**
  * Contains response data for the postAsyncRetryFailed operation.
  */
-export type LROsPostAsyncRetryFailedResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsPostAsyncRetryFailedResponse = LROsPostAsyncRetryFailedHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4347,21 +3450,7 @@ export type LROsPostAsyncRetryFailedResponse = {
 /**
  * Contains response data for the postAsyncRetrycanceled operation.
  */
-export type LROsPostAsyncRetrycanceledResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/canceled/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/canceled/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsPostAsyncRetrycanceledResponse = LROsPostAsyncRetrycanceledHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -4376,34 +3465,7 @@ export type LROsPostAsyncRetrycanceledResponse = {
 /**
  * Contains response data for the beginPut200Succeeded operation.
  */
-export type LROsBeginPut200SucceededResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200SucceededResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4422,34 +3484,7 @@ export type LROsBeginPut200SucceededResponse = {
 /**
  * Contains response data for the beginPut200SucceededNoState operation.
  */
-export type LROsBeginPut200SucceededNoStateResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200SucceededNoStateResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4468,34 +3503,7 @@ export type LROsBeginPut200SucceededNoStateResponse = {
 /**
  * Contains response data for the beginPut202Retry200 operation.
  */
-export type LROsBeginPut202Retry200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut202Retry200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4514,34 +3522,7 @@ export type LROsBeginPut202Retry200Response = {
 /**
  * Contains response data for the beginPut201CreatingSucceeded200 operation.
  */
-export type LROsBeginPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4560,34 +3541,7 @@ export type LROsBeginPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the beginPut200UpdatingSucceeded204 operation.
  */
-export type LROsBeginPut200UpdatingSucceeded204Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200UpdatingSucceeded204Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4606,34 +3560,7 @@ export type LROsBeginPut200UpdatingSucceeded204Response = {
 /**
  * Contains response data for the beginPut201CreatingFailed200 operation.
  */
-export type LROsBeginPut201CreatingFailed200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut201CreatingFailed200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4652,34 +3579,7 @@ export type LROsBeginPut201CreatingFailed200Response = {
 /**
  * Contains response data for the beginPut200Acceptedcanceled200 operation.
  */
-export type LROsBeginPut200Acceptedcanceled200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPut200Acceptedcanceled200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4698,9 +3598,7 @@ export type LROsBeginPut200Acceptedcanceled200Response = {
 /**
  * Contains response data for the beginPutNonResource operation.
  */
-export type LROsBeginPutNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsBeginPutNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -4719,9 +3617,7 @@ export type LROsBeginPutNonResourceResponse = {
 /**
  * Contains response data for the beginPutAsyncNonResource operation.
  */
-export type LROsBeginPutAsyncNonResourceResponse = {
-  name?: string;
-  id?: string;
+export type LROsBeginPutAsyncNonResourceResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -4740,19 +3636,7 @@ export type LROsBeginPutAsyncNonResourceResponse = {
 /**
  * Contains response data for the beginPutSubResource operation.
  */
-export type LROsBeginPutSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsBeginPutSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -4771,19 +3655,7 @@ export type LROsBeginPutSubResourceResponse = {
 /**
  * Contains response data for the beginPutAsyncSubResource operation.
  */
-export type LROsBeginPutAsyncSubResourceResponse = {
-  /**
-   * Sub Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues1;
+export type LROsBeginPutAsyncSubResourceResponse = SubProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -4802,9 +3674,7 @@ export type LROsBeginPutAsyncSubResourceResponse = {
 /**
  * Contains response data for the beginPost200WithPayload operation.
  */
-export type LROsBeginPost200WithPayloadResponse = {
-  name?: string;
-  id?: string;
+export type LROsBeginPost200WithPayloadResponse = Sku & {
   /**
    * The underlying HTTP response.
    */
@@ -4824,34 +3694,7 @@ export type LROsBeginPost200WithPayloadResponse = {
  * Contains response data for the beginPostDoubleHeadersFinalLocationGet
  * operation.
  */
-export type LROsBeginPostDoubleHeadersFinalLocationGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPostDoubleHeadersFinalLocationGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4871,34 +3714,7 @@ export type LROsBeginPostDoubleHeadersFinalLocationGetResponse = {
  * Contains response data for the beginPostDoubleHeadersFinalAzureHeaderGet
  * operation.
  */
-export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4918,34 +3734,7 @@ export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetResponse = {
  * Contains response data for the
  * beginPostDoubleHeadersFinalAzureHeaderGetDefault operation.
  */
-export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -4964,34 +3753,7 @@ export type LROsBeginPostDoubleHeadersFinalAzureHeaderGetDefaultResponse = {
 /**
  * Contains response data for the put201CreatingSucceeded200 operation.
  */
-export type LRORetrysPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5010,48 +3772,7 @@ export type LRORetrysPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the putAsyncRelativeRetrySucceeded operation.
  */
-export type LRORetrysPutAsyncRelativeRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysPutAsyncRelativeRetrySucceededResponse = Product & LRORetrysPutAsyncRelativeRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5075,43 +3796,7 @@ export type LRORetrysPutAsyncRelativeRetrySucceededResponse = {
  * Contains response data for the deleteProvisioning202Accepted200Succeeded
  * operation.
  */
-export type LRORetrysDeleteProvisioning202Accepted200SucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/delete/provisioning/202/accepted/200/succeeded
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysDeleteProvisioning202Accepted200SucceededResponse = Product & LRORetrysDeleteProvisioning202Accepted200SucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5134,15 +3819,7 @@ export type LRORetrysDeleteProvisioning202Accepted200SucceededResponse = {
 /**
  * Contains response data for the delete202Retry200 operation.
  */
-export type LRORetrysDelete202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysDelete202Retry200Response = LRORetrysDelete202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5157,21 +3834,7 @@ export type LRORetrysDelete202Retry200Response = {
 /**
  * Contains response data for the deleteAsyncRelativeRetrySucceeded operation.
  */
-export type LRORetrysDeleteAsyncRelativeRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/deleteasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/deleteasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysDeleteAsyncRelativeRetrySucceededResponse = LRORetrysDeleteAsyncRelativeRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5186,15 +3849,7 @@ export type LRORetrysDeleteAsyncRelativeRetrySucceededResponse = {
 /**
  * Contains response data for the post202Retry200 operation.
  */
-export type LRORetrysPost202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysPost202Retry200Response = LRORetrysPost202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5209,21 +3864,7 @@ export type LRORetrysPost202Retry200Response = {
 /**
  * Contains response data for the postAsyncRelativeRetrySucceeded operation.
  */
-export type LRORetrysPostAsyncRelativeRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/retryerror/putasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LRORetrysPostAsyncRelativeRetrySucceededResponse = LRORetrysPostAsyncRelativeRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5238,34 +3879,7 @@ export type LRORetrysPostAsyncRelativeRetrySucceededResponse = {
 /**
  * Contains response data for the beginPut201CreatingSucceeded200 operation.
  */
-export type LRORetrysBeginPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LRORetrysBeginPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5284,34 +3898,7 @@ export type LRORetrysBeginPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the putNonRetry400 operation.
  */
-export type LROSADsPutNonRetry400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutNonRetry400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5330,34 +3917,7 @@ export type LROSADsPutNonRetry400Response = {
 /**
  * Contains response data for the putNonRetry201Creating400 operation.
  */
-export type LROSADsPutNonRetry201Creating400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutNonRetry201Creating400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5377,34 +3937,7 @@ export type LROSADsPutNonRetry201Creating400Response = {
  * Contains response data for the putNonRetry201Creating400InvalidJson
  * operation.
  */
-export type LROSADsPutNonRetry201Creating400InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutNonRetry201Creating400InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5423,48 +3956,7 @@ export type LROSADsPutNonRetry201Creating400InvalidJsonResponse = {
 /**
  * Contains response data for the putAsyncRelativeRetry400 operation.
  */
-export type LROSADsPutAsyncRelativeRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetry400Response = Product & LROSADsPutAsyncRelativeRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5487,15 +3979,7 @@ export type LROSADsPutAsyncRelativeRetry400Response = {
 /**
  * Contains response data for the deleteNonRetry400 operation.
  */
-export type LROSADsDeleteNonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteNonRetry400Response = LROSADsDeleteNonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5510,15 +3994,7 @@ export type LROSADsDeleteNonRetry400Response = {
 /**
  * Contains response data for the delete202NonRetry400 operation.
  */
-export type LROSADsDelete202NonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/delete/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDelete202NonRetry400Response = LROSADsDelete202NonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5533,21 +4009,7 @@ export type LROSADsDelete202NonRetry400Response = {
 /**
  * Contains response data for the deleteAsyncRelativeRetry400 operation.
  */
-export type LROSADsDeleteAsyncRelativeRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/deleteasync/retry/operationResults/400
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/deleteasync/retry/operationResults/400
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetry400Response = LROSADsDeleteAsyncRelativeRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5562,15 +4024,7 @@ export type LROSADsDeleteAsyncRelativeRetry400Response = {
 /**
  * Contains response data for the postNonRetry400 operation.
  */
-export type LROSADsPostNonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostNonRetry400Response = LROSADsPostNonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5585,15 +4039,7 @@ export type LROSADsPostNonRetry400Response = {
 /**
  * Contains response data for the post202NonRetry400 operation.
  */
-export type LROSADsPost202NonRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/retryerror/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPost202NonRetry400Response = LROSADsPost202NonRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5608,21 +4054,7 @@ export type LROSADsPost202NonRetry400Response = {
 /**
  * Contains response data for the postAsyncRelativeRetry400 operation.
  */
-export type LROSADsPostAsyncRelativeRetry400Response = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/nonretryerror/putasync/retry/operationResults/400
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetry400Response = LROSADsPostAsyncRelativeRetry400Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -5638,34 +4070,7 @@ export type LROSADsPostAsyncRelativeRetry400Response = {
  * Contains response data for the putError201NoProvisioningStatePayload
  * operation.
  */
-export type LROSADsPutError201NoProvisioningStatePayloadResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutError201NoProvisioningStatePayloadResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5684,48 +4089,7 @@ export type LROSADsPutError201NoProvisioningStatePayloadResponse = {
 /**
  * Contains response data for the putAsyncRelativeRetryNoStatus operation.
  */
-export type LROSADsPutAsyncRelativeRetryNoStatusResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryNoStatusResponse = Product & LROSADsPutAsyncRelativeRetryNoStatusHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5749,48 +4113,7 @@ export type LROSADsPutAsyncRelativeRetryNoStatusResponse = {
  * Contains response data for the putAsyncRelativeRetryNoStatusPayload
  * operation.
  */
-export type LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse = Product & LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5813,21 +4136,7 @@ export type LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse = {
 /**
  * Contains response data for the deleteAsyncRelativeRetryNoStatus operation.
  */
-export type LROSADsDeleteAsyncRelativeRetryNoStatusResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/deleteasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetryNoStatusResponse = LROSADsDeleteAsyncRelativeRetryNoStatusHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5842,15 +4151,7 @@ export type LROSADsDeleteAsyncRelativeRetryNoStatusResponse = {
 /**
  * Contains response data for the post202NoLocation operation.
  */
-export type LROSADsPost202NoLocationResponse = {
-  /**
-   * Location to poll for result status: will not be set
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPost202NoLocationResponse = LROSADsPost202NoLocationHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5865,21 +4166,7 @@ export type LROSADsPost202NoLocationResponse = {
 /**
  * Contains response data for the postAsyncRelativeRetryNoPayload operation.
  */
-export type LROSADsPostAsyncRelativeRetryNoPayloadResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/putasync/retry/failed/operationResults/nopayload
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/putasync/retry/failed/operationResults/nopayload
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetryNoPayloadResponse = LROSADsPostAsyncRelativeRetryNoPayloadHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -5894,34 +4181,7 @@ export type LROSADsPostAsyncRelativeRetryNoPayloadResponse = {
 /**
  * Contains response data for the put200InvalidJson operation.
  */
-export type LROSADsPut200InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPut200InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -5940,48 +4200,7 @@ export type LROSADsPut200InvalidJsonResponse = {
 /**
  * Contains response data for the putAsyncRelativeRetryInvalidHeader operation.
  */
-export type LROSADsPutAsyncRelativeRetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryInvalidHeaderResponse = Product & LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6005,48 +4224,7 @@ export type LROSADsPutAsyncRelativeRetryInvalidHeaderResponse = {
  * Contains response data for the putAsyncRelativeRetryInvalidJsonPolling
  * operation.
  */
-export type LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/putasync/retry/failed/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse = Product & LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6069,15 +4247,7 @@ export type LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse = {
 /**
  * Contains response data for the delete202RetryInvalidHeader operation.
  */
-export type LROSADsDelete202RetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsDelete202RetryInvalidHeaderResponse = LROSADsDelete202RetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6093,19 +4263,7 @@ export type LROSADsDelete202RetryInvalidHeaderResponse = {
  * Contains response data for the deleteAsyncRelativeRetryInvalidHeader
  * operation.
  */
-export type LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse = LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6121,21 +4279,7 @@ export type LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse = {
  * Contains response data for the deleteAsyncRelativeRetryInvalidJsonPolling
  * operation.
  */
-export type LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse = LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6150,15 +4294,7 @@ export type LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse = {
 /**
  * Contains response data for the post202RetryInvalidHeader operation.
  */
-export type LROSADsPost202RetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to /foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsPost202RetryInvalidHeaderResponse = LROSADsPost202RetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6174,19 +4310,7 @@ export type LROSADsPost202RetryInvalidHeaderResponse = {
  * Contains response data for the postAsyncRelativeRetryInvalidHeader
  * operation.
  */
-export type LROSADsPostAsyncRelativeRetryInvalidHeaderResponse = {
-  /**
-   * Location to poll for result status: will be set to foo
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to foo
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to /bar
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetryInvalidHeaderResponse = LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6202,21 +4326,7 @@ export type LROSADsPostAsyncRelativeRetryInvalidHeaderResponse = {
  * Contains response data for the postAsyncRelativeRetryInvalidJsonPolling
  * operation.
  */
-export type LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse = LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6231,34 +4341,7 @@ export type LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse = {
 /**
  * Contains response data for the beginPutNonRetry400 operation.
  */
-export type LROSADsBeginPutNonRetry400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutNonRetry400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6277,34 +4360,7 @@ export type LROSADsBeginPutNonRetry400Response = {
 /**
  * Contains response data for the beginPutNonRetry201Creating400 operation.
  */
-export type LROSADsBeginPutNonRetry201Creating400Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutNonRetry201Creating400Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6324,34 +4380,7 @@ export type LROSADsBeginPutNonRetry201Creating400Response = {
  * Contains response data for the beginPutNonRetry201Creating400InvalidJson
  * operation.
  */
-export type LROSADsBeginPutNonRetry201Creating400InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutNonRetry201Creating400InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6371,34 +4400,7 @@ export type LROSADsBeginPutNonRetry201Creating400InvalidJsonResponse = {
  * Contains response data for the beginPutError201NoProvisioningStatePayload
  * operation.
  */
-export type LROSADsBeginPutError201NoProvisioningStatePayloadResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPutError201NoProvisioningStatePayloadResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6417,34 +4419,7 @@ export type LROSADsBeginPutError201NoProvisioningStatePayloadResponse = {
 /**
  * Contains response data for the beginPut200InvalidJson operation.
  */
-export type LROSADsBeginPut200InvalidJsonResponse = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROSADsBeginPut200InvalidJsonResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6463,48 +4438,7 @@ export type LROSADsBeginPut200InvalidJsonResponse = {
 /**
  * Contains response data for the putAsyncRetrySucceeded operation.
  */
-export type LROsCustomHeaderPutAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  locationHeader: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsCustomHeaderPutAsyncRetrySucceededResponse = Product & LROsCustomHeaderPutAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6527,34 +4461,7 @@ export type LROsCustomHeaderPutAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the put201CreatingSucceeded200 operation.
  */
-export type LROsCustomHeaderPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsCustomHeaderPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -6573,15 +4480,7 @@ export type LROsCustomHeaderPut201CreatingSucceeded200Response = {
 /**
  * Contains response data for the post202Retry200 operation.
  */
-export type LROsCustomHeaderPost202Retry200Response = {
-  /**
-   * Location to poll for result status: will be set to /lro/customheader/post/202/retry/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsCustomHeaderPost202Retry200Response = LROsCustomHeaderPost202Retry200Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -6596,21 +4495,7 @@ export type LROsCustomHeaderPost202Retry200Response = {
 /**
  * Contains response data for the postAsyncRetrySucceeded operation.
  */
-export type LROsCustomHeaderPostAsyncRetrySucceededResponse = {
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  azureAsyncOperation: string;
-  /**
-   * Location to poll for result status: will be set to
-   * /lro/customheader/putasync/retry/succeeded/operationResults/200
-   */
-  location: string;
-  /**
-   * Number of milliseconds until the next poll should be sent, will be set to zero
-   */
-  retryAfter: number;
+export type LROsCustomHeaderPostAsyncRetrySucceededResponse = LROsCustomHeaderPostAsyncRetrySucceededHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -6625,34 +4510,7 @@ export type LROsCustomHeaderPostAsyncRetrySucceededResponse = {
 /**
  * Contains response data for the beginPut201CreatingSucceeded200 operation.
  */
-export type LROsCustomHeaderBeginPut201CreatingSucceeded200Response = {
-  /**
-   * Resource Id
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  /**
-   * Resource Type
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly type?: string;
-  tags?: { [propertyName: string]: string };
-  /**
-   * Resource Location
-   */
-  location?: string;
-  /**
-   * Resource Name
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly name?: string;
-  provisioningState?: string;
-  /**
-   * Possible values include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating', 'Created',
-   * 'Updating', 'Updated', 'Deleting', 'Deleted', 'OK'
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly provisioningStateValues?: ProvisioningStateValues;
+export type LROsCustomHeaderBeginPut201CreatingSucceeded200Response = Product & {
   /**
    * The underlying HTTP response.
    */

--- a/test/enumunion/generated/BodyString/models/index.ts
+++ b/test/enumunion/generated/BodyString/models/index.ts
@@ -372,15 +372,7 @@ export type EnumModelGetReferencedResponse = {
 /**
  * Contains response data for the getReferencedConstant operation.
  */
-export type EnumModelGetReferencedConstantResponse = {
-  /**
-   * Referenced Color Constant Description.
-   */
-  colorConstant: string;
-  /**
-   * Sample string.
-   */
-  field1?: string;
+export type EnumModelGetReferencedConstantResponse = RefColorConstant & {
   /**
    * The underlying HTTP response.
    */

--- a/test/metadata/generated/lib/models/index.ts
+++ b/test/metadata/generated/lib/models/index.ts
@@ -744,20 +744,7 @@ export enum MyKind {
 /**
  * Contains response data for the getValid operation.
  */
-export type BasicGetValidResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetValidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -776,20 +763,7 @@ export type BasicGetValidResponse = {
 /**
  * Contains response data for the getInvalid operation.
  */
-export type BasicGetInvalidResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetInvalidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -808,20 +782,7 @@ export type BasicGetInvalidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type BasicGetEmptyResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetEmptyResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -840,20 +801,7 @@ export type BasicGetEmptyResponse = {
 /**
  * Contains response data for the getNull operation.
  */
-export type BasicGetNullResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetNullResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -872,20 +820,7 @@ export type BasicGetNullResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type BasicGetNotProvidedResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetNotProvidedResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -904,9 +839,7 @@ export type BasicGetNotProvidedResponse = {
 /**
  * Contains response data for the getInt operation.
  */
-export type PrimitiveGetIntResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetIntResponse = IntWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -925,9 +858,7 @@ export type PrimitiveGetIntResponse = {
 /**
  * Contains response data for the getLong operation.
  */
-export type PrimitiveGetLongResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetLongResponse = LongWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -946,9 +877,7 @@ export type PrimitiveGetLongResponse = {
 /**
  * Contains response data for the getFloat operation.
  */
-export type PrimitiveGetFloatResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetFloatResponse = FloatWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -967,9 +896,7 @@ export type PrimitiveGetFloatResponse = {
 /**
  * Contains response data for the getDouble operation.
  */
-export type PrimitiveGetDoubleResponse = {
-  field1?: number;
-  field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose?: number;
+export type PrimitiveGetDoubleResponse = DoubleWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -988,9 +915,7 @@ export type PrimitiveGetDoubleResponse = {
 /**
  * Contains response data for the getBool operation.
  */
-export type PrimitiveGetBoolResponse = {
-  fieldTrue?: boolean;
-  fieldFalse?: boolean;
+export type PrimitiveGetBoolResponse = BooleanWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1009,10 +934,7 @@ export type PrimitiveGetBoolResponse = {
 /**
  * Contains response data for the getString operation.
  */
-export type PrimitiveGetStringResponse = {
-  field?: string;
-  empty?: string;
-  nullProperty?: string;
+export type PrimitiveGetStringResponse = StringWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1031,9 +953,7 @@ export type PrimitiveGetStringResponse = {
 /**
  * Contains response data for the getDate operation.
  */
-export type PrimitiveGetDateResponse = {
-  field?: Date;
-  leap?: Date;
+export type PrimitiveGetDateResponse = DateWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1052,9 +972,7 @@ export type PrimitiveGetDateResponse = {
 /**
  * Contains response data for the getDateTime operation.
  */
-export type PrimitiveGetDateTimeResponse = {
-  field?: Date;
-  now?: Date;
+export type PrimitiveGetDateTimeResponse = DatetimeWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1073,9 +991,7 @@ export type PrimitiveGetDateTimeResponse = {
 /**
  * Contains response data for the getDateTimeRfc1123 operation.
  */
-export type PrimitiveGetDateTimeRfc1123Response = {
-  field?: Date;
-  now?: Date;
+export type PrimitiveGetDateTimeRfc1123Response = Datetimerfc1123Wrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1094,8 +1010,7 @@ export type PrimitiveGetDateTimeRfc1123Response = {
 /**
  * Contains response data for the getDuration operation.
  */
-export type PrimitiveGetDurationResponse = {
-  field?: string;
+export type PrimitiveGetDurationResponse = DurationWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1114,8 +1029,7 @@ export type PrimitiveGetDurationResponse = {
 /**
  * Contains response data for the getByte operation.
  */
-export type PrimitiveGetByteResponse = {
-  field?: Uint8Array;
+export type PrimitiveGetByteResponse = ByteWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1134,8 +1048,7 @@ export type PrimitiveGetByteResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type ArrayModelGetValidResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetValidResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1154,8 +1067,7 @@ export type ArrayModelGetValidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type ArrayModelGetEmptyResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetEmptyResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1174,8 +1086,7 @@ export type ArrayModelGetEmptyResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type ArrayModelGetNotProvidedResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetNotProvidedResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1194,8 +1105,7 @@ export type ArrayModelGetNotProvidedResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type DictionaryGetValidResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetValidResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1214,8 +1124,7 @@ export type DictionaryGetValidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type DictionaryGetEmptyResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetEmptyResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1234,8 +1143,7 @@ export type DictionaryGetEmptyResponse = {
 /**
  * Contains response data for the getNull operation.
  */
-export type DictionaryGetNullResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetNullResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1254,8 +1162,7 @@ export type DictionaryGetNullResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type DictionaryGetNotProvidedResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetNotProvidedResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1274,12 +1181,7 @@ export type DictionaryGetNotProvidedResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type InheritanceGetValidResponse = {
-  id?: number;
-  name?: string;
-  color?: string;
-  hates?: Dog[];
-  breed?: string;
+export type InheritanceGetValidResponse = Siamese & {
   /**
    * The underlying HTTP response.
    */
@@ -1298,14 +1200,7 @@ export type InheritanceGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type PolymorphismGetValidResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
+export type PolymorphismGetValidResponse = FishUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1324,16 +1219,7 @@ export type PolymorphismGetValidResponse = {
 /**
  * Contains response data for the getComplicated operation.
  */
-export type PolymorphismGetComplicatedResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
-  location?: string;
-  iswild?: boolean;
+export type PolymorphismGetComplicatedResponse = SalmonUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1352,16 +1238,7 @@ export type PolymorphismGetComplicatedResponse = {
 /**
  * Contains response data for the putMissingDiscriminator operation.
  */
-export type PolymorphismPutMissingDiscriminatorResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
-  location?: string;
-  iswild?: boolean;
+export type PolymorphismPutMissingDiscriminatorResponse = SalmonUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1380,14 +1257,7 @@ export type PolymorphismPutMissingDiscriminatorResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type PolymorphicrecursiveGetValidResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
+export type PolymorphicrecursiveGetValidResponse = FishUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1406,12 +1276,7 @@ export type PolymorphicrecursiveGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type ReadonlypropertyGetValidResponse = {
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  size?: number;
+export type ReadonlypropertyGetValidResponse = ReadonlyObj & {
   /**
    * The underlying HTTP response.
    */
@@ -1430,13 +1295,7 @@ export type ReadonlypropertyGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type FlattencomplexGetValidResponse = {
-  propB1?: string;
-  /**
-   * Polymorphic Discriminator
-   */
-  kind: string;
-  propBH1?: string;
+export type FlattencomplexGetValidResponse = MyBaseTypeUnion & {
   /**
    * The underlying HTTP response.
    */

--- a/test/no-client-validation/generated/Validation/models/index.ts
+++ b/test/no-client-validation/generated/Validation/models/index.ts
@@ -124,33 +124,7 @@ export enum EnumConst {
 /**
  * Contains response data for the validationOfMethodParameters operation.
  */
-export type ValidationOfMethodParametersResponse = {
-  /**
-   * Non required array of unique items from 0 to 6 elements.
-   */
-  displayNames?: string[];
-  /**
-   * Non required int betwen 0 and 100 exclusive.
-   */
-  capacity?: number;
-  /**
-   * Image URL representing the product.
-   */
-  image?: string;
-  child: ChildProduct;
-  constChild: ConstantProduct;
-  /**
-   * Constant int
-   */
-  constInt: number;
-  /**
-   * Constant string
-   */
-  constString: string;
-  /**
-   * Constant string as Enum. Possible values include: 'constant_string_as_enum'
-   */
-  constStringAsEnum?: EnumConst;
+export type ValidationOfMethodParametersResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -169,33 +143,7 @@ export type ValidationOfMethodParametersResponse = {
 /**
  * Contains response data for the validationOfBody operation.
  */
-export type ValidationOfBodyResponse = {
-  /**
-   * Non required array of unique items from 0 to 6 elements.
-   */
-  displayNames?: string[];
-  /**
-   * Non required int betwen 0 and 100 exclusive.
-   */
-  capacity?: number;
-  /**
-   * Image URL representing the product.
-   */
-  image?: string;
-  child: ChildProduct;
-  constChild: ConstantProduct;
-  /**
-   * Constant int
-   */
-  constInt: number;
-  /**
-   * Constant string
-   */
-  constString: string;
-  /**
-   * Constant string as Enum. Possible values include: 'constant_string_as_enum'
-   */
-  constStringAsEnum?: EnumConst;
+export type ValidationOfBodyResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -214,33 +162,7 @@ export type ValidationOfBodyResponse = {
 /**
  * Contains response data for the postWithConstantInBody operation.
  */
-export type PostWithConstantInBodyResponse = {
-  /**
-   * Non required array of unique items from 0 to 6 elements.
-   */
-  displayNames?: string[];
-  /**
-   * Non required int betwen 0 and 100 exclusive.
-   */
-  capacity?: number;
-  /**
-   * Image URL representing the product.
-   */
-  image?: string;
-  child: ChildProduct;
-  constChild: ConstantProduct;
-  /**
-   * Constant int
-   */
-  constInt: number;
-  /**
-   * Constant string
-   */
-  constString: string;
-  /**
-   * Constant string as Enum. Possible values include: 'constant_string_as_enum'
-   */
-  constStringAsEnum?: EnumConst;
+export type PostWithConstantInBodyResponse = Product & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/acceptanceTests.ts
+++ b/test/vanilla/acceptanceTests.ts
@@ -1600,7 +1600,6 @@ describe('typescript', function () {
           var putDictionary: { [propertyName: string]: Date } =
             { 0: new Date('2000-12-01T00:00:01Z'), 1: new Date('1980-01-01T23:11:35Z'), 2: new Date('1492-10-12T18:15:01Z') };
           const result = await testClient.dictionary.getDateTimeValid();
-          delete result._response;
           assert.deepEqual(result, getDictionary);
           await testClient.dictionary.putDateTimeValid(putDictionary);
         });
@@ -1643,7 +1642,6 @@ describe('typescript', function () {
 
           const testDictionary: { [propertyName: string]: Date } = { "0": new Date("2000-12-01t00:00:01z"), "1": null };
           const result = await testClient.dictionary.getDateTimeInvalidNull();
-          delete result._response;
           assert.deepEqual(result, testDictionary);
         });
 
@@ -1651,7 +1649,6 @@ describe('typescript', function () {
           var testDictionary: { [propertyName: string]: Date } = { "0": new Date("2000-12-01t00:00:01z"), "1": new Date("date-time") };
           testClient.dictionary.getDateTimeInvalidChars(function (error, result) {
             should.not.exist(error);
-            delete result._response;
             assert.deepEqual(util.inspect(result), util.inspect(testDictionary));
             done();
           });
@@ -2614,7 +2611,6 @@ describe('typescript', function () {
 
         const result3 = await testClient.multipleResponses.get200Model201ModelDefaultError201Valid();
         should.exist(result3);
-        delete result3._response;
         assert.deepEqual(result3, { 'statusCode': '201', 'textStatusCode': 'Created' });
 
         await msAssert.throwsAsync(testClient.multipleResponses.get200Model201ModelDefaultError400Valid(),

--- a/test/vanilla/generated/BodyComplex/models/index.ts
+++ b/test/vanilla/generated/BodyComplex/models/index.ts
@@ -744,20 +744,7 @@ export enum MyKind {
 /**
  * Contains response data for the getValid operation.
  */
-export type BasicGetValidResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetValidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -776,20 +763,7 @@ export type BasicGetValidResponse = {
 /**
  * Contains response data for the getInvalid operation.
  */
-export type BasicGetInvalidResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetInvalidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -808,20 +782,7 @@ export type BasicGetInvalidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type BasicGetEmptyResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetEmptyResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -840,20 +801,7 @@ export type BasicGetEmptyResponse = {
 /**
  * Contains response data for the getNull operation.
  */
-export type BasicGetNullResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetNullResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -872,20 +820,7 @@ export type BasicGetNullResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type BasicGetNotProvidedResponse = {
-  /**
-   * Basic Id
-   */
-  id?: number;
-  /**
-   * Name property with a very long description that does not fit on a single line and a line
-   * break.
-   */
-  name?: string;
-  /**
-   * Possible values include: 'cyan', 'Magenta', 'YELLOW', 'blacK'
-   */
-  color?: CMYKColors;
+export type BasicGetNotProvidedResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -904,9 +839,7 @@ export type BasicGetNotProvidedResponse = {
 /**
  * Contains response data for the getInt operation.
  */
-export type PrimitiveGetIntResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetIntResponse = IntWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -925,9 +858,7 @@ export type PrimitiveGetIntResponse = {
 /**
  * Contains response data for the getLong operation.
  */
-export type PrimitiveGetLongResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetLongResponse = LongWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -946,9 +877,7 @@ export type PrimitiveGetLongResponse = {
 /**
  * Contains response data for the getFloat operation.
  */
-export type PrimitiveGetFloatResponse = {
-  field1?: number;
-  field2?: number;
+export type PrimitiveGetFloatResponse = FloatWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -967,9 +896,7 @@ export type PrimitiveGetFloatResponse = {
 /**
  * Contains response data for the getDouble operation.
  */
-export type PrimitiveGetDoubleResponse = {
-  field1?: number;
-  field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose?: number;
+export type PrimitiveGetDoubleResponse = DoubleWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -988,9 +915,7 @@ export type PrimitiveGetDoubleResponse = {
 /**
  * Contains response data for the getBool operation.
  */
-export type PrimitiveGetBoolResponse = {
-  fieldTrue?: boolean;
-  fieldFalse?: boolean;
+export type PrimitiveGetBoolResponse = BooleanWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1009,10 +934,7 @@ export type PrimitiveGetBoolResponse = {
 /**
  * Contains response data for the getString operation.
  */
-export type PrimitiveGetStringResponse = {
-  field?: string;
-  empty?: string;
-  nullProperty?: string;
+export type PrimitiveGetStringResponse = StringWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1031,9 +953,7 @@ export type PrimitiveGetStringResponse = {
 /**
  * Contains response data for the getDate operation.
  */
-export type PrimitiveGetDateResponse = {
-  field?: Date;
-  leap?: Date;
+export type PrimitiveGetDateResponse = DateWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1052,9 +972,7 @@ export type PrimitiveGetDateResponse = {
 /**
  * Contains response data for the getDateTime operation.
  */
-export type PrimitiveGetDateTimeResponse = {
-  field?: Date;
-  now?: Date;
+export type PrimitiveGetDateTimeResponse = DatetimeWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1073,9 +991,7 @@ export type PrimitiveGetDateTimeResponse = {
 /**
  * Contains response data for the getDateTimeRfc1123 operation.
  */
-export type PrimitiveGetDateTimeRfc1123Response = {
-  field?: Date;
-  now?: Date;
+export type PrimitiveGetDateTimeRfc1123Response = Datetimerfc1123Wrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1094,8 +1010,7 @@ export type PrimitiveGetDateTimeRfc1123Response = {
 /**
  * Contains response data for the getDuration operation.
  */
-export type PrimitiveGetDurationResponse = {
-  field?: string;
+export type PrimitiveGetDurationResponse = DurationWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1114,8 +1029,7 @@ export type PrimitiveGetDurationResponse = {
 /**
  * Contains response data for the getByte operation.
  */
-export type PrimitiveGetByteResponse = {
-  field?: Uint8Array;
+export type PrimitiveGetByteResponse = ByteWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1134,8 +1048,7 @@ export type PrimitiveGetByteResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type ArrayModelGetValidResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetValidResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1154,8 +1067,7 @@ export type ArrayModelGetValidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type ArrayModelGetEmptyResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetEmptyResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1174,8 +1086,7 @@ export type ArrayModelGetEmptyResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type ArrayModelGetNotProvidedResponse = {
-  arrayProperty?: string[];
+export type ArrayModelGetNotProvidedResponse = ArrayWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1194,8 +1105,7 @@ export type ArrayModelGetNotProvidedResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type DictionaryGetValidResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetValidResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1214,8 +1124,7 @@ export type DictionaryGetValidResponse = {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type DictionaryGetEmptyResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetEmptyResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1234,8 +1143,7 @@ export type DictionaryGetEmptyResponse = {
 /**
  * Contains response data for the getNull operation.
  */
-export type DictionaryGetNullResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetNullResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1254,8 +1162,7 @@ export type DictionaryGetNullResponse = {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type DictionaryGetNotProvidedResponse = {
-  defaultProgram?: { [propertyName: string]: string };
+export type DictionaryGetNotProvidedResponse = DictionaryWrapper & {
   /**
    * The underlying HTTP response.
    */
@@ -1274,12 +1181,7 @@ export type DictionaryGetNotProvidedResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type InheritanceGetValidResponse = {
-  id?: number;
-  name?: string;
-  color?: string;
-  hates?: Dog[];
-  breed?: string;
+export type InheritanceGetValidResponse = Siamese & {
   /**
    * The underlying HTTP response.
    */
@@ -1298,14 +1200,7 @@ export type InheritanceGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type PolymorphismGetValidResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
+export type PolymorphismGetValidResponse = FishUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1324,16 +1219,7 @@ export type PolymorphismGetValidResponse = {
 /**
  * Contains response data for the getComplicated operation.
  */
-export type PolymorphismGetComplicatedResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
-  location?: string;
-  iswild?: boolean;
+export type PolymorphismGetComplicatedResponse = SalmonUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1352,16 +1238,7 @@ export type PolymorphismGetComplicatedResponse = {
 /**
  * Contains response data for the putMissingDiscriminator operation.
  */
-export type PolymorphismPutMissingDiscriminatorResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
-  location?: string;
-  iswild?: boolean;
+export type PolymorphismPutMissingDiscriminatorResponse = SalmonUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1380,14 +1257,7 @@ export type PolymorphismPutMissingDiscriminatorResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type PolymorphicrecursiveGetValidResponse = {
-  species?: string;
-  length: number;
-  siblings?: FishUnion[];
-  /**
-   * Polymorphic Discriminator
-   */
-  fishtype: string;
+export type PolymorphicrecursiveGetValidResponse = FishUnion & {
   /**
    * The underlying HTTP response.
    */
@@ -1406,12 +1276,7 @@ export type PolymorphicrecursiveGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type ReadonlypropertyGetValidResponse = {
-  /**
-   * **NOTE: This property will not be serialized. It can only be populated by the server.**
-   */
-  readonly id?: string;
-  size?: number;
+export type ReadonlypropertyGetValidResponse = ReadonlyObj & {
   /**
    * The underlying HTTP response.
    */
@@ -1430,13 +1295,7 @@ export type ReadonlypropertyGetValidResponse = {
 /**
  * Contains response data for the getValid operation.
  */
-export type FlattencomplexGetValidResponse = {
-  propB1?: string;
-  /**
-   * Polymorphic Discriminator
-   */
-  kind: string;
-  propBH1?: string;
+export type FlattencomplexGetValidResponse = MyBaseTypeUnion & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/BodyString/models/index.ts
+++ b/test/vanilla/generated/BodyString/models/index.ts
@@ -386,15 +386,7 @@ export type EnumModelGetReferencedResponse = {
 /**
  * Contains response data for the getReferencedConstant operation.
  */
-export type EnumModelGetReferencedConstantResponse = {
-  /**
-   * Referenced Color Constant Description.
-   */
-  colorConstant: string;
-  /**
-   * Sample string.
-   */
-  field1?: string;
+export type EnumModelGetReferencedConstantResponse = RefColorConstant & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/ComplexModelClient/models/index.ts
+++ b/test/vanilla/generated/ComplexModelClient/models/index.ts
@@ -138,11 +138,7 @@ export interface ComplexModelClientUpdateOptionalParams extends msRest.RequestOp
 /**
  * Contains response data for the list operation.
  */
-export type ListResponse = {
-  /**
-   * Array of products
-   */
-  productArray?: Product[];
+export type ListResponse = CatalogArray & {
   /**
    * The underlying HTTP response.
    */
@@ -161,11 +157,7 @@ export type ListResponse = {
 /**
  * Contains response data for the create operation.
  */
-export type CreateResponse = {
-  /**
-   * Dictionary of products
-   */
-  productDictionary?: { [propertyName: string]: Product };
+export type CreateResponse = CatalogDictionary & {
   /**
    * The underlying HTTP response.
    */
@@ -184,11 +176,7 @@ export type CreateResponse = {
 /**
  * Contains response data for the update operation.
  */
-export type UpdateResponse = {
-  /**
-   * Array of products
-   */
-  productArray?: Product[];
+export type UpdateResponse = CatalogArray & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/Header/models/index.ts
+++ b/test/vanilla/generated/Header/models/index.ts
@@ -276,11 +276,7 @@ export enum GreyscaleColors {
 /**
  * Contains response data for the responseExistingKey operation.
  */
-export type HeaderResponseExistingKeyResponse = {
-  /**
-   * response with header value "User-Agent": "overwrite"
-   */
-  userAgent: string;
+export type HeaderResponseExistingKeyResponse = HeaderResponseExistingKeyHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -295,11 +291,7 @@ export type HeaderResponseExistingKeyResponse = {
 /**
  * Contains response data for the responseProtectedKey operation.
  */
-export type HeaderResponseProtectedKeyResponse = {
-  /**
-   * response with header value "Content-Type": "text/html"
-   */
-  contentType: string;
+export type HeaderResponseProtectedKeyResponse = HeaderResponseProtectedKeyHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -314,11 +306,7 @@ export type HeaderResponseProtectedKeyResponse = {
 /**
  * Contains response data for the responseInteger operation.
  */
-export type HeaderResponseIntegerResponse = {
-  /**
-   * response with header value "value": 1 or -2
-   */
-  value: number;
+export type HeaderResponseIntegerResponse = HeaderResponseIntegerHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -333,11 +321,7 @@ export type HeaderResponseIntegerResponse = {
 /**
  * Contains response data for the responseLong operation.
  */
-export type HeaderResponseLongResponse = {
-  /**
-   * response with header value "value": 105 or -2
-   */
-  value: number;
+export type HeaderResponseLongResponse = HeaderResponseLongHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -352,11 +336,7 @@ export type HeaderResponseLongResponse = {
 /**
  * Contains response data for the responseFloat operation.
  */
-export type HeaderResponseFloatResponse = {
-  /**
-   * response with header value "value": 0.07 or -3.0
-   */
-  value: number;
+export type HeaderResponseFloatResponse = HeaderResponseFloatHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -371,11 +351,7 @@ export type HeaderResponseFloatResponse = {
 /**
  * Contains response data for the responseDouble operation.
  */
-export type HeaderResponseDoubleResponse = {
-  /**
-   * response with header value "value": 7e120 or -3.0
-   */
-  value: number;
+export type HeaderResponseDoubleResponse = HeaderResponseDoubleHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -390,11 +366,7 @@ export type HeaderResponseDoubleResponse = {
 /**
  * Contains response data for the responseBool operation.
  */
-export type HeaderResponseBoolResponse = {
-  /**
-   * response with header value "value": true or false
-   */
-  value: boolean;
+export type HeaderResponseBoolResponse = HeaderResponseBoolHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -409,11 +381,7 @@ export type HeaderResponseBoolResponse = {
 /**
  * Contains response data for the responseString operation.
  */
-export type HeaderResponseStringResponse = {
-  /**
-   * response with header values "The quick brown fox jumps over the lazy dog" or null or ""
-   */
-  value: string;
+export type HeaderResponseStringResponse = HeaderResponseStringHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -428,11 +396,7 @@ export type HeaderResponseStringResponse = {
 /**
  * Contains response data for the responseDate operation.
  */
-export type HeaderResponseDateResponse = {
-  /**
-   * response with header values "2010-01-01" or "0001-01-01"
-   */
-  value: Date;
+export type HeaderResponseDateResponse = HeaderResponseDateHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -447,11 +411,7 @@ export type HeaderResponseDateResponse = {
 /**
  * Contains response data for the responseDatetime operation.
  */
-export type HeaderResponseDatetimeResponse = {
-  /**
-   * response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
-   */
-  value: Date;
+export type HeaderResponseDatetimeResponse = HeaderResponseDatetimeHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -466,11 +426,7 @@ export type HeaderResponseDatetimeResponse = {
 /**
  * Contains response data for the responseDatetimeRfc1123 operation.
  */
-export type HeaderResponseDatetimeRfc1123Response = {
-  /**
-   * response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
-   */
-  value: Date;
+export type HeaderResponseDatetimeRfc1123Response = HeaderResponseDatetimeRfc1123Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -485,11 +441,7 @@ export type HeaderResponseDatetimeRfc1123Response = {
 /**
  * Contains response data for the responseDuration operation.
  */
-export type HeaderResponseDurationResponse = {
-  /**
-   * response with header values "P123DT22H14M12.011S"
-   */
-  value: string;
+export type HeaderResponseDurationResponse = HeaderResponseDurationHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -504,11 +456,7 @@ export type HeaderResponseDurationResponse = {
 /**
  * Contains response data for the responseByte operation.
  */
-export type HeaderResponseByteResponse = {
-  /**
-   * response with header values "啊齄丂狛狜隣郎隣兀﨩"
-   */
-  value: Uint8Array;
+export type HeaderResponseByteResponse = HeaderResponseByteHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -523,11 +471,7 @@ export type HeaderResponseByteResponse = {
 /**
  * Contains response data for the responseEnum operation.
  */
-export type HeaderResponseEnumResponse = {
-  /**
-   * response with header values "GREY" or null. Possible values include: 'White', 'black', 'GREY'
-   */
-  value: GreyscaleColors;
+export type HeaderResponseEnumResponse = HeaderResponseEnumHeaders & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/Http/models/index.ts
+++ b/test/vanilla/generated/Http/models/index.ts
@@ -1174,11 +1174,7 @@ export type HttpSuccessGet200Response = {
 /**
  * Contains response data for the head300 operation.
  */
-export type HttpRedirectsHead300Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/head/200'
-   */
-  location: Location;
+export type HttpRedirectsHead300Response = HttpRedirectsHead300Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1193,11 +1189,7 @@ export type HttpRedirectsHead300Response = {
 /**
  * Contains response data for the get300 operation.
  */
-export type HttpRedirectsGet300Response = Array<string> & {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/get/200'
-   */
-  location: Location1;
+export type HttpRedirectsGet300Response = Array<string> & HttpRedirectsGet300Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1220,11 +1212,7 @@ export type HttpRedirectsGet300Response = Array<string> & {
 /**
  * Contains response data for the head301 operation.
  */
-export type HttpRedirectsHead301Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/head/200'
-   */
-  location: Location2;
+export type HttpRedirectsHead301Response = HttpRedirectsHead301Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1239,11 +1227,7 @@ export type HttpRedirectsHead301Response = {
 /**
  * Contains response data for the get301 operation.
  */
-export type HttpRedirectsGet301Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/get/200'
-   */
-  location: Location3;
+export type HttpRedirectsGet301Response = HttpRedirectsGet301Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1258,11 +1242,7 @@ export type HttpRedirectsGet301Response = {
 /**
  * Contains response data for the put301 operation.
  */
-export type HttpRedirectsPut301Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/failure/500'
-   */
-  location: Location4;
+export type HttpRedirectsPut301Response = HttpRedirectsPut301Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1277,11 +1257,7 @@ export type HttpRedirectsPut301Response = {
 /**
  * Contains response data for the head302 operation.
  */
-export type HttpRedirectsHead302Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/head/200'
-   */
-  location: Location5;
+export type HttpRedirectsHead302Response = HttpRedirectsHead302Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1296,11 +1272,7 @@ export type HttpRedirectsHead302Response = {
 /**
  * Contains response data for the get302 operation.
  */
-export type HttpRedirectsGet302Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/get/200'
-   */
-  location: Location6;
+export type HttpRedirectsGet302Response = HttpRedirectsGet302Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1315,11 +1287,7 @@ export type HttpRedirectsGet302Response = {
 /**
  * Contains response data for the patch302 operation.
  */
-export type HttpRedirectsPatch302Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/failure/500'
-   */
-  location: Location7;
+export type HttpRedirectsPatch302Response = HttpRedirectsPatch302Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1334,11 +1302,7 @@ export type HttpRedirectsPatch302Response = {
 /**
  * Contains response data for the post303 operation.
  */
-export type HttpRedirectsPost303Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/get/200'
-   */
-  location: Location8;
+export type HttpRedirectsPost303Response = HttpRedirectsPost303Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1353,11 +1317,7 @@ export type HttpRedirectsPost303Response = {
 /**
  * Contains response data for the head307 operation.
  */
-export type HttpRedirectsHead307Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/head/200'
-   */
-  location: Location9;
+export type HttpRedirectsHead307Response = HttpRedirectsHead307Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1372,11 +1332,7 @@ export type HttpRedirectsHead307Response = {
 /**
  * Contains response data for the get307 operation.
  */
-export type HttpRedirectsGet307Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/get/200'
-   */
-  location: Location10;
+export type HttpRedirectsGet307Response = HttpRedirectsGet307Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1391,11 +1347,7 @@ export type HttpRedirectsGet307Response = {
 /**
  * Contains response data for the put307 operation.
  */
-export type HttpRedirectsPut307Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/put/200'
-   */
-  location: Location11;
+export type HttpRedirectsPut307Response = HttpRedirectsPut307Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1410,11 +1362,7 @@ export type HttpRedirectsPut307Response = {
 /**
  * Contains response data for the patch307 operation.
  */
-export type HttpRedirectsPatch307Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/patch/200'
-   */
-  location: Location12;
+export type HttpRedirectsPatch307Response = HttpRedirectsPatch307Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1429,11 +1377,7 @@ export type HttpRedirectsPatch307Response = {
 /**
  * Contains response data for the post307 operation.
  */
-export type HttpRedirectsPost307Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/post/200'
-   */
-  location: Location13;
+export type HttpRedirectsPost307Response = HttpRedirectsPost307Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1448,11 +1392,7 @@ export type HttpRedirectsPost307Response = {
 /**
  * Contains response data for the delete307 operation.
  */
-export type HttpRedirectsDelete307Response = {
-  /**
-   * The redirect location for this request. Possible values include: '/http/success/delete/200'
-   */
-  location: Location14;
+export type HttpRedirectsDelete307Response = HttpRedirectsDelete307Headers & {
   /**
    * The underlying HTTP response.
    */
@@ -1467,9 +1407,7 @@ export type HttpRedirectsDelete307Response = {
 /**
  * Contains response data for the head400 operation.
  */
-export type HttpClientFailureHead400Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureHead400Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1488,9 +1426,7 @@ export type HttpClientFailureHead400Response = {
 /**
  * Contains response data for the get400 operation.
  */
-export type HttpClientFailureGet400Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureGet400Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1509,9 +1445,7 @@ export type HttpClientFailureGet400Response = {
 /**
  * Contains response data for the put400 operation.
  */
-export type HttpClientFailurePut400Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePut400Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1530,9 +1464,7 @@ export type HttpClientFailurePut400Response = {
 /**
  * Contains response data for the patch400 operation.
  */
-export type HttpClientFailurePatch400Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePatch400Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1551,9 +1483,7 @@ export type HttpClientFailurePatch400Response = {
 /**
  * Contains response data for the post400 operation.
  */
-export type HttpClientFailurePost400Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePost400Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1572,9 +1502,7 @@ export type HttpClientFailurePost400Response = {
 /**
  * Contains response data for the delete400 operation.
  */
-export type HttpClientFailureDelete400Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureDelete400Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1593,9 +1521,7 @@ export type HttpClientFailureDelete400Response = {
 /**
  * Contains response data for the head401 operation.
  */
-export type HttpClientFailureHead401Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureHead401Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1614,9 +1540,7 @@ export type HttpClientFailureHead401Response = {
 /**
  * Contains response data for the get402 operation.
  */
-export type HttpClientFailureGet402Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureGet402Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1635,9 +1559,7 @@ export type HttpClientFailureGet402Response = {
 /**
  * Contains response data for the get403 operation.
  */
-export type HttpClientFailureGet403Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureGet403Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1656,9 +1578,7 @@ export type HttpClientFailureGet403Response = {
 /**
  * Contains response data for the put404 operation.
  */
-export type HttpClientFailurePut404Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePut404Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1677,9 +1597,7 @@ export type HttpClientFailurePut404Response = {
 /**
  * Contains response data for the patch405 operation.
  */
-export type HttpClientFailurePatch405Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePatch405Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1698,9 +1616,7 @@ export type HttpClientFailurePatch405Response = {
 /**
  * Contains response data for the post406 operation.
  */
-export type HttpClientFailurePost406Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePost406Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1719,9 +1635,7 @@ export type HttpClientFailurePost406Response = {
 /**
  * Contains response data for the delete407 operation.
  */
-export type HttpClientFailureDelete407Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureDelete407Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1740,9 +1654,7 @@ export type HttpClientFailureDelete407Response = {
 /**
  * Contains response data for the put409 operation.
  */
-export type HttpClientFailurePut409Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePut409Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1761,9 +1673,7 @@ export type HttpClientFailurePut409Response = {
 /**
  * Contains response data for the head410 operation.
  */
-export type HttpClientFailureHead410Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureHead410Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1782,9 +1692,7 @@ export type HttpClientFailureHead410Response = {
 /**
  * Contains response data for the get411 operation.
  */
-export type HttpClientFailureGet411Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureGet411Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1803,9 +1711,7 @@ export type HttpClientFailureGet411Response = {
 /**
  * Contains response data for the get412 operation.
  */
-export type HttpClientFailureGet412Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureGet412Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1824,9 +1730,7 @@ export type HttpClientFailureGet412Response = {
 /**
  * Contains response data for the put413 operation.
  */
-export type HttpClientFailurePut413Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePut413Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1845,9 +1749,7 @@ export type HttpClientFailurePut413Response = {
 /**
  * Contains response data for the patch414 operation.
  */
-export type HttpClientFailurePatch414Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePatch414Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1866,9 +1768,7 @@ export type HttpClientFailurePatch414Response = {
 /**
  * Contains response data for the post415 operation.
  */
-export type HttpClientFailurePost415Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailurePost415Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1887,9 +1787,7 @@ export type HttpClientFailurePost415Response = {
 /**
  * Contains response data for the get416 operation.
  */
-export type HttpClientFailureGet416Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureGet416Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1908,9 +1806,7 @@ export type HttpClientFailureGet416Response = {
 /**
  * Contains response data for the delete417 operation.
  */
-export type HttpClientFailureDelete417Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureDelete417Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1929,9 +1825,7 @@ export type HttpClientFailureDelete417Response = {
 /**
  * Contains response data for the head429 operation.
  */
-export type HttpClientFailureHead429Response = {
-  status?: number;
-  message?: string;
+export type HttpClientFailureHead429Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1950,9 +1844,7 @@ export type HttpClientFailureHead429Response = {
 /**
  * Contains response data for the head501 operation.
  */
-export type HttpServerFailureHead501Response = {
-  status?: number;
-  message?: string;
+export type HttpServerFailureHead501Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1971,9 +1863,7 @@ export type HttpServerFailureHead501Response = {
 /**
  * Contains response data for the get501 operation.
  */
-export type HttpServerFailureGet501Response = {
-  status?: number;
-  message?: string;
+export type HttpServerFailureGet501Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -1992,9 +1882,7 @@ export type HttpServerFailureGet501Response = {
 /**
  * Contains response data for the post505 operation.
  */
-export type HttpServerFailurePost505Response = {
-  status?: number;
-  message?: string;
+export type HttpServerFailurePost505Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -2013,9 +1901,7 @@ export type HttpServerFailurePost505Response = {
 /**
  * Contains response data for the delete505 operation.
  */
-export type HttpServerFailureDelete505Response = {
-  status?: number;
-  message?: string;
+export type HttpServerFailureDelete505Response = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -2035,8 +1921,7 @@ export type HttpServerFailureDelete505Response = {
  * Contains response data for the get200Model204NoModelDefaultError200Valid
  * operation.
  */
-export type MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2056,8 +1941,7 @@ export type MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse =
  * Contains response data for the get200Model204NoModelDefaultError204Valid
  * operation.
  */
-export type MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2077,8 +1961,7 @@ export type MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse =
  * Contains response data for the get200Model204NoModelDefaultError201Invalid
  * operation.
  */
-export type MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2098,8 +1981,7 @@ export type MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse
  * Contains response data for the get200Model204NoModelDefaultError202None
  * operation.
  */
-export type MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2119,8 +2001,7 @@ export type MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse = 
  * Contains response data for the get200Model204NoModelDefaultError400Valid
  * operation.
  */
-export type MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2140,8 +2021,7 @@ export type MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse =
  * Contains response data for the get200Model201ModelDefaultError200Valid
  * operation.
  */
-export type MultipleResponsesGet200Model201ModelDefaultError200ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model201ModelDefaultError200ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2161,8 +2041,7 @@ export type MultipleResponsesGet200Model201ModelDefaultError200ValidResponse = {
  * Contains response data for the get200Model201ModelDefaultError201Valid
  * operation.
  */
-export type MultipleResponsesGet200Model201ModelDefaultError201ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model201ModelDefaultError201ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2182,8 +2061,7 @@ export type MultipleResponsesGet200Model201ModelDefaultError201ValidResponse = {
  * Contains response data for the get200Model201ModelDefaultError400Valid
  * operation.
  */
-export type MultipleResponsesGet200Model201ModelDefaultError400ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200Model201ModelDefaultError400ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2298,8 +2176,7 @@ export type MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidR
 /**
  * Contains response data for the getDefaultModelA200Valid operation.
  */
-export type MultipleResponsesGetDefaultModelA200ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGetDefaultModelA200ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2318,8 +2195,7 @@ export type MultipleResponsesGetDefaultModelA200ValidResponse = {
 /**
  * Contains response data for the getDefaultModelA200None operation.
  */
-export type MultipleResponsesGetDefaultModelA200NoneResponse = {
-  statusCode?: string;
+export type MultipleResponsesGetDefaultModelA200NoneResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2338,8 +2214,7 @@ export type MultipleResponsesGetDefaultModelA200NoneResponse = {
 /**
  * Contains response data for the getDefaultModelA400Valid operation.
  */
-export type MultipleResponsesGetDefaultModelA400ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGetDefaultModelA400ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2358,8 +2233,7 @@ export type MultipleResponsesGetDefaultModelA400ValidResponse = {
 /**
  * Contains response data for the getDefaultModelA400None operation.
  */
-export type MultipleResponsesGetDefaultModelA400NoneResponse = {
-  statusCode?: string;
+export type MultipleResponsesGetDefaultModelA400NoneResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2378,8 +2252,7 @@ export type MultipleResponsesGetDefaultModelA400NoneResponse = {
 /**
  * Contains response data for the get200ModelA200None operation.
  */
-export type MultipleResponsesGet200ModelA200NoneResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA200NoneResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2398,8 +2271,7 @@ export type MultipleResponsesGet200ModelA200NoneResponse = {
 /**
  * Contains response data for the get200ModelA200Valid operation.
  */
-export type MultipleResponsesGet200ModelA200ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA200ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2418,8 +2290,7 @@ export type MultipleResponsesGet200ModelA200ValidResponse = {
 /**
  * Contains response data for the get200ModelA200Invalid operation.
  */
-export type MultipleResponsesGet200ModelA200InvalidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA200InvalidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2438,8 +2309,7 @@ export type MultipleResponsesGet200ModelA200InvalidResponse = {
 /**
  * Contains response data for the get200ModelA400None operation.
  */
-export type MultipleResponsesGet200ModelA400NoneResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA400NoneResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2458,8 +2328,7 @@ export type MultipleResponsesGet200ModelA400NoneResponse = {
 /**
  * Contains response data for the get200ModelA400Valid operation.
  */
-export type MultipleResponsesGet200ModelA400ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA400ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2478,8 +2347,7 @@ export type MultipleResponsesGet200ModelA400ValidResponse = {
 /**
  * Contains response data for the get200ModelA400Invalid operation.
  */
-export type MultipleResponsesGet200ModelA400InvalidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA400InvalidResponse = A & {
   /**
    * The underlying HTTP response.
    */
@@ -2498,8 +2366,7 @@ export type MultipleResponsesGet200ModelA400InvalidResponse = {
 /**
  * Contains response data for the get200ModelA202Valid operation.
  */
-export type MultipleResponsesGet200ModelA202ValidResponse = {
-  statusCode?: string;
+export type MultipleResponsesGet200ModelA202ValidResponse = A & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/ModelFlattening/models/index.ts
+++ b/test/vanilla/generated/ModelFlattening/models/index.ts
@@ -414,10 +414,7 @@ export type GetDictionaryResponse = {
 /**
  * Contains response data for the getResourceCollection operation.
  */
-export type GetResourceCollectionResponse = {
-  productresource?: FlattenedProduct;
-  arrayofresources?: FlattenedProduct[];
-  dictionaryofresources?: { [propertyName: string]: FlattenedProduct };
+export type GetResourceCollectionResponse = ResourceCollection & {
   /**
    * The underlying HTTP response.
    */
@@ -436,32 +433,7 @@ export type GetResourceCollectionResponse = {
 /**
  * Contains response data for the putSimpleProduct operation.
  */
-export type PutSimpleProductResponse = {
-  /**
-   * Unique identifier representing a specific product for a given latitude & longitude. For
-   * example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
-   */
-  productId: string;
-  /**
-   * Description of product.
-   */
-  description?: string;
-  /**
-   * Display name of product.
-   */
-  maxProductDisplayName: string;
-  /**
-   * Capacity of product. For example, 4 people.
-   */
-  capacity: string;
-  /**
-   * Generic URL value.
-   */
-  genericValue?: string;
-  /**
-   * URL value.
-   */
-  odatavalue?: string;
+export type PutSimpleProductResponse = SimpleProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -480,32 +452,7 @@ export type PutSimpleProductResponse = {
 /**
  * Contains response data for the postFlattenedSimpleProduct operation.
  */
-export type PostFlattenedSimpleProductResponse = {
-  /**
-   * Unique identifier representing a specific product for a given latitude & longitude. For
-   * example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
-   */
-  productId: string;
-  /**
-   * Description of product.
-   */
-  description?: string;
-  /**
-   * Display name of product.
-   */
-  maxProductDisplayName: string;
-  /**
-   * Capacity of product. For example, 4 people.
-   */
-  capacity: string;
-  /**
-   * Generic URL value.
-   */
-  genericValue?: string;
-  /**
-   * URL value.
-   */
-  odatavalue?: string;
+export type PostFlattenedSimpleProductResponse = SimpleProduct & {
   /**
    * The underlying HTTP response.
    */
@@ -524,32 +471,7 @@ export type PostFlattenedSimpleProductResponse = {
 /**
  * Contains response data for the putSimpleProductWithGrouping operation.
  */
-export type PutSimpleProductWithGroupingResponse = {
-  /**
-   * Unique identifier representing a specific product for a given latitude & longitude. For
-   * example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
-   */
-  productId: string;
-  /**
-   * Description of product.
-   */
-  description?: string;
-  /**
-   * Display name of product.
-   */
-  maxProductDisplayName: string;
-  /**
-   * Capacity of product. For example, 4 people.
-   */
-  capacity: string;
-  /**
-   * Generic URL value.
-   */
-  genericValue?: string;
-  /**
-   * URL value.
-   */
-  odatavalue?: string;
+export type PutSimpleProductWithGroupingResponse = SimpleProduct & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/RequiredOptional/models/index.ts
+++ b/test/vanilla/generated/RequiredOptional/models/index.ts
@@ -341,9 +341,7 @@ export interface ExplicitPostOptionalArrayHeaderOptionalParams extends msRest.Re
 /**
  * Contains response data for the getRequiredPath operation.
  */
-export type ImplicitGetRequiredPathResponse = {
-  status?: number;
-  message?: string;
+export type ImplicitGetRequiredPathResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -362,9 +360,7 @@ export type ImplicitGetRequiredPathResponse = {
 /**
  * Contains response data for the getRequiredGlobalPath operation.
  */
-export type ImplicitGetRequiredGlobalPathResponse = {
-  status?: number;
-  message?: string;
+export type ImplicitGetRequiredGlobalPathResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -383,9 +379,7 @@ export type ImplicitGetRequiredGlobalPathResponse = {
 /**
  * Contains response data for the getRequiredGlobalQuery operation.
  */
-export type ImplicitGetRequiredGlobalQueryResponse = {
-  status?: number;
-  message?: string;
+export type ImplicitGetRequiredGlobalQueryResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -404,9 +398,7 @@ export type ImplicitGetRequiredGlobalQueryResponse = {
 /**
  * Contains response data for the getOptionalGlobalQuery operation.
  */
-export type ImplicitGetOptionalGlobalQueryResponse = {
-  status?: number;
-  message?: string;
+export type ImplicitGetOptionalGlobalQueryResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -425,9 +417,7 @@ export type ImplicitGetOptionalGlobalQueryResponse = {
 /**
  * Contains response data for the postRequiredIntegerParameter operation.
  */
-export type ExplicitPostRequiredIntegerParameterResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredIntegerParameterResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -446,9 +436,7 @@ export type ExplicitPostRequiredIntegerParameterResponse = {
 /**
  * Contains response data for the postRequiredIntegerProperty operation.
  */
-export type ExplicitPostRequiredIntegerPropertyResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredIntegerPropertyResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -467,9 +455,7 @@ export type ExplicitPostRequiredIntegerPropertyResponse = {
 /**
  * Contains response data for the postRequiredIntegerHeader operation.
  */
-export type ExplicitPostRequiredIntegerHeaderResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredIntegerHeaderResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -488,9 +474,7 @@ export type ExplicitPostRequiredIntegerHeaderResponse = {
 /**
  * Contains response data for the postRequiredStringParameter operation.
  */
-export type ExplicitPostRequiredStringParameterResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredStringParameterResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -509,9 +493,7 @@ export type ExplicitPostRequiredStringParameterResponse = {
 /**
  * Contains response data for the postRequiredStringProperty operation.
  */
-export type ExplicitPostRequiredStringPropertyResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredStringPropertyResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -530,9 +512,7 @@ export type ExplicitPostRequiredStringPropertyResponse = {
 /**
  * Contains response data for the postRequiredStringHeader operation.
  */
-export type ExplicitPostRequiredStringHeaderResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredStringHeaderResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -551,9 +531,7 @@ export type ExplicitPostRequiredStringHeaderResponse = {
 /**
  * Contains response data for the postRequiredClassParameter operation.
  */
-export type ExplicitPostRequiredClassParameterResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredClassParameterResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -572,9 +550,7 @@ export type ExplicitPostRequiredClassParameterResponse = {
 /**
  * Contains response data for the postRequiredClassProperty operation.
  */
-export type ExplicitPostRequiredClassPropertyResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredClassPropertyResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -593,9 +569,7 @@ export type ExplicitPostRequiredClassPropertyResponse = {
 /**
  * Contains response data for the postRequiredArrayParameter operation.
  */
-export type ExplicitPostRequiredArrayParameterResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredArrayParameterResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -614,9 +588,7 @@ export type ExplicitPostRequiredArrayParameterResponse = {
 /**
  * Contains response data for the postRequiredArrayProperty operation.
  */
-export type ExplicitPostRequiredArrayPropertyResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredArrayPropertyResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */
@@ -635,9 +607,7 @@ export type ExplicitPostRequiredArrayPropertyResponse = {
 /**
  * Contains response data for the postRequiredArrayHeader operation.
  */
-export type ExplicitPostRequiredArrayHeaderResponse = {
-  status?: number;
-  message?: string;
+export type ExplicitPostRequiredArrayHeaderResponse = ErrorModel & {
   /**
    * The underlying HTTP response.
    */

--- a/test/vanilla/generated/Validation/models/index.ts
+++ b/test/vanilla/generated/Validation/models/index.ts
@@ -124,33 +124,7 @@ export enum EnumConst {
 /**
  * Contains response data for the validationOfMethodParameters operation.
  */
-export type ValidationOfMethodParametersResponse = {
-  /**
-   * Non required array of unique items from 0 to 6 elements.
-   */
-  displayNames?: string[];
-  /**
-   * Non required int betwen 0 and 100 exclusive.
-   */
-  capacity?: number;
-  /**
-   * Image URL representing the product.
-   */
-  image?: string;
-  child: ChildProduct;
-  constChild: ConstantProduct;
-  /**
-   * Constant int
-   */
-  constInt: number;
-  /**
-   * Constant string
-   */
-  constString: string;
-  /**
-   * Constant string as Enum. Possible values include: 'constant_string_as_enum'
-   */
-  constStringAsEnum?: EnumConst;
+export type ValidationOfMethodParametersResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -169,33 +143,7 @@ export type ValidationOfMethodParametersResponse = {
 /**
  * Contains response data for the validationOfBody operation.
  */
-export type ValidationOfBodyResponse = {
-  /**
-   * Non required array of unique items from 0 to 6 elements.
-   */
-  displayNames?: string[];
-  /**
-   * Non required int betwen 0 and 100 exclusive.
-   */
-  capacity?: number;
-  /**
-   * Image URL representing the product.
-   */
-  image?: string;
-  child: ChildProduct;
-  constChild: ConstantProduct;
-  /**
-   * Constant int
-   */
-  constInt: number;
-  /**
-   * Constant string
-   */
-  constString: string;
-  /**
-   * Constant string as Enum. Possible values include: 'constant_string_as_enum'
-   */
-  constStringAsEnum?: EnumConst;
+export type ValidationOfBodyResponse = Product & {
   /**
    * The underlying HTTP response.
    */
@@ -214,33 +162,7 @@ export type ValidationOfBodyResponse = {
 /**
  * Contains response data for the postWithConstantInBody operation.
  */
-export type PostWithConstantInBodyResponse = {
-  /**
-   * Non required array of unique items from 0 to 6 elements.
-   */
-  displayNames?: string[];
-  /**
-   * Non required int betwen 0 and 100 exclusive.
-   */
-  capacity?: number;
-  /**
-   * Image URL representing the product.
-   */
-  image?: string;
-  child: ChildProduct;
-  constChild: ConstantProduct;
-  /**
-   * Constant int
-   */
-  constInt: number;
-  /**
-   * Constant string
-   */
-  constString: string;
-  /**
-   * Constant string as Enum. Possible values include: 'constant_string_as_enum'
-   */
-  constStringAsEnum?: EnumConst;
+export type PostWithConstantInBodyResponse = Product & {
   /**
    * The underlying HTTP response.
    */

--- a/test/xml/generated/Xml/models/index.ts
+++ b/test/xml/generated/Xml/models/index.ts
@@ -819,15 +819,7 @@ export enum ArchiveStatus {
 /**
  * Contains response data for the getComplexTypeRefNoMeta operation.
  */
-export type XmlGetComplexTypeRefNoMetaResponse = {
-  /**
-   * XML will use RefToModel
-   */
-  refToModel?: ComplexTypeNoMeta;
-  /**
-   * Something else (just to avoid flattening)
-   */
-  something?: string;
+export type XmlGetComplexTypeRefNoMetaResponse = RootWithRefAndNoMeta & {
   /**
    * The underlying HTTP response.
    */
@@ -846,15 +838,7 @@ export type XmlGetComplexTypeRefNoMetaResponse = {
 /**
  * Contains response data for the getComplexTypeRefWithMeta operation.
  */
-export type XmlGetComplexTypeRefWithMetaResponse = {
-  /**
-   * XML will use XMLComplexTypeWithMeta
-   */
-  refToModel?: ComplexTypeWithMeta;
-  /**
-   * Something else (just to avoid flattening)
-   */
-  something?: string;
+export type XmlGetComplexTypeRefWithMetaResponse = RootWithRefAndMeta & {
   /**
    * The underlying HTTP response.
    */
@@ -873,11 +857,7 @@ export type XmlGetComplexTypeRefWithMetaResponse = {
 /**
  * Contains response data for the getSimple operation.
  */
-export type XmlGetSimpleResponse = {
-  title?: string;
-  date?: string;
-  author?: string;
-  slides?: Slide[];
+export type XmlGetSimpleResponse = Slideshow & {
   /**
    * The underlying HTTP response.
    */
@@ -896,9 +876,7 @@ export type XmlGetSimpleResponse = {
 /**
  * Contains response data for the getWrappedLists operation.
  */
-export type XmlGetWrappedListsResponse = {
-  goodApples?: string[];
-  badApples?: string[];
+export type XmlGetWrappedListsResponse = AppleBarrel & {
   /**
    * The underlying HTTP response.
    */
@@ -917,11 +895,7 @@ export type XmlGetWrappedListsResponse = {
 /**
  * Contains response data for the getHeaders operation.
  */
-export type XmlGetHeadersResponse = {
-  /**
-   * A custom response header.
-   */
-  customHeader: string;
+export type XmlGetHeadersResponse = XmlGetHeadersHeaders & {
   /**
    * The underlying HTTP response.
    */
@@ -936,11 +910,7 @@ export type XmlGetHeadersResponse = {
 /**
  * Contains response data for the getEmptyList operation.
  */
-export type XmlGetEmptyListResponse = {
-  title?: string;
-  date?: string;
-  author?: string;
-  slides?: Slide[];
+export type XmlGetEmptyListResponse = Slideshow & {
   /**
    * The underlying HTTP response.
    */
@@ -959,9 +929,7 @@ export type XmlGetEmptyListResponse = {
 /**
  * Contains response data for the getEmptyWrappedLists operation.
  */
-export type XmlGetEmptyWrappedListsResponse = {
-  goodApples?: string[];
-  badApples?: string[];
+export type XmlGetEmptyWrappedListsResponse = AppleBarrel & {
   /**
    * The underlying HTTP response.
    */
@@ -1037,13 +1005,7 @@ export type XmlGetEmptyRootListResponse = Array<Banana> & {
 /**
  * Contains response data for the getEmptyChildElement operation.
  */
-export type XmlGetEmptyChildElementResponse = {
-  name?: string;
-  flavor?: string;
-  /**
-   * The time at which you should reconsider eating this banana
-   */
-  expiration?: Date;
+export type XmlGetEmptyChildElementResponse = Banana & {
   /**
    * The underlying HTTP response.
    */
@@ -1062,13 +1024,7 @@ export type XmlGetEmptyChildElementResponse = {
 /**
  * Contains response data for the listContainers operation.
  */
-export type XmlListContainersResponse = {
-  serviceEndpoint: string;
-  prefix: string;
-  marker?: string;
-  maxResults: number;
-  containers?: Container[];
-  nextMarker: string;
+export type XmlListContainersResponse = ListContainersResponse & {
   /**
    * The underlying HTTP response.
    */
@@ -1087,32 +1043,7 @@ export type XmlListContainersResponse = {
 /**
  * Contains response data for the getServiceProperties operation.
  */
-export type XmlGetServicePropertiesResponse = {
-  /**
-   * Azure Analytics Logging settings
-   */
-  logging?: Logging;
-  /**
-   * A summary of request statistics grouped by API in hourly aggregates for blobs
-   */
-  hourMetrics?: Metrics;
-  /**
-   * a summary of request statistics grouped by API in minute aggregates for blobs
-   */
-  minuteMetrics?: Metrics;
-  /**
-   * The set of CORS rules.
-   */
-  cors?: CorsRule[];
-  /**
-   * The default version to use for requests to the Blob service if an incoming request's version
-   * is not specified. Possible values include version 2008-10-27 and all more recent versions
-   */
-  defaultServiceVersion?: string;
-  /**
-   * The Delete Retention Policy for the service
-   */
-  deleteRetentionPolicy?: RetentionPolicy;
+export type XmlGetServicePropertiesResponse = StorageServiceProperties & {
   /**
    * The underlying HTTP response.
    */
@@ -1150,15 +1081,7 @@ export type XmlGetAclsResponse = Array<SignedIdentifier> & {
 /**
  * Contains response data for the listBlobs operation.
  */
-export type XmlListBlobsResponse = {
-  serviceEndpoint: string;
-  containerName: string;
-  prefix: string;
-  marker: string;
-  maxResults: number;
-  delimiter: string;
-  blobs: Blobs;
-  nextMarker: string;
+export type XmlListBlobsResponse = ListBlobsResponse & {
   /**
    * The underlying HTTP response.
    */


### PR DESCRIPTION
This fixes the flattened body types used for paging by simply intersecting with the body type instead of copying the properties over.

See https://github.com/Azure/autorest.typescript/blob/master/src/azure/Templates/PageModelTemplate.cshtml#L29

These kinds of special cases in generating model interfaces make it seem like it's simpler to just reuse those definitions instead of figuring out how to emit them over again.

I added some paging tests that use the flattened response so that we can properly exercise its behavior.