### PR TITLE
Fix polymorphism

### DIFF
--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -844,12 +844,16 @@ namespace AutoRest.TypeScript
                             polymorphicDiscriminator.QuotedStringProperty("serializedName", composite.PolymorphicDiscriminator);
                             polymorphicDiscriminator.QuotedStringProperty("clientName", Singleton<CodeNamerTS>.Instance.GetPropertyName(composite.PolymorphicDiscriminator));
                         });
-
+                        typeObject.QuotedStringProperty("uberParent", composite.Name);
+                    }
+                    else if (composite.ImmediatePolymorphicSubtypes.Any())
+                    {
                         CompositeType polymorphicType = composite;
                         while (polymorphicType.BaseModelType != null)
                         {
                             polymorphicType = polymorphicType.BaseModelType;
                         }
+                        typeObject.TextProperty("polymorphicDiscriminator", polymorphicType.Name + ".type.polymorphicDiscriminator");
                         typeObject.QuotedStringProperty("uberParent", polymorphicType.Name);
                     }
 

--- a/test/azure/generated/AzureCompositeModelClient/models/mappers.ts
+++ b/test/azure/generated/AzureCompositeModelClient/models/mappers.ts
@@ -344,6 +344,8 @@ export const Salmon: msRest.CompositeMapper = {
   serializedName: "salmon",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: Fish.type.polymorphicDiscriminator,
+    uberParent: "Fish",
     className: "Salmon",
     modelProperties: {
       ...Fish.type.modelProperties,
@@ -389,6 +391,8 @@ export const Shark: msRest.CompositeMapper = {
   serializedName: "shark",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: Fish.type.polymorphicDiscriminator,
+    uberParent: "Fish",
     className: "Shark",
     modelProperties: {
       ...Fish.type.modelProperties,

--- a/test/metadata/generated/BodyComplex/lib/models/mappers.ts
+++ b/test/metadata/generated/BodyComplex/lib/models/mappers.ts
@@ -202,6 +202,8 @@ export const Salmon: msRest.CompositeMapper = {
   serializedName: "salmon",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: Fish.type.polymorphicDiscriminator,
+    uberParent: "Fish",
     className: "Salmon",
     modelProperties: {
       ...Fish.type.modelProperties,
@@ -247,6 +249,8 @@ export const Shark: msRest.CompositeMapper = {
   serializedName: "shark",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: Fish.type.polymorphicDiscriminator,
+    uberParent: "Fish",
     className: "Shark",
     modelProperties: {
       ...Fish.type.modelProperties,

--- a/test/vanilla/acceptanceTests.ts
+++ b/test/vanilla/acceptanceTests.ts
@@ -890,8 +890,8 @@ describe('typescript', function () {
         });
       });
 
-      it.skip('should properly handle invalid value for Duration', function (done) {
-        testClient.duration.getInvalid(function (error, result) {
+      it('should properly handle invalid value for Duration', function (done) {
+        testClient.duration.getInvalid(function (error) {
           should.exist(error);
           done();
         });

--- a/test/vanilla/complexTypesTests.ts
+++ b/test/vanilla/complexTypesTests.ts
@@ -410,40 +410,44 @@ describe('typescript', function () {
       });
 
       var getRawSalmon = () => (<AutoRestComplexTestServiceModels.SalmonUnion>{
-        "species": "king",
-        "length": 1,
-        "siblings": [
+        fishtype: "smart_salmon",
+        location: "alaska",
+        iswild: true,
+        species: "king",
+        additionalProperty1: 1,
+        additionalProperty2: false,
+        additionalProperty3: "hello",
+        additionalProperty4: { a: 1, b: 2 },
+        additionalProperty5: [1, 3],
+        length: 1,
+        siblings: [
           <AutoRestComplexTestServiceModels.Shark>{
-            "species": "predator",
-            "length": 20,
-            "fishtype": "shark",
-            "age": 6,
-            "birthday": new Date("2012-01-05T01:00:00.000Z")
+            species: "predator",
+            length: 20,
+            fishtype: "shark",
+            age: 6,
+            birthday: new Date("2012-01-05T01:00:00.000Z")
           },
           <AutoRestComplexTestServiceModels.Sawshark>{
-            "species": "dangerous",
-            "length": 10,
-            "fishtype": "sawshark",
-            "age": 105,
-            "birthday": new Date("1900-01-05T01:00:00.000Z"),
-            "picture": new Uint8Array([255, 255, 255, 255, 254])
+            species: "dangerous",
+            length: 10,
+            fishtype: "sawshark",
+            age: 105,
+            birthday: new Date("1900-01-05T01:00:00.000Z"),
+            picture: new Uint8Array([255, 255, 255, 255, 254])
           },
           <AutoRestComplexTestServiceModels.Goblinshark>{
-            "species": "scary",
-            "length": 30,
-            "color": "pinkish-gray" as AutoRestComplexTestServiceModels.GoblinSharkColor,
-            "fishtype": "goblin",
-            "age": 1,
-            "birthday": new Date("2015-08-08T00:00:00.000Z"),
-            "jawsize": 5
+            species: "scary",
+            length: 30,
+            color: "pinkish-gray" as AutoRestComplexTestServiceModels.GoblinSharkColor,
+            fishtype: "goblin",
+            age: 1,
+            birthday: new Date("2015-08-08T00:00:00.000Z"),
+            jawsize: 5
           }
-        ],
-        "fishtype": "smart_salmon",
-        "location": "alaska",
-        "iswild": true
+        ]
       });
-      // Still need to support additionalProperties: true.
-      //Today Autorest converts additionalProperties: <boolean value> into a dictionary all the time.
+
       it('should get complicated polymorphic types', function (done) {
         testClient.polymorphism.getComplicated(function (err, result, req, res) {
           should.not.exist(err);
@@ -466,13 +470,8 @@ describe('typescript', function () {
         });
       });
 
-      // This test will fail until we support addtionalProperties with boolean value in Autorest.
-      it.skip('should put complicated polymorphic types', function (done) {
-        testClient.polymorphism.putComplicated(getRawSalmon(), function (err, result, req, res) {
-          should.not.exist(err);
-          assert.deepEqual(result, getRawSalmon());
-          done();
-        });
+      it('should put complicated polymorphic types', async function () {
+        await testClient.polymorphism.putComplicated(getRawSalmon());
       });
     });
 

--- a/test/vanilla/generated/BodyComplex/models/mappers.ts
+++ b/test/vanilla/generated/BodyComplex/models/mappers.ts
@@ -202,6 +202,8 @@ export const Salmon: msRest.CompositeMapper = {
   serializedName: "salmon",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: Fish.type.polymorphicDiscriminator,
+    uberParent: "Fish",
     className: "Salmon",
     modelProperties: {
       ...Fish.type.modelProperties,
@@ -247,6 +249,8 @@ export const Shark: msRest.CompositeMapper = {
   serializedName: "shark",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: Fish.type.polymorphicDiscriminator,
+    uberParent: "Fish",
     className: "Shark",
     modelProperties: {
       ...Fish.type.modelProperties,


### PR DESCRIPTION
Resolves #281 by emitting the polymorphicDiscriminator in any type that contains polymorphic subtypes (i.e. because SmartSalmon exists, put it in Salmon too, not just in Fish)

Will want to make sure there aren't more polymorphism tests to cover.