### PR TITLE
Metadata and bundle size fixes

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -63,19 +63,16 @@ task 'test/metadata', '', ['test/vanilla-metadata', 'test/azure-metadata'], (don
 task 'test/vanilla-metadata', '', [], (done) ->
   cwd = "#{basefolder}/test/metadata/generated"
   await execute "npm install", { cwd: cwd, silent: false }, defer _
-  await execute "npm run build", { cwd: cwd, silent: false }, defer _
   done()
 
 task 'test/azure-metadata', '', [], (done) ->
   cwd = "#{basefolder}/test/azuremetadata/generated"
   await execute "npm install", {cwd: cwd, silent: false }, defer _
-  await execute "npm run build", {cwd: cwd, silent: false }, defer _
   done()
 
 task 'test/multiapi', '', [], (done) ->
   cwd = "#{basefolder}/test/multiapi/generated"
   await execute "npm install", {cwd: cwd, silent: false }, defer _
-  await execute "npm run build", {cwd: cwd, silent: false }, defer _
   done()
 
 task 'test/typecheck', 'type check generated code', [], (done) ->

--- a/src/azure/CodeGeneratorTSa.cs
+++ b/src/azure/CodeGeneratorTSa.cs
@@ -72,14 +72,13 @@ namespace AutoRest.TypeScript.Azure
             {
                 if (codeModel.MultiApi && string.IsNullOrEmpty(codeModel.DefaultApiVersion))
                 {
-                    await Write(new PackageJsonMultiApi() { Model = codeModel },
+                    await Write(new PackageJsonMultiApi { Model = codeModel },
                         Path.Combine("../", "package.json"));
 
-
-                    await Write(new TsConfigMultiApi() { Model = codeModel },
+                    await Write(new TsConfigMultiApi { Model = codeModel },
                         Path.Combine("../", "tsconfig.json"));
 
-                    await Write(new TsConfigWebpackMultiApi() { Model = codeModel },
+                    await Write(new TsConfigWebpackMultiApi { Model = codeModel },
                         Path.Combine("../", "tsconfig.esm.json"));
                 }
                 else
@@ -93,7 +92,7 @@ namespace AutoRest.TypeScript.Azure
                     await Write(nodeTsConfig, Path.Combine("../", "tsconfig.json"));
 
                     //tsconfig.esm.json
-                    var webpackTsConfig = new TsConfigWebpack();
+                    var webpackTsConfig = new TsConfigWebpack { Model = codeModel };
                     await Write(webpackTsConfig, Path.Combine("../", "tsconfig.esm.json"));
 
                     // webpack.config.js

--- a/src/vanilla/CodeGeneratorTS.cs
+++ b/src/vanilla/CodeGeneratorTS.cs
@@ -86,7 +86,7 @@ namespace AutoRest.TypeScript
                 await Write(nodeTsConfig, Path.Combine("../", "tsconfig.json"));
 
                 //tsconfig.esm.json
-                var webpackTsConfig = new TsConfigWebpack();
+                var webpackTsConfig = new TsConfigWebpack { Model = codeModel };
                 await Write(webpackTsConfig, Path.Combine("../", "tsconfig.esm.json"));
 
                 // webpack.config.js

--- a/src/vanilla/Templates/PackageJson.cshtml
+++ b/src/vanilla/Templates/PackageJson.cshtml
@@ -18,9 +18,9 @@
   "license": "MIT",
 @if (string.IsNullOrEmpty(Model.DefaultApiVersion))
 {
-@:  "main": "./cjs/lib/@(Model.Name.ToCamelCase()).js",
-@:  "module": "./esm/lib/@(Model.Name.ToCamelCase()).js",
-@:  "types": "./cjs/lib/@(Model.Name.ToCamelCase()).d.ts",
+@:  "main": "./cjs/@(Model.Name.ToCamelCase()).js",
+@:  "module": "./esm/@(Model.Name.ToCamelCase()).js",
+@:  "types": "./cjs/@(Model.Name.ToCamelCase()).d.ts",
 }
 else
 {

--- a/src/vanilla/Templates/PackageJson.cshtml
+++ b/src/vanilla/Templates/PackageJson.cshtml
@@ -18,8 +18,9 @@
   "license": "MIT",
 @if (string.IsNullOrEmpty(Model.DefaultApiVersion))
 {
-@:  "main": "./dist/lib/@(Model.Name.ToCamelCase()).js",
-@:  "types": "./typings/lib/@(Model.Name.ToCamelCase()).d.ts",
+@:  "main": "./cjs/lib/@(Model.Name.ToCamelCase()).js",
+@:  "module": "./esm/lib/@(Model.Name.ToCamelCase()).js",
+@:  "types": "./cjs/lib/@(Model.Name.ToCamelCase()).d.ts",
 }
 else
 {
@@ -28,7 +29,6 @@ else
 @:  "types": "./@(Model.DefaultApiVersion)/cjs/lib/@(Model.Name.ToCamelCase()).d.ts",
 }
   "devDependencies": {
-    "ts-loader": "^4.4.2",
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",
     "webpack": "^4.17.2",
@@ -43,6 +43,7 @@ else
     "url": "@(Model.BugsUrl)"
   },
   "scripts": {
-    "build": "tsc @(string.IsNullOrEmpty(Model.DefaultApiVersion) ? "" : "-b ")&& webpack"
+    "build": "tsc @(string.IsNullOrEmpty(Model.DefaultApiVersion) ? "&& tsc -p tsconfig.esm.json" : "-b") && webpack",
+    "prepare": "npm run build"
   }
 }

--- a/src/vanilla/Templates/TsConfigWebpack.cshtml
+++ b/src/vanilla/Templates/TsConfigWebpack.cshtml
@@ -1,9 +1,8 @@
-﻿@using AutoRest.TypeScript.vanilla.Templates
-@inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>
+﻿@inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-@if(string.IsNullOrEmpty(Model.DefaultApiVersion))
+@if(string.IsNullOrEmpty(Model.Settings.DefaultApiVersion))
 {
 @:    "outDir": "./esm",
 }

--- a/src/vanilla/Templates/TsConfigWebpack.cshtml
+++ b/src/vanilla/Templates/TsConfigWebpack.cshtml
@@ -1,8 +1,12 @@
 ﻿@using AutoRest.TypeScript.vanilla.Templates
-@inherits AutoRest.Core.Template<object>
+@inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+@if(string.IsNullOrEmpty(Model.DefaultApiVersion))
+{
+@:    "outDir": "./esm",
+}
     "module": "es6",
     "target": "es5"
   }

--- a/src/vanilla/Templates/WebpackConfig.cshtml
+++ b/src/vanilla/Templates/WebpackConfig.cshtml
@@ -16,13 +16,13 @@ const config = {
 @if (!string.IsNullOrEmpty(Model.DefaultApiVersion))
 {
 <text>
-  entry: './@(Model.DefaultApiVersion)/lib/@(Model.Name.ToCamelCase()).ts',
+  entry: './@(Model.DefaultApiVersion)/esm/lib/@(Model.Name.ToCamelCase()).js',
 </text>
 }
 else
 {
 <text>
-  entry: './lib/@(Model.Name.ToCamelCase()).ts',
+  entry: './esm/@(Model.Name.ToCamelCase()).js',
 </text>
 }
   devtool: 'source-map',
@@ -31,28 +31,6 @@ else
     path: __dirname,
     libraryTarget: 'var',
     library: '@(Model.Name.ToCamelCase())'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        options: {
-@if (!string.IsNullOrEmpty(Model.DefaultApiVersion))
-{
-<text>
-          configFile: path.join(__dirname, '@(Model.DefaultApiVersion)/tsconfig.esm.json'),
-</text>
-}
-else
-{
-<text>
-          configFile: path.join(__dirname, "tsconfig.esm.json")
-</text>
-}
-        }
-      }
-    ]
   },
   // "ms-rest-js" and "ms-rest-azure-js" are dependencies of this library.
   // Customer is expected to import/include this library in browser javascript

--- a/test/azuremetadata/generated/package.json
+++ b/test/azuremetadata/generated/package.json
@@ -14,9 +14,9 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "main": "./cjs/lib/autoRestLongRunningOperationTestService.js",
-  "module": "./esm/lib/autoRestLongRunningOperationTestService.js",
-  "types": "./cjs/lib/autoRestLongRunningOperationTestService.d.ts",
+  "main": "./cjs/autoRestLongRunningOperationTestService.js",
+  "module": "./esm/autoRestLongRunningOperationTestService.js",
+  "types": "./cjs/autoRestLongRunningOperationTestService.d.ts",
   "devDependencies": {
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",

--- a/test/azuremetadata/generated/package.json
+++ b/test/azuremetadata/generated/package.json
@@ -14,10 +14,10 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "main": "./dist/lib/autoRestLongRunningOperationTestService.js",
-  "types": "./typings/lib/autoRestLongRunningOperationTestService.d.ts",
+  "main": "./cjs/lib/autoRestLongRunningOperationTestService.js",
+  "module": "./esm/lib/autoRestLongRunningOperationTestService.js",
+  "types": "./cjs/lib/autoRestLongRunningOperationTestService.d.ts",
   "devDependencies": {
-    "ts-loader": "^4.4.2",
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",
     "webpack": "^4.17.2",
@@ -32,6 +32,7 @@
     "url": "https://github.com/azure/azure-sdk-for-js/issues"
   },
   "scripts": {
-    "build": "tsc && webpack"
+    "build": "tsc && tsc -p tsconfig.esm.json && webpack",
+    "prepare": "npm run build"
   }
 }

--- a/test/azuremetadata/generated/tsconfig.esm.json
+++ b/test/azuremetadata/generated/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+    "outDir": "./esm",
     "module": "es6",
     "target": "es5"
   }

--- a/test/azuremetadata/generated/webpack.config.js
+++ b/test/azuremetadata/generated/webpack.config.js
@@ -7,24 +7,13 @@ const path = require('path');
  */
 const config = {
   mode: 'production',
-  entry: './lib/autoRestLongRunningOperationTestService.ts',
+  entry: './esm/autoRestLongRunningOperationTestService.js',
   devtool: 'source-map',
   output: {
     filename: 'autoRestLongRunningOperationTestServiceBundle.js',
     path: __dirname,
     libraryTarget: 'var',
     library: 'autoRestLongRunningOperationTestService'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        options: {
-          configFile: path.join(__dirname, "tsconfig.esm.json")
-        }
-      }
-    ]
   },
   // "ms-rest-js" and "ms-rest-azure-js" are dependencies of this library.
   // Customer is expected to import/include this library in browser javascript

--- a/test/metadata/generated/package.json
+++ b/test/metadata/generated/package.json
@@ -14,10 +14,10 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "main": "./dist/lib/autoRestComplexTestService.js",
-  "types": "./typings/lib/autoRestComplexTestService.d.ts",
+  "main": "./cjs/lib/autoRestComplexTestService.js",
+  "module": "./esm/lib/autoRestComplexTestService.js",
+  "types": "./cjs/lib/autoRestComplexTestService.d.ts",
   "devDependencies": {
-    "ts-loader": "^4.4.2",
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",
     "webpack": "^4.17.2",
@@ -32,6 +32,7 @@
     "url": "https://github.com/azure/azure-sdk-for-js/issues"
   },
   "scripts": {
-    "build": "tsc && webpack"
+    "build": "tsc && tsc -p tsconfig.esm.json && webpack",
+    "prepare": "npm run build"
   }
 }

--- a/test/metadata/generated/package.json
+++ b/test/metadata/generated/package.json
@@ -14,9 +14,9 @@
     "isomorphic"
   ],
   "license": "MIT",
-  "main": "./cjs/lib/autoRestComplexTestService.js",
-  "module": "./esm/lib/autoRestComplexTestService.js",
-  "types": "./cjs/lib/autoRestComplexTestService.d.ts",
+  "main": "./cjs/autoRestComplexTestService.js",
+  "module": "./esm/autoRestComplexTestService.js",
+  "types": "./cjs/autoRestComplexTestService.d.ts",
   "devDependencies": {
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",

--- a/test/metadata/generated/tsconfig.esm.json
+++ b/test/metadata/generated/tsconfig.esm.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
+    "outDir": "./esm",
     "module": "es6",
     "target": "es5"
   }

--- a/test/metadata/generated/webpack.config.js
+++ b/test/metadata/generated/webpack.config.js
@@ -7,24 +7,13 @@ const path = require('path');
  */
 const config = {
   mode: 'production',
-  entry: './lib/autoRestComplexTestService.ts',
+  entry: './esm/autoRestComplexTestService.js',
   devtool: 'source-map',
   output: {
     filename: 'autoRestComplexTestServiceBundle.js',
     path: __dirname,
     libraryTarget: 'var',
     library: 'autoRestComplexTestService'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        options: {
-          configFile: path.join(__dirname, "tsconfig.esm.json")
-        }
-      }
-    ]
   },
   // "ms-rest-js" and "ms-rest-azure-js" are dependencies of this library.
   // Customer is expected to import/include this library in browser javascript

--- a/test/multiapi/generated/package.json
+++ b/test/multiapi/generated/package.json
@@ -18,7 +18,6 @@
   "module": "./2018-02-01/esm/lib/autoRestParameterizedCustomHostTestClient.js",
   "types": "./2018-02-01/cjs/lib/autoRestParameterizedCustomHostTestClient.d.ts",
   "devDependencies": {
-    "ts-loader": "^4.4.2",
     "tslib": "^1.9.3",
     "typescript": "^3.0.3",
     "webpack": "^4.17.2",
@@ -33,6 +32,7 @@
     "url": "https://github.com/azure/azure-sdk-for-js/issues"
   },
   "scripts": {
-    "build": "tsc -b && webpack"
+    "build": "tsc -b && webpack",
+    "prepare": "npm run build"
   }
 }

--- a/test/multiapi/generated/webpack.config.js
+++ b/test/multiapi/generated/webpack.config.js
@@ -7,24 +7,13 @@ const path = require('path');
  */
 const config = {
   mode: 'production',
-  entry: './2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts',
+  entry: './2018-02-01/esm/lib/autoRestParameterizedCustomHostTestClient.js',
   devtool: 'source-map',
   output: {
     filename: 'autoRestParameterizedCustomHostTestClientBundle.js',
     path: __dirname,
     libraryTarget: 'var',
     library: 'autoRestParameterizedCustomHostTestClient'
-  },
-  module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        loader: 'ts-loader',
-        options: {
-          configFile: path.join(__dirname, '2018-02-01/tsconfig.esm.json'),
-        }
-      }
-    ]
   },
   // "ms-rest-js" and "ms-rest-azure-js" are dependencies of this library.
   // Customer is expected to import/include this library in browser javascript


### PR DESCRIPTION
- ts-loader doesn't yet support ts projects that use the new project references feature, so instead using the esm outputs as inputs to webpack
- Added a "prepare" script to build the generated project

I really wish I understood why the multiapi case puts the outputs in `./cjs/lib/file.js` and the metadata case puts the outputs in `./cjs/file.js`. I've pretty much overdosed on typescript configuration so I'm just gonna let it be for now.

Metadata tests just tend to bring up corner cases--to test the custom module resolution via the inner package.json files, we have to run an npm install in the multiapi folder before bundling. 