### PR TITLE
Remove optional parameter properties from constructor comments

### DIFF
--- a/src/DSL/TSDocumentationComment.cs
+++ b/src/DSL/TSDocumentationComment.cs
@@ -19,7 +19,9 @@ namespace AutoRest.TypeScript.DSL
             Parameters,
             Returns,
             Resolve,
-            Reject
+            Reject,
+            Class,
+            Constructor
         }
 
         public TSDocumentationComment(TSBuilder builder)
@@ -36,7 +38,7 @@ namespace AutoRest.TypeScript.DSL
                 builder.AddToPrefix(" * ");
                 builder.WordWrapWidth = TSBuilder.multiLineCommentWordWrapWidth;
             }
-            else
+            else if (currentState != State.Class && newState != State.Constructor)
             {
                 Line();
             }
@@ -108,6 +110,18 @@ namespace AutoRest.TypeScript.DSL
         public void Line(string text)
         {
             builder.Line(text);
+        }
+
+        public void Class()
+        {
+            SetCurrentState(State.Class);
+            builder.Line("@class");
+        }
+
+        public void Constructor()
+        {
+            SetCurrentState(State.Constructor);
+            builder.Line("@constructor");
         }
     }
 }

--- a/src/DSL/TSDocumentationComment.cs
+++ b/src/DSL/TSDocumentationComment.cs
@@ -19,9 +19,7 @@ namespace AutoRest.TypeScript.DSL
             Parameters,
             Returns,
             Resolve,
-            Reject,
-            Class,
-            Constructor
+            Reject
         }
 
         public TSDocumentationComment(TSBuilder builder)
@@ -38,7 +36,7 @@ namespace AutoRest.TypeScript.DSL
                 builder.AddToPrefix(" * ");
                 builder.WordWrapWidth = TSBuilder.multiLineCommentWordWrapWidth;
             }
-            else if (currentState != State.Class && newState != State.Constructor)
+            else
             {
                 Line();
             }
@@ -110,18 +108,6 @@ namespace AutoRest.TypeScript.DSL
         public void Line(string text)
         {
             builder.Line(text);
-        }
-
-        public void Class()
-        {
-            SetCurrentState(State.Class);
-            builder.Line("@class");
-        }
-
-        public void Constructor()
-        {
-            SetCurrentState(State.Constructor);
-            builder.Line("@constructor");
         }
     }
 }

--- a/src/azure/Templates/AzureServiceClientContextTemplate.cshtml
+++ b/src/azure/Templates/AzureServiceClientContextTemplate.cshtml
@@ -1,7 +1,6 @@
 ﻿@using System.Linq
 @using AutoRest.Core.Model
 @using AutoRest.Core.Utilities
-@using AutoRest.TypeScript.vanilla.Templates
 @using AutoRest.TypeScript
 @using AutoRest.TypeScript.Azure.Model
 @inherits AutoRest.Core.Template<CodeModelTSa>
@@ -31,36 +30,7 @@ export class @(Model.ContextName) extends msRestAzure.AzureServiceClient {
   @:@(property.Name): @(property.ModelType.TSType(false));
 }
   @EmptyLine
-  /**
-   * @@class
-   * Initializes a new instance of the @Model.Name class.
-   * @@constructor
-   *
-@foreach (var param in requiredParameters)
-{
-   @:* @@param {@param.ModelType.Name.ToCamelCase()} @param.Name - @param.Documentation
-   @:*
-}
-@if(!Model.IsCustomBaseUri)
-{
-   @:* @@param {string} [baseUri] - The base URI of the service.
-   @:*
-}
-   * @@param {object} [options] - The parameter options
-   *
-   * @@param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @@param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @@param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-@foreach (var param in optionalParameters)
-{
-   @:* @@param {@param.ModelType.Name.ToCamelCase()} [options.@param.Name] - @param.Documentation
-   @:*
-}
-   */
+  @(Model.GenerateConstructorComment(Model.Name))
 @{ var clientOptionType = Model.OptionalParameterTypeForClientConstructor == "AzureServiceClientOptions" ? "msRestAzure.AzureServiceClientOptions" : Model.OptionalParameterTypeForClientConstructor;}
   constructor(@(!string.IsNullOrEmpty(Model.RequiredConstructorParametersTS) ? Model.RequiredConstructorParametersTS + ", " : "")options?: @clientOptionType) {
 @foreach (var param in requiredParameters)

--- a/src/azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/azure/Templates/AzureServiceClientTemplate.cshtml
@@ -1,6 +1,4 @@
 ﻿@using System.Linq
-@using AutoRest.Core.Utilities
-@using AutoRest.TypeScript.vanilla.Templates
 @using AutoRest.TypeScript.Model
 @using AutoRest.TypeScript.Azure.Model
 @inherits AutoRest.Core.Template<CodeModelTSa>
@@ -10,8 +8,6 @@
 @EmptyLine
 @(Model.GenerateAzureServiceClientImports())
 @EmptyLine
-@{var requiredParameters = Model.Properties.Where(p => p.IsRequired && !p.IsConstant && string.IsNullOrEmpty(p.DefaultValue));}
-@{var optionalParameters = Model.Properties.Where(p => (!p.IsRequired || p.IsRequired && !string.IsNullOrEmpty(p.DefaultValue)) && !p.IsConstant && !p.Name.EqualsIgnoreCase("apiVersion"));}
 @EmptyLine
 class @(Model.Name) extends @(Model.ContextName) {
 @if (Model.MethodGroupModels.Any())
@@ -23,36 +19,7 @@ foreach (var methodGroup in Model.MethodGroupModels)
 }
 @EmptyLine
 }
-  /**
-   * @@class
-   * Initializes a new instance of the @Model.Name class.
-   * @@constructor
-   *
-@foreach (var param in requiredParameters)
-{
-   @:* @@param {@param.ModelType.Name.ToCamelCase()} @param.Name - @param.Documentation
-   @:*
-}
-@if(!Model.IsCustomBaseUri)
-{
-   @:* @@param {string} [baseUri] - The base URI of the service.
-   @:*
-}
-   * @@param {object} [options] - The parameter options
-   *
-   * @@param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @@param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @@param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-@foreach (var param in optionalParameters)
-{
-   @:* @@param {@param.ModelType.Name.ToCamelCase()} [options.@param.Name] - @param.Documentation
-   @:*
-}
-   */
+  @(Model.GenerateConstructorComment(Model.Name))
 @{ var clientOptionType = Model.OptionalParameterTypeForClientConstructor == "AzureServiceClientOptions" ? "msRestAzure.AzureServiceClientOptions" : Model.OptionalParameterTypeForClientConstructor;}
   constructor(@(!string.IsNullOrEmpty(Model.RequiredConstructorParametersTS) ? Model.RequiredConstructorParametersTS + ", " : "")options?: @clientOptionType) {
     super(@(!string.IsNullOrEmpty(Model.RequiredConstructorParameters) ? Model.RequiredConstructorParameters + ", " : "")options);

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -617,5 +617,30 @@ namespace AutoRest.TypeScript.Model
             });
             return builder.ToString();
         }
+
+        public string GenerateConstructorComment(string className)
+        {
+            TSBuilder builder = new TSBuilder();
+            builder.DocumentationComment(comment =>
+            {
+                comment.Class();
+                comment.Description($"Initializes a new instance of the {className} class.");
+                comment.Constructor();
+
+                IEnumerable<Property> requiredParameters = Properties.Where(p => p.IsRequired && !p.IsConstant && string.IsNullOrEmpty(p.DefaultValue));
+                foreach (Property requiredParameter in requiredParameters)
+                {
+                    comment.Parameter(requiredParameter.ModelType.Name.ToCamelCase(), requiredParameter.Name, requiredParameter.Documentation);
+                }
+
+                if (!IsCustomBaseUri)
+                {
+                    comment.Parameter("string", "baseUri", "The base URI of the service.", isOptional: true);
+                }
+
+                comment.Parameter("object", "options", "The parameter options", isOptional: true);
+            });
+            return builder.ToString();
+        }
     }
 }

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -623,10 +623,8 @@ namespace AutoRest.TypeScript.Model
             TSBuilder builder = new TSBuilder();
             builder.DocumentationComment(comment =>
             {
-                comment.Class();
                 comment.Description($"Initializes a new instance of the {className} class.");
-                comment.Constructor();
-
+                
                 IEnumerable<Property> requiredParameters = Properties.Where(p => p.IsRequired && !p.IsConstant && string.IsNullOrEmpty(p.DefaultValue));
                 foreach (Property requiredParameter in requiredParameters)
                 {

--- a/src/vanilla/Templates/ServiceClientContextTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientContextTemplate.cshtml
@@ -2,7 +2,6 @@
 @using AutoRest.Core.Model
 @using AutoRest.Core.Utilities
 @using AutoRest.TypeScript
-@using AutoRest.TypeScript.vanilla.Templates
 @inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>
 /*
 @Header(" * ")
@@ -36,42 +35,7 @@ export class @(Model.ContextName) extends msRest.ServiceClient {
     }
 }
 @EmptyLine
-  /**
-   * @@class
-   * Initializes a new instance of the @(Model.ContextName) class.
-   * @@constructor
-   *
-@foreach (var param in requiredParameters)
-{
-<text>
-   * @@param {@param.ModelType.Name.ToCamelCase()} @param.Name - @param.Documentation
-   *
-</text>
-}
-@if (!Model.IsCustomBaseUri)
-{
-<text>
-   * @@param {string} [baseUri] - The base URI of the service.
-   *
-</text>
-}
-   * @@param {object} [options] - The parameter options
-   *
-   * @@param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @@param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @@param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-@foreach (var param in optionalParameters)
-{
-<text>
-   * @@param {@param.ModelType.Name.ToCamelCase()} [options.@param.Name] - @param.Documentation
-   *
-</text>
-}
-   */
+  @(Model.GenerateConstructorComment(Model.ContextName))
 @{ var clientOptionType = Model.OptionalParameterTypeForClientConstructor == "ServiceClientOptions" ? "msRest.ServiceClientOptions" : Model.OptionalParameterTypeForClientConstructor;}
   constructor(@(!string.IsNullOrEmpty(Model.RequiredConstructorParametersTS) ? Model.RequiredConstructorParametersTS + ", " : "")options?: @clientOptionType) {
 @foreach (var param in requiredParameters)

--- a/src/vanilla/Templates/ServiceClientTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientTemplate.cshtml
@@ -1,13 +1,10 @@
 ﻿@using System.Linq
-@using AutoRest.Core.Utilities
-@using AutoRest.TypeScript.vanilla.Templates
 @inherits AutoRest.Core.Template<AutoRest.TypeScript.Model.CodeModelTS>
 /*
 @Header(" * ")
  */
 @EmptyLine
 @(Model.GenerateServiceClientImports())
-@{var optionalParameters = Model.Properties.Where(p => (!p.IsRequired || p.IsRequired && !string.IsNullOrEmpty(p.DefaultValue)) && !p.IsConstant);}
 @EmptyLine
 class @(Model.Name) extends @(Model.ContextName) {
 @if (Model.MethodGroupModels.Any())
@@ -23,35 +20,7 @@ class @(Model.Name) extends @(Model.ContextName) {
 @EmptyLine
 </text>
 }
-  /**
-   * @@class
-   * Initializes a new instance of the @Model.Name class.
-   * @@constructor
-   *
-@if (!Model.IsCustomBaseUri)
-{
-<text>
-   * @@param {string} [baseUri] - The base URI of the service.
-   *
-</text>
-}
-   * @@param {object} [options] - The parameter options
-   *
-   * @@param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @@param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @@param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-@foreach (var param in optionalParameters)
-{
-<text>
-   * @@param {@param.ModelType.Name.ToCamelCase()} [options.@param.Name] - @param.Documentation
-   *
-</text>
-}
-   */
+  @(Model.GenerateConstructorComment(Model.Name))
 @{ var clientOptionType = Model.OptionalParameterTypeForClientConstructor == "ServiceClientOptions" ? "msRest.ServiceClientOptions" : Model.OptionalParameterTypeForClientConstructor;}
   constructor(@(!string.IsNullOrEmpty(Model.RequiredConstructorParametersTS) ? Model.RequiredConstructorParametersTS + ", " : "")options?: @clientOptionType) {
     super(@(!string.IsNullOrEmpty(Model.RequiredConstructorParameters) ? Model.RequiredConstructorParameters + ", " : "")options);

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -30,9 +30,7 @@ class AzureCompositeModel extends AzureCompositeModelContext {
   flattencomplex: operations.Flattencomplex;
 
   /**
-   * @class
    * Initializes a new instance of the AzureCompositeModel class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -34,25 +34,12 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    * Initializes a new instance of the AzureCompositeModel class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModelContext.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModelContext.ts
@@ -29,25 +29,12 @@ export class AzureCompositeModelContext extends msRestAzure.AzureServiceClient {
    * Initializes a new instance of the AzureCompositeModel class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModelContext.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModelContext.ts
@@ -25,9 +25,7 @@ export class AzureCompositeModelContext extends msRestAzure.AzureServiceClient {
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AzureCompositeModel class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
@@ -25,25 +25,12 @@ class AutoRestParameterGroupingTestService extends AutoRestParameterGroupingTest
    * Initializes a new instance of the AutoRestParameterGroupingTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
@@ -21,9 +21,7 @@ class AutoRestParameterGroupingTestService extends AutoRestParameterGroupingTest
   parameterGrouping: operations.ParameterGrouping;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterGroupingTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestServiceContext.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestParameterGroupingTestServiceContext extends msRestAzure.Azu
    * Initializes a new instance of the AutoRestParameterGroupingTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestServiceContext.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestParameterGroupingTestServiceContext extends msRestAzure.Azu
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterGroupingTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -22,25 +22,12 @@ class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext
    * Initializes a new instance of the AutoRestReportServiceForAzure class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -18,9 +18,7 @@ import { AutoRestReportServiceForAzureContext } from "./autoRestReportServiceFor
 
 class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestReportServiceForAzure class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzureContext.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzureContext.ts
@@ -23,9 +23,7 @@ export class AutoRestReportServiceForAzureContext extends msRestAzure.AzureServi
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestReportServiceForAzure class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzureContext.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzureContext.ts
@@ -27,25 +27,12 @@ export class AutoRestReportServiceForAzureContext extends msRestAzure.AzureServi
    * Initializes a new instance of the AutoRestReportServiceForAzure class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -18,9 +18,7 @@ import { AutoRestResourceFlatteningTestServiceContext } from "./autoRestResource
 
 class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTestServiceContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -22,25 +22,12 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestServiceContext.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestResourceFlatteningTestServiceContext extends msRestAzure.Az
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestServiceContext.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestResourceFlatteningTestServiceContext extends msRestAzure.Az
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
@@ -32,27 +32,15 @@ class AutoRestAzureSpecialParametersTestClient extends AutoRestAzureSpecialParam
    * Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
+   * @param {string} subscriptionId The subscription id, which appears in the path, always modeled in
+   * credentials. The value is always '1234-5678-9012-3456'
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, subscriptionId, baseUri, options);

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
@@ -28,9 +28,7 @@ class AutoRestAzureSpecialParametersTestClient extends AutoRestAzureSpecialParam
   header: operations.Header;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClientContext.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClientContext.ts
@@ -31,27 +31,15 @@ export class AutoRestAzureSpecialParametersTestClientContext extends msRestAzure
    * Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - The subscription id, which appears in the path, always modeled in credentials. The value is always '1234-5678-9012-3456'
+   * @param {string} subscriptionId The subscription id, which appears in the path, always modeled in
+   * credentials. The value is always '1234-5678-9012-3456'
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClientContext.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClientContext.ts
@@ -27,9 +27,7 @@ export class AutoRestAzureSpecialParametersTestClientContext extends msRestAzure
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -24,25 +24,10 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.host] - A string value that is used as a global part of the parameterized host
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     super(credentials, options);

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -20,9 +20,7 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
   paths: operations.Paths;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
@@ -30,25 +30,10 @@ export class AutoRestParameterizedHostTestClientContext extends msRestAzure.Azur
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.host] - A string value that is used as a global part of the parameterized host
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
@@ -26,9 +26,7 @@ export class AutoRestParameterizedHostTestClientContext extends msRestAzure.Azur
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Head/autoRestHeadTestService.ts
+++ b/test/azure/generated/Head/autoRestHeadTestService.ts
@@ -25,25 +25,12 @@ class AutoRestHeadTestService extends AutoRestHeadTestServiceContext {
    * Initializes a new instance of the AutoRestHeadTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/Head/autoRestHeadTestService.ts
+++ b/test/azure/generated/Head/autoRestHeadTestService.ts
@@ -21,9 +21,7 @@ class AutoRestHeadTestService extends AutoRestHeadTestServiceContext {
   httpSuccess: operations.HttpSuccess;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestHeadTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Head/autoRestHeadTestServiceContext.ts
+++ b/test/azure/generated/Head/autoRestHeadTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestHeadTestServiceContext extends msRestAzure.AzureServiceClie
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestHeadTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Head/autoRestHeadTestServiceContext.ts
+++ b/test/azure/generated/Head/autoRestHeadTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestHeadTestServiceContext extends msRestAzure.AzureServiceClie
    * Initializes a new instance of the AutoRestHeadTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
@@ -25,25 +25,12 @@ class AutoRestHeadExceptionTestService extends AutoRestHeadExceptionTestServiceC
    * Initializes a new instance of the AutoRestHeadExceptionTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
@@ -21,9 +21,7 @@ class AutoRestHeadExceptionTestService extends AutoRestHeadExceptionTestServiceC
   headException: operations.HeadException;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestHeadExceptionTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestServiceContext.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestHeadExceptionTestServiceContext extends msRestAzure.AzureSe
    * Initializes a new instance of the AutoRestHeadExceptionTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestServiceContext.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestHeadExceptionTestServiceContext extends msRestAzure.AzureSe
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestHeadExceptionTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
@@ -24,9 +24,7 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
   lROsCustomHeader: operations.LROsCustomHeader;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
@@ -28,25 +28,12 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestServiceContext.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestLongRunningOperationTestServiceContext extends msRestAzure.
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestServiceContext.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestLongRunningOperationTestServiceContext extends msRestAzure.
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Paging/autoRestPagingTestService.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestService.ts
@@ -25,25 +25,12 @@ class AutoRestPagingTestService extends AutoRestPagingTestServiceContext {
    * Initializes a new instance of the AutoRestPagingTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/Paging/autoRestPagingTestService.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestService.ts
@@ -21,9 +21,7 @@ class AutoRestPagingTestService extends AutoRestPagingTestServiceContext {
   paging: operations.Paging;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestPagingTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Paging/autoRestPagingTestServiceContext.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestPagingTestServiceContext extends msRestAzure.AzureServiceCl
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestPagingTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/Paging/autoRestPagingTestServiceContext.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestPagingTestServiceContext extends msRestAzure.AzureServiceCl
    * Initializes a new instance of the AutoRestPagingTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/StorageManagementClient/storageManagementClient.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClient.ts
@@ -26,27 +26,15 @@ class StorageManagementClient extends StorageManagementClientContext {
    * Initializes a new instance of the StorageManagementClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
+   * @param {string} subscriptionId Gets subscription credentials which uniquely identify Microsoft
+   * Azure subscription. The subscription ID forms part of the URI for every service call.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, subscriptionId, baseUri, options);

--- a/test/azure/generated/StorageManagementClient/storageManagementClient.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClient.ts
@@ -22,9 +22,7 @@ class StorageManagementClient extends StorageManagementClientContext {
   usage: operations.UsageOperations;
 
   /**
-   * @class
    * Initializes a new instance of the StorageManagementClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/StorageManagementClient/storageManagementClientContext.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClientContext.ts
@@ -31,27 +31,15 @@ export class StorageManagementClientContext extends msRestAzure.AzureServiceClie
    * Initializes a new instance of the StorageManagementClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.
+   * @param {string} subscriptionId Gets subscription credentials which uniquely identify Microsoft
+   * Azure subscription. The subscription ID forms part of the URI for every service call.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/StorageManagementClient/storageManagementClientContext.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClientContext.ts
@@ -27,9 +27,7 @@ export class StorageManagementClientContext extends msRestAzure.AzureServiceClie
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the StorageManagementClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
@@ -21,9 +21,7 @@ class MicrosoftAzureTestUrl extends MicrosoftAzureTestUrlContext {
   group: operations.Group;
 
   /**
-   * @class
    * Initializes a new instance of the MicrosoftAzureTestUrl class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
@@ -25,27 +25,14 @@ class MicrosoftAzureTestUrl extends MicrosoftAzureTestUrlContext {
    * Initializes a new instance of the MicrosoftAzureTestUrl class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - Subscription Id.
+   * @param {string} subscriptionId Subscription Id.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, subscriptionId, baseUri, options);

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
@@ -31,27 +31,14 @@ export class MicrosoftAzureTestUrlContext extends msRestAzure.AzureServiceClient
    * Initializes a new instance of the MicrosoftAzureTestUrl class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - Subscription Id.
+   * @param {string} subscriptionId Subscription Id.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
@@ -27,9 +27,7 @@ export class MicrosoftAzureTestUrlContext extends msRestAzure.AzureServiceClient
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the MicrosoftAzureTestUrl class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestService.ts
+++ b/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestService.ts
@@ -24,9 +24,7 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
   lROsCustomHeader: operations.LROsCustomHeader;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestService.ts
+++ b/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestService.ts
@@ -28,25 +28,12 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestServiceContext.ts
+++ b/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestServiceContext.ts
@@ -27,25 +27,12 @@ export class AutoRestLongRunningOperationTestServiceContext extends msRestAzure.
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestServiceContext.ts
+++ b/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestServiceContext.ts
@@ -23,9 +23,7 @@ export class AutoRestLongRunningOperationTestServiceContext extends msRestAzure.
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/date-time-as-string/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/date-time-as-string/generated/BodyDate/autoRestDateTestService.ts
@@ -19,9 +19,7 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
   dateModel: operations.DateModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/date-time-as-string/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/date-time-as-string/generated/BodyDate/autoRestDateTestService.ts
@@ -23,17 +23,9 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
    * Initializes a new instance of the AutoRestDateTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/date-time-as-string/generated/BodyDate/autoRestDateTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDate/autoRestDateTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestDateTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestDateTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/date-time-as-string/generated/BodyDate/autoRestDateTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDate/autoRestDateTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestDateTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -23,17 +23,9 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
    * Initializes a new instance of the AutoRestDateTimeTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -19,9 +19,7 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
   datetime: operations.Datetime;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTimeTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestDateTimeTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestDateTimeTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestDateTimeTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTimeTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -19,9 +19,7 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
   datetimerfc1123: operations.Datetimerfc1123;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -23,17 +23,9 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestRFC1123DateTimeTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestRFC1123DateTimeTestServiceContext extends msRest.ServiceCli
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
@@ -24,17 +24,9 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
    * Initializes a new instance of the AutoRestSwaggerBATService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
@@ -20,9 +20,7 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
   enumModel: operations.EnumModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATServiceContext.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestSwaggerBATServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATServiceContext.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/metadata/generated/BodyComplex/lib/autoRestComplexTestService.ts
+++ b/test/metadata/generated/BodyComplex/lib/autoRestComplexTestService.ts
@@ -31,17 +31,9 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
    * Initializes a new instance of the AutoRestComplexTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/metadata/generated/BodyComplex/lib/autoRestComplexTestService.ts
+++ b/test/metadata/generated/BodyComplex/lib/autoRestComplexTestService.ts
@@ -27,9 +27,7 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
   flattencomplex: operations.Flattencomplex;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestComplexTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/metadata/generated/BodyComplex/lib/autoRestComplexTestServiceContext.ts
+++ b/test/metadata/generated/BodyComplex/lib/autoRestComplexTestServiceContext.ts
@@ -17,9 +17,7 @@ export class AutoRestComplexTestServiceContext extends msRest.ServiceClient {
   apiVersion: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestComplexTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/metadata/generated/BodyComplex/lib/autoRestComplexTestServiceContext.ts
+++ b/test/metadata/generated/BodyComplex/lib/autoRestComplexTestServiceContext.ts
@@ -21,17 +21,9 @@ export class AutoRestComplexTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestComplexTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClient.ts
+++ b/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClient.ts
@@ -16,9 +16,7 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
   paths: operations.Paths;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClient.ts
+++ b/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClient.ts
@@ -20,25 +20,10 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.host] - A string value that is used as a global part of the parameterized host
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     super(credentials, options);

--- a/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClientContext.ts
+++ b/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClientContext.ts
@@ -22,9 +22,7 @@ export class AutoRestParameterizedHostTestClientContext extends msRestAzure.Azur
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClientContext.ts
+++ b/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClientContext.ts
@@ -26,25 +26,10 @@ export class AutoRestParameterizedHostTestClientContext extends msRestAzure.Azur
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.host] - A string value that is used as a global part of the parameterized host
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     if (credentials == undefined) {

--- a/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts
@@ -16,9 +16,7 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
   paths: operations.Paths;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts
@@ -20,27 +20,12 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - The subscription id with value 'test12'.
+   * @param {string} subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.dnsSuffix] - A string value that is used as a global part of the parameterized host. Default value 'host'.
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     super(credentials, subscriptionId, options);

--- a/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClientContext.ts
+++ b/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClientContext.ts
@@ -24,9 +24,7 @@ export class AutoRestParameterizedCustomHostTestClientContext extends msRestAzur
   longRunningOperationRetryTimeout: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
-   * @constructor
    *
    * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
    * connect to Azure.

--- a/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClientContext.ts
+++ b/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClientContext.ts
@@ -28,27 +28,12 @@ export class AutoRestParameterizedCustomHostTestClientContext extends msRestAzur
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
    * @constructor
    *
-   * @param {msRest.ServiceClientCredentials} credentials - Credentials needed for the client to connect to Azure.
+   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
+   * connect to Azure.
    *
-   * @param {string} subscriptionId - The subscription id with value 'test12'.
+   * @param {string} subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.dnsSuffix] - A string value that is used as a global part of the parameterized host. Default value 'host'.
-   *
-   * @param {string} [options.acceptLanguage] - The preferred language for the response.
-   *
-   * @param {number} [options.longRunningOperationRetryTimeout] - The retry timeout in seconds for Long Running Operations. Default value is 30.
-   *
-   * @param {boolean} [options.generateClientRequestId] - Whether a unique x-ms-client-request-id should be generated. When set to true a unique x-ms-client-request-id value is generated and included in each request. Default is true.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     if (credentials == undefined) {

--- a/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
@@ -16,9 +16,7 @@ import { AutoRestValidationTestContext } from "./autoRestValidationTestContext";
 
 class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestValidationTest class.
-   * @constructor
    *
    * @param {string} subscriptionId Subscription ID.
    *

--- a/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
@@ -20,17 +20,13 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * Initializes a new instance of the AutoRestValidationTest class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} subscriptionId Subscription ID.
    *
-   * @param {object} [options] - The parameter options
+   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(subscriptionId, apiVersion, baseUri, options);

--- a/test/no-client-validation/generated/Validation/autoRestValidationTestContext.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTestContext.ts
@@ -22,21 +22,13 @@ export class AutoRestValidationTestContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestValidationTestContext class.
    * @constructor
    *
-   * @param {string} subscriptionId - Subscription ID.
+   * @param {string} subscriptionId Subscription ID.
    *
-   * @param {string} apiVersion - Required string following pattern \d{2}-\d{2}-\d{4}
+   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     if (subscriptionId === null || subscriptionId === undefined) {

--- a/test/no-client-validation/generated/Validation/autoRestValidationTestContext.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTestContext.ts
@@ -18,9 +18,7 @@ export class AutoRestValidationTestContext extends msRest.ServiceClient {
   apiVersion: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestValidationTestContext class.
-   * @constructor
    *
    * @param {string} subscriptionId Subscription ID.
    *

--- a/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
    * Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
   header: operations.Header;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
+++ b/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATHeaderServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATHeaderServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
+++ b/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATHeaderServiceContext extends msRest.ServiceClient
    * Initializes a new instance of the AutoRestSwaggerBATHeaderServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
@@ -20,19 +20,11 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    * Initializes a new instance of the AutoRestRenameParameterTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} noRetryPolicy A query parameter.
    *
-   * @param {object} [options] - The parameter options
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.withCredentialsProperty] - A query parameter.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(noRetryPolicy: string, baseUri?: string, options?: Models.AutoRestRenameParameterTestServiceOptions) {
     super(noRetryPolicy, baseUri, options);

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
@@ -16,9 +16,7 @@ import { AutoRestRenameParameterTestServiceContext } from "./autoRestRenameParam
 
 class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServiceContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestRenameParameterTestService class.
-   * @constructor
    *
    * @param {string} noRetryPolicy A query parameter.
    *

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestServiceContext.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestServiceContext.ts
@@ -19,9 +19,7 @@ export class AutoRestRenameParameterTestServiceContext extends msRest.ServiceCli
   noRetryPolicy: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRenameParameterTestServiceContext class.
-   * @constructor
    *
    * @param {string} noRetryPolicy A query parameter.
    *

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestServiceContext.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestServiceContext.ts
@@ -23,21 +23,11 @@ export class AutoRestRenameParameterTestServiceContext extends msRest.ServiceCli
    * Initializes a new instance of the AutoRestRenameParameterTestServiceContext class.
    * @constructor
    *
-   * @param {string} noRetryPolicy - A query parameter.
+   * @param {string} noRetryPolicy A query parameter.
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.withCredentialsProperty] - A query parameter.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(noRetryPolicy: string, baseUri?: string, options?: Models.AutoRestRenameParameterTestServiceOptions) {
     if (noRetryPolicy === null || noRetryPolicy === undefined) {

--- a/test/vanilla/generated/AdditionalProperties/additionalPropertiesClient.ts
+++ b/test/vanilla/generated/AdditionalProperties/additionalPropertiesClient.ts
@@ -23,17 +23,9 @@ class AdditionalPropertiesClient extends AdditionalPropertiesClientContext {
    * Initializes a new instance of the AdditionalPropertiesClient class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/AdditionalProperties/additionalPropertiesClient.ts
+++ b/test/vanilla/generated/AdditionalProperties/additionalPropertiesClient.ts
@@ -19,9 +19,7 @@ class AdditionalPropertiesClient extends AdditionalPropertiesClientContext {
   pets: operations.Pets;
 
   /**
-   * @class
    * Initializes a new instance of the AdditionalPropertiesClient class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/AdditionalProperties/additionalPropertiesClientContext.ts
+++ b/test/vanilla/generated/AdditionalProperties/additionalPropertiesClientContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AdditionalPropertiesClientContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AdditionalPropertiesClientContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/AdditionalProperties/additionalPropertiesClientContext.ts
+++ b/test/vanilla/generated/AdditionalProperties/additionalPropertiesClientContext.ts
@@ -20,17 +20,9 @@ export class AdditionalPropertiesClientContext extends msRest.ServiceClient {
    * Initializes a new instance of the AdditionalPropertiesClientContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATArrayService extends AutoRestSwaggerBATArrayServiceConte
   arrayModel: operations.ArrayModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATArrayService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATArrayService extends AutoRestSwaggerBATArrayServiceConte
    * Initializes a new instance of the AutoRestSwaggerBATArrayService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayServiceContext.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATArrayServiceContext extends msRest.ServiceClient 
    * Initializes a new instance of the AutoRestSwaggerBATArrayServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayServiceContext.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATArrayServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATArrayServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
@@ -23,17 +23,9 @@ class AutoRestBoolTestService extends AutoRestBoolTestServiceContext {
    * Initializes a new instance of the AutoRestBoolTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
@@ -19,9 +19,7 @@ class AutoRestBoolTestService extends AutoRestBoolTestServiceContext {
   bool: operations.Bool;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestBoolTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestServiceContext.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestBoolTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestBoolTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestServiceContext.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestBoolTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestBoolTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATByteService extends AutoRestSwaggerBATByteServiceContext
   byteModel: operations.ByteModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATByteService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATByteService extends AutoRestSwaggerBATByteServiceContext
    * Initializes a new instance of the AutoRestSwaggerBATByteService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteServiceContext.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATByteServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATByteServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteServiceContext.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATByteServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestSwaggerBATByteServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
@@ -31,17 +31,9 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
    * Initializes a new instance of the AutoRestComplexTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
@@ -27,9 +27,7 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
   flattencomplex: operations.Flattencomplex;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestComplexTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestServiceContext.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestServiceContext.ts
@@ -17,9 +17,7 @@ export class AutoRestComplexTestServiceContext extends msRest.ServiceClient {
   apiVersion: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestComplexTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestServiceContext.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestServiceContext.ts
@@ -21,17 +21,9 @@ export class AutoRestComplexTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestComplexTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
@@ -19,9 +19,7 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
   dateModel: operations.DateModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
@@ -23,17 +23,9 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
    * Initializes a new instance of the AutoRestDateTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDate/autoRestDateTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestDateTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestDateTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDate/autoRestDateTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestDateTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -23,17 +23,9 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
    * Initializes a new instance of the AutoRestDateTimeTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -19,9 +19,7 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
   datetime: operations.Datetime;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTimeTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestDateTimeTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestDateTimeTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestDateTimeTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDateTimeTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -19,9 +19,7 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
   datetimerfc1123: operations.Datetimerfc1123;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -23,17 +23,9 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestRFC1123DateTimeTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestRFC1123DateTimeTestServiceContext extends msRest.ServiceCli
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATdictionaryService extends AutoRestSwaggerBATdictionarySe
   dictionary: operations.Dictionary;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATdictionaryService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATdictionaryService extends AutoRestSwaggerBATdictionarySe
    * Initializes a new instance of the AutoRestSwaggerBATdictionaryService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryServiceContext.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATdictionaryServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATdictionaryServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryServiceContext.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATdictionaryServiceContext extends msRest.ServiceCl
    * Initializes a new instance of the AutoRestSwaggerBATdictionaryServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
@@ -19,9 +19,7 @@ class AutoRestDurationTestService extends AutoRestDurationTestServiceContext {
   duration: operations.Duration;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDurationTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
@@ -23,17 +23,9 @@ class AutoRestDurationTestService extends AutoRestDurationTestServiceContext {
    * Initializes a new instance of the AutoRestDurationTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestDurationTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestDurationTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestDurationTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestDurationTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATFileService extends AutoRestSwaggerBATFileServiceContext
    * Initializes a new instance of the AutoRestSwaggerBATFileService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATFileService extends AutoRestSwaggerBATFileServiceContext
   files: operations.Files;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATFileService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileServiceContext.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATFileServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATFileServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileServiceContext.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATFileServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestSwaggerBATFileServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATFormDataService extends AutoRestSwaggerBATFormDataServic
    * Initializes a new instance of the AutoRestSwaggerBATFormDataService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATFormDataService extends AutoRestSwaggerBATFormDataServic
   formdata: operations.Formdata;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATFormDataService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataServiceContext.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATFormDataServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATFormDataServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataServiceContext.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATFormDataServiceContext extends msRest.ServiceClie
    * Initializes a new instance of the AutoRestSwaggerBATFormDataServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
@@ -23,17 +23,9 @@ class AutoRestIntegerTestService extends AutoRestIntegerTestServiceContext {
    * Initializes a new instance of the AutoRestIntegerTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
@@ -19,9 +19,7 @@ class AutoRestIntegerTestService extends AutoRestIntegerTestServiceContext {
   intModel: operations.IntModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestIntegerTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestServiceContext.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestIntegerTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestIntegerTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestServiceContext.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestIntegerTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestIntegerTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
@@ -23,17 +23,9 @@ class AutoRestNumberTestService extends AutoRestNumberTestServiceContext {
    * Initializes a new instance of the AutoRestNumberTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
@@ -19,9 +19,7 @@ class AutoRestNumberTestService extends AutoRestNumberTestServiceContext {
   number: operations.Number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestNumberTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestServiceContext.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestNumberTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestNumberTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestServiceContext.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestNumberTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestNumberTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
@@ -24,17 +24,9 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
    * Initializes a new instance of the AutoRestSwaggerBATService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
@@ -20,9 +20,7 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
   enumModel: operations.EnumModel;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATServiceContext.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestSwaggerBATServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATServiceContext.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -20,17 +20,9 @@ class ComplexModelClient extends ComplexModelClientContext {
    * Initializes a new instance of the ComplexModelClient class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -16,9 +16,7 @@ import { ComplexModelClientContext } from "./complexModelClientContext";
 
 class ComplexModelClient extends ComplexModelClientContext {
   /**
-   * @class
    * Initializes a new instance of the ComplexModelClient class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ComplexModelClient/complexModelClientContext.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClientContext.ts
@@ -22,17 +22,9 @@ export class ComplexModelClientContext extends msRest.ServiceClient {
    * Initializes a new instance of the ComplexModelClientContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/ComplexModelClient/complexModelClientContext.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClientContext.ts
@@ -18,9 +18,7 @@ export class ComplexModelClientContext extends msRest.ServiceClient {
   apiVersion: string;
 
   /**
-   * @class
    * Initializes a new instance of the ComplexModelClientContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
@@ -20,9 +20,7 @@ class CompositeBoolInt extends CompositeBoolIntContext {
   intModel: operations.IntModel;
 
   /**
-   * @class
    * Initializes a new instance of the CompositeBoolInt class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
@@ -24,17 +24,9 @@ class CompositeBoolInt extends CompositeBoolIntContext {
    * Initializes a new instance of the CompositeBoolInt class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolIntContext.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolIntContext.ts
@@ -20,17 +20,9 @@ export class CompositeBoolIntContext extends msRest.ServiceClient {
    * Initializes a new instance of the CompositeBoolIntContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolIntContext.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolIntContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class CompositeBoolIntContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the CompositeBoolIntContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -22,17 +22,7 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    * @constructor
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.host] - A string value that is used as a global part of the parameterized host
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(options?: Models.AutoRestParameterizedHostTestClientOptions) {
     super(options);

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -18,9 +18,7 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
   paths: operations.Paths;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
-   * @constructor
    *
    * @param {object} [options] The parameter options
    */

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
@@ -18,9 +18,7 @@ export class AutoRestParameterizedHostTestClientContext extends msRest.ServiceCl
   host?: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedHostTestClientContext class.
-   * @constructor
    *
    * @param {object} [options] The parameter options
    */

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
@@ -22,17 +22,7 @@ export class AutoRestParameterizedHostTestClientContext extends msRest.ServiceCl
    * Initializes a new instance of the AutoRestParameterizedHostTestClientContext class.
    * @constructor
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.host] - A string value that is used as a global part of the parameterized host
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(options?: Models.AutoRestParameterizedHostTestClientOptions) {
 

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
@@ -18,9 +18,7 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
   paths: operations.Paths;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
-   * @constructor
    *
    * @param {string} subscriptionId The subscription id with value 'test12'.
    *

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
@@ -22,17 +22,9 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
    * @constructor
    *
-   * @param {object} [options] - The parameter options
+   * @param {string} subscriptionId The subscription id with value 'test12'.
    *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.dnsSuffix] - A string value that is used as a global part of the parameterized host. Default value 'host'.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     super(subscriptionId, options);

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClientContext.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClientContext.ts
@@ -23,19 +23,9 @@ export class AutoRestParameterizedCustomHostTestClientContext extends msRest.Ser
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClientContext class.
    * @constructor
    *
-   * @param {string} subscriptionId - The subscription id with value 'test12'.
+   * @param {string} subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.dnsSuffix] - A string value that is used as a global part of the parameterized host. Default value 'host'.
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     if (subscriptionId === null || subscriptionId === undefined) {

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClientContext.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClientContext.ts
@@ -19,9 +19,7 @@ export class AutoRestParameterizedCustomHostTestClientContext extends msRest.Ser
   dnsSuffix?: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClientContext class.
-   * @constructor
    *
    * @param {string} subscriptionId The subscription id with value 'test12'.
    *

--- a/test/vanilla/generated/ExtensibleEnum/petStoreInc.ts
+++ b/test/vanilla/generated/ExtensibleEnum/petStoreInc.ts
@@ -19,9 +19,7 @@ class PetStoreInc extends PetStoreIncContext {
   pet: operations.PetOperations;
 
   /**
-   * @class
    * Initializes a new instance of the PetStoreInc class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ExtensibleEnum/petStoreInc.ts
+++ b/test/vanilla/generated/ExtensibleEnum/petStoreInc.ts
@@ -23,17 +23,9 @@ class PetStoreInc extends PetStoreIncContext {
    * Initializes a new instance of the PetStoreInc class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/ExtensibleEnum/petStoreIncContext.ts
+++ b/test/vanilla/generated/ExtensibleEnum/petStoreIncContext.ts
@@ -20,17 +20,9 @@ export class PetStoreIncContext extends msRest.ServiceClient {
    * Initializes a new instance of the PetStoreIncContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/ExtensibleEnum/petStoreIncContext.ts
+++ b/test/vanilla/generated/ExtensibleEnum/petStoreIncContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class PetStoreIncContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the PetStoreIncContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
    * Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
   header: operations.Header;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATHeaderServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATHeaderServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATHeaderServiceContext extends msRest.ServiceClient
    * Initializes a new instance of the AutoRestSwaggerBATHeaderServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
@@ -29,17 +29,9 @@ class AutoRestHttpInfrastructureTestService extends AutoRestHttpInfrastructureTe
    * Initializes a new instance of the AutoRestHttpInfrastructureTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
@@ -25,9 +25,7 @@ class AutoRestHttpInfrastructureTestService extends AutoRestHttpInfrastructureTe
   multipleResponses: operations.MultipleResponses;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestHttpInfrastructureTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestServiceContext.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestHttpInfrastructureTestServiceContext extends msRest.Service
    * Initializes a new instance of the AutoRestHttpInfrastructureTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestServiceContext.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestHttpInfrastructureTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestHttpInfrastructureTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -20,17 +20,9 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -16,9 +16,7 @@ import { AutoRestResourceFlatteningTestServiceContext } from "./autoRestResource
 
 class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTestServiceContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestServiceContext.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestResourceFlatteningTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestResourceFlatteningTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestServiceContext.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestResourceFlatteningTestServiceContext extends msRest.Service
    * Initializes a new instance of the AutoRestResourceFlatteningTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
@@ -19,9 +19,7 @@ class AutoRestParameterFlattening extends AutoRestParameterFlatteningContext {
   availabilitySets: operations.AvailabilitySets;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterFlattening class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
@@ -23,17 +23,9 @@ class AutoRestParameterFlattening extends AutoRestParameterFlatteningContext {
    * Initializes a new instance of the AutoRestParameterFlattening class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlatteningContext.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlatteningContext.ts
@@ -20,17 +20,9 @@ export class AutoRestParameterFlatteningContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestParameterFlatteningContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlatteningContext.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlatteningContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestParameterFlatteningContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestParameterFlatteningContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -20,17 +20,9 @@ class AutoRestReportService extends AutoRestReportServiceContext {
    * Initializes a new instance of the AutoRestReportService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -16,9 +16,7 @@ import { AutoRestReportServiceContext } from "./autoRestReportServiceContext";
 
 class AutoRestReportService extends AutoRestReportServiceContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestReportService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Report/autoRestReportServiceContext.ts
+++ b/test/vanilla/generated/Report/autoRestReportServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestReportServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestReportServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Report/autoRestReportServiceContext.ts
+++ b/test/vanilla/generated/Report/autoRestReportServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestReportServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestReportServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
@@ -19,9 +19,7 @@ class AutoRestRequiredOptionalTestService extends AutoRestRequiredOptionalTestSe
   explicit: operations.Explicit;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRequiredOptionalTestService class.
-   * @constructor
    *
    * @param {string} requiredGlobalPath number of items to skip
    *

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
@@ -23,19 +23,13 @@ class AutoRestRequiredOptionalTestService extends AutoRestRequiredOptionalTestSe
    * Initializes a new instance of the AutoRestRequiredOptionalTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} requiredGlobalPath number of items to skip
    *
-   * @param {object} [options] - The parameter options
+   * @param {string} requiredGlobalQuery number of items to skip
    *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {number} [options.optionalGlobalQuery] - number of items to skip
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(requiredGlobalPath: string, requiredGlobalQuery: string, baseUri?: string, options?: Models.AutoRestRequiredOptionalTestServiceOptions) {
     super(requiredGlobalPath, requiredGlobalQuery, baseUri, options);

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestServiceContext.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestServiceContext.ts
@@ -20,9 +20,7 @@ export class AutoRestRequiredOptionalTestServiceContext extends msRest.ServiceCl
   optionalGlobalQuery?: number;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestRequiredOptionalTestServiceContext class.
-   * @constructor
    *
    * @param {string} requiredGlobalPath number of items to skip
    *

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestServiceContext.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestServiceContext.ts
@@ -24,23 +24,13 @@ export class AutoRestRequiredOptionalTestServiceContext extends msRest.ServiceCl
    * Initializes a new instance of the AutoRestRequiredOptionalTestServiceContext class.
    * @constructor
    *
-   * @param {string} requiredGlobalPath - number of items to skip
+   * @param {string} requiredGlobalPath number of items to skip
    *
-   * @param {string} requiredGlobalQuery - number of items to skip
+   * @param {string} requiredGlobalQuery number of items to skip
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {number} [options.optionalGlobalQuery] - number of items to skip
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(requiredGlobalPath: string, requiredGlobalQuery: string, baseUri?: string, options?: Models.AutoRestRequiredOptionalTestServiceOptions) {
     if (requiredGlobalPath === null || requiredGlobalPath === undefined) {

--- a/test/vanilla/generated/Url/autoRestUrlTestService.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestService.ts
@@ -24,19 +24,11 @@ class AutoRestUrlTestService extends AutoRestUrlTestServiceContext {
    * Initializes a new instance of the AutoRestUrlTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} globalStringPath A string value 'globalItemStringPath' that appears in the path
    *
-   * @param {object} [options] - The parameter options
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.globalStringQuery] - should contain value null
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(globalStringPath: string, baseUri?: string, options?: Models.AutoRestUrlTestServiceOptions) {
     super(globalStringPath, baseUri, options);

--- a/test/vanilla/generated/Url/autoRestUrlTestService.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestService.ts
@@ -20,9 +20,7 @@ class AutoRestUrlTestService extends AutoRestUrlTestServiceContext {
   pathItems: operations.PathItems;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestUrlTestService class.
-   * @constructor
    *
    * @param {string} globalStringPath A string value 'globalItemStringPath' that appears in the path
    *

--- a/test/vanilla/generated/Url/autoRestUrlTestServiceContext.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestServiceContext.ts
@@ -19,9 +19,7 @@ export class AutoRestUrlTestServiceContext extends msRest.ServiceClient {
   globalStringQuery?: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestUrlTestServiceContext class.
-   * @constructor
    *
    * @param {string} globalStringPath A string value 'globalItemStringPath' that appears in the path
    *

--- a/test/vanilla/generated/Url/autoRestUrlTestServiceContext.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestServiceContext.ts
@@ -23,21 +23,11 @@ export class AutoRestUrlTestServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestUrlTestServiceContext class.
    * @constructor
    *
-   * @param {string} globalStringPath - A string value 'globalItemStringPath' that appears in the path
+   * @param {string} globalStringPath A string value 'globalItemStringPath' that appears in the path
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
-   * @param {string} [options.globalStringQuery] - should contain value null
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(globalStringPath: string, baseUri?: string, options?: Models.AutoRestUrlTestServiceOptions) {
     if (globalStringPath === null || globalStringPath === undefined) {

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
@@ -19,9 +19,7 @@ class AutoRestUrlMutliCollectionFormatTestService extends AutoRestUrlMutliCollec
   queries: operations.Queries;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
@@ -23,17 +23,9 @@ class AutoRestUrlMutliCollectionFormatTestService extends AutoRestUrlMutliCollec
    * Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestServiceContext.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestUrlMutliCollectionFormatTestServiceContext extends msRest.S
    * Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestServiceContext.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestUrlMutliCollectionFormatTestServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -16,9 +16,7 @@ import { AutoRestValidationTestContext } from "./autoRestValidationTestContext";
 
 class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
-   * @class
    * Initializes a new instance of the AutoRestValidationTest class.
-   * @constructor
    *
    * @param {string} subscriptionId Subscription ID.
    *

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -20,17 +20,13 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * Initializes a new instance of the AutoRestValidationTest class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} subscriptionId Subscription ID.
    *
-   * @param {object} [options] - The parameter options
+   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(subscriptionId, apiVersion, baseUri, options);

--- a/test/vanilla/generated/Validation/autoRestValidationTestContext.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTestContext.ts
@@ -22,21 +22,13 @@ export class AutoRestValidationTestContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestValidationTestContext class.
    * @constructor
    *
-   * @param {string} subscriptionId - Subscription ID.
+   * @param {string} subscriptionId Subscription ID.
    *
-   * @param {string} apiVersion - Required string following pattern \d{2}-\d{2}-\d{4}
+   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     if (subscriptionId === null || subscriptionId === undefined) {

--- a/test/vanilla/generated/Validation/autoRestValidationTestContext.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTestContext.ts
@@ -18,9 +18,7 @@ export class AutoRestValidationTestContext extends msRest.ServiceClient {
   apiVersion: string;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestValidationTestContext class.
-   * @constructor
    *
    * @param {string} subscriptionId Subscription ID.
    *

--- a/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensions.ts
+++ b/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensions.ts
@@ -23,17 +23,9 @@ class XMSErrorResponseExtensions extends XMSErrorResponseExtensionsContext {
    * Initializes a new instance of the XMSErrorResponseExtensions class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensions.ts
+++ b/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensions.ts
@@ -19,9 +19,7 @@ class XMSErrorResponseExtensions extends XMSErrorResponseExtensionsContext {
   pet: operations.PetOperations;
 
   /**
-   * @class
    * Initializes a new instance of the XMSErrorResponseExtensions class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensionsContext.ts
+++ b/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensionsContext.ts
@@ -20,17 +20,9 @@ export class XMSErrorResponseExtensionsContext extends msRest.ServiceClient {
    * Initializes a new instance of the XMSErrorResponseExtensionsContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensionsContext.ts
+++ b/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensionsContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class XMSErrorResponseExtensionsContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the XMSErrorResponseExtensionsContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
@@ -23,17 +23,9 @@ class AutoRestSwaggerBATXMLService extends AutoRestSwaggerBATXMLServiceContext {
    * Initializes a new instance of the AutoRestSwaggerBATXMLService class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
@@ -19,9 +19,7 @@ class AutoRestSwaggerBATXMLService extends AutoRestSwaggerBATXMLServiceContext {
   xml: operations.Xml;
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATXMLService class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLServiceContext.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLServiceContext.ts
@@ -20,17 +20,9 @@ export class AutoRestSwaggerBATXMLServiceContext extends msRest.ServiceClient {
    * Initializes a new instance of the AutoRestSwaggerBATXMLServiceContext class.
    * @constructor
    *
-   * @param {string} [baseUri] - The base URI of the service.
+   * @param {string} [baseUri] The base URI of the service.
    *
-   * @param {object} [options] - The parameter options
-   *
-   * @param {Array} [options.filters] - Filters to be added to the request pipeline
-   *
-   * @param {object} [options.requestOptions] - The request options. Detailed info can be found at
-   * {@link https://github.github.io/fetch/#Request Options doc}
-   *
-   * @param {boolean} [options.noRetryPolicy] - If set to true, turn off default retry policy
-   *
+   * @param {object} [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLServiceContext.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLServiceContext.ts
@@ -16,9 +16,7 @@ const packageVersion = "";
 export class AutoRestSwaggerBATXMLServiceContext extends msRest.ServiceClient {
 
   /**
-   * @class
    * Initializes a new instance of the AutoRestSwaggerBATXMLServiceContext class.
-   * @constructor
    *
    * @param {string} [baseUri] The base URI of the service.
    *


### PR DESCRIPTION
Resolves https://github.com/Azure/autorest.typescript/issues/301.
Resolves https://github.com/Azure/autorest.typescript/issues/299.