### PR TITLE
Remove parameter types from jsdoc comments

### DIFF
--- a/src/DSL/TSDocumentationComment.cs
+++ b/src/DSL/TSDocumentationComment.cs
@@ -17,9 +17,7 @@ namespace AutoRest.TypeScript.DSL
             Summary,
             Description,
             Parameters,
-            Returns,
-            Resolve,
-            Reject
+            Returns
         }
 
         public TSDocumentationComment(TSBuilder builder)
@@ -32,13 +30,13 @@ namespace AutoRest.TypeScript.DSL
         {
             if (currentState == State.Start)
             {
-                Line("/**");
+                builder.Line("/**");
                 builder.AddToPrefix(" * ");
                 builder.WordWrapWidth = TSBuilder.multiLineCommentWordWrapWidth;
             }
             else
             {
-                Line();
+                builder.Line();
             }
             currentState = newState;
         }
@@ -49,7 +47,7 @@ namespace AutoRest.TypeScript.DSL
             {
                 builder.WordWrapWidth = previousWordWrapWidth;
                 builder.RemoveFromPrefix(" * ");
-                Line(" */");
+                builder.Line(" */");
             }
         }
 
@@ -63,7 +61,7 @@ namespace AutoRest.TypeScript.DSL
             if (!string.IsNullOrEmpty(text))
             {
                 SetCurrentState(State.Summary);
-                Line($"@summary {text}");
+                builder.Line($"@summary {text}");
             }
         }
 
@@ -71,43 +69,22 @@ namespace AutoRest.TypeScript.DSL
         {
             if (!string.IsNullOrEmpty(text))
             {
+                bool isFirstTag = (currentState == State.Start);
                 SetCurrentState(State.Description);
-                Line(text);
+                builder.Line($"{(isFirstTag ? "" : "@description ")}{text}");
             }
         }
 
         public void Parameter(string parameterName, string parameterDocumentation, bool isOptional = false)
         {
             SetCurrentState(State.Parameters);
-            Line($"@param {(isOptional ? '[' + parameterName + ']' : parameterName)} {parameterDocumentation}");
+            builder.Line($"@param {(isOptional ? '[' + parameterName + ']' : parameterName)} {parameterDocumentation}");
         }
 
         public void Returns(string returnDocumentation)
         {
             SetCurrentState(State.Returns);
-            Line($"@returns {returnDocumentation}");
-        }
-
-        public void Resolve(string resolveType, string resolveDocumentation)
-        {
-            SetCurrentState(State.Resolve);
-            Line($"@resolve {{{resolveType}}} {resolveDocumentation}");
-        }
-
-        public void Reject(string rejectType, string rejectDocumentation)
-        {
-            SetCurrentState(State.Reject);
-            Line($"@reject {{{rejectType}}} {rejectDocumentation}");
-        }
-
-        public void Line()
-        {
-            builder.Line();
-        }
-
-        public void Line(string text)
-        {
-            builder.Line(text);
+            builder.Line($"@returns {returnDocumentation}");
         }
     }
 }

--- a/src/DSL/TSDocumentationComment.cs
+++ b/src/DSL/TSDocumentationComment.cs
@@ -82,10 +82,10 @@ namespace AutoRest.TypeScript.DSL
             Line($"@param {(isOptional ? '[' + parameterName + ']' : parameterName)} {parameterDocumentation}");
         }
 
-        public void Returns(string returnType, string returnDocumentation)
+        public void Returns(string returnDocumentation)
         {
             SetCurrentState(State.Returns);
-            Line($"@returns {{{returnType}}} {returnDocumentation}");
+            Line($"@returns {returnDocumentation}");
         }
 
         public void Resolve(string resolveType, string resolveDocumentation)

--- a/src/DSL/TSDocumentationComment.cs
+++ b/src/DSL/TSDocumentationComment.cs
@@ -76,10 +76,10 @@ namespace AutoRest.TypeScript.DSL
             }
         }
 
-        public void Parameter(string parameterType, string parameterName, string parameterDocumentation, bool isOptional = false)
+        public void Parameter(string parameterName, string parameterDocumentation, bool isOptional = false)
         {
             SetCurrentState(State.Parameters);
-            Line($"@param {{{parameterType}}} {(isOptional ? '[' + parameterName + ']' : parameterName)} {parameterDocumentation}");
+            Line($"@param {(isOptional ? '[' + parameterName + ']' : parameterName)} {parameterDocumentation}");
         }
 
         public void Returns(string returnType, string returnDocumentation)

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -628,15 +628,15 @@ namespace AutoRest.TypeScript.Model
                 IEnumerable<Property> requiredParameters = Properties.Where(p => p.IsRequired && !p.IsConstant && string.IsNullOrEmpty(p.DefaultValue));
                 foreach (Property requiredParameter in requiredParameters)
                 {
-                    comment.Parameter(requiredParameter.ModelType.Name.ToCamelCase(), requiredParameter.Name, requiredParameter.Documentation);
+                    comment.Parameter(requiredParameter.Name, requiredParameter.Documentation);
                 }
 
                 if (!IsCustomBaseUri)
                 {
-                    comment.Parameter("string", "baseUri", "The base URI of the service.", isOptional: true);
+                    comment.Parameter("baseUri", "The base URI of the service.", isOptional: true);
                 }
 
-                comment.Parameter("object", "options", "The parameter options", isOptional: true);
+                comment.Parameter("options", "The parameter options", isOptional: true);
             });
             return builder.ToString();
         }

--- a/src/vanilla/Model/MethodTS.cs
+++ b/src/vanilla/Model/MethodTS.cs
@@ -437,7 +437,7 @@ namespace AutoRest.TypeScript.Model
 
                     foreach (Parameter parameter in LocalParametersWithOptions)
                     {
-                        comment.Parameter(ProvideParameterType(parameter.ModelType, true), parameter.Name, parameter.Documentation, !parameter.IsRequired);
+                        comment.Parameter(parameter.Name, parameter.Documentation, !parameter.IsRequired);
                     }
                 });
 
@@ -451,12 +451,12 @@ namespace AutoRest.TypeScript.Model
                 {
                     if (flavor == MethodFlavor.Callback)
                     {
-                        comment.Parameter("ServiceCallback", "callback", "The callback.");
+                        comment.Parameter("callback", "The callback.");
                         comment.Returns("ServiceCallback", "callback(err, result, request, operationRes)");
                     }
                     else if (flavor == MethodFlavor.Promise)
                     {
-                        comment.Parameter("ServiceClient", "optionalCallback", "The optional callback.", true);
+                        comment.Parameter("optionalCallback", "The optional callback.", true);
                         comment.Returns("ServiceCallback|Promise", "If a callback was passed as the last parameter, then it returns the callback, else returns a Promise.");
                         comment.Line("{Promise} A promise is returned.");
                         comment.Line($"                     @resolve {{{ReturnTypeTSString}}} - The deserialized result object.");

--- a/src/vanilla/Model/MethodTS.cs
+++ b/src/vanilla/Model/MethodTS.cs
@@ -443,7 +443,7 @@ namespace AutoRest.TypeScript.Model
 
                 if (flavor == MethodFlavor.HttpOperationResponse)
                 {
-                    comment.Returns("Promise", "A promise is returned");
+                    comment.Returns("A promise is returned");
                     comment.Resolve("HttpOperationResponse", "The deserialized result object.");
                     comment.Reject("Error|ServiceError", "The error object.");
                 }
@@ -452,12 +452,12 @@ namespace AutoRest.TypeScript.Model
                     if (flavor == MethodFlavor.Callback)
                     {
                         comment.Parameter("callback", "The callback.");
-                        comment.Returns("ServiceCallback", "callback(err, result, request, operationRes)");
+                        comment.Returns("callback(err, result, request, operationRes)");
                     }
                     else if (flavor == MethodFlavor.Promise)
                     {
                         comment.Parameter("optionalCallback", "The optional callback.", true);
-                        comment.Returns("ServiceCallback|Promise", "If a callback was passed as the last parameter, then it returns the callback, else returns a Promise.");
+                        comment.Returns("If a callback was passed as the last parameter, then it returns the callback, else returns a Promise.");
                         comment.Line("{Promise} A promise is returned.");
                         comment.Line($"                     @resolve {{{ReturnTypeTSString}}} - The deserialized result object.");
                         comment.Line($"                     @reject {{Error | ServiceError}} - The error object.");

--- a/src/vanilla/Model/MethodTS.cs
+++ b/src/vanilla/Model/MethodTS.cs
@@ -432,8 +432,8 @@ namespace AutoRest.TypeScript.Model
             {
                 comment.WithWordWrap(Settings.Instance?.MaximumCommentColumns ?? Settings.DefaultMaximumCommentColumns, () =>
                 {
-                    comment.Summary(Summary);
                     comment.Description(Description);
+                    comment.Summary(Summary);
 
                     foreach (Parameter parameter in LocalParametersWithOptions)
                     {
@@ -441,34 +441,21 @@ namespace AutoRest.TypeScript.Model
                     }
                 });
 
-                if (flavor == MethodFlavor.HttpOperationResponse)
+                switch (flavor)
                 {
-                    comment.Returns("A promise is returned");
-                    comment.Resolve("HttpOperationResponse", "The deserialized result object.");
-                    comment.Reject("Error|ServiceError", "The error object.");
-                }
-                else
-                {
-                    if (flavor == MethodFlavor.Callback)
-                    {
+                    case MethodFlavor.HttpOperationResponse:
+                        comment.Returns("A promise is returned");
+                        break;
+
+                    case MethodFlavor.Callback:
                         comment.Parameter("callback", "The callback.");
                         comment.Returns("callback(err, result, request, operationRes)");
-                    }
-                    else if (flavor == MethodFlavor.Promise)
-                    {
+                        break;
+
+                    case MethodFlavor.Promise:
                         comment.Parameter("optionalCallback", "The optional callback.", true);
                         comment.Returns("If a callback was passed as the last parameter, then it returns the callback, else returns a Promise.");
-                        comment.Line("{Promise} A promise is returned.");
-                        comment.Line($"                     @resolve {{{ReturnTypeTSString}}} - The deserialized result object.");
-                        comment.Line($"                     @reject {{Error | ServiceError}} - The error object.");
-                        comment.Line("{ServiceCallback} optionalCallback(err, result, request, operationRes)");
-                    }
-                    comment.Line($"                     {{Error|ServiceError}}  err        - The Error object if an error occurred, null otherwise.");
-                    comment.Line($"                     {{{ReturnTypeTSString}}} [result]   - The deserialized result object if an error did not occur.");
-                    comment.Line($"                     {ReturnTypeInfo}");
-                    comment.Line($"                     {{WebResource}} [request]  - The HTTP Request object if an error did not occur.");
-                    comment.Line($"                     {{HttpOperationResponse}} [response] - The HTTP Response stream if an error did not occur.");
-
+                        break;
                 }
             });
 

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -63,7 +63,7 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -95,7 +95,7 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -32,12 +32,11 @@ class AzureCompositeModel extends AzureCompositeModelContext {
   /**
    * Initializes a new instance of the AzureCompositeModel class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);
@@ -60,9 +59,9 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    * The response includes the display name and other details about each product, and lists the
    * products in the proper display order.
    *
-   * @param {string} resourceGroupName Resource Group ID.
+   * @param resourceGroupName Resource Group ID.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -90,11 +89,11 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    *
    * Resets products.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} resourceGroupName Resource Group ID.
+   * @param resourceGroupName Resource Group ID.
    *
-   * @param {AzureCompositeModelCreateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -123,11 +122,11 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    *
    * Resets products.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} resourceGroupName Resource Group ID.
+   * @param resourceGroupName Resource Group ID.
    *
-   * @param {AzureCompositeModelUpdateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModel.ts
@@ -53,21 +53,17 @@ class AzureCompositeModel extends AzureCompositeModelContext {
   // methods on the client.
 
   /**
-   * @summary Product Types
-   *
    * The Products endpoint returns information about the Uber products offered at a given location.
    * The response includes the display name and other details about each product, and lists the
    * products in the proper display order.
+   *
+   * @summary Product Types
    *
    * @param resourceGroupName Resource Group ID.
    *
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   list(resourceGroupName: string): Promise<Models.ListResponse>;
   list(resourceGroupName: string, options: msRest.RequestOptionsBase): Promise<Models.ListResponse>;
@@ -85,9 +81,9 @@ class AzureCompositeModel extends AzureCompositeModelContext {
   // methods on the client.
 
   /**
-   * @summary Create products
-   *
    * Resets products.
+   *
+   * @summary Create products
    *
    * @param subscriptionId Subscription ID.
    *
@@ -96,10 +92,6 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   create(subscriptionId: string, resourceGroupName: string): Promise<Models.CreateResponse>;
   create(subscriptionId: string, resourceGroupName: string, options: Models.AzureCompositeModelCreateOptionalParams): Promise<Models.CreateResponse>;
@@ -118,9 +110,9 @@ class AzureCompositeModel extends AzureCompositeModelContext {
   // methods on the client.
 
   /**
-   * @summary Update products
-   *
    * Resets products.
+   *
+   * @summary Update products
    *
    * @param subscriptionId Subscription ID.
    *
@@ -129,10 +121,6 @@ class AzureCompositeModel extends AzureCompositeModelContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   update(subscriptionId: string, resourceGroupName: string): Promise<Models.UpdateResponse>;
   update(subscriptionId: string, resourceGroupName: string, options: Models.AzureCompositeModelUpdateOptionalParams): Promise<Models.UpdateResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/azureCompositeModelContext.ts
+++ b/test/azure/generated/AzureCompositeModelClient/azureCompositeModelContext.ts
@@ -27,12 +27,11 @@ export class AzureCompositeModelContext extends msRestAzure.AzureServiceClient {
   /**
    * Initializes a new instance of the AzureCompositeModel class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
@@ -31,7 +31,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -79,7 +79,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -103,7 +103,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
@@ -29,7 +29,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class ArrayModel {
   /**
    * Put complex types with array property
    *
-   * @param {ArrayModelPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -77,7 +77,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property which is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -101,7 +101,7 @@ export class ArrayModel {
   /**
    * Put complex types with array property which is empty
    *
-   * @param {ArrayModelPutEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property while server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/arrayModel.ts
@@ -32,10 +32,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.ArrayModelGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetValidResponse>;
@@ -56,10 +52,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.ArrayModelPutValidOptionalParams): Promise<msRest.RestResponse>;
@@ -80,10 +72,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.ArrayModelGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetEmptyResponse>;
@@ -104,10 +92,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: Models.ArrayModelPutEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -128,10 +112,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.ArrayModelGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetNotProvidedResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
@@ -32,10 +32,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.BasicGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.BasicGetValidResponse>;
@@ -58,10 +54,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.Basic): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.Basic, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.BasicGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.BasicGetInvalidResponse>;
@@ -107,10 +95,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.BasicGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.BasicGetEmptyResponse>;
@@ -131,10 +115,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.BasicGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.BasicGetNullResponse>;
@@ -155,10 +135,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.BasicGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.BasicGetNotProvidedResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
@@ -29,7 +29,7 @@ export class BasicOperations {
   /**
    * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,9 +53,9 @@ export class BasicOperations {
   /**
    * Please put {id: 2, name: 'abc', color: 'Magenta'}
    *
-   * @param {Basic} complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+   * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,7 +80,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type that is invalid for the local strong type
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,7 +104,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type that is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -128,7 +128,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type whose properties are null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -152,7 +152,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type while the server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/basicOperations.ts
@@ -31,7 +31,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -57,7 +57,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -130,7 +130,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -154,7 +154,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
@@ -31,7 +31,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -79,7 +79,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -103,7 +103,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -151,7 +151,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
@@ -29,7 +29,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Dictionary {
   /**
    * Put complex types with dictionary property
    *
-   * @param {DictionaryPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -77,7 +77,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property which is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -101,7 +101,7 @@ export class Dictionary {
   /**
    * Put complex types with dictionary property which is empty
    *
-   * @param {DictionaryPutEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property which is null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -149,7 +149,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property while server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/dictionary.ts
@@ -32,10 +32,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.DictionaryGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetValidResponse>;
@@ -56,10 +52,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.DictionaryPutValidOptionalParams): Promise<msRest.RestResponse>;
@@ -80,10 +72,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.DictionaryGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetEmptyResponse>;
@@ -104,10 +92,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: Models.DictionaryPutEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -128,10 +112,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DictionaryGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNullResponse>;
@@ -152,10 +132,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.DictionaryGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNotProvidedResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
@@ -27,7 +27,7 @@ export class Flattencomplex {
   }
 
   /**
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
@@ -30,10 +30,6 @@ export class Flattencomplex {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.FlattencomplexGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.FlattencomplexGetValidResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/flattencomplex.ts
@@ -29,7 +29,7 @@ export class Flattencomplex {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
@@ -29,7 +29,7 @@ export class Inheritance {
   /**
    * Get complex types that extend others
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,11 +53,11 @@ export class Inheritance {
   /**
    * Put complex types that extend others
    *
-   * @param {Siamese} complexBody Please put a siamese with id=2, name="Siameee", color=green,
-   * breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and
-   * the 2nd one named "Tomato" with id=-1 and food="french fries".
+   * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+   * which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one
+   * named "Tomato" with id=-1 and food="french fries".
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
@@ -31,7 +31,7 @@ export class Inheritance {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -59,7 +59,7 @@ export class Inheritance {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/inheritance.ts
@@ -32,10 +32,6 @@ export class Inheritance {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.InheritanceGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.InheritanceGetValidResponse>;
@@ -60,10 +56,6 @@ export class Inheritance {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.Siamese): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.Siamese, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
@@ -31,7 +31,7 @@ export class Polymorphicrecursive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class Polymorphicrecursive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
@@ -32,10 +32,6 @@ export class Polymorphicrecursive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.PolymorphicrecursiveGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.PolymorphicrecursiveGetValidResponse>;
@@ -110,10 +106,6 @@ export class Polymorphicrecursive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphicrecursive.ts
@@ -29,7 +29,7 @@ export class Polymorphicrecursive {
   /**
    * Get complex types that are polymorphic and have recursive references
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Polymorphicrecursive {
   /**
    * Put complex types that are polymorphic and have recursive references
    *
-   * @param {FishUnion} complexBody Please put a salmon that looks like this:
+   * @param complexBody Please put a salmon that looks like this:
    * {
    * "fishtype": "salmon",
    * "species": "king",
@@ -107,7 +107,7 @@ export class Polymorphicrecursive {
    * ]
    * }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
@@ -31,7 +31,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -89,7 +89,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -115,7 +115,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -142,7 +142,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -169,7 +169,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -223,7 +223,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
@@ -32,10 +32,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.PolymorphismGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.PolymorphismGetValidResponse>;
@@ -90,10 +86,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -116,10 +108,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplicated(): Promise<Models.PolymorphismGetComplicatedResponse>;
   getComplicated(options: msRest.RequestOptionsBase): Promise<Models.PolymorphismGetComplicatedResponse>;
@@ -143,10 +131,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplicated(complexBody: Models.SalmonUnion): Promise<msRest.RestResponse>;
   putComplicated(complexBody: Models.SalmonUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -170,10 +154,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMissingDiscriminator(complexBody: Models.SalmonUnion): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
   putMissingDiscriminator(complexBody: Models.SalmonUnion, options: msRest.RequestOptionsBase): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
@@ -224,10 +204,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValidMissingRequired(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValidMissingRequired(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/polymorphism.ts
@@ -29,7 +29,7 @@ export class Polymorphism {
   /**
    * Get complex types that are polymorphic
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic
    *
-   * @param {FishUnion} complexBody Please put a salmon that looks like this:
+   * @param complexBody Please put a salmon that looks like this:
    * {
    * 'fishtype':'Salmon',
    * 'location':'alaska',
@@ -87,7 +87,7 @@ export class Polymorphism {
    * ]
    * };
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -113,7 +113,7 @@ export class Polymorphism {
    * Get complex types that are polymorphic, but not at the root of the hierarchy; also have
    * additional properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -138,9 +138,9 @@ export class Polymorphism {
    * Put complex types that are polymorphic, but not at the root of the hierarchy; also have
    * additional properties
    *
-   * @param {SalmonUnion} complexBody
+   * @param complexBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -165,9 +165,9 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic, omitting the discriminator
    *
-   * @param {SalmonUnion} complexBody
+   * @param complexBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -193,8 +193,8 @@ export class Polymorphism {
    * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the
    * request should not be allowed from the client
    *
-   * @param {FishUnion} complexBody Please attempt put a sawshark that looks like this, the client
-   * should not allow this data to be sent:
+   * @param complexBody Please attempt put a sawshark that looks like this, the client should not
+   * allow this data to be sent:
    * {
    * "fishtype": "sawshark",
    * "species": "snaggle toothed",
@@ -221,7 +221,7 @@ export class Polymorphism {
    * ]
    * }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
@@ -29,7 +29,7 @@ export class Primitive {
   /**
    * Get complex types with integer properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,9 +53,9 @@ export class Primitive {
   /**
    * Put complex types with integer properties
    *
-   * @param {IntWrapper} complexBody Please put -1 and 2
+   * @param complexBody Please put -1 and 2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,7 +80,7 @@ export class Primitive {
   /**
    * Get complex types with long properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,9 +104,9 @@ export class Primitive {
   /**
    * Put complex types with long properties
    *
-   * @param {LongWrapper} complexBody Please put 1099511627775 and -999511627788
+   * @param complexBody Please put 1099511627775 and -999511627788
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -131,7 +131,7 @@ export class Primitive {
   /**
    * Get complex types with float properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -155,9 +155,9 @@ export class Primitive {
   /**
    * Put complex types with float properties
    *
-   * @param {FloatWrapper} complexBody Please put 1.05 and -0.003
+   * @param complexBody Please put 1.05 and -0.003
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -182,7 +182,7 @@ export class Primitive {
   /**
    * Get complex types with double properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -206,10 +206,10 @@ export class Primitive {
   /**
    * Put complex types with double properties
    *
-   * @param {DoubleWrapper} complexBody Please put 3e-100 and
+   * @param complexBody Please put 3e-100 and
    * -0.000000000000000000000000000000000000000000000000000000005
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -234,7 +234,7 @@ export class Primitive {
   /**
    * Get complex types with bool properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -258,9 +258,9 @@ export class Primitive {
   /**
    * Put complex types with bool properties
    *
-   * @param {BooleanWrapper} complexBody Please put true and false
+   * @param complexBody Please put true and false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -285,7 +285,7 @@ export class Primitive {
   /**
    * Get complex types with string properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -309,9 +309,9 @@ export class Primitive {
   /**
    * Put complex types with string properties
    *
-   * @param {StringWrapper} complexBody Please put 'goodrequest', '', and null
+   * @param complexBody Please put 'goodrequest', '', and null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -336,7 +336,7 @@ export class Primitive {
   /**
    * Get complex types with date properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -360,9 +360,9 @@ export class Primitive {
   /**
    * Put complex types with date properties
    *
-   * @param {DateWrapper} complexBody Please put '0001-01-01' and '2016-02-29'
+   * @param complexBody Please put '0001-01-01' and '2016-02-29'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -387,7 +387,7 @@ export class Primitive {
   /**
    * Get complex types with datetime properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -411,10 +411,9 @@ export class Primitive {
   /**
    * Put complex types with datetime properties
    *
-   * @param {DatetimeWrapper} complexBody Please put '0001-01-01T12:00:00-04:00' and
-   * '2015-05-18T11:38:00-08:00'
+   * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -439,7 +438,7 @@ export class Primitive {
   /**
    * Get complex types with datetimeRfc1123 properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -463,10 +462,10 @@ export class Primitive {
   /**
    * Put complex types with datetimeRfc1123 properties
    *
-   * @param {Datetimerfc1123Wrapper} complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon,
-   * 18 May 2015 11:38:00 GMT'
+   * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00
+   * GMT'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -491,7 +490,7 @@ export class Primitive {
   /**
    * Get complex types with duration properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -515,7 +514,7 @@ export class Primitive {
   /**
    * Put complex types with duration properties
    *
-   * @param {PrimitivePutDurationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -539,7 +538,7 @@ export class Primitive {
   /**
    * Get complex types with byte properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -563,7 +562,7 @@ export class Primitive {
   /**
    * Put complex types with byte properties
    *
-   * @param {PrimitivePutByteOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
@@ -32,10 +32,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInt(): Promise<Models.PrimitiveGetIntResponse>;
   getInt(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetIntResponse>;
@@ -58,10 +54,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putInt(complexBody: Models.IntWrapper): Promise<msRest.RestResponse>;
   putInt(complexBody: Models.IntWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLong(): Promise<Models.PrimitiveGetLongResponse>;
   getLong(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetLongResponse>;
@@ -109,10 +97,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLong(complexBody: Models.LongWrapper): Promise<msRest.RestResponse>;
   putLong(complexBody: Models.LongWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -134,10 +118,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloat(): Promise<Models.PrimitiveGetFloatResponse>;
   getFloat(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetFloatResponse>;
@@ -160,10 +140,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFloat(complexBody: Models.FloatWrapper): Promise<msRest.RestResponse>;
   putFloat(complexBody: Models.FloatWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -185,10 +161,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDouble(): Promise<Models.PrimitiveGetDoubleResponse>;
   getDouble(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDoubleResponse>;
@@ -212,10 +184,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDouble(complexBody: Models.DoubleWrapper): Promise<msRest.RestResponse>;
   putDouble(complexBody: Models.DoubleWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -237,10 +205,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBool(): Promise<Models.PrimitiveGetBoolResponse>;
   getBool(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetBoolResponse>;
@@ -263,10 +227,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBool(complexBody: Models.BooleanWrapper): Promise<msRest.RestResponse>;
   putBool(complexBody: Models.BooleanWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -288,10 +248,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getString(): Promise<Models.PrimitiveGetStringResponse>;
   getString(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetStringResponse>;
@@ -314,10 +270,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putString(complexBody: Models.StringWrapper): Promise<msRest.RestResponse>;
   putString(complexBody: Models.StringWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -339,10 +291,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDate(): Promise<Models.PrimitiveGetDateResponse>;
   getDate(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateResponse>;
@@ -365,10 +313,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDate(complexBody: Models.DateWrapper): Promise<msRest.RestResponse>;
   putDate(complexBody: Models.DateWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -390,10 +334,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTime(): Promise<Models.PrimitiveGetDateTimeResponse>;
   getDateTime(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateTimeResponse>;
@@ -416,10 +356,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTime(complexBody: Models.DatetimeWrapper): Promise<msRest.RestResponse>;
   putDateTime(complexBody: Models.DatetimeWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -441,10 +377,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeRfc1123(): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
   getDateTimeRfc1123(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
@@ -468,10 +400,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeRfc1123(complexBody: Models.Datetimerfc1123Wrapper): Promise<msRest.RestResponse>;
   putDateTimeRfc1123(complexBody: Models.Datetimerfc1123Wrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -493,10 +421,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDuration(): Promise<Models.PrimitiveGetDurationResponse>;
   getDuration(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDurationResponse>;
@@ -517,10 +441,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDuration(): Promise<msRest.RestResponse>;
   putDuration(options: Models.PrimitivePutDurationOptionalParams): Promise<msRest.RestResponse>;
@@ -541,10 +461,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByte(): Promise<Models.PrimitiveGetByteResponse>;
   getByte(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetByteResponse>;
@@ -565,10 +481,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putByte(): Promise<msRest.RestResponse>;
   putByte(options: Models.PrimitivePutByteOptionalParams): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/primitive.ts
@@ -31,7 +31,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -57,7 +57,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -108,7 +108,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -133,7 +133,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -159,7 +159,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -184,7 +184,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -211,7 +211,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -236,7 +236,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -262,7 +262,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -287,7 +287,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -313,7 +313,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -338,7 +338,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -364,7 +364,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -389,7 +389,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -415,7 +415,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -440,7 +440,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -467,7 +467,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -492,7 +492,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -516,7 +516,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -540,7 +540,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -564,7 +564,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
@@ -32,10 +32,6 @@ export class Readonlyproperty {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.ReadonlypropertyGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.ReadonlypropertyGetValidResponse>;
@@ -56,10 +52,6 @@ export class Readonlyproperty {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.ReadonlypropertyPutValidOptionalParams): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
@@ -31,7 +31,7 @@ export class Readonlyproperty {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class Readonlyproperty {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
+++ b/test/azure/generated/AzureCompositeModelClient/operations/readonlyproperty.ts
@@ -29,7 +29,7 @@ export class Readonlyproperty {
   /**
    * Get complex types that have readonly properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Readonlyproperty {
   /**
    * Put complex types that have readonly properties
    *
-   * @param {ReadonlypropertyPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestService.ts
@@ -23,12 +23,11 @@ class AutoRestParameterGroupingTestService extends AutoRestParameterGroupingTest
   /**
    * Initializes a new instance of the AutoRestParameterGroupingTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestServiceContext.ts
+++ b/test/azure/generated/AzureParameterGrouping/autoRestParameterGroupingTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestParameterGroupingTestServiceContext extends msRestAzure.Azu
   /**
    * Initializes a new instance of the AutoRestParameterGroupingTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
@@ -29,10 +29,9 @@ export class ParameterGrouping {
   /**
    * Post a bunch of required parameters grouped
    *
-   * @param {ParameterGroupingPostRequiredParameters} parameterGroupingPostRequiredParameters
-   * Additional parameters for the operation
+   * @param parameterGroupingPostRequiredParameters Additional parameters for the operation
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -57,7 +56,7 @@ export class ParameterGrouping {
   /**
    * Post a bunch of optional parameters grouped
    *
-   * @param {ParameterGroupingPostOptionalOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -81,7 +80,7 @@ export class ParameterGrouping {
   /**
    * Post parameters from multiple different parameter groups
    *
-   * @param {ParameterGroupingPostMultiParamGroupsOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -105,8 +104,7 @@ export class ParameterGrouping {
   /**
    * Post parameters with a shared parameter group object
    *
-   * @param {ParameterGroupingPostSharedParameterGroupObjectOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
@@ -33,7 +33,7 @@ export class ParameterGrouping {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -58,7 +58,7 @@ export class ParameterGrouping {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class ParameterGrouping {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class ParameterGrouping {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
+++ b/test/azure/generated/AzureParameterGrouping/operations/parameterGrouping.ts
@@ -34,10 +34,6 @@ export class ParameterGrouping {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequired(parameterGroupingPostRequiredParameters: Models.ParameterGroupingPostRequiredParameters): Promise<msRest.RestResponse>;
   postRequired(parameterGroupingPostRequiredParameters: Models.ParameterGroupingPostRequiredParameters, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -59,10 +55,6 @@ export class ParameterGrouping {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptional(): Promise<msRest.RestResponse>;
   postOptional(options: Models.ParameterGroupingPostOptionalOptionalParams): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class ParameterGrouping {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postMultiParamGroups(): Promise<msRest.RestResponse>;
   postMultiParamGroups(options: Models.ParameterGroupingPostMultiParamGroupsOptionalParams): Promise<msRest.RestResponse>;
@@ -107,10 +95,6 @@ export class ParameterGrouping {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postSharedParameterGroupObject(): Promise<msRest.RestResponse>;
   postSharedParameterGroupObject(options: Models.ParameterGroupingPostSharedParameterGroupObjectOptionalParams): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -37,10 +37,6 @@ class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getReport(): Promise<Models.GetReportResponse>;
   getReport(options: Models.AutoRestReportServiceForAzureGetReportOptionalParams): Promise<Models.GetReportResponse>;

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -20,12 +20,11 @@ class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext
   /**
    * Initializes a new instance of the AutoRestReportServiceForAzure class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);
@@ -35,7 +34,7 @@ class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext
   /**
    * Get test coverage report
    *
-   * @param {AutoRestReportServiceForAzureGetReportOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzure.ts
@@ -36,7 +36,7 @@ class AutoRestReportServiceForAzure extends AutoRestReportServiceForAzureContext
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureReport/autoRestReportServiceForAzureContext.ts
+++ b/test/azure/generated/AzureReport/autoRestReportServiceForAzureContext.ts
@@ -25,12 +25,11 @@ export class AutoRestReportServiceForAzureContext extends msRestAzure.AzureServi
   /**
    * Initializes a new instance of the AutoRestReportServiceForAzure class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -37,10 +37,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putArray(): Promise<msRest.RestResponse>;
   putArray(options: Models.AutoRestResourceFlatteningTestServicePutArrayOptionalParams): Promise<msRest.RestResponse>;
@@ -62,10 +58,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArray(): Promise<Models.GetArrayResponse>;
   getArray(options: msRest.RequestOptionsBase): Promise<Models.GetArrayResponse>;
@@ -87,10 +79,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDictionary(): Promise<msRest.RestResponse>;
   putDictionary(options: Models.AutoRestResourceFlatteningTestServicePutDictionaryOptionalParams): Promise<msRest.RestResponse>;
@@ -112,10 +100,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionary(): Promise<Models.GetDictionaryResponse>;
   getDictionary(options: msRest.RequestOptionsBase): Promise<Models.GetDictionaryResponse>;
@@ -137,10 +121,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putResourceCollection(): Promise<msRest.RestResponse>;
   putResourceCollection(options: Models.AutoRestResourceFlatteningTestServicePutResourceCollectionOptionalParams): Promise<msRest.RestResponse>;
@@ -162,10 +142,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getResourceCollection(): Promise<Models.GetResourceCollectionResponse>;
   getResourceCollection(options: msRest.RequestOptionsBase): Promise<Models.GetResourceCollectionResponse>;

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -20,12 +20,11 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);
@@ -35,8 +34,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put External Resource as an Array
    *
-   * @param {AutoRestResourceFlatteningTestServicePutArrayOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -61,7 +59,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Get External Resource as an Array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -86,8 +84,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put External Resource as a Dictionary
    *
-   * @param {AutoRestResourceFlatteningTestServicePutDictionaryOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -112,7 +109,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Get External Resource as a Dictionary
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -137,8 +134,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put External Resource as a ResourceCollection
    *
-   * @param {AutoRestResourceFlatteningTestServicePutResourceCollectionOptionalParams} [options]
-   * Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -163,7 +159,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Get External Resource as a ResourceCollection
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestService.ts
@@ -36,7 +36,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -61,7 +61,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -86,7 +86,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -111,7 +111,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -136,7 +136,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -161,7 +161,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureResource/autoRestResourceFlatteningTestServiceContext.ts
+++ b/test/azure/generated/AzureResource/autoRestResourceFlatteningTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestResourceFlatteningTestServiceContext extends msRestAzure.Az
   /**
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClient.ts
@@ -30,15 +30,14 @@ class AutoRestAzureSpecialParametersTestClient extends AutoRestAzureSpecialParam
   /**
    * Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId The subscription id, which appears in the path, always modeled in
+   * @param subscriptionId The subscription id, which appears in the path, always modeled in
    * credentials. The value is always '1234-5678-9012-3456'
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, subscriptionId, baseUri, options);

--- a/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClientContext.ts
+++ b/test/azure/generated/AzureSpecials/autoRestAzureSpecialParametersTestClientContext.ts
@@ -29,15 +29,14 @@ export class AutoRestAzureSpecialParametersTestClientContext extends msRestAzure
   /**
    * Initializes a new instance of the AutoRestAzureSpecialParametersTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId The subscription id, which appears in the path, always modeled in
+   * @param subscriptionId The subscription id, which appears in the path, always modeled in
    * credentials. The value is always '1234-5678-9012-3456'
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
@@ -28,7 +28,7 @@ export class ApiVersionDefault {
   /**
    * GET method with api-version modeled in global settings.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class ApiVersionDefault {
   /**
    * GET method with api-version modeled in global settings.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class ApiVersionDefault {
   /**
    * GET method with api-version modeled in global settings.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class ApiVersionDefault {
   /**
    * GET method with api-version modeled in global settings.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
@@ -30,7 +30,7 @@ export class ApiVersionDefault {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class ApiVersionDefault {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class ApiVersionDefault {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class ApiVersionDefault {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionDefault.ts
@@ -31,10 +31,6 @@ export class ApiVersionDefault {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodGlobalValid(): Promise<msRest.RestResponse>;
   getMethodGlobalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -55,10 +51,6 @@ export class ApiVersionDefault {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodGlobalNotProvidedValid(): Promise<msRest.RestResponse>;
   getMethodGlobalNotProvidedValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class ApiVersionDefault {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getPathGlobalValid(): Promise<msRest.RestResponse>;
   getPathGlobalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -103,10 +91,6 @@ export class ApiVersionDefault {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSwaggerGlobalValid(): Promise<msRest.RestResponse>;
   getSwaggerGlobalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
@@ -31,7 +31,7 @@ export class ApiVersionLocal {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class ApiVersionLocal {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -79,7 +79,7 @@ export class ApiVersionLocal {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -103,7 +103,7 @@ export class ApiVersionLocal {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
@@ -29,7 +29,7 @@ export class ApiVersionLocal {
   /**
    * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class ApiVersionLocal {
   /**
    * Get method with api-version modeled in the method.  pass in api-version = null to succeed
    *
-   * @param {ApiVersionLocalGetMethodLocalNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -77,7 +77,7 @@ export class ApiVersionLocal {
   /**
    * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -101,7 +101,7 @@ export class ApiVersionLocal {
   /**
    * Get method with api-version modeled in the method.  pass in api-version = '2.0' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
+++ b/test/azure/generated/AzureSpecials/operations/apiVersionLocal.ts
@@ -32,10 +32,6 @@ export class ApiVersionLocal {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodLocalValid(): Promise<msRest.RestResponse>;
   getMethodLocalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -56,10 +52,6 @@ export class ApiVersionLocal {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodLocalNull(): Promise<msRest.RestResponse>;
   getMethodLocalNull(options: Models.ApiVersionLocalGetMethodLocalNullOptionalParams): Promise<msRest.RestResponse>;
@@ -80,10 +72,6 @@ export class ApiVersionLocal {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getPathLocalValid(): Promise<msRest.RestResponse>;
   getPathLocalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -104,10 +92,6 @@ export class ApiVersionLocal {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSwaggerLocalValid(): Promise<msRest.RestResponse>;
   getSwaggerLocalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/header.ts
+++ b/test/azure/generated/AzureSpecials/operations/header.ts
@@ -33,7 +33,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -61,7 +61,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -88,7 +88,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/header.ts
+++ b/test/azure/generated/AzureSpecials/operations/header.ts
@@ -34,10 +34,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   customNamedRequestId(fooClientRequestId: string): Promise<Models.HeaderCustomNamedRequestIdResponse>;
   customNamedRequestId(fooClientRequestId: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderCustomNamedRequestIdResponse>;
@@ -62,10 +58,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   customNamedRequestIdParamGrouping(headerCustomNamedRequestIdParamGroupingParameters: Models.HeaderCustomNamedRequestIdParamGroupingParameters): Promise<Models.HeaderCustomNamedRequestIdParamGroupingResponse>;
   customNamedRequestIdParamGrouping(headerCustomNamedRequestIdParamGroupingParameters: Models.HeaderCustomNamedRequestIdParamGroupingParameters, options: msRest.RequestOptionsBase): Promise<Models.HeaderCustomNamedRequestIdParamGroupingResponse>;
@@ -89,10 +81,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   customNamedRequestIdHead(fooClientRequestId: string): Promise<Models.HeaderCustomNamedRequestIdHeadResponse>;
   customNamedRequestIdHead(fooClientRequestId: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderCustomNamedRequestIdHeadResponse>;

--- a/test/azure/generated/AzureSpecials/operations/header.ts
+++ b/test/azure/generated/AzureSpecials/operations/header.ts
@@ -29,9 +29,9 @@ export class Header {
   /**
    * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
    *
-   * @param {string} fooClientRequestId The fooRequestId
+   * @param fooClientRequestId The fooRequestId
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -57,10 +57,9 @@ export class Header {
    * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request,
    * via a parameter group
    *
-   * @param {HeaderCustomNamedRequestIdParamGroupingParameters}
-   * headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
+   * @param headerCustomNamedRequestIdParamGroupingParameters Additional parameters for the operation
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -85,9 +84,9 @@ export class Header {
   /**
    * Send foo-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
    *
-   * @param {string} fooClientRequestId The fooRequestId
+   * @param fooClientRequestId The fooRequestId
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/odata.ts
+++ b/test/azure/generated/AzureSpecials/operations/odata.ts
@@ -29,7 +29,7 @@ export class Odata {
   /**
    * Specify filter parameter with value '$filter=id gt 5 and name eq 'foo'&$orderby=id&$top=10'
    *
-   * @param {OdataGetWithFilterOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/odata.ts
+++ b/test/azure/generated/AzureSpecials/operations/odata.ts
@@ -32,10 +32,6 @@ export class Odata {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWithFilter(): Promise<msRest.RestResponse>;
   getWithFilter(options: Models.OdataGetWithFilterOptionalParams): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/odata.ts
+++ b/test/azure/generated/AzureSpecials/operations/odata.ts
@@ -31,7 +31,7 @@ export class Odata {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
+++ b/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
@@ -33,7 +33,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -60,7 +60,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -85,7 +85,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -111,7 +111,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -136,7 +136,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -162,7 +162,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -187,7 +187,7 @@ export class SkipUrlEncoding {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
+++ b/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
@@ -34,10 +34,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodPathValid(unencodedPathParam: string): Promise<msRest.RestResponse>;
   getMethodPathValid(unencodedPathParam: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -61,10 +57,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getPathPathValid(unencodedPathParam: string): Promise<msRest.RestResponse>;
   getPathPathValid(unencodedPathParam: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -86,10 +78,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSwaggerPathValid(): Promise<msRest.RestResponse>;
   getSwaggerPathValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -112,10 +100,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodQueryValid(q1: string): Promise<msRest.RestResponse>;
   getMethodQueryValid(q1: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -137,10 +121,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMethodQueryNull(): Promise<msRest.RestResponse>;
   getMethodQueryNull(options: Models.SkipUrlEncodingGetMethodQueryNullOptionalParams): Promise<msRest.RestResponse>;
@@ -163,10 +143,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getPathQueryValid(q1: string): Promise<msRest.RestResponse>;
   getPathQueryValid(q1: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -188,10 +164,6 @@ export class SkipUrlEncoding {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSwaggerQueryValid(): Promise<msRest.RestResponse>;
   getSwaggerQueryValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
+++ b/test/azure/generated/AzureSpecials/operations/skipUrlEncoding.ts
@@ -29,9 +29,9 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded path parameter with value 'path1/path2/path3'
    *
-   * @param {string} unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+   * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -56,9 +56,9 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded path parameter with value 'path1/path2/path3'
    *
-   * @param {string} unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
+   * @param unencodedPathParam Unencoded path parameter with value 'path1/path2/path3'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -83,7 +83,7 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded path parameter with value 'path1/path2/path3'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,9 +107,9 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
    *
-   * @param {string} q1 Unencoded query parameter with value 'value1&q2=value2&q3=value3'
+   * @param q1 Unencoded query parameter with value 'value1&q2=value2&q3=value3'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -134,7 +134,7 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded query parameter with value null
    *
-   * @param {SkipUrlEncodingGetMethodQueryNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -158,9 +158,9 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
    *
-   * @param {string} q1 Unencoded query parameter with value 'value1&q2=value2&q3=value3'
+   * @param q1 Unencoded query parameter with value 'value1&q2=value2&q3=value3'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -185,7 +185,7 @@ export class SkipUrlEncoding {
   /**
    * Get method with unencoded query parameter with value 'value1&q2=value2&q3=value3'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
@@ -29,7 +29,7 @@ export class SubscriptionInCredentials {
    * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -54,7 +54,7 @@ export class SubscriptionInCredentials {
    * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to
    * null, and client-side validation should prevent you from making this call
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -79,7 +79,7 @@ export class SubscriptionInCredentials {
    * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,7 +104,7 @@ export class SubscriptionInCredentials {
    * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -129,7 +129,7 @@ export class SubscriptionInCredentials {
    * POST method with subscriptionId modeled in credentials.  Set the credential subscriptionId to
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
@@ -31,7 +31,7 @@ export class SubscriptionInCredentials {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class SubscriptionInCredentials {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -81,7 +81,7 @@ export class SubscriptionInCredentials {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class SubscriptionInCredentials {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -131,7 +131,7 @@ export class SubscriptionInCredentials {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInCredentials.ts
@@ -32,10 +32,6 @@ export class SubscriptionInCredentials {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postMethodGlobalValid(): Promise<msRest.RestResponse>;
   postMethodGlobalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -57,10 +53,6 @@ export class SubscriptionInCredentials {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postMethodGlobalNull(): Promise<msRest.RestResponse>;
   postMethodGlobalNull(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -82,10 +74,6 @@ export class SubscriptionInCredentials {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postMethodGlobalNotProvidedValid(): Promise<msRest.RestResponse>;
   postMethodGlobalNotProvidedValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -107,10 +95,6 @@ export class SubscriptionInCredentials {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postPathGlobalValid(): Promise<msRest.RestResponse>;
   postPathGlobalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -132,10 +116,6 @@ export class SubscriptionInCredentials {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postSwaggerGlobalValid(): Promise<msRest.RestResponse>;
   postSwaggerGlobalValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
@@ -33,7 +33,7 @@ export class SubscriptionInMethod {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -62,7 +62,7 @@ export class SubscriptionInMethod {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -90,7 +90,7 @@ export class SubscriptionInMethod {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -119,7 +119,7 @@ export class SubscriptionInMethod {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
@@ -34,10 +34,6 @@ export class SubscriptionInMethod {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postMethodLocalValid(subscriptionId: string): Promise<msRest.RestResponse>;
   postMethodLocalValid(subscriptionId: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -63,10 +59,6 @@ export class SubscriptionInMethod {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postMethodLocalNull(subscriptionId: string): Promise<msRest.RestResponse>;
   postMethodLocalNull(subscriptionId: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -91,10 +83,6 @@ export class SubscriptionInMethod {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postPathLocalValid(subscriptionId: string): Promise<msRest.RestResponse>;
   postPathLocalValid(subscriptionId: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -120,10 +108,6 @@ export class SubscriptionInMethod {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postSwaggerLocalValid(subscriptionId: string): Promise<msRest.RestResponse>;
   postSwaggerLocalValid(subscriptionId: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
+++ b/test/azure/generated/AzureSpecials/operations/subscriptionInMethod.ts
@@ -29,10 +29,9 @@ export class SubscriptionInMethod {
    * POST method with subscriptionId modeled in the method.  pass in subscription id =
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {string} subscriptionId This should appear as a method parameter, use value
-   * '1234-5678-9012-3456'
+   * @param subscriptionId This should appear as a method parameter, use value '1234-5678-9012-3456'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -58,10 +57,10 @@ export class SubscriptionInMethod {
    * POST method with subscriptionId modeled in the method.  pass in subscription id = null,
    * client-side validation should prevent you from making this call
    *
-   * @param {string} subscriptionId This should appear as a method parameter, use value null,
-   * client-side validation should prvenet the call
+   * @param subscriptionId This should appear as a method parameter, use value null, client-side
+   * validation should prvenet the call
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -87,10 +86,9 @@ export class SubscriptionInMethod {
    * POST method with subscriptionId modeled in the method.  pass in subscription id =
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {string} subscriptionId Should appear as a method parameter -use value
-   * '1234-5678-9012-3456'
+   * @param subscriptionId Should appear as a method parameter -use value '1234-5678-9012-3456'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -116,10 +114,10 @@ export class SubscriptionInMethod {
    * POST method with subscriptionId modeled in the method.  pass in subscription id =
    * '1234-5678-9012-3456' to succeed
    *
-   * @param {string} subscriptionId The subscriptionId, which appears in the path, the value is
-   * always '1234-5678-9012-3456'
+   * @param subscriptionId The subscriptionId, which appears in the path, the value is always
+   * '1234-5678-9012-3456'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
+++ b/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
@@ -29,7 +29,7 @@ export class XMsClientRequestId {
    * Get method that overwrites x-ms-client-request header with value
    * 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -54,10 +54,10 @@ export class XMsClientRequestId {
    * Get method that overwrites x-ms-client-request header with value
    * 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
    *
-   * @param {string} xMsClientRequestId This should appear as a method parameter, use value
+   * @param xMsClientRequestId This should appear as a method parameter, use value
    * '9C4D50EE-2D56-4CD3-8152-34347DC9F2B0'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
+++ b/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
@@ -32,10 +32,6 @@ export class XMsClientRequestId {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get(): Promise<msRest.RestResponse>;
   get(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -60,10 +56,6 @@ export class XMsClientRequestId {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramGet(xMsClientRequestId: string): Promise<msRest.RestResponse>;
   paramGet(xMsClientRequestId: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
+++ b/test/azure/generated/AzureSpecials/operations/xMsClientRequestId.ts
@@ -31,7 +31,7 @@ export class XMsClientRequestId {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -59,7 +59,7 @@ export class XMsClientRequestId {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -22,10 +22,9 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
   /**
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     super(credentials, options);

--- a/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
+++ b/test/azure/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
@@ -28,10 +28,9 @@ export class AutoRestParameterizedHostTestClientContext extends msRestAzure.Azur
   /**
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/CustomBaseUri/operations/paths.ts
+++ b/test/azure/generated/CustomBaseUri/operations/paths.ts
@@ -32,7 +32,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/CustomBaseUri/operations/paths.ts
+++ b/test/azure/generated/CustomBaseUri/operations/paths.ts
@@ -28,9 +28,9 @@ export class Paths {
   /**
    * Get a 200 to test a valid base uri
    *
-   * @param {string} accountName Account Name
+   * @param accountName Account Name
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/CustomBaseUri/operations/paths.ts
+++ b/test/azure/generated/CustomBaseUri/operations/paths.ts
@@ -33,10 +33,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(accountName: string): Promise<msRest.RestResponse>;
   getEmpty(accountName: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/Head/autoRestHeadTestService.ts
+++ b/test/azure/generated/Head/autoRestHeadTestService.ts
@@ -23,12 +23,11 @@ class AutoRestHeadTestService extends AutoRestHeadTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestHeadTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/Head/autoRestHeadTestServiceContext.ts
+++ b/test/azure/generated/Head/autoRestHeadTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestHeadTestServiceContext extends msRestAzure.AzureServiceClie
   /**
    * Initializes a new instance of the AutoRestHeadTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/Head/operations/httpSuccess.ts
+++ b/test/azure/generated/Head/operations/httpSuccess.ts
@@ -29,7 +29,7 @@ export class HttpSuccess {
   /**
    * Return 200 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class HttpSuccess {
   /**
    * Return 204 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -77,7 +77,7 @@ export class HttpSuccess {
   /**
    * Return 404 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/Head/operations/httpSuccess.ts
+++ b/test/azure/generated/Head/operations/httpSuccess.ts
@@ -31,7 +31,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -79,7 +79,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Head/operations/httpSuccess.ts
+++ b/test/azure/generated/Head/operations/httpSuccess.ts
@@ -32,10 +32,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head200(): Promise<Models.HttpSuccessHead200Response>;
   head200(options: msRest.RequestOptionsBase): Promise<Models.HttpSuccessHead200Response>;
@@ -56,10 +52,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head204(): Promise<Models.HttpSuccessHead204Response>;
   head204(options: msRest.RequestOptionsBase): Promise<Models.HttpSuccessHead204Response>;
@@ -80,10 +72,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head404(): Promise<Models.HttpSuccessHead404Response>;
   head404(options: msRest.RequestOptionsBase): Promise<Models.HttpSuccessHead404Response>;

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestService.ts
@@ -23,12 +23,11 @@ class AutoRestHeadExceptionTestService extends AutoRestHeadExceptionTestServiceC
   /**
    * Initializes a new instance of the AutoRestHeadExceptionTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestServiceContext.ts
+++ b/test/azure/generated/HeadExceptions/autoRestHeadExceptionTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestHeadExceptionTestServiceContext extends msRestAzure.AzureSe
   /**
    * Initializes a new instance of the AutoRestHeadExceptionTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/HeadExceptions/operations/headException.ts
+++ b/test/azure/generated/HeadExceptions/operations/headException.ts
@@ -31,10 +31,6 @@ export class HeadException {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head200(): Promise<msRest.RestResponse>;
   head200(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -55,10 +51,6 @@ export class HeadException {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head204(): Promise<msRest.RestResponse>;
   head204(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class HeadException {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head404(): Promise<msRest.RestResponse>;
   head404(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/azure/generated/HeadExceptions/operations/headException.ts
+++ b/test/azure/generated/HeadExceptions/operations/headException.ts
@@ -28,7 +28,7 @@ export class HeadException {
   /**
    * Return 200 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HeadException {
   /**
    * Return 204 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HeadException {
   /**
    * Return 404 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/HeadExceptions/operations/headException.ts
+++ b/test/azure/generated/HeadExceptions/operations/headException.ts
@@ -30,7 +30,7 @@ export class HeadException {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HeadException {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HeadException {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestService.ts
@@ -26,12 +26,11 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
   /**
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/Lro/autoRestLongRunningOperationTestServiceContext.ts
+++ b/test/azure/generated/Lro/autoRestLongRunningOperationTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestLongRunningOperationTestServiceContext extends msRestAzure.
   /**
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/Lro/operations/lRORetrys.ts
+++ b/test/azure/generated/Lro/operations/lRORetrys.ts
@@ -35,7 +35,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -73,7 +73,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -91,7 +91,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -146,7 +146,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -164,7 +164,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -186,7 +186,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -208,7 +208,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -229,7 +229,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -250,7 +250,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -271,7 +271,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -293,7 +293,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Lro/operations/lRORetrys.ts
+++ b/test/azure/generated/Lro/operations/lRORetrys.ts
@@ -33,7 +33,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LRORetrysPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysPutAsyncRelativeRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -71,7 +71,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -89,7 +89,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Polls
    * return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,7 +107,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class LRORetrys {
    * Long running post request, service returns a 500, then a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LRORetrysPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -144,7 +144,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysPostAsyncRelativeRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -162,7 +162,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LRORetrysBeginPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -184,8 +184,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysBeginPutAsyncRelativeRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -207,7 +206,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -228,7 +227,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Polls
    * return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -249,7 +248,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -270,7 +269,7 @@ export class LRORetrys {
    * Long running post request, service returns a 500, then a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LRORetrysBeginPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -292,8 +291,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysBeginPostAsyncRelativeRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/Lro/operations/lRORetrys.ts
+++ b/test/azure/generated/Lro/operations/lRORetrys.ts
@@ -36,10 +36,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingSucceeded200(options?: Models.LRORetrysPut201CreatingSucceeded200OptionalParams): Promise<Models.LRORetrysPut201CreatingSucceeded200Response> {
     return this.beginPut201CreatingSucceeded200(options)
@@ -55,10 +51,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetrySucceeded(options?: Models.LRORetrysPutAsyncRelativeRetrySucceededOptionalParams): Promise<Models.LRORetrysPutAsyncRelativeRetrySucceededResponse> {
     return this.beginPutAsyncRelativeRetrySucceeded(options)
@@ -74,10 +66,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<Models.LRORetrysDeleteProvisioning202Accepted200SucceededResponse> {
     return this.beginDeleteProvisioning202Accepted200Succeeded(options)
@@ -92,10 +80,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202Retry200(options?: msRest.RequestOptionsBase): Promise<Models.LRORetrysDelete202Retry200Response> {
     return this.beginDelete202Retry200(options)
@@ -110,10 +94,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<Models.LRORetrysDeleteAsyncRelativeRetrySucceededResponse> {
     return this.beginDeleteAsyncRelativeRetrySucceeded(options)
@@ -128,10 +108,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202Retry200(options?: Models.LRORetrysPost202Retry200OptionalParams): Promise<Models.LRORetrysPost202Retry200Response> {
     return this.beginPost202Retry200(options)
@@ -147,10 +123,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetrySucceeded(options?: Models.LRORetrysPostAsyncRelativeRetrySucceededOptionalParams): Promise<Models.LRORetrysPostAsyncRelativeRetrySucceededResponse> {
     return this.beginPostAsyncRelativeRetrySucceeded(options)
@@ -165,10 +137,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingSucceeded200(options?: Models.LRORetrysBeginPut201CreatingSucceeded200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -187,10 +155,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetrySucceeded(options?: Models.LRORetrysBeginPutAsyncRelativeRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -209,10 +173,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -230,10 +190,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202Retry200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -251,10 +207,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -272,10 +224,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202Retry200(options?: Models.LRORetrysBeginPost202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -294,10 +242,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetrySucceeded(options?: Models.LRORetrysBeginPostAsyncRelativeRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azure/generated/Lro/operations/lROSADs.ts
+++ b/test/azure/generated/Lro/operations/lROSADs.ts
@@ -34,10 +34,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonRetry400(options?: Models.LROSADsPutNonRetry400OptionalParams): Promise<Models.LROSADsPutNonRetry400Response> {
     return this.beginPutNonRetry400(options)
@@ -52,10 +48,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonRetry201Creating400(options?: Models.LROSADsPutNonRetry201Creating400OptionalParams): Promise<Models.LROSADsPutNonRetry201Creating400Response> {
     return this.beginPutNonRetry201Creating400(options)
@@ -70,10 +62,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonRetry201Creating400InvalidJson(options?: Models.LROSADsPutNonRetry201Creating400InvalidJsonOptionalParams): Promise<Models.LROSADsPutNonRetry201Creating400InvalidJsonResponse> {
     return this.beginPutNonRetry201Creating400InvalidJson(options)
@@ -88,10 +76,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetry400(options?: Models.LROSADsPutAsyncRelativeRetry400OptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetry400Response> {
     return this.beginPutAsyncRelativeRetry400(options)
@@ -105,10 +89,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteNonRetry400(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteNonRetry400Response> {
     return this.beginDeleteNonRetry400(options)
@@ -122,10 +102,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202NonRetry400(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDelete202NonRetry400Response> {
     return this.beginDelete202NonRetry400(options)
@@ -140,10 +116,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetry400(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetry400Response> {
     return this.beginDeleteAsyncRelativeRetry400(options)
@@ -157,10 +129,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postNonRetry400(options?: Models.LROSADsPostNonRetry400OptionalParams): Promise<Models.LROSADsPostNonRetry400Response> {
     return this.beginPostNonRetry400(options)
@@ -174,10 +142,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202NonRetry400(options?: Models.LROSADsPost202NonRetry400OptionalParams): Promise<Models.LROSADsPost202NonRetry400Response> {
     return this.beginPost202NonRetry400(options)
@@ -192,10 +156,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetry400(options?: Models.LROSADsPostAsyncRelativeRetry400OptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetry400Response> {
     return this.beginPostAsyncRelativeRetry400(options)
@@ -209,10 +169,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putError201NoProvisioningStatePayload(options?: Models.LROSADsPutError201NoProvisioningStatePayloadOptionalParams): Promise<Models.LROSADsPutError201NoProvisioningStatePayloadResponse> {
     return this.beginPutError201NoProvisioningStatePayload(options)
@@ -228,10 +184,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryNoStatus(options?: Models.LROSADsPutAsyncRelativeRetryNoStatusOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryNoStatusResponse> {
     return this.beginPutAsyncRelativeRetryNoStatus(options)
@@ -247,10 +199,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryNoStatusPayload(options?: Models.LROSADsPutAsyncRelativeRetryNoStatusPayloadOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse> {
     return this.beginPutAsyncRelativeRetryNoStatusPayload(options)
@@ -264,10 +212,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
     return this.beginDelete204Succeeded(options)
@@ -282,10 +226,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetryNoStatus(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetryNoStatusResponse> {
     return this.beginDeleteAsyncRelativeRetryNoStatus(options)
@@ -300,10 +240,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202NoLocation(options?: Models.LROSADsPost202NoLocationOptionalParams): Promise<Models.LROSADsPost202NoLocationResponse> {
     return this.beginPost202NoLocation(options)
@@ -319,10 +255,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetryNoPayload(options?: Models.LROSADsPostAsyncRelativeRetryNoPayloadOptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetryNoPayloadResponse> {
     return this.beginPostAsyncRelativeRetryNoPayload(options)
@@ -337,10 +269,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200InvalidJson(options?: Models.LROSADsPut200InvalidJsonOptionalParams): Promise<Models.LROSADsPut200InvalidJsonResponse> {
     return this.beginPut200InvalidJson(options)
@@ -356,10 +284,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsPutAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryInvalidHeaderResponse> {
     return this.beginPutAsyncRelativeRetryInvalidHeader(options)
@@ -375,10 +299,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsPutAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse> {
     return this.beginPutAsyncRelativeRetryInvalidJsonPolling(options)
@@ -393,10 +313,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202RetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDelete202RetryInvalidHeaderResponse> {
     return this.beginDelete202RetryInvalidHeader(options)
@@ -411,10 +327,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse> {
     return this.beginDeleteAsyncRelativeRetryInvalidHeader(options)
@@ -429,10 +341,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetryInvalidJsonPolling(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse> {
     return this.beginDeleteAsyncRelativeRetryInvalidJsonPolling(options)
@@ -447,10 +355,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202RetryInvalidHeader(options?: Models.LROSADsPost202RetryInvalidHeaderOptionalParams): Promise<Models.LROSADsPost202RetryInvalidHeaderResponse> {
     return this.beginPost202RetryInvalidHeader(options)
@@ -466,10 +370,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsPostAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetryInvalidHeaderResponse> {
     return this.beginPostAsyncRelativeRetryInvalidHeader(options)
@@ -485,10 +385,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsPostAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse> {
     return this.beginPostAsyncRelativeRetryInvalidJsonPolling(options)
@@ -501,10 +397,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonRetry400(options?: Models.LROSADsBeginPutNonRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -522,10 +414,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonRetry201Creating400(options?: Models.LROSADsBeginPutNonRetry201Creating400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -543,10 +431,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonRetry201Creating400InvalidJson(options?: Models.LROSADsBeginPutNonRetry201Creating400InvalidJsonOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -564,10 +448,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetry400(options?: Models.LROSADsBeginPutAsyncRelativeRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -584,10 +464,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteNonRetry400(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -604,10 +480,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202NonRetry400(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -625,10 +497,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetry400(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -645,10 +513,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostNonRetry400(options?: Models.LROSADsBeginPostNonRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -665,10 +529,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202NonRetry400(options?: Models.LROSADsBeginPost202NonRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -686,10 +546,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetry400(options?: Models.LROSADsBeginPostAsyncRelativeRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -706,10 +562,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutError201NoProvisioningStatePayload(options?: Models.LROSADsBeginPutError201NoProvisioningStatePayloadOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -728,10 +580,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryNoStatus(options?: Models.LROSADsBeginPutAsyncRelativeRetryNoStatusOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -750,10 +598,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryNoStatusPayload(options?: Models.LROSADsBeginPutAsyncRelativeRetryNoStatusPayloadOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -770,10 +614,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -791,10 +631,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetryNoStatus(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -812,10 +648,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202NoLocation(options?: Models.LROSADsBeginPost202NoLocationOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -834,10 +666,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetryNoPayload(options?: Models.LROSADsBeginPostAsyncRelativeRetryNoPayloadOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -855,10 +683,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200InvalidJson(options?: Models.LROSADsBeginPut200InvalidJsonOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -877,10 +701,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsBeginPutAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -899,10 +719,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsBeginPutAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -920,10 +736,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202RetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -941,10 +753,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -962,10 +770,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetryInvalidJsonPolling(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -983,10 +787,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202RetryInvalidHeader(options?: Models.LROSADsBeginPost202RetryInvalidHeaderOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1005,10 +805,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsBeginPostAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1027,10 +823,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsBeginPostAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azure/generated/Lro/operations/lROSADs.ts
+++ b/test/azure/generated/Lro/operations/lROSADs.ts
@@ -31,7 +31,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 400 to the initial request
    *
-   * @param {LROSADsPutNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -49,7 +49,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsPutNonRetry201Creating400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -67,8 +67,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsPutNonRetry201Creating400InvalidJsonOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -86,7 +85,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,7 +102,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 400 with an error body
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -120,7 +119,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 202 with a location header
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -138,7 +137,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -155,7 +154,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 400 with no error body
    *
-   * @param {LROSADsPostNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,7 +171,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 202 with a location header
    *
-   * @param {LROSADsPost202NonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -190,7 +189,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsPostAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -207,8 +206,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 201 to the initial request with no payload
    *
-   * @param {LROSADsPutError201NoProvisioningStatePayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -227,7 +225,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetryNoStatusOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -246,8 +244,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetryNoStatusPayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -264,7 +261,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 204 to the initial request, indicating success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -282,7 +279,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -300,7 +297,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, without a location
    * header.
    *
-   * @param {LROSADsPost202NoLocationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -319,7 +316,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPostAsyncRelativeRetryNoPayloadOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -337,7 +334,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 to the initial request, with an entity that is
    * not a valid json
    *
-   * @param {LROSADsPut200InvalidJsonOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -356,7 +353,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsPutAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -375,8 +372,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -394,7 +390,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request receing a reponse with
    * an invalid 'Location' and 'Retry-After' headers
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -412,7 +408,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. The endpoint
    * indicated in the Azure-AsyncOperation header is invalid
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -430,7 +426,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -448,7 +444,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, with invalid 'Location'
    * and 'Retry-After' headers.
    *
-   * @param {LROSADsPost202RetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -467,7 +463,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsPostAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -486,8 +482,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPostAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -503,7 +498,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 400 to the initial request
    *
-   * @param {LROSADsBeginPutNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -524,7 +519,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsBeginPutNonRetry201Creating400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -545,8 +540,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsBeginPutNonRetry201Creating400InvalidJsonOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -567,7 +561,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -587,7 +581,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 400 with an error body
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -607,7 +601,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 202 with a location header
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -628,7 +622,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -648,7 +642,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 400 with no error body
    *
-   * @param {LROSADsBeginPostNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -668,7 +662,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 202 with a location header
    *
-   * @param {LROSADsBeginPost202NonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -689,7 +683,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -709,8 +703,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 201 to the initial request with no payload
    *
-   * @param {LROSADsBeginPutError201NoProvisioningStatePayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -732,7 +725,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryNoStatusOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -754,8 +747,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryNoStatusPayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -775,7 +767,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 204 to the initial request, indicating success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -796,7 +788,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -817,7 +809,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, without a location
    * header.
    *
-   * @param {LROSADsBeginPost202NoLocationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -839,8 +831,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetryNoPayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -861,7 +852,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 to the initial request, with an entity that is
    * not a valid json
    *
-   * @param {LROSADsBeginPut200InvalidJsonOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -883,8 +874,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -906,8 +896,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -928,7 +917,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request receing a reponse with
    * an invalid 'Location' and 'Retry-After' headers
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -949,7 +938,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. The endpoint
    * indicated in the Azure-AsyncOperation header is invalid
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -970,7 +959,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -991,7 +980,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, with invalid 'Location'
    * and 'Retry-After' headers.
    *
-   * @param {LROSADsBeginPost202RetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1013,8 +1002,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1036,8 +1024,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/Lro/operations/lROSADs.ts
+++ b/test/azure/generated/Lro/operations/lROSADs.ts
@@ -33,7 +33,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -51,7 +51,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -69,7 +69,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -87,7 +87,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -104,7 +104,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -121,7 +121,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -139,7 +139,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -156,7 +156,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -173,7 +173,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -191,7 +191,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -208,7 +208,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -227,7 +227,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -246,7 +246,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -263,7 +263,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -281,7 +281,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -299,7 +299,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -318,7 +318,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -336,7 +336,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -355,7 +355,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -374,7 +374,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -392,7 +392,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -410,7 +410,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -428,7 +428,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -446,7 +446,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -465,7 +465,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -484,7 +484,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -500,7 +500,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -521,7 +521,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -542,7 +542,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -563,7 +563,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -583,7 +583,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -603,7 +603,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -624,7 +624,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -644,7 +644,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -664,7 +664,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -685,7 +685,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -705,7 +705,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -727,7 +727,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -749,7 +749,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -769,7 +769,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -790,7 +790,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -811,7 +811,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -833,7 +833,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -854,7 +854,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -876,7 +876,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -898,7 +898,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -919,7 +919,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -940,7 +940,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -961,7 +961,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -982,7 +982,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1004,7 +1004,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1026,7 +1026,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -32,7 +32,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that
    * contains ProvisioningState=’Succeeded’.
    *
-   * @param {LROsPut200SucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -50,7 +50,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that does
    * not contain ProvisioningState=’Succeeded’.
    *
-   * @param {LROsPut200SucceededNoStateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -69,7 +69,7 @@ export class LROs {
    * that points to a polling URL that returns a 200 and an entity that doesn't contains
    * ProvisioningState
    *
-   * @param {LROsPut202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -88,7 +88,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,7 +107,7 @@ export class LROs {
    * contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsPut200UpdatingSucceeded204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -126,7 +126,7 @@ export class LROs {
    * contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {LROsPut201CreatingFailed200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -145,7 +145,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {LROsPut200Acceptedcanceled200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -163,7 +163,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with location header.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {LROsPutNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -182,7 +182,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -201,7 +201,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -220,7 +220,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -239,7 +239,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncNoRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -257,7 +257,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation
    * header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {LROsPutAsyncNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -274,7 +274,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsPutNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -291,7 +291,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsPutAsyncNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -308,7 +308,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsPutSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -325,7 +325,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsPutAsyncSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -344,7 +344,7 @@ export class LROs {
    * contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -363,7 +363,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -382,7 +382,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -399,7 +399,7 @@ export class LROs {
   /**
    * Long running delete succeeds and returns right away
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -417,7 +417,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -435,7 +435,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -453,7 +453,7 @@ export class LROs {
    * Long running delete request, service returns a location header in the initial request.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -471,7 +471,7 @@ export class LROs {
    * Long running delete request, service returns an Azure-AsyncOperation header in the initial
    * request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -489,7 +489,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -507,7 +507,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -525,7 +525,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -543,7 +543,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -561,7 +561,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header.
    * Poll returns a 200 with a response body after success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -579,7 +579,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' and
    * 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -597,7 +597,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header,
    * 204 with noresponse body after success
    *
-   * @param {LROsPost202NoRetry204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -616,7 +616,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -635,7 +635,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -654,7 +654,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object if you support initial Autorest behavior.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -673,7 +673,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -692,7 +692,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -711,7 +711,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -730,7 +730,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -747,7 +747,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that
    * contains ProvisioningState=’Succeeded’.
    *
-   * @param {LROsBeginPut200SucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -768,7 +768,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that does
    * not contain ProvisioningState=’Succeeded’.
    *
-   * @param {LROsBeginPut200SucceededNoStateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -790,7 +790,7 @@ export class LROs {
    * that points to a polling URL that returns a 200 and an entity that doesn't contains
    * ProvisioningState
    *
-   * @param {LROsBeginPut202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -812,7 +812,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsBeginPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -834,7 +834,7 @@ export class LROs {
    * contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsBeginPut200UpdatingSucceeded204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -856,7 +856,7 @@ export class LROs {
    * contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {LROsBeginPut201CreatingFailed200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -878,7 +878,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {LROsBeginPut200Acceptedcanceled200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -899,7 +899,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with location header.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {LROsBeginPutNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -921,7 +921,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -943,7 +943,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -965,7 +965,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -987,7 +987,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncNoRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1008,7 +1008,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation
    * header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {LROsBeginPutAsyncNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1028,7 +1028,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsBeginPutNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1048,7 +1048,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsBeginPutAsyncNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1068,7 +1068,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsBeginPutSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1088,7 +1088,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsBeginPutAsyncSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1110,7 +1110,7 @@ export class LROs {
    * contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1132,7 +1132,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1154,7 +1154,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1174,7 +1174,7 @@ export class LROs {
   /**
    * Long running delete succeeds and returns right away
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1195,7 +1195,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1216,7 +1216,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1237,7 +1237,7 @@ export class LROs {
    * Long running delete request, service returns a location header in the initial request.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1258,7 +1258,7 @@ export class LROs {
    * Long running delete request, service returns an Azure-AsyncOperation header in the initial
    * request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1279,7 +1279,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1300,7 +1300,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1321,7 +1321,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1342,7 +1342,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1363,7 +1363,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header.
    * Poll returns a 200 with a response body after success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1384,7 +1384,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' and
    * 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsBeginPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1405,7 +1405,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header,
    * 204 with noresponse body after success
    *
-   * @param {LROsBeginPost202NoRetry204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1427,7 +1427,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1449,7 +1449,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1471,7 +1471,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object if you support initial Autorest behavior.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1493,7 +1493,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1515,7 +1515,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1537,7 +1537,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1559,7 +1559,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -34,7 +34,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -52,7 +52,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -71,7 +71,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -90,7 +90,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -147,7 +147,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -165,7 +165,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -184,7 +184,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -241,7 +241,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -259,7 +259,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -276,7 +276,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -293,7 +293,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -310,7 +310,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -327,7 +327,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -346,7 +346,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -365,7 +365,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -384,7 +384,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -401,7 +401,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -419,7 +419,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -437,7 +437,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -455,7 +455,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -473,7 +473,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -491,7 +491,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -509,7 +509,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -527,7 +527,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -545,7 +545,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -563,7 +563,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -581,7 +581,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -599,7 +599,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -618,7 +618,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -637,7 +637,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -656,7 +656,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -675,7 +675,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -694,7 +694,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -713,7 +713,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -732,7 +732,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -749,7 +749,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -770,7 +770,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -792,7 +792,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -814,7 +814,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -836,7 +836,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -858,7 +858,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -880,7 +880,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -901,7 +901,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -923,7 +923,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -945,7 +945,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -967,7 +967,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -989,7 +989,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1010,7 +1010,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1030,7 +1030,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1050,7 +1050,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1070,7 +1070,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1090,7 +1090,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1112,7 +1112,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1134,7 +1134,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1156,7 +1156,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1176,7 +1176,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1197,7 +1197,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1218,7 +1218,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1239,7 +1239,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1260,7 +1260,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1281,7 +1281,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1302,7 +1302,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1323,7 +1323,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1344,7 +1344,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1365,7 +1365,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1386,7 +1386,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1407,7 +1407,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1429,7 +1429,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1451,7 +1451,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1473,7 +1473,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1495,7 +1495,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1517,7 +1517,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1539,7 +1539,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1561,7 +1561,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Lro/operations/lROs.ts
+++ b/test/azure/generated/Lro/operations/lROs.ts
@@ -35,10 +35,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200Succeeded(options?: Models.LROsPut200SucceededOptionalParams): Promise<Models.LROsPut200SucceededResponse> {
     return this.beginPut200Succeeded(options)
@@ -53,10 +49,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200SucceededNoState(options?: Models.LROsPut200SucceededNoStateOptionalParams): Promise<Models.LROsPut200SucceededNoStateResponse> {
     return this.beginPut200SucceededNoState(options)
@@ -72,10 +64,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put202Retry200(options?: Models.LROsPut202Retry200OptionalParams): Promise<Models.LROsPut202Retry200Response> {
     return this.beginPut202Retry200(options)
@@ -91,10 +79,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingSucceeded200(options?: Models.LROsPut201CreatingSucceeded200OptionalParams): Promise<Models.LROsPut201CreatingSucceeded200Response> {
     return this.beginPut201CreatingSucceeded200(options)
@@ -110,10 +94,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200UpdatingSucceeded204(options?: Models.LROsPut200UpdatingSucceeded204OptionalParams): Promise<Models.LROsPut200UpdatingSucceeded204Response> {
     return this.beginPut200UpdatingSucceeded204(options)
@@ -129,10 +109,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingFailed200(options?: Models.LROsPut201CreatingFailed200OptionalParams): Promise<Models.LROsPut201CreatingFailed200Response> {
     return this.beginPut201CreatingFailed200(options)
@@ -148,10 +124,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200Acceptedcanceled200(options?: Models.LROsPut200Acceptedcanceled200OptionalParams): Promise<Models.LROsPut200Acceptedcanceled200Response> {
     return this.beginPut200Acceptedcanceled200(options)
@@ -166,10 +138,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNoHeaderInRetry(options?: Models.LROsPutNoHeaderInRetryOptionalParams): Promise<Models.LROsPutNoHeaderInRetryResponse> {
     return this.beginPutNoHeaderInRetry(options)
@@ -185,10 +153,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRetrySucceeded(options?: Models.LROsPutAsyncRetrySucceededOptionalParams): Promise<Models.LROsPutAsyncRetrySucceededResponse> {
     return this.beginPutAsyncRetrySucceeded(options)
@@ -204,10 +168,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNoRetrySucceeded(options?: Models.LROsPutAsyncNoRetrySucceededOptionalParams): Promise<Models.LROsPutAsyncNoRetrySucceededResponse> {
     return this.beginPutAsyncNoRetrySucceeded(options)
@@ -223,10 +183,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRetryFailed(options?: Models.LROsPutAsyncRetryFailedOptionalParams): Promise<Models.LROsPutAsyncRetryFailedResponse> {
     return this.beginPutAsyncRetryFailed(options)
@@ -242,10 +198,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNoRetrycanceled(options?: Models.LROsPutAsyncNoRetrycanceledOptionalParams): Promise<Models.LROsPutAsyncNoRetrycanceledResponse> {
     return this.beginPutAsyncNoRetrycanceled(options)
@@ -260,10 +212,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNoHeaderInRetry(options?: Models.LROsPutAsyncNoHeaderInRetryOptionalParams): Promise<Models.LROsPutAsyncNoHeaderInRetryResponse> {
     return this.beginPutAsyncNoHeaderInRetry(options)
@@ -277,10 +225,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonResource(options?: Models.LROsPutNonResourceOptionalParams): Promise<Models.LROsPutNonResourceResponse> {
     return this.beginPutNonResource(options)
@@ -294,10 +238,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNonResource(options?: Models.LROsPutAsyncNonResourceOptionalParams): Promise<Models.LROsPutAsyncNonResourceResponse> {
     return this.beginPutAsyncNonResource(options)
@@ -311,10 +251,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSubResource(options?: Models.LROsPutSubResourceOptionalParams): Promise<Models.LROsPutSubResourceResponse> {
     return this.beginPutSubResource(options)
@@ -328,10 +264,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncSubResource(options?: Models.LROsPutAsyncSubResourceOptionalParams): Promise<Models.LROsPutAsyncSubResourceResponse> {
     return this.beginPutAsyncSubResource(options)
@@ -347,10 +279,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteProvisioning202Accepted200SucceededResponse> {
     return this.beginDeleteProvisioning202Accepted200Succeeded(options)
@@ -366,10 +294,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202DeletingFailed200(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteProvisioning202DeletingFailed200Response> {
     return this.beginDeleteProvisioning202DeletingFailed200(options)
@@ -385,10 +309,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202Deletingcanceled200(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteProvisioning202Deletingcanceled200Response> {
     return this.beginDeleteProvisioning202Deletingcanceled200(options)
@@ -402,10 +322,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
     return this.beginDelete204Succeeded(options)
@@ -420,10 +336,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202Retry200(options?: msRest.RequestOptionsBase): Promise<Models.LROsDelete202Retry200Response> {
     return this.beginDelete202Retry200(options)
@@ -438,10 +350,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202NoRetry204(options?: msRest.RequestOptionsBase): Promise<Models.LROsDelete202NoRetry204Response> {
     return this.beginDelete202NoRetry204(options)
@@ -456,10 +364,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteNoHeaderInRetryResponse> {
     return this.beginDeleteNoHeaderInRetry(options)
@@ -474,10 +378,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncNoHeaderInRetryResponse> {
     return this.beginDeleteAsyncNoHeaderInRetry(options)
@@ -492,10 +392,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncRetrySucceededResponse> {
     return this.beginDeleteAsyncRetrySucceeded(options)
@@ -510,10 +406,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncNoRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncNoRetrySucceededResponse> {
     return this.beginDeleteAsyncNoRetrySucceeded(options)
@@ -528,10 +420,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRetryFailed(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncRetryFailedResponse> {
     return this.beginDeleteAsyncRetryFailed(options)
@@ -546,10 +434,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRetrycanceled(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncRetrycanceledResponse> {
     return this.beginDeleteAsyncRetrycanceled(options)
@@ -564,10 +448,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post200WithPayload(options?: msRest.RequestOptionsBase): Promise<Models.LROsPost200WithPayloadResponse> {
     return this.beginPost200WithPayload(options)
@@ -582,10 +462,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202Retry200(options?: Models.LROsPost202Retry200OptionalParams): Promise<Models.LROsPost202Retry200Response> {
     return this.beginPost202Retry200(options)
@@ -600,10 +476,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202NoRetry204(options?: Models.LROsPost202NoRetry204OptionalParams): Promise<Models.LROsPost202NoRetry204Response> {
     return this.beginPost202NoRetry204(options)
@@ -619,10 +491,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postDoubleHeadersFinalLocationGet(options?: msRest.RequestOptionsBase): Promise<Models.LROsPostDoubleHeadersFinalLocationGetResponse> {
     return this.beginPostDoubleHeadersFinalLocationGet(options)
@@ -638,10 +506,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postDoubleHeadersFinalAzureHeaderGet(options?: msRest.RequestOptionsBase): Promise<Models.LROsPostDoubleHeadersFinalAzureHeaderGetResponse> {
     return this.beginPostDoubleHeadersFinalAzureHeaderGet(options)
@@ -657,10 +521,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postDoubleHeadersFinalAzureHeaderGetDefault(options?: msRest.RequestOptionsBase): Promise<Models.LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse> {
     return this.beginPostDoubleHeadersFinalAzureHeaderGetDefault(options)
@@ -676,10 +536,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetrySucceeded(options?: Models.LROsPostAsyncRetrySucceededOptionalParams): Promise<Models.LROsPostAsyncRetrySucceededResponse> {
     return this.beginPostAsyncRetrySucceeded(options)
@@ -695,10 +551,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncNoRetrySucceeded(options?: Models.LROsPostAsyncNoRetrySucceededOptionalParams): Promise<Models.LROsPostAsyncNoRetrySucceededResponse> {
     return this.beginPostAsyncNoRetrySucceeded(options)
@@ -714,10 +566,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetryFailed(options?: Models.LROsPostAsyncRetryFailedOptionalParams): Promise<Models.LROsPostAsyncRetryFailedResponse> {
     return this.beginPostAsyncRetryFailed(options)
@@ -733,10 +581,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetrycanceled(options?: Models.LROsPostAsyncRetrycanceledOptionalParams): Promise<Models.LROsPostAsyncRetrycanceledResponse> {
     return this.beginPostAsyncRetrycanceled(options)
@@ -750,10 +594,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200Succeeded(options?: Models.LROsBeginPut200SucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -771,10 +611,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200SucceededNoState(options?: Models.LROsBeginPut200SucceededNoStateOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -793,10 +629,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut202Retry200(options?: Models.LROsBeginPut202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -815,10 +647,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingSucceeded200(options?: Models.LROsBeginPut201CreatingSucceeded200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -837,10 +665,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200UpdatingSucceeded204(options?: Models.LROsBeginPut200UpdatingSucceeded204OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -859,10 +683,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingFailed200(options?: Models.LROsBeginPut201CreatingFailed200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -881,10 +701,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200Acceptedcanceled200(options?: Models.LROsBeginPut200Acceptedcanceled200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -902,10 +718,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNoHeaderInRetry(options?: Models.LROsBeginPutNoHeaderInRetryOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -924,10 +736,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRetrySucceeded(options?: Models.LROsBeginPutAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -946,10 +754,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNoRetrySucceeded(options?: Models.LROsBeginPutAsyncNoRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -968,10 +772,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRetryFailed(options?: Models.LROsBeginPutAsyncRetryFailedOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -990,10 +790,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNoRetrycanceled(options?: Models.LROsBeginPutAsyncNoRetrycanceledOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1011,10 +807,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNoHeaderInRetry(options?: Models.LROsBeginPutAsyncNoHeaderInRetryOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1031,10 +823,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonResource(options?: Models.LROsBeginPutNonResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1051,10 +839,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNonResource(options?: Models.LROsBeginPutAsyncNonResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1071,10 +855,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutSubResource(options?: Models.LROsBeginPutSubResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1091,10 +871,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncSubResource(options?: Models.LROsBeginPutAsyncSubResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1113,10 +889,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1135,10 +907,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202DeletingFailed200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1157,10 +925,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202Deletingcanceled200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1177,10 +941,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1198,10 +958,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202Retry200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1219,10 +975,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202NoRetry204(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1240,10 +992,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1261,10 +1009,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1282,10 +1026,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1303,10 +1043,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncNoRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1324,10 +1060,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRetryFailed(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1345,10 +1077,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRetrycanceled(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1366,10 +1094,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost200WithPayload(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1387,10 +1111,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202Retry200(options?: Models.LROsBeginPost202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1408,10 +1128,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202NoRetry204(options?: Models.LROsBeginPost202NoRetry204OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1430,10 +1146,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostDoubleHeadersFinalLocationGet(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1452,10 +1164,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostDoubleHeadersFinalAzureHeaderGet(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1474,10 +1182,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostDoubleHeadersFinalAzureHeaderGetDefault(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1496,10 +1200,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetrySucceeded(options?: Models.LROsBeginPostAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1518,10 +1218,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncNoRetrySucceeded(options?: Models.LROsBeginPostAsyncNoRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1540,10 +1236,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetryFailed(options?: Models.LROsBeginPostAsyncRetryFailedOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1562,10 +1254,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetrycanceled(options?: Models.LROsBeginPostAsyncRetrycanceledOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azure/generated/Lro/operations/lROsCustomHeader.ts
+++ b/test/azure/generated/Lro/operations/lROsCustomHeader.ts
@@ -36,7 +36,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -75,7 +75,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -95,7 +95,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -114,7 +114,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -137,7 +137,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -159,7 +159,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -182,7 +182,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Lro/operations/lROsCustomHeader.ts
+++ b/test/azure/generated/Lro/operations/lROsCustomHeader.ts
@@ -37,10 +37,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRetrySucceeded(options?: Models.LROsCustomHeaderPutAsyncRetrySucceededOptionalParams): Promise<Models.LROsCustomHeaderPutAsyncRetrySucceededResponse> {
     return this.beginPutAsyncRetrySucceeded(options)
@@ -57,10 +53,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingSucceeded200(options?: Models.LROsCustomHeaderPut201CreatingSucceeded200OptionalParams): Promise<Models.LROsCustomHeaderPut201CreatingSucceeded200Response> {
     return this.beginPut201CreatingSucceeded200(options)
@@ -76,10 +68,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202Retry200(options?: Models.LROsCustomHeaderPost202Retry200OptionalParams): Promise<Models.LROsCustomHeaderPost202Retry200Response> {
     return this.beginPost202Retry200(options)
@@ -96,10 +84,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetrySucceeded(options?: Models.LROsCustomHeaderPostAsyncRetrySucceededOptionalParams): Promise<Models.LROsCustomHeaderPostAsyncRetrySucceededResponse> {
     return this.beginPostAsyncRetrySucceeded(options)
@@ -115,10 +99,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRetrySucceeded(options?: Models.LROsCustomHeaderBeginPutAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -138,10 +118,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingSucceeded200(options?: Models.LROsCustomHeaderBeginPut201CreatingSucceeded200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -160,10 +136,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202Retry200(options?: Models.LROsCustomHeaderBeginPost202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -183,10 +155,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetrySucceeded(options?: Models.LROsCustomHeaderBeginPostAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azure/generated/Lro/operations/lROsCustomHeader.ts
+++ b/test/azure/generated/Lro/operations/lROsCustomHeader.ts
@@ -34,7 +34,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderPutAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -54,7 +54,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns
    * a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsCustomHeaderPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -73,7 +73,7 @@ export class LROsCustomHeader {
    * requests. Long running post request, service returns a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsCustomHeaderPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -93,7 +93,7 @@ export class LROsCustomHeader {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderPostAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -112,8 +112,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderBeginPutAsyncRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -136,8 +135,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns
    * a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsCustomHeaderBeginPut201CreatingSucceeded200OptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -159,7 +157,7 @@ export class LROsCustomHeader {
    * requests. Long running post request, service returns a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsCustomHeaderBeginPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -182,8 +180,7 @@ export class LROsCustomHeader {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderBeginPostAsyncRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/Paging/autoRestPagingTestService.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestService.ts
@@ -23,12 +23,11 @@ class AutoRestPagingTestService extends AutoRestPagingTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestPagingTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azure/generated/Paging/autoRestPagingTestServiceContext.ts
+++ b/test/azure/generated/Paging/autoRestPagingTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestPagingTestServiceContext extends msRestAzure.AzureServiceCl
   /**
    * Initializes a new instance of the AutoRestPagingTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/Paging/operations/paging.ts
+++ b/test/azure/generated/Paging/operations/paging.ts
@@ -32,7 +32,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -80,7 +80,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -132,7 +132,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -157,7 +157,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -181,7 +181,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -205,7 +205,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -229,7 +229,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -257,7 +257,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -285,7 +285,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -311,7 +311,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -333,7 +333,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -364,7 +364,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -390,7 +390,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -412,7 +412,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -439,7 +439,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -466,7 +466,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -493,7 +493,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -521,7 +521,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -549,7 +549,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -576,7 +576,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -603,7 +603,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -630,7 +630,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -658,7 +658,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -676,7 +676,7 @@ export class Paging {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/Paging/operations/paging.ts
+++ b/test/azure/generated/Paging/operations/paging.ts
@@ -33,10 +33,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSinglePages(): Promise<Models.PagingGetSinglePagesResponse>;
   getSinglePages(options: msRest.RequestOptionsBase): Promise<Models.PagingGetSinglePagesResponse>;
@@ -57,10 +53,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePages(): Promise<Models.PagingGetMultiplePagesResponse>;
   getMultiplePages(options: Models.PagingGetMultiplePagesOptionalParams): Promise<Models.PagingGetMultiplePagesResponse>;
@@ -81,10 +73,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOdataMultiplePages(): Promise<Models.PagingGetOdataMultiplePagesResponse>;
   getOdataMultiplePages(options: Models.PagingGetOdataMultiplePagesOptionalParams): Promise<Models.PagingGetOdataMultiplePagesResponse>;
@@ -107,10 +95,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesWithOffset(pagingGetMultiplePagesWithOffsetOptions: Models.PagingGetMultiplePagesWithOffsetOptions): Promise<Models.PagingGetMultiplePagesWithOffsetResponse>;
   getMultiplePagesWithOffset(pagingGetMultiplePagesWithOffsetOptions: Models.PagingGetMultiplePagesWithOffsetOptions, options: Models.PagingGetMultiplePagesWithOffsetOptionalParams): Promise<Models.PagingGetMultiplePagesWithOffsetResponse>;
@@ -133,10 +117,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesRetryFirst(): Promise<Models.PagingGetMultiplePagesRetryFirstResponse>;
   getMultiplePagesRetryFirst(options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesRetryFirstResponse>;
@@ -158,10 +138,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesRetrySecond(): Promise<Models.PagingGetMultiplePagesRetrySecondResponse>;
   getMultiplePagesRetrySecond(options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesRetrySecondResponse>;
@@ -182,10 +158,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSinglePagesFailure(): Promise<Models.PagingGetSinglePagesFailureResponse>;
   getSinglePagesFailure(options: msRest.RequestOptionsBase): Promise<Models.PagingGetSinglePagesFailureResponse>;
@@ -206,10 +178,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesFailure(): Promise<Models.PagingGetMultiplePagesFailureResponse>;
   getMultiplePagesFailure(options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesFailureResponse>;
@@ -230,10 +198,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesFailureUri(): Promise<Models.PagingGetMultiplePagesFailureUriResponse>;
   getMultiplePagesFailureUri(options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesFailureUriResponse>;
@@ -258,10 +222,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesFragmentNextLink(apiVersion: string, tenant: string): Promise<Models.PagingGetMultiplePagesFragmentNextLinkResponse>;
   getMultiplePagesFragmentNextLink(apiVersion: string, tenant: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesFragmentNextLinkResponse>;
@@ -286,10 +246,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesFragmentWithGroupingNextLink(customParameterGroup: Models.CustomParameterGroup): Promise<Models.PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse>;
   getMultiplePagesFragmentWithGroupingNextLink(customParameterGroup: Models.CustomParameterGroup, options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesFragmentWithGroupingNextLinkResponse>;
@@ -312,10 +268,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesLRO(options?: Models.PagingGetMultiplePagesLROOptionalParams): Promise<Models.PagingGetMultiplePagesLROResponse> {
     return this.beginGetMultiplePagesLRO(options)
@@ -334,10 +286,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   nextFragment(apiVersion: string, tenant: string, nextLink: string): Promise<Models.PagingNextFragmentResponse>;
   nextFragment(apiVersion: string, tenant: string, nextLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingNextFragmentResponse>;
@@ -365,10 +313,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   nextFragmentWithGrouping(nextLink: string, customParameterGroup: Models.CustomParameterGroup): Promise<Models.PagingNextFragmentWithGroupingResponse>;
   nextFragmentWithGrouping(nextLink: string, customParameterGroup: Models.CustomParameterGroup, options: msRest.RequestOptionsBase): Promise<Models.PagingNextFragmentWithGroupingResponse>;
@@ -391,10 +335,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginGetMultiplePagesLRO(options?: Models.PagingBeginGetMultiplePagesLROOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -413,10 +353,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSinglePagesNext(nextPageLink: string): Promise<Models.PagingGetSinglePagesNextResponse>;
   getSinglePagesNext(nextPageLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetSinglePagesNextResponse>;
@@ -440,10 +376,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesNext(nextPageLink: string): Promise<Models.PagingGetMultiplePagesNextResponse>;
   getMultiplePagesNext(nextPageLink: string, options: Models.PagingGetMultiplePagesNextOptionalParams): Promise<Models.PagingGetMultiplePagesNextResponse>;
@@ -467,10 +399,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOdataMultiplePagesNext(nextPageLink: string): Promise<Models.PagingGetOdataMultiplePagesNextResponse>;
   getOdataMultiplePagesNext(nextPageLink: string, options: Models.PagingGetOdataMultiplePagesNextOptionalParams): Promise<Models.PagingGetOdataMultiplePagesNextResponse>;
@@ -494,10 +422,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesWithOffsetNext(nextPageLink: string): Promise<Models.PagingGetMultiplePagesWithOffsetNextResponse>;
   getMultiplePagesWithOffsetNext(nextPageLink: string, options: Models.PagingGetMultiplePagesWithOffsetNextOptionalParams): Promise<Models.PagingGetMultiplePagesWithOffsetNextResponse>;
@@ -522,10 +446,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesRetryFirstNext(nextPageLink: string): Promise<Models.PagingGetMultiplePagesRetryFirstNextResponse>;
   getMultiplePagesRetryFirstNext(nextPageLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesRetryFirstNextResponse>;
@@ -550,10 +470,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesRetrySecondNext(nextPageLink: string): Promise<Models.PagingGetMultiplePagesRetrySecondNextResponse>;
   getMultiplePagesRetrySecondNext(nextPageLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesRetrySecondNextResponse>;
@@ -577,10 +493,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSinglePagesFailureNext(nextPageLink: string): Promise<Models.PagingGetSinglePagesFailureNextResponse>;
   getSinglePagesFailureNext(nextPageLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetSinglePagesFailureNextResponse>;
@@ -604,10 +516,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesFailureNext(nextPageLink: string): Promise<Models.PagingGetMultiplePagesFailureNextResponse>;
   getMultiplePagesFailureNext(nextPageLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesFailureNextResponse>;
@@ -631,10 +539,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesFailureUriNext(nextPageLink: string): Promise<Models.PagingGetMultiplePagesFailureUriNextResponse>;
   getMultiplePagesFailureUriNext(nextPageLink: string, options: msRest.RequestOptionsBase): Promise<Models.PagingGetMultiplePagesFailureUriNextResponse>;
@@ -659,10 +563,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMultiplePagesLRONext(nextPageLink: string, options?: Models.PagingGetMultiplePagesLRONextOptionalParams): Promise<Models.PagingGetMultiplePagesLRONextResponse> {
     return this.beginGetMultiplePagesLRONext(nextPageLink, options)
@@ -677,10 +577,6 @@ export class Paging {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginGetMultiplePagesLRONext(nextPageLink: string, options?: Models.PagingBeginGetMultiplePagesLRONextOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azure/generated/Paging/operations/paging.ts
+++ b/test/azure/generated/Paging/operations/paging.ts
@@ -30,7 +30,7 @@ export class Paging {
   /**
    * A paging operation that finishes on the first call without a nextlink
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -54,7 +54,7 @@ export class Paging {
   /**
    * A paging operation that includes a nextLink that has 10 pages
    *
-   * @param {PagingGetMultiplePagesOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -78,7 +78,7 @@ export class Paging {
   /**
    * A paging operation that includes a nextLink in odata format that has 10 pages
    *
-   * @param {PagingGetOdataMultiplePagesOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -102,10 +102,9 @@ export class Paging {
   /**
    * A paging operation that includes a nextLink that has 10 pages
    *
-   * @param {PagingGetMultiplePagesWithOffsetOptions} pagingGetMultiplePagesWithOffsetOptions
-   * Additional parameters for the operation
+   * @param pagingGetMultiplePagesWithOffsetOptions Additional parameters for the operation
    *
-   * @param {PagingGetMultiplePagesWithOffsetOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -131,7 +130,7 @@ export class Paging {
    * A paging operation that fails on the first call with 500 and then retries and then get a
    * response including a nextLink that has 10 pages
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -156,7 +155,7 @@ export class Paging {
    * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first
    * with 500. The client should retry and finish all 10 pages eventually.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -180,7 +179,7 @@ export class Paging {
   /**
    * A paging operation that receives a 400 on the first call
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -204,7 +203,7 @@ export class Paging {
   /**
    * A paging operation that receives a 400 on the second call
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -228,7 +227,7 @@ export class Paging {
   /**
    * A paging operation that receives an invalid nextLink
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -252,11 +251,11 @@ export class Paging {
   /**
    * A paging operation that doesn't return a full URL, just a fragment
    *
-   * @param {string} apiVersion Sets the api version to use.
+   * @param apiVersion Sets the api version to use.
    *
-   * @param {string} tenant Sets the tenant to use.
+   * @param tenant Sets the tenant to use.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -282,9 +281,9 @@ export class Paging {
   /**
    * A paging operation that doesn't return a full URL, just a fragment with parameters grouped
    *
-   * @param {CustomParameterGroup} customParameterGroup Additional parameters for the operation
+   * @param customParameterGroup Additional parameters for the operation
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -310,7 +309,7 @@ export class Paging {
   /**
    * A long-running paging operation that includes a nextLink that has 10 pages
    *
-   * @param {PagingGetMultiplePagesLROOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -326,13 +325,13 @@ export class Paging {
   /**
    * A paging operation that doesn't return a full URL, just a fragment
    *
-   * @param {string} apiVersion Sets the api version to use.
+   * @param apiVersion Sets the api version to use.
    *
-   * @param {string} tenant Sets the tenant to use.
+   * @param tenant Sets the tenant to use.
    *
-   * @param {string} nextLink Next link for list operation.
+   * @param nextLink Next link for list operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -359,11 +358,11 @@ export class Paging {
   /**
    * A paging operation that doesn't return a full URL, just a fragment
    *
-   * @param {string} nextLink Next link for list operation.
+   * @param nextLink Next link for list operation.
    *
-   * @param {CustomParameterGroup} customParameterGroup Additional parameters for the operation
+   * @param customParameterGroup Additional parameters for the operation
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -389,7 +388,7 @@ export class Paging {
   /**
    * A long-running paging operation that includes a nextLink that has 10 pages
    *
-   * @param {PagingBeginGetMultiplePagesLROOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -409,9 +408,9 @@ export class Paging {
   /**
    * A paging operation that finishes on the first call without a nextlink
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -436,9 +435,9 @@ export class Paging {
   /**
    * A paging operation that includes a nextLink that has 10 pages
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {PagingGetMultiplePagesNextOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -463,9 +462,9 @@ export class Paging {
   /**
    * A paging operation that includes a nextLink in odata format that has 10 pages
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {PagingGetOdataMultiplePagesNextOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -490,9 +489,9 @@ export class Paging {
   /**
    * A paging operation that includes a nextLink that has 10 pages
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {PagingGetMultiplePagesWithOffsetNextOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -518,9 +517,9 @@ export class Paging {
    * A paging operation that fails on the first call with 500 and then retries and then get a
    * response including a nextLink that has 10 pages
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -546,9 +545,9 @@ export class Paging {
    * A paging operation that includes a nextLink that has 10 pages, of which the 2nd call fails first
    * with 500. The client should retry and finish all 10 pages eventually.
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -573,9 +572,9 @@ export class Paging {
   /**
    * A paging operation that receives a 400 on the first call
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -600,9 +599,9 @@ export class Paging {
   /**
    * A paging operation that receives a 400 on the second call
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -627,9 +626,9 @@ export class Paging {
   /**
    * A paging operation that receives an invalid nextLink
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -655,9 +654,9 @@ export class Paging {
   /**
    * A long-running paging operation that includes a nextLink that has 10 pages
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {PagingGetMultiplePagesLRONextOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -673,9 +672,9 @@ export class Paging {
   /**
    * A long-running paging operation that includes a nextLink that has 10 pages
    *
-   * @param {string} nextPageLink The NextLink from the previous successful call to List operation.
+   * @param nextPageLink The NextLink from the previous successful call to List operation.
    *
-   * @param {PagingBeginGetMultiplePagesLRONextOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
+++ b/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
@@ -36,7 +36,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -73,7 +73,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -95,7 +95,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -129,7 +129,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -170,7 +170,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -201,7 +201,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -228,7 +228,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -255,7 +255,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -286,7 +286,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -323,7 +323,7 @@ export class StorageAccounts {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
+++ b/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
@@ -30,11 +30,11 @@ export class StorageAccounts {
   /**
    * Checks that account name is valid and is not in use.
    *
-   * @param {StorageAccountCheckNameAvailabilityParameters} accountName The name of the storage
-   * account within the specified resource group. Storage account names must be between 3 and 24
-   * characters in length and use numbers and lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -63,16 +63,15 @@ export class StorageAccounts {
    * account is already created and subsequent PUT request is issued with exact same set of
    * properties, then HTTP 200 would be returned.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account within the specified resource group.
-   * Storage account names must be between 3 and 24 characters in length and use numbers and
-   * lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {StorageAccountCreateParameters} parameters The parameters to provide for the created
-   * account.
+   * @param parameters The parameters to provide for the created account.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -88,13 +87,13 @@ export class StorageAccounts {
   /**
    * Deletes a storage account in Microsoft Azure.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account within the specified resource group.
-   * Storage account names must be between 3 and 24 characters in length and use numbers and
-   * lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -122,13 +121,13 @@ export class StorageAccounts {
    * account type, location, and account status. The ListKeys operation should be used to retrieve
    * storage keys.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account within the specified resource group.
-   * Storage account names must be between 3 and 24 characters in length and use numbers and
-   * lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -160,16 +159,16 @@ export class StorageAccounts {
    * account. If you want to change storage account keys, use the RegenerateKey operation. The
    * location and name of the storage account cannot be changed after creation.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account within the specified resource group.
-   * Storage account names must be between 3 and 24 characters in length and use numbers and
-   * lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {StorageAccountUpdateParameters} parameters The parameters to update on the account. Note
-   * that only one property can be changed at a time using this API.
+   * @param parameters The parameters to update on the account. Note that only one property can be
+   * changed at a time using this API.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -196,11 +195,11 @@ export class StorageAccounts {
   /**
    * Lists the access keys for the specified storage account.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account.
+   * @param accountName The name of the storage account.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -227,7 +226,7 @@ export class StorageAccounts {
    * Lists all the storage accounts available under the subscription. Note that storage keys are not
    * returned; use the ListKeys operation for this.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -252,9 +251,9 @@ export class StorageAccounts {
    * Lists all the storage accounts available under the given resource group. Note that storage keys
    * are not returned; use the ListKeys operation for this.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -279,13 +278,13 @@ export class StorageAccounts {
   /**
    * Regenerates the access keys for the specified storage account.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account within the specified resource group.
-   * Storage account names must be between 3 and 24 characters in length and use numbers and
-   * lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {StorageAccountsRegenerateKeyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -314,16 +313,15 @@ export class StorageAccounts {
    * account is already created and subsequent PUT request is issued with exact same set of
    * properties, then HTTP 200 would be returned.
    *
-   * @param {string} resourceGroupName The name of the resource group within the user’s subscription.
+   * @param resourceGroupName The name of the resource group within the user’s subscription.
    *
-   * @param {string} accountName The name of the storage account within the specified resource group.
-   * Storage account names must be between 3 and 24 characters in length and use numbers and
-   * lower-case letters only.
+   * @param accountName The name of the storage account within the specified resource group. Storage
+   * account names must be between 3 and 24 characters in length and use numbers and lower-case
+   * letters only.
    *
-   * @param {StorageAccountCreateParameters} parameters The parameters to provide for the created
-   * account.
+   * @param parameters The parameters to provide for the created account.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
+++ b/test/azure/generated/StorageManagementClient/operations/storageAccounts.ts
@@ -37,10 +37,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   checkNameAvailability(accountName: Models.StorageAccountCheckNameAvailabilityParameters): Promise<Models.StorageAccountsCheckNameAvailabilityResponse>;
   checkNameAvailability(accountName: Models.StorageAccountCheckNameAvailabilityParameters, options: msRest.RequestOptionsBase): Promise<Models.StorageAccountsCheckNameAvailabilityResponse>;
@@ -74,10 +70,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   create(resourceGroupName: string, accountName: string, parameters: Models.StorageAccountCreateParameters, options?: msRest.RequestOptionsBase): Promise<Models.StorageAccountsCreateResponse> {
     return this.beginCreate(resourceGroupName, accountName, parameters, options)
@@ -96,10 +88,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteMethod(resourceGroupName: string, accountName: string): Promise<msRest.RestResponse>;
   deleteMethod(resourceGroupName: string, accountName: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -130,10 +118,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getProperties(resourceGroupName: string, accountName: string): Promise<Models.StorageAccountsGetPropertiesResponse>;
   getProperties(resourceGroupName: string, accountName: string, options: msRest.RequestOptionsBase): Promise<Models.StorageAccountsGetPropertiesResponse>;
@@ -171,10 +155,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   update(resourceGroupName: string, accountName: string, parameters: Models.StorageAccountUpdateParameters): Promise<Models.StorageAccountsUpdateResponse>;
   update(resourceGroupName: string, accountName: string, parameters: Models.StorageAccountUpdateParameters, options: msRest.RequestOptionsBase): Promise<Models.StorageAccountsUpdateResponse>;
@@ -202,10 +182,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   listKeys(resourceGroupName: string, accountName: string): Promise<Models.StorageAccountsListKeysResponse>;
   listKeys(resourceGroupName: string, accountName: string, options: msRest.RequestOptionsBase): Promise<Models.StorageAccountsListKeysResponse>;
@@ -229,10 +205,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   list(): Promise<Models.StorageAccountsListResponse>;
   list(options: msRest.RequestOptionsBase): Promise<Models.StorageAccountsListResponse>;
@@ -256,10 +228,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   listByResourceGroup(resourceGroupName: string): Promise<Models.StorageAccountsListByResourceGroupResponse>;
   listByResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase): Promise<Models.StorageAccountsListByResourceGroupResponse>;
@@ -287,10 +255,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   regenerateKey(resourceGroupName: string, accountName: string): Promise<Models.StorageAccountsRegenerateKeyResponse>;
   regenerateKey(resourceGroupName: string, accountName: string, options: Models.StorageAccountsRegenerateKeyOptionalParams): Promise<Models.StorageAccountsRegenerateKeyResponse>;
@@ -324,10 +288,6 @@ export class StorageAccounts {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginCreate(resourceGroupName: string, accountName: string, parameters: Models.StorageAccountCreateParameters, options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
+++ b/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
@@ -29,7 +29,7 @@ export class UsageOperations {
   /**
    * Gets the current usage count and the limit for the resources under the subscription.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
+++ b/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
@@ -32,10 +32,6 @@ export class UsageOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   list(): Promise<Models.UsageListResponse>;
   list(options: msRest.RequestOptionsBase): Promise<Models.UsageListResponse>;

--- a/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
+++ b/test/azure/generated/StorageManagementClient/operations/usageOperations.ts
@@ -31,7 +31,7 @@ export class UsageOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/StorageManagementClient/storageManagementClient.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClient.ts
@@ -24,15 +24,14 @@ class StorageManagementClient extends StorageManagementClientContext {
   /**
    * Initializes a new instance of the StorageManagementClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId Gets subscription credentials which uniquely identify Microsoft
-   * Azure subscription. The subscription ID forms part of the URI for every service call.
+   * @param subscriptionId Gets subscription credentials which uniquely identify Microsoft Azure
+   * subscription. The subscription ID forms part of the URI for every service call.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, subscriptionId, baseUri, options);

--- a/test/azure/generated/StorageManagementClient/storageManagementClientContext.ts
+++ b/test/azure/generated/StorageManagementClient/storageManagementClientContext.ts
@@ -29,15 +29,14 @@ export class StorageManagementClientContext extends msRestAzure.AzureServiceClie
   /**
    * Initializes a new instance of the StorageManagementClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId Gets subscription credentials which uniquely identify Microsoft
-   * Azure subscription. The subscription ID forms part of the URI for every service call.
+   * @param subscriptionId Gets subscription credentials which uniquely identify Microsoft Azure
+   * subscription. The subscription ID forms part of the URI for every service call.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrl.ts
@@ -23,14 +23,13 @@ class MicrosoftAzureTestUrl extends MicrosoftAzureTestUrlContext {
   /**
    * Initializes a new instance of the MicrosoftAzureTestUrl class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId Subscription Id.
+   * @param subscriptionId Subscription Id.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, subscriptionId, baseUri, options);

--- a/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/microsoftAzureTestUrlContext.ts
@@ -29,14 +29,13 @@ export class MicrosoftAzureTestUrlContext extends msRestAzure.AzureServiceClient
   /**
    * Initializes a new instance of the MicrosoftAzureTestUrl class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId Subscription Id.
+   * @param subscriptionId Subscription Id.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
@@ -29,9 +29,9 @@ export class Group {
   /**
    * Provides a resouce group with name 'testgroup101' and location 'West US'.
    *
-   * @param {string} resourceGroupName Resource Group name 'testgroup101'.
+   * @param resourceGroupName Resource Group name 'testgroup101'.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
@@ -33,7 +33,7 @@ export class Group {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
+++ b/test/azure/generated/SubscriptionIdApiVersion/operations/group.ts
@@ -34,10 +34,6 @@ export class Group {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSampleResourceGroup(resourceGroupName: string): Promise<Models.GroupGetSampleResourceGroupResponse>;
   getSampleResourceGroup(resourceGroupName: string, options: msRest.RequestOptionsBase): Promise<Models.GroupGetSampleResourceGroupResponse>;

--- a/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestService.ts
+++ b/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestService.ts
@@ -26,12 +26,11 @@ class AutoRestLongRunningOperationTestService extends AutoRestLongRunningOperati
   /**
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     super(credentials, baseUri, options);

--- a/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestServiceContext.ts
+++ b/test/azuremetadata/generated/Lro/lib/autoRestLongRunningOperationTestServiceContext.ts
@@ -25,12 +25,11 @@ export class AutoRestLongRunningOperationTestServiceContext extends msRestAzure.
   /**
    * Initializes a new instance of the AutoRestLongRunningOperationTestService class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, baseUri?: string, options?: msRestAzure.AzureServiceClientOptions) {
     if (credentials == undefined) {

--- a/test/azuremetadata/generated/Lro/lib/operations/lRORetrys.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lRORetrys.ts
@@ -35,7 +35,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -73,7 +73,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -91,7 +91,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -146,7 +146,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -164,7 +164,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -186,7 +186,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -208,7 +208,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -229,7 +229,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -250,7 +250,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -271,7 +271,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -293,7 +293,7 @@ export class LRORetrys {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lRORetrys.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lRORetrys.ts
@@ -33,7 +33,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LRORetrysPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysPutAsyncRelativeRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -71,7 +71,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -89,7 +89,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Polls
    * return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,7 +107,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class LRORetrys {
    * Long running post request, service returns a 500, then a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LRORetrysPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -144,7 +144,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysPostAsyncRelativeRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -162,7 +162,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LRORetrysBeginPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -184,8 +184,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysBeginPutAsyncRelativeRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -207,7 +206,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Accepted’.  Polls return this value until the last poll
    * returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -228,7 +227,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Polls
    * return this value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -249,7 +248,7 @@ export class LRORetrys {
    * Long running delete request, service returns a 500, then a 202 to the initial request. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -270,7 +269,7 @@ export class LRORetrys {
    * Long running post request, service returns a 500, then a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LRORetrysBeginPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -292,8 +291,7 @@ export class LRORetrys {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LRORetrysBeginPostAsyncRelativeRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lRORetrys.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lRORetrys.ts
@@ -36,10 +36,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingSucceeded200(options?: Models.LRORetrysPut201CreatingSucceeded200OptionalParams): Promise<Models.LRORetrysPut201CreatingSucceeded200Response> {
     return this.beginPut201CreatingSucceeded200(options)
@@ -55,10 +51,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetrySucceeded(options?: Models.LRORetrysPutAsyncRelativeRetrySucceededOptionalParams): Promise<Models.LRORetrysPutAsyncRelativeRetrySucceededResponse> {
     return this.beginPutAsyncRelativeRetrySucceeded(options)
@@ -74,10 +66,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<Models.LRORetrysDeleteProvisioning202Accepted200SucceededResponse> {
     return this.beginDeleteProvisioning202Accepted200Succeeded(options)
@@ -92,10 +80,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202Retry200(options?: msRest.RequestOptionsBase): Promise<Models.LRORetrysDelete202Retry200Response> {
     return this.beginDelete202Retry200(options)
@@ -110,10 +94,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<Models.LRORetrysDeleteAsyncRelativeRetrySucceededResponse> {
     return this.beginDeleteAsyncRelativeRetrySucceeded(options)
@@ -128,10 +108,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202Retry200(options?: Models.LRORetrysPost202Retry200OptionalParams): Promise<Models.LRORetrysPost202Retry200Response> {
     return this.beginPost202Retry200(options)
@@ -147,10 +123,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetrySucceeded(options?: Models.LRORetrysPostAsyncRelativeRetrySucceededOptionalParams): Promise<Models.LRORetrysPostAsyncRelativeRetrySucceededResponse> {
     return this.beginPostAsyncRelativeRetrySucceeded(options)
@@ -165,10 +137,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingSucceeded200(options?: Models.LRORetrysBeginPut201CreatingSucceeded200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -187,10 +155,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetrySucceeded(options?: Models.LRORetrysBeginPutAsyncRelativeRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -209,10 +173,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -230,10 +190,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202Retry200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -251,10 +207,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -272,10 +224,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202Retry200(options?: Models.LRORetrysBeginPost202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -294,10 +242,6 @@ export class LRORetrys {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetrySucceeded(options?: Models.LRORetrysBeginPostAsyncRelativeRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azuremetadata/generated/Lro/lib/operations/lROSADs.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROSADs.ts
@@ -34,10 +34,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonRetry400(options?: Models.LROSADsPutNonRetry400OptionalParams): Promise<Models.LROSADsPutNonRetry400Response> {
     return this.beginPutNonRetry400(options)
@@ -52,10 +48,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonRetry201Creating400(options?: Models.LROSADsPutNonRetry201Creating400OptionalParams): Promise<Models.LROSADsPutNonRetry201Creating400Response> {
     return this.beginPutNonRetry201Creating400(options)
@@ -70,10 +62,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonRetry201Creating400InvalidJson(options?: Models.LROSADsPutNonRetry201Creating400InvalidJsonOptionalParams): Promise<Models.LROSADsPutNonRetry201Creating400InvalidJsonResponse> {
     return this.beginPutNonRetry201Creating400InvalidJson(options)
@@ -88,10 +76,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetry400(options?: Models.LROSADsPutAsyncRelativeRetry400OptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetry400Response> {
     return this.beginPutAsyncRelativeRetry400(options)
@@ -105,10 +89,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteNonRetry400(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteNonRetry400Response> {
     return this.beginDeleteNonRetry400(options)
@@ -122,10 +102,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202NonRetry400(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDelete202NonRetry400Response> {
     return this.beginDelete202NonRetry400(options)
@@ -140,10 +116,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetry400(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetry400Response> {
     return this.beginDeleteAsyncRelativeRetry400(options)
@@ -157,10 +129,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postNonRetry400(options?: Models.LROSADsPostNonRetry400OptionalParams): Promise<Models.LROSADsPostNonRetry400Response> {
     return this.beginPostNonRetry400(options)
@@ -174,10 +142,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202NonRetry400(options?: Models.LROSADsPost202NonRetry400OptionalParams): Promise<Models.LROSADsPost202NonRetry400Response> {
     return this.beginPost202NonRetry400(options)
@@ -192,10 +156,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetry400(options?: Models.LROSADsPostAsyncRelativeRetry400OptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetry400Response> {
     return this.beginPostAsyncRelativeRetry400(options)
@@ -209,10 +169,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putError201NoProvisioningStatePayload(options?: Models.LROSADsPutError201NoProvisioningStatePayloadOptionalParams): Promise<Models.LROSADsPutError201NoProvisioningStatePayloadResponse> {
     return this.beginPutError201NoProvisioningStatePayload(options)
@@ -228,10 +184,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryNoStatus(options?: Models.LROSADsPutAsyncRelativeRetryNoStatusOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryNoStatusResponse> {
     return this.beginPutAsyncRelativeRetryNoStatus(options)
@@ -247,10 +199,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryNoStatusPayload(options?: Models.LROSADsPutAsyncRelativeRetryNoStatusPayloadOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryNoStatusPayloadResponse> {
     return this.beginPutAsyncRelativeRetryNoStatusPayload(options)
@@ -264,10 +212,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
     return this.beginDelete204Succeeded(options)
@@ -282,10 +226,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetryNoStatus(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetryNoStatusResponse> {
     return this.beginDeleteAsyncRelativeRetryNoStatus(options)
@@ -300,10 +240,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202NoLocation(options?: Models.LROSADsPost202NoLocationOptionalParams): Promise<Models.LROSADsPost202NoLocationResponse> {
     return this.beginPost202NoLocation(options)
@@ -319,10 +255,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetryNoPayload(options?: Models.LROSADsPostAsyncRelativeRetryNoPayloadOptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetryNoPayloadResponse> {
     return this.beginPostAsyncRelativeRetryNoPayload(options)
@@ -337,10 +269,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200InvalidJson(options?: Models.LROSADsPut200InvalidJsonOptionalParams): Promise<Models.LROSADsPut200InvalidJsonResponse> {
     return this.beginPut200InvalidJson(options)
@@ -356,10 +284,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsPutAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryInvalidHeaderResponse> {
     return this.beginPutAsyncRelativeRetryInvalidHeader(options)
@@ -375,10 +299,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsPutAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<Models.LROSADsPutAsyncRelativeRetryInvalidJsonPollingResponse> {
     return this.beginPutAsyncRelativeRetryInvalidJsonPolling(options)
@@ -393,10 +313,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202RetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDelete202RetryInvalidHeaderResponse> {
     return this.beginDelete202RetryInvalidHeader(options)
@@ -411,10 +327,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetryInvalidHeaderResponse> {
     return this.beginDeleteAsyncRelativeRetryInvalidHeader(options)
@@ -429,10 +341,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRelativeRetryInvalidJsonPolling(options?: msRest.RequestOptionsBase): Promise<Models.LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingResponse> {
     return this.beginDeleteAsyncRelativeRetryInvalidJsonPolling(options)
@@ -447,10 +355,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202RetryInvalidHeader(options?: Models.LROSADsPost202RetryInvalidHeaderOptionalParams): Promise<Models.LROSADsPost202RetryInvalidHeaderResponse> {
     return this.beginPost202RetryInvalidHeader(options)
@@ -466,10 +370,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsPostAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetryInvalidHeaderResponse> {
     return this.beginPostAsyncRelativeRetryInvalidHeader(options)
@@ -485,10 +385,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsPostAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<Models.LROSADsPostAsyncRelativeRetryInvalidJsonPollingResponse> {
     return this.beginPostAsyncRelativeRetryInvalidJsonPolling(options)
@@ -501,10 +397,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonRetry400(options?: Models.LROSADsBeginPutNonRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -522,10 +414,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonRetry201Creating400(options?: Models.LROSADsBeginPutNonRetry201Creating400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -543,10 +431,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonRetry201Creating400InvalidJson(options?: Models.LROSADsBeginPutNonRetry201Creating400InvalidJsonOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -564,10 +448,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetry400(options?: Models.LROSADsBeginPutAsyncRelativeRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -584,10 +464,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteNonRetry400(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -604,10 +480,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202NonRetry400(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -625,10 +497,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetry400(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -645,10 +513,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostNonRetry400(options?: Models.LROSADsBeginPostNonRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -665,10 +529,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202NonRetry400(options?: Models.LROSADsBeginPost202NonRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -686,10 +546,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetry400(options?: Models.LROSADsBeginPostAsyncRelativeRetry400OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -706,10 +562,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutError201NoProvisioningStatePayload(options?: Models.LROSADsBeginPutError201NoProvisioningStatePayloadOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -728,10 +580,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryNoStatus(options?: Models.LROSADsBeginPutAsyncRelativeRetryNoStatusOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -750,10 +598,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryNoStatusPayload(options?: Models.LROSADsBeginPutAsyncRelativeRetryNoStatusPayloadOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -770,10 +614,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -791,10 +631,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetryNoStatus(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -812,10 +648,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202NoLocation(options?: Models.LROSADsBeginPost202NoLocationOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -834,10 +666,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetryNoPayload(options?: Models.LROSADsBeginPostAsyncRelativeRetryNoPayloadOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -855,10 +683,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200InvalidJson(options?: Models.LROSADsBeginPut200InvalidJsonOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -877,10 +701,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsBeginPutAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -899,10 +719,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsBeginPutAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -920,10 +736,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202RetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -941,10 +753,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetryInvalidHeader(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -962,10 +770,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRelativeRetryInvalidJsonPolling(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -983,10 +787,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202RetryInvalidHeader(options?: Models.LROSADsBeginPost202RetryInvalidHeaderOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1005,10 +805,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetryInvalidHeader(options?: Models.LROSADsBeginPostAsyncRelativeRetryInvalidHeaderOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1027,10 +823,6 @@ export class LROSADs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRelativeRetryInvalidJsonPolling(options?: Models.LROSADsBeginPostAsyncRelativeRetryInvalidJsonPollingOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azuremetadata/generated/Lro/lib/operations/lROSADs.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROSADs.ts
@@ -31,7 +31,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 400 to the initial request
    *
-   * @param {LROSADsPutNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -49,7 +49,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsPutNonRetry201Creating400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -67,8 +67,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsPutNonRetry201Creating400InvalidJsonOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -86,7 +85,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,7 +102,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 400 with an error body
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -120,7 +119,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 202 with a location header
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -138,7 +137,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -155,7 +154,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 400 with no error body
    *
-   * @param {LROSADsPostNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,7 +171,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 202 with a location header
    *
-   * @param {LROSADsPost202NonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -190,7 +189,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsPostAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -207,8 +206,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 201 to the initial request with no payload
    *
-   * @param {LROSADsPutError201NoProvisioningStatePayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -227,7 +225,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetryNoStatusOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -246,8 +244,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetryNoStatusPayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -264,7 +261,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 204 to the initial request, indicating success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -282,7 +279,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -300,7 +297,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, without a location
    * header.
    *
-   * @param {LROSADsPost202NoLocationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -319,7 +316,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPostAsyncRelativeRetryNoPayloadOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -337,7 +334,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 to the initial request, with an entity that is
    * not a valid json
    *
-   * @param {LROSADsPut200InvalidJsonOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -356,7 +353,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsPutAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -375,8 +372,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPutAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -394,7 +390,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request receing a reponse with
    * an invalid 'Location' and 'Retry-After' headers
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -412,7 +408,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. The endpoint
    * indicated in the Azure-AsyncOperation header is invalid
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -430,7 +426,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -448,7 +444,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, with invalid 'Location'
    * and 'Retry-After' headers.
    *
-   * @param {LROSADsPost202RetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -467,7 +463,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsPostAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -486,8 +482,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsPostAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -503,7 +498,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 400 to the initial request
    *
-   * @param {LROSADsBeginPutNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -524,7 +519,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsBeginPutNonRetry201Creating400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -545,8 +540,7 @@ export class LROSADs {
    * Long running put request, service returns a Product with 'ProvisioningState' = 'Creating' and
    * 201 response code
    *
-   * @param {LROSADsBeginPutNonRetry201Creating400InvalidJsonOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -567,7 +561,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 with ProvisioningState=’Creating’. Poll the
    * endpoint indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -587,7 +581,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 400 with an error body
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -607,7 +601,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 202 with a location header
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -628,7 +622,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -648,7 +642,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 400 with no error body
    *
-   * @param {LROSADsBeginPostNonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -668,7 +662,7 @@ export class LROSADs {
   /**
    * Long running post request, service returns a 202 with a location header
    *
-   * @param {LROSADsBeginPost202NonRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -689,7 +683,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetry400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -709,8 +703,7 @@ export class LROSADs {
   /**
    * Long running put request, service returns a 201 to the initial request with no payload
    *
-   * @param {LROSADsBeginPutError201NoProvisioningStatePayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -732,7 +725,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryNoStatusOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -754,8 +747,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryNoStatusPayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -775,7 +767,7 @@ export class LROSADs {
   /**
    * Long running delete request, service returns a 204 to the initial request, indicating success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -796,7 +788,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -817,7 +809,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, without a location
    * header.
    *
-   * @param {LROSADsBeginPost202NoLocationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -839,8 +831,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetryNoPayloadOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -861,7 +852,7 @@ export class LROSADs {
    * Long running put request, service returns a 200 to the initial request, with an entity that is
    * not a valid json
    *
-   * @param {LROSADsBeginPut200InvalidJsonOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -883,8 +874,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -906,8 +896,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPutAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -928,7 +917,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request receing a reponse with
    * an invalid 'Location' and 'Retry-After' headers
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -949,7 +938,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. The endpoint
    * indicated in the Azure-AsyncOperation header is invalid
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -970,7 +959,7 @@ export class LROSADs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -991,7 +980,7 @@ export class LROSADs {
    * Long running post request, service returns a 202 to the initial request, with invalid 'Location'
    * and 'Retry-After' headers.
    *
-   * @param {LROSADsBeginPost202RetryInvalidHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1013,8 +1002,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. The endpoint indicated in the Azure-AsyncOperation header
    * is invalid.
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetryInvalidHeaderOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1036,8 +1024,7 @@ export class LROSADs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROSADsBeginPostAsyncRelativeRetryInvalidJsonPollingOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lROSADs.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROSADs.ts
@@ -33,7 +33,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -51,7 +51,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -69,7 +69,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -87,7 +87,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -104,7 +104,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -121,7 +121,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -139,7 +139,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -156,7 +156,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -173,7 +173,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -191,7 +191,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -208,7 +208,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -227,7 +227,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -246,7 +246,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -263,7 +263,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -281,7 +281,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -299,7 +299,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -318,7 +318,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -336,7 +336,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -355,7 +355,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -374,7 +374,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -392,7 +392,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -410,7 +410,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -428,7 +428,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -446,7 +446,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -465,7 +465,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -484,7 +484,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -500,7 +500,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -521,7 +521,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -542,7 +542,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -563,7 +563,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -583,7 +583,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -603,7 +603,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -624,7 +624,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -644,7 +644,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -664,7 +664,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -685,7 +685,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -705,7 +705,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -727,7 +727,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -749,7 +749,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -769,7 +769,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -790,7 +790,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -811,7 +811,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -833,7 +833,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -854,7 +854,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -876,7 +876,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -898,7 +898,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -919,7 +919,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -940,7 +940,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -961,7 +961,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -982,7 +982,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1004,7 +1004,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1026,7 +1026,7 @@ export class LROSADs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lROs.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROs.ts
@@ -32,7 +32,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that
    * contains ProvisioningState=’Succeeded’.
    *
-   * @param {LROsPut200SucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -50,7 +50,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that does
    * not contain ProvisioningState=’Succeeded’.
    *
-   * @param {LROsPut200SucceededNoStateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -69,7 +69,7 @@ export class LROs {
    * that points to a polling URL that returns a 200 and an entity that doesn't contains
    * ProvisioningState
    *
-   * @param {LROsPut202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -88,7 +88,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,7 +107,7 @@ export class LROs {
    * contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsPut200UpdatingSucceeded204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -126,7 +126,7 @@ export class LROs {
    * contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {LROsPut201CreatingFailed200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -145,7 +145,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {LROsPut200Acceptedcanceled200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -163,7 +163,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with location header.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {LROsPutNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -182,7 +182,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -201,7 +201,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -220,7 +220,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -239,7 +239,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPutAsyncNoRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -257,7 +257,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation
    * header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {LROsPutAsyncNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -274,7 +274,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsPutNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -291,7 +291,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsPutAsyncNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -308,7 +308,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsPutSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -325,7 +325,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsPutAsyncSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -344,7 +344,7 @@ export class LROs {
    * contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -363,7 +363,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -382,7 +382,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -399,7 +399,7 @@ export class LROs {
   /**
    * Long running delete succeeds and returns right away
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -417,7 +417,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -435,7 +435,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -453,7 +453,7 @@ export class LROs {
    * Long running delete request, service returns a location header in the initial request.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -471,7 +471,7 @@ export class LROs {
    * Long running delete request, service returns an Azure-AsyncOperation header in the initial
    * request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -489,7 +489,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -507,7 +507,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -525,7 +525,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -543,7 +543,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -561,7 +561,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header.
    * Poll returns a 200 with a response body after success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -579,7 +579,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' and
    * 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -597,7 +597,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header,
    * 204 with noresponse body after success
    *
-   * @param {LROsPost202NoRetry204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -616,7 +616,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -635,7 +635,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -654,7 +654,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object if you support initial Autorest behavior.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -673,7 +673,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -692,7 +692,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -711,7 +711,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -730,7 +730,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsPostAsyncRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -747,7 +747,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that
    * contains ProvisioningState=’Succeeded’.
    *
-   * @param {LROsBeginPut200SucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -768,7 +768,7 @@ export class LROs {
    * Long running put request, service returns a 200 to the initial request, with an entity that does
    * not contain ProvisioningState=’Succeeded’.
    *
-   * @param {LROsBeginPut200SucceededNoStateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -790,7 +790,7 @@ export class LROs {
    * that points to a polling URL that returns a 200 and an entity that doesn't contains
    * ProvisioningState
    *
-   * @param {LROsBeginPut202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -812,7 +812,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsBeginPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -834,7 +834,7 @@ export class LROs {
    * contains ProvisioningState=’Updating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsBeginPut200UpdatingSucceeded204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -856,7 +856,7 @@ export class LROs {
    * contains ProvisioningState=’Created’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {LROsBeginPut201CreatingFailed200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -878,7 +878,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {LROsBeginPut200Acceptedcanceled200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -899,7 +899,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with location header.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {LROsBeginPutNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -921,7 +921,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -943,7 +943,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -965,7 +965,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -987,7 +987,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPutAsyncNoRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1008,7 +1008,7 @@ export class LROs {
    * Long running put request, service returns a 202 to the initial request with Azure-AsyncOperation
    * header. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {LROsBeginPutAsyncNoHeaderInRetryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1028,7 +1028,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsBeginPutNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1048,7 +1048,7 @@ export class LROs {
   /**
    * Long running put request with non resource.
    *
-   * @param {LROsBeginPutAsyncNonResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1068,7 +1068,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsBeginPutSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1088,7 +1088,7 @@ export class LROs {
   /**
    * Long running put request with sub resource.
    *
-   * @param {LROsBeginPutAsyncSubResourceOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1110,7 +1110,7 @@ export class LROs {
    * contains ProvisioningState=’Accepted’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1132,7 +1132,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Failed’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1154,7 +1154,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns a
    * ‘200’ with ProvisioningState=’Canceled’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1174,7 +1174,7 @@ export class LROs {
   /**
    * Long running delete succeeds and returns right away
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1195,7 +1195,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1216,7 +1216,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Polls return this
    * value until the last poll returns a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1237,7 +1237,7 @@ export class LROs {
    * Long running delete request, service returns a location header in the initial request.
    * Subsequent calls to operation status do not contain location header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1258,7 +1258,7 @@ export class LROs {
    * Long running delete request, service returns an Azure-AsyncOperation header in the initial
    * request. Subsequent calls to operation status do not contain Azure-AsyncOperation header.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1279,7 +1279,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1300,7 +1300,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1321,7 +1321,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1342,7 +1342,7 @@ export class LROs {
    * Long running delete request, service returns a 202 to the initial request. Poll the endpoint
    * indicated in the Azure-AsyncOperation header for operation status
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1363,7 +1363,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header.
    * Poll returns a 200 with a response body after success.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1384,7 +1384,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' and
    * 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsBeginPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1405,7 +1405,7 @@ export class LROs {
    * Long running post request, service returns a 202 to the initial request, with 'Location' header,
    * 204 with noresponse body after success
    *
-   * @param {LROsBeginPost202NoRetry204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1427,7 +1427,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1449,7 +1449,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1471,7 +1471,7 @@ export class LROs {
    * Azure-Async header. Poll Azure-Async and it's success. Should NOT poll Location to get the final
    * object if you support initial Autorest behavior.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1493,7 +1493,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1515,7 +1515,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncNoRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1537,7 +1537,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncRetryFailedOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1559,7 +1559,7 @@ export class LROs {
    * contains ProvisioningState=’Creating’. Poll the endpoint indicated in the Azure-AsyncOperation
    * header for operation status
    *
-   * @param {LROsBeginPostAsyncRetrycanceledOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lROs.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROs.ts
@@ -34,7 +34,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -52,7 +52,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -71,7 +71,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -90,7 +90,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -147,7 +147,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -165,7 +165,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -184,7 +184,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -241,7 +241,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -259,7 +259,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -276,7 +276,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -293,7 +293,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -310,7 +310,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -327,7 +327,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -346,7 +346,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -365,7 +365,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -384,7 +384,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -401,7 +401,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -419,7 +419,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -437,7 +437,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -455,7 +455,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -473,7 +473,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -491,7 +491,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -509,7 +509,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -527,7 +527,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -545,7 +545,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -563,7 +563,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -581,7 +581,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -599,7 +599,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -618,7 +618,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -637,7 +637,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -656,7 +656,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -675,7 +675,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -694,7 +694,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -713,7 +713,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -732,7 +732,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -749,7 +749,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -770,7 +770,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -792,7 +792,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -814,7 +814,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -836,7 +836,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -858,7 +858,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -880,7 +880,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -901,7 +901,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -923,7 +923,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -945,7 +945,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -967,7 +967,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -989,7 +989,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1010,7 +1010,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1030,7 +1030,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1050,7 +1050,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1070,7 +1070,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1090,7 +1090,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1112,7 +1112,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1134,7 +1134,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1156,7 +1156,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1176,7 +1176,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1197,7 +1197,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1218,7 +1218,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1239,7 +1239,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1260,7 +1260,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1281,7 +1281,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1302,7 +1302,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1323,7 +1323,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1344,7 +1344,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1365,7 +1365,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1386,7 +1386,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1407,7 +1407,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1429,7 +1429,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1451,7 +1451,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1473,7 +1473,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1495,7 +1495,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1517,7 +1517,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1539,7 +1539,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1561,7 +1561,7 @@ export class LROs {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lROs.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROs.ts
@@ -35,10 +35,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200Succeeded(options?: Models.LROsPut200SucceededOptionalParams): Promise<Models.LROsPut200SucceededResponse> {
     return this.beginPut200Succeeded(options)
@@ -53,10 +49,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200SucceededNoState(options?: Models.LROsPut200SucceededNoStateOptionalParams): Promise<Models.LROsPut200SucceededNoStateResponse> {
     return this.beginPut200SucceededNoState(options)
@@ -72,10 +64,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put202Retry200(options?: Models.LROsPut202Retry200OptionalParams): Promise<Models.LROsPut202Retry200Response> {
     return this.beginPut202Retry200(options)
@@ -91,10 +79,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingSucceeded200(options?: Models.LROsPut201CreatingSucceeded200OptionalParams): Promise<Models.LROsPut201CreatingSucceeded200Response> {
     return this.beginPut201CreatingSucceeded200(options)
@@ -110,10 +94,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200UpdatingSucceeded204(options?: Models.LROsPut200UpdatingSucceeded204OptionalParams): Promise<Models.LROsPut200UpdatingSucceeded204Response> {
     return this.beginPut200UpdatingSucceeded204(options)
@@ -129,10 +109,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingFailed200(options?: Models.LROsPut201CreatingFailed200OptionalParams): Promise<Models.LROsPut201CreatingFailed200Response> {
     return this.beginPut201CreatingFailed200(options)
@@ -148,10 +124,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200Acceptedcanceled200(options?: Models.LROsPut200Acceptedcanceled200OptionalParams): Promise<Models.LROsPut200Acceptedcanceled200Response> {
     return this.beginPut200Acceptedcanceled200(options)
@@ -166,10 +138,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNoHeaderInRetry(options?: Models.LROsPutNoHeaderInRetryOptionalParams): Promise<Models.LROsPutNoHeaderInRetryResponse> {
     return this.beginPutNoHeaderInRetry(options)
@@ -185,10 +153,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRetrySucceeded(options?: Models.LROsPutAsyncRetrySucceededOptionalParams): Promise<Models.LROsPutAsyncRetrySucceededResponse> {
     return this.beginPutAsyncRetrySucceeded(options)
@@ -204,10 +168,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNoRetrySucceeded(options?: Models.LROsPutAsyncNoRetrySucceededOptionalParams): Promise<Models.LROsPutAsyncNoRetrySucceededResponse> {
     return this.beginPutAsyncNoRetrySucceeded(options)
@@ -223,10 +183,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRetryFailed(options?: Models.LROsPutAsyncRetryFailedOptionalParams): Promise<Models.LROsPutAsyncRetryFailedResponse> {
     return this.beginPutAsyncRetryFailed(options)
@@ -242,10 +198,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNoRetrycanceled(options?: Models.LROsPutAsyncNoRetrycanceledOptionalParams): Promise<Models.LROsPutAsyncNoRetrycanceledResponse> {
     return this.beginPutAsyncNoRetrycanceled(options)
@@ -260,10 +212,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNoHeaderInRetry(options?: Models.LROsPutAsyncNoHeaderInRetryOptionalParams): Promise<Models.LROsPutAsyncNoHeaderInRetryResponse> {
     return this.beginPutAsyncNoHeaderInRetry(options)
@@ -277,10 +225,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonResource(options?: Models.LROsPutNonResourceOptionalParams): Promise<Models.LROsPutNonResourceResponse> {
     return this.beginPutNonResource(options)
@@ -294,10 +238,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncNonResource(options?: Models.LROsPutAsyncNonResourceOptionalParams): Promise<Models.LROsPutAsyncNonResourceResponse> {
     return this.beginPutAsyncNonResource(options)
@@ -311,10 +251,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSubResource(options?: Models.LROsPutSubResourceOptionalParams): Promise<Models.LROsPutSubResourceResponse> {
     return this.beginPutSubResource(options)
@@ -328,10 +264,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncSubResource(options?: Models.LROsPutAsyncSubResourceOptionalParams): Promise<Models.LROsPutAsyncSubResourceResponse> {
     return this.beginPutAsyncSubResource(options)
@@ -347,10 +279,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteProvisioning202Accepted200SucceededResponse> {
     return this.beginDeleteProvisioning202Accepted200Succeeded(options)
@@ -366,10 +294,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202DeletingFailed200(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteProvisioning202DeletingFailed200Response> {
     return this.beginDeleteProvisioning202DeletingFailed200(options)
@@ -385,10 +309,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteProvisioning202Deletingcanceled200(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteProvisioning202Deletingcanceled200Response> {
     return this.beginDeleteProvisioning202Deletingcanceled200(options)
@@ -402,10 +322,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRest.RestResponse> {
     return this.beginDelete204Succeeded(options)
@@ -420,10 +336,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202Retry200(options?: msRest.RequestOptionsBase): Promise<Models.LROsDelete202Retry200Response> {
     return this.beginDelete202Retry200(options)
@@ -438,10 +350,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202NoRetry204(options?: msRest.RequestOptionsBase): Promise<Models.LROsDelete202NoRetry204Response> {
     return this.beginDelete202NoRetry204(options)
@@ -456,10 +364,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteNoHeaderInRetryResponse> {
     return this.beginDeleteNoHeaderInRetry(options)
@@ -474,10 +378,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncNoHeaderInRetryResponse> {
     return this.beginDeleteAsyncNoHeaderInRetry(options)
@@ -492,10 +392,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncRetrySucceededResponse> {
     return this.beginDeleteAsyncRetrySucceeded(options)
@@ -510,10 +406,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncNoRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncNoRetrySucceededResponse> {
     return this.beginDeleteAsyncNoRetrySucceeded(options)
@@ -528,10 +420,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRetryFailed(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncRetryFailedResponse> {
     return this.beginDeleteAsyncRetryFailed(options)
@@ -546,10 +434,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   deleteAsyncRetrycanceled(options?: msRest.RequestOptionsBase): Promise<Models.LROsDeleteAsyncRetrycanceledResponse> {
     return this.beginDeleteAsyncRetrycanceled(options)
@@ -564,10 +448,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post200WithPayload(options?: msRest.RequestOptionsBase): Promise<Models.LROsPost200WithPayloadResponse> {
     return this.beginPost200WithPayload(options)
@@ -582,10 +462,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202Retry200(options?: Models.LROsPost202Retry200OptionalParams): Promise<Models.LROsPost202Retry200Response> {
     return this.beginPost202Retry200(options)
@@ -600,10 +476,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202NoRetry204(options?: Models.LROsPost202NoRetry204OptionalParams): Promise<Models.LROsPost202NoRetry204Response> {
     return this.beginPost202NoRetry204(options)
@@ -619,10 +491,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postDoubleHeadersFinalLocationGet(options?: msRest.RequestOptionsBase): Promise<Models.LROsPostDoubleHeadersFinalLocationGetResponse> {
     return this.beginPostDoubleHeadersFinalLocationGet(options)
@@ -638,10 +506,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postDoubleHeadersFinalAzureHeaderGet(options?: msRest.RequestOptionsBase): Promise<Models.LROsPostDoubleHeadersFinalAzureHeaderGetResponse> {
     return this.beginPostDoubleHeadersFinalAzureHeaderGet(options)
@@ -657,10 +521,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postDoubleHeadersFinalAzureHeaderGetDefault(options?: msRest.RequestOptionsBase): Promise<Models.LROsPostDoubleHeadersFinalAzureHeaderGetDefaultResponse> {
     return this.beginPostDoubleHeadersFinalAzureHeaderGetDefault(options)
@@ -676,10 +536,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetrySucceeded(options?: Models.LROsPostAsyncRetrySucceededOptionalParams): Promise<Models.LROsPostAsyncRetrySucceededResponse> {
     return this.beginPostAsyncRetrySucceeded(options)
@@ -695,10 +551,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncNoRetrySucceeded(options?: Models.LROsPostAsyncNoRetrySucceededOptionalParams): Promise<Models.LROsPostAsyncNoRetrySucceededResponse> {
     return this.beginPostAsyncNoRetrySucceeded(options)
@@ -714,10 +566,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetryFailed(options?: Models.LROsPostAsyncRetryFailedOptionalParams): Promise<Models.LROsPostAsyncRetryFailedResponse> {
     return this.beginPostAsyncRetryFailed(options)
@@ -733,10 +581,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetrycanceled(options?: Models.LROsPostAsyncRetrycanceledOptionalParams): Promise<Models.LROsPostAsyncRetrycanceledResponse> {
     return this.beginPostAsyncRetrycanceled(options)
@@ -750,10 +594,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200Succeeded(options?: Models.LROsBeginPut200SucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -771,10 +611,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200SucceededNoState(options?: Models.LROsBeginPut200SucceededNoStateOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -793,10 +629,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut202Retry200(options?: Models.LROsBeginPut202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -815,10 +647,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingSucceeded200(options?: Models.LROsBeginPut201CreatingSucceeded200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -837,10 +665,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200UpdatingSucceeded204(options?: Models.LROsBeginPut200UpdatingSucceeded204OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -859,10 +683,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingFailed200(options?: Models.LROsBeginPut201CreatingFailed200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -881,10 +701,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut200Acceptedcanceled200(options?: Models.LROsBeginPut200Acceptedcanceled200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -902,10 +718,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNoHeaderInRetry(options?: Models.LROsBeginPutNoHeaderInRetryOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -924,10 +736,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRetrySucceeded(options?: Models.LROsBeginPutAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -946,10 +754,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNoRetrySucceeded(options?: Models.LROsBeginPutAsyncNoRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -968,10 +772,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRetryFailed(options?: Models.LROsBeginPutAsyncRetryFailedOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -990,10 +790,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNoRetrycanceled(options?: Models.LROsBeginPutAsyncNoRetrycanceledOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1011,10 +807,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNoHeaderInRetry(options?: Models.LROsBeginPutAsyncNoHeaderInRetryOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1031,10 +823,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutNonResource(options?: Models.LROsBeginPutNonResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1051,10 +839,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncNonResource(options?: Models.LROsBeginPutAsyncNonResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1071,10 +855,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutSubResource(options?: Models.LROsBeginPutSubResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1091,10 +871,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncSubResource(options?: Models.LROsBeginPutAsyncSubResourceOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1113,10 +889,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202Accepted200Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1135,10 +907,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202DeletingFailed200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1157,10 +925,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteProvisioning202Deletingcanceled200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1177,10 +941,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete204Succeeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1198,10 +958,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202Retry200(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1219,10 +975,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDelete202NoRetry204(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1240,10 +992,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1261,10 +1009,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncNoHeaderInRetry(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1282,10 +1026,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1303,10 +1043,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncNoRetrySucceeded(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1324,10 +1060,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRetryFailed(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1345,10 +1077,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginDeleteAsyncRetrycanceled(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1366,10 +1094,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost200WithPayload(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1387,10 +1111,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202Retry200(options?: Models.LROsBeginPost202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1408,10 +1128,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202NoRetry204(options?: Models.LROsBeginPost202NoRetry204OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1430,10 +1146,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostDoubleHeadersFinalLocationGet(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1452,10 +1164,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostDoubleHeadersFinalAzureHeaderGet(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1474,10 +1182,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostDoubleHeadersFinalAzureHeaderGetDefault(options?: msRest.RequestOptionsBase): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1496,10 +1200,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetrySucceeded(options?: Models.LROsBeginPostAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1518,10 +1218,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncNoRetrySucceeded(options?: Models.LROsBeginPostAsyncNoRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1540,10 +1236,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetryFailed(options?: Models.LROsBeginPostAsyncRetryFailedOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -1562,10 +1254,6 @@ export class LROs {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetrycanceled(options?: Models.LROsBeginPostAsyncRetrycanceledOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azuremetadata/generated/Lro/lib/operations/lROsCustomHeader.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROsCustomHeader.ts
@@ -36,7 +36,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -75,7 +75,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -95,7 +95,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -114,7 +114,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -137,7 +137,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -159,7 +159,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -182,7 +182,7 @@ export class LROsCustomHeader {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/azuremetadata/generated/Lro/lib/operations/lROsCustomHeader.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROsCustomHeader.ts
@@ -37,10 +37,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAsyncRetrySucceeded(options?: Models.LROsCustomHeaderPutAsyncRetrySucceededOptionalParams): Promise<Models.LROsCustomHeaderPutAsyncRetrySucceededResponse> {
     return this.beginPutAsyncRetrySucceeded(options)
@@ -57,10 +53,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201CreatingSucceeded200(options?: Models.LROsCustomHeaderPut201CreatingSucceeded200OptionalParams): Promise<Models.LROsCustomHeaderPut201CreatingSucceeded200Response> {
     return this.beginPut201CreatingSucceeded200(options)
@@ -76,10 +68,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202Retry200(options?: Models.LROsCustomHeaderPost202Retry200OptionalParams): Promise<Models.LROsCustomHeaderPost202Retry200Response> {
     return this.beginPost202Retry200(options)
@@ -96,10 +84,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postAsyncRetrySucceeded(options?: Models.LROsCustomHeaderPostAsyncRetrySucceededOptionalParams): Promise<Models.LROsCustomHeaderPostAsyncRetrySucceededResponse> {
     return this.beginPostAsyncRetrySucceeded(options)
@@ -115,10 +99,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPutAsyncRetrySucceeded(options?: Models.LROsCustomHeaderBeginPutAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -138,10 +118,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPut201CreatingSucceeded200(options?: Models.LROsCustomHeaderBeginPut201CreatingSucceeded200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -160,10 +136,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPost202Retry200(options?: Models.LROsCustomHeaderBeginPost202Retry200OptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(
@@ -183,10 +155,6 @@ export class LROsCustomHeader {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   beginPostAsyncRetrySucceeded(options?: Models.LROsCustomHeaderBeginPostAsyncRetrySucceededOptionalParams): Promise<msRestAzure.LROPoller> {
     return this.client.sendLRORequest(

--- a/test/azuremetadata/generated/Lro/lib/operations/lROsCustomHeader.ts
+++ b/test/azuremetadata/generated/Lro/lib/operations/lROsCustomHeader.ts
@@ -34,7 +34,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderPutAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -54,7 +54,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns
    * a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsCustomHeaderPut201CreatingSucceeded200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -73,7 +73,7 @@ export class LROsCustomHeader {
    * requests. Long running post request, service returns a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsCustomHeaderPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -93,7 +93,7 @@ export class LROsCustomHeader {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderPostAsyncRetrySucceededOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -112,8 +112,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderBeginPutAsyncRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -136,8 +135,7 @@ export class LROsCustomHeader {
    * that contains ProvisioningState=’Creating’.  Polls return this value until the last poll returns
    * a ‘200’ with ProvisioningState=’Succeeded’
    *
-   * @param {LROsCustomHeaderBeginPut201CreatingSucceeded200OptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -159,7 +157,7 @@ export class LROsCustomHeader {
    * requests. Long running post request, service returns a 202 to the initial request, with
    * 'Location' and 'Retry-After' headers, Polls return a 200 with a response body after success
    *
-   * @param {LROsCustomHeaderBeginPost202Retry200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -182,8 +180,7 @@ export class LROsCustomHeader {
    * entity that contains ProvisioningState=’Creating’. Poll the endpoint indicated in the
    * Azure-AsyncOperation header for operation status
    *
-   * @param {LROsCustomHeaderBeginPostAsyncRetrySucceededOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/date-time-as-string/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/date-time-as-string/generated/BodyDate/autoRestDateTestService.ts
@@ -21,9 +21,9 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestDateTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/date-time-as-string/generated/BodyDate/autoRestDateTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDate/autoRestDateTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestDateTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestDateTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/date-time-as-string/generated/BodyDate/operations/dateModel.ts
+++ b/test/date-time-as-string/generated/BodyDate/operations/dateModel.ts
@@ -30,7 +30,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -179,7 +179,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -204,7 +204,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/date-time-as-string/generated/BodyDate/operations/dateModel.ts
+++ b/test/date-time-as-string/generated/BodyDate/operations/dateModel.ts
@@ -28,7 +28,7 @@ export class DateModel {
   /**
    * Get null date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class DateModel {
   /**
    * Get invalid date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class DateModel {
   /**
    * Get overflow date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class DateModel {
   /**
    * Get underflow date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,9 +124,9 @@ export class DateModel {
   /**
    * Put max date value 9999-12-31
    *
-   * @param {Date | string} dateBody
+   * @param dateBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class DateModel {
   /**
    * Get max date value 9999-12-31
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,9 +175,9 @@ export class DateModel {
   /**
    * Put min date value 0000-01-01
    *
-   * @param {Date | string} dateBody
+   * @param dateBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -202,7 +202,7 @@ export class DateModel {
   /**
    * Get min date value 0000-01-01
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/date-time-as-string/generated/BodyDate/operations/dateModel.ts
+++ b/test/date-time-as-string/generated/BodyDate/operations/dateModel.ts
@@ -31,10 +31,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DateModelGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetNullResponse>;
@@ -55,10 +51,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidDate(): Promise<Models.DateModelGetInvalidDateResponse>;
   getInvalidDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetInvalidDateResponse>;
@@ -79,10 +71,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflowDate(): Promise<Models.DateModelGetOverflowDateResponse>;
   getOverflowDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetOverflowDateResponse>;
@@ -103,10 +91,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflowDate(): Promise<Models.DateModelGetUnderflowDateResponse>;
   getUnderflowDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetUnderflowDateResponse>;
@@ -129,10 +113,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMaxDate(dateBody: Date | string): Promise<msRest.RestResponse>;
   putMaxDate(dateBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -154,10 +134,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMaxDate(): Promise<Models.DateModelGetMaxDateResponse>;
   getMaxDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetMaxDateResponse>;
@@ -180,10 +156,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMinDate(dateBody: Date | string): Promise<msRest.RestResponse>;
   putMinDate(dateBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -205,10 +177,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMinDate(): Promise<Models.DateModelGetMinDateResponse>;
   getMinDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetMinDateResponse>;

--- a/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -21,9 +21,9 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestDateTimeTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestDateTimeTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestDateTimeTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/date-time-as-string/generated/BodyDateTime/operations/datetime.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/operations/datetime.ts
@@ -28,7 +28,7 @@ export class Datetime {
   /**
    * Get null datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Datetime {
   /**
    * Get invalid datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Datetime {
   /**
    * Get overflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Datetime {
   /**
    * Get underflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,11 +124,11 @@ export class Datetime {
   /**
    * Put max datetime value 9999-12-31T23:59:59.9999999Z
    *
-   * @param {string} datetimeBody
+   * @param datetimeBody
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -153,7 +153,7 @@ export class Datetime {
   /**
    * Get max datetime value 9999-12-31t23:59:59.9999999z
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -177,7 +177,7 @@ export class Datetime {
   /**
    * Get max datetime value 9999-12-31T23:59:59.9999999Z
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -201,11 +201,11 @@ export class Datetime {
   /**
    * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00
    *
-   * @param {string} datetimeBody
+   * @param datetimeBody
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -230,7 +230,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -254,7 +254,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -278,11 +278,11 @@ export class Datetime {
   /**
    * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00
    *
-   * @param {string} datetimeBody
+   * @param datetimeBody
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -307,7 +307,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -331,7 +331,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -355,11 +355,11 @@ export class Datetime {
   /**
    * Put min datetime value 0001-01-01T00:00:00Z
    *
-   * @param {string} datetimeBody
+   * @param datetimeBody
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -384,7 +384,7 @@ export class Datetime {
   /**
    * Get min datetime value 0001-01-01T00:00:00Z
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -408,11 +408,11 @@ export class Datetime {
   /**
    * Put min datetime value 0001-01-01T00:00:00+14:00
    *
-   * @param {string} datetimeBody
+   * @param datetimeBody
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -437,7 +437,7 @@ export class Datetime {
   /**
    * Get min datetime value 0001-01-01T00:00:00+14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -461,11 +461,11 @@ export class Datetime {
   /**
    * Put min datetime value 0001-01-01T00:00:00-14:00
    *
-   * @param {string} datetimeBody
+   * @param datetimeBody
    * **NOTE: This entity will be treated as a string instead of a Date because the API can
    * potentially deal with a higher precision value than what is supported by JavaScript.**
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -490,7 +490,7 @@ export class Datetime {
   /**
    * Get min datetime value 0001-01-01T00:00:00-14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/date-time-as-string/generated/BodyDateTime/operations/datetime.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/operations/datetime.ts
@@ -30,7 +30,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -130,7 +130,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -155,7 +155,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -179,7 +179,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -207,7 +207,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -232,7 +232,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -256,7 +256,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -284,7 +284,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -309,7 +309,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -333,7 +333,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -361,7 +361,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -386,7 +386,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -414,7 +414,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -439,7 +439,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -467,7 +467,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -492,7 +492,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/date-time-as-string/generated/BodyDateTime/operations/datetime.ts
+++ b/test/date-time-as-string/generated/BodyDateTime/operations/datetime.ts
@@ -31,10 +31,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DatetimeGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetNullResponse>;
@@ -55,10 +51,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.DatetimeGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetInvalidResponse>;
@@ -79,10 +71,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflow(): Promise<Models.DatetimeGetOverflowResponse>;
   getOverflow(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetOverflowResponse>;
@@ -103,10 +91,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflow(): Promise<Models.DatetimeGetUnderflowResponse>;
   getUnderflow(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUnderflowResponse>;
@@ -131,10 +115,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMaxDateTime(datetimeBody: string): Promise<msRest.RestResponse>;
   putUtcMaxDateTime(datetimeBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -156,10 +136,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcLowercaseMaxDateTime(): Promise<Models.DatetimeGetUtcLowercaseMaxDateTimeResponse>;
   getUtcLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUtcLowercaseMaxDateTimeResponse>;
@@ -180,10 +156,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcUppercaseMaxDateTime(): Promise<Models.DatetimeGetUtcUppercaseMaxDateTimeResponse>;
   getUtcUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUtcUppercaseMaxDateTimeResponse>;
@@ -208,10 +180,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalPositiveOffsetMaxDateTime(datetimeBody: string): Promise<msRest.RestResponse>;
   putLocalPositiveOffsetMaxDateTime(datetimeBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -233,10 +201,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPositiveOffsetLowercaseMaxDateTime(): Promise<Models.DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse>;
   getLocalPositiveOffsetLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse>;
@@ -257,10 +221,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPositiveOffsetUppercaseMaxDateTime(): Promise<Models.DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse>;
   getLocalPositiveOffsetUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse>;
@@ -285,10 +245,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalNegativeOffsetMaxDateTime(datetimeBody: string): Promise<msRest.RestResponse>;
   putLocalNegativeOffsetMaxDateTime(datetimeBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -310,10 +266,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalNegativeOffsetUppercaseMaxDateTime(): Promise<Models.DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse>;
   getLocalNegativeOffsetUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse>;
@@ -334,10 +286,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalNegativeOffsetLowercaseMaxDateTime(): Promise<Models.DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse>;
   getLocalNegativeOffsetLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse>;
@@ -362,10 +310,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMinDateTime(datetimeBody: string): Promise<msRest.RestResponse>;
   putUtcMinDateTime(datetimeBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -387,10 +331,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcMinDateTime(): Promise<Models.DatetimeGetUtcMinDateTimeResponse>;
   getUtcMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUtcMinDateTimeResponse>;
@@ -415,10 +355,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalPositiveOffsetMinDateTime(datetimeBody: string): Promise<msRest.RestResponse>;
   putLocalPositiveOffsetMinDateTime(datetimeBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -440,10 +376,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPositiveOffsetMinDateTime(): Promise<Models.DatetimeGetLocalPositiveOffsetMinDateTimeResponse>;
   getLocalPositiveOffsetMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalPositiveOffsetMinDateTimeResponse>;
@@ -468,10 +400,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalNegativeOffsetMinDateTime(datetimeBody: string): Promise<msRest.RestResponse>;
   putLocalNegativeOffsetMinDateTime(datetimeBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -493,10 +421,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalNegativeOffsetMinDateTime(): Promise<Models.DatetimeGetLocalNegativeOffsetMinDateTimeResponse>;
   getLocalNegativeOffsetMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalNegativeOffsetMinDateTimeResponse>;

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -21,9 +21,9 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
   /**
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestRFC1123DateTimeTestServiceContext extends msRest.ServiceCli
   /**
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -30,7 +30,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -177,7 +177,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -228,7 +228,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -28,7 +28,7 @@ export class Datetimerfc1123 {
   /**
    * Get null datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Datetimerfc1123 {
   /**
    * Get invalid datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Datetimerfc1123 {
   /**
    * Get overflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Datetimerfc1123 {
   /**
    * Get underflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,9 +124,9 @@ export class Datetimerfc1123 {
   /**
    * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class Datetimerfc1123 {
   /**
    * Get max datetime value fri, 31 dec 9999 23:59:59 gmt
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,7 +175,7 @@ export class Datetimerfc1123 {
   /**
    * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -199,9 +199,9 @@ export class Datetimerfc1123 {
   /**
    * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,7 +226,7 @@ export class Datetimerfc1123 {
   /**
    * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/date-time-as-string/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/date-time-as-string/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -31,10 +31,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.Datetimerfc1123GetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetNullResponse>;
@@ -55,10 +51,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.Datetimerfc1123GetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetInvalidResponse>;
@@ -79,10 +71,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflow(): Promise<Models.Datetimerfc1123GetOverflowResponse>;
   getOverflow(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetOverflowResponse>;
@@ -103,10 +91,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflow(): Promise<Models.Datetimerfc1123GetUnderflowResponse>;
   getUnderflow(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUnderflowResponse>;
@@ -129,10 +113,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMaxDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putUtcMaxDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -154,10 +134,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcLowercaseMaxDateTime(): Promise<Models.Datetimerfc1123GetUtcLowercaseMaxDateTimeResponse>;
   getUtcLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUtcLowercaseMaxDateTimeResponse>;
@@ -178,10 +154,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcUppercaseMaxDateTime(): Promise<Models.Datetimerfc1123GetUtcUppercaseMaxDateTimeResponse>;
   getUtcUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUtcUppercaseMaxDateTimeResponse>;
@@ -204,10 +176,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMinDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putUtcMinDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -229,10 +197,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcMinDateTime(): Promise<Models.Datetimerfc1123GetUtcMinDateTimeResponse>;
   getUtcMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUtcMinDateTimeResponse>;

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATService.ts
@@ -22,9 +22,9 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/enumunion/generated/BodyString/autoRestSwaggerBATServiceContext.ts
+++ b/test/enumunion/generated/BodyString/autoRestSwaggerBATServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/enumunion/generated/BodyString/operations/enumModel.ts
+++ b/test/enumunion/generated/BodyString/operations/enumModel.ts
@@ -30,7 +30,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -81,7 +81,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -107,7 +107,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -132,7 +132,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -156,7 +156,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/enumunion/generated/BodyString/operations/enumModel.ts
+++ b/test/enumunion/generated/BodyString/operations/enumModel.ts
@@ -28,7 +28,7 @@ export class EnumModel {
   /**
    * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,9 +52,9 @@ export class EnumModel {
   /**
    * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
    *
-   * @param {Colors} stringBody Possible values include: 'red color', 'green-color', 'blue_color'
+   * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -79,7 +79,7 @@ export class EnumModel {
   /**
    * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,9 +103,9 @@ export class EnumModel {
   /**
    * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
    *
-   * @param {Colors} enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
+   * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -130,7 +130,7 @@ export class EnumModel {
   /**
    * Get value 'green-color' from the constant.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -154,7 +154,7 @@ export class EnumModel {
   /**
    * Sends value 'green-color' from a constant
    *
-   * @param {EnumModelPutReferencedConstantOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/enumunion/generated/BodyString/operations/enumModel.ts
+++ b/test/enumunion/generated/BodyString/operations/enumModel.ts
@@ -31,10 +31,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotExpandable(): Promise<Models.EnumModelGetNotExpandableResponse>;
   getNotExpandable(options: msRest.RequestOptionsBase): Promise<Models.EnumModelGetNotExpandableResponse>;
@@ -57,10 +53,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNotExpandable(stringBody: Models.Colors): Promise<msRest.RestResponse>;
   putNotExpandable(stringBody: Models.Colors, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -82,10 +74,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getReferenced(): Promise<Models.EnumModelGetReferencedResponse>;
   getReferenced(options: msRest.RequestOptionsBase): Promise<Models.EnumModelGetReferencedResponse>;
@@ -108,10 +96,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putReferenced(enumStringBody: Models.Colors): Promise<msRest.RestResponse>;
   putReferenced(enumStringBody: Models.Colors, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -133,10 +117,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getReferencedConstant(): Promise<Models.EnumModelGetReferencedConstantResponse>;
   getReferencedConstant(options: msRest.RequestOptionsBase): Promise<Models.EnumModelGetReferencedConstantResponse>;
@@ -157,10 +137,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putReferencedConstant(): Promise<msRest.RestResponse>;
   putReferencedConstant(options: Models.EnumModelPutReferencedConstantOptionalParams): Promise<msRest.RestResponse>;

--- a/test/enumunion/generated/BodyString/operations/string.ts
+++ b/test/enumunion/generated/BodyString/operations/string.ts
@@ -31,10 +31,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.StringGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.StringGetNullResponse>;
@@ -55,10 +51,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNull(): Promise<msRest.RestResponse>;
   putNull(options: Models.StringPutNullOptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.StringGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.StringGetEmptyResponse>;
@@ -103,10 +91,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMbcs(): Promise<Models.StringGetMbcsResponse>;
   getMbcs(options: msRest.RequestOptionsBase): Promise<Models.StringGetMbcsResponse>;
@@ -151,10 +131,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMbcs(): Promise<msRest.RestResponse>;
   putMbcs(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -176,10 +152,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWhitespace(): Promise<Models.StringGetWhitespaceResponse>;
   getWhitespace(options: msRest.RequestOptionsBase): Promise<Models.StringGetWhitespaceResponse>;
@@ -201,10 +173,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putWhitespace(): Promise<msRest.RestResponse>;
   putWhitespace(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -225,10 +193,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.StringGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.StringGetNotProvidedResponse>;
@@ -249,10 +213,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBase64Encoded(): Promise<Models.StringGetBase64EncodedResponse>;
   getBase64Encoded(options: msRest.RequestOptionsBase): Promise<Models.StringGetBase64EncodedResponse>;
@@ -273,10 +233,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBase64UrlEncoded(): Promise<Models.StringGetBase64UrlEncodedResponse>;
   getBase64UrlEncoded(options: msRest.RequestOptionsBase): Promise<Models.StringGetBase64UrlEncodedResponse>;
@@ -299,10 +255,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBase64UrlEncoded(stringBody: Uint8Array): Promise<msRest.RestResponse>;
   putBase64UrlEncoded(stringBody: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -324,10 +276,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNullBase64UrlEncoded(): Promise<Models.StringGetNullBase64UrlEncodedResponse>;
   getNullBase64UrlEncoded(options: msRest.RequestOptionsBase): Promise<Models.StringGetNullBase64UrlEncodedResponse>;

--- a/test/enumunion/generated/BodyString/operations/string.ts
+++ b/test/enumunion/generated/BodyString/operations/string.ts
@@ -30,7 +30,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -175,7 +175,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -200,7 +200,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -224,7 +224,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -248,7 +248,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -272,7 +272,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -298,7 +298,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -323,7 +323,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/enumunion/generated/BodyString/operations/string.ts
+++ b/test/enumunion/generated/BodyString/operations/string.ts
@@ -28,7 +28,7 @@ export class String {
   /**
    * Get null string value value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class String {
   /**
    * Set string value null
    *
-   * @param {StringPutNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class String {
   /**
    * Get empty string value value ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class String {
   /**
    * Set string value empty ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class String {
   /**
    * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class String {
   /**
    * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -173,7 +173,7 @@ export class String {
    * Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for
    * all good men to come to the aid of their country<tab><space><space>'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -198,7 +198,7 @@ export class String {
    * Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for
    * all good men to come to the aid of their country<tab><space><space>'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -222,7 +222,7 @@ export class String {
   /**
    * Get String value when no string value is sent in response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -246,7 +246,7 @@ export class String {
   /**
    * Get value that is base64 encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -270,7 +270,7 @@ export class String {
   /**
    * Get value that is base64url encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -294,9 +294,9 @@ export class String {
   /**
    * Put value that is base64url encoded
    *
-   * @param {Uint8Array} stringBody
+   * @param stringBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -321,7 +321,7 @@ export class String {
   /**
    * Get null value that is expected to be base64url encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/autoRestComplexTestService.ts
+++ b/test/metadata/generated/BodyComplex/lib/autoRestComplexTestService.ts
@@ -29,9 +29,9 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestComplexTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/metadata/generated/BodyComplex/lib/autoRestComplexTestServiceContext.ts
+++ b/test/metadata/generated/BodyComplex/lib/autoRestComplexTestServiceContext.ts
@@ -19,9 +19,9 @@ export class AutoRestComplexTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestComplexTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/metadata/generated/BodyComplex/lib/operations/arrayModel.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/arrayModel.ts
@@ -28,7 +28,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class ArrayModel {
   /**
    * Put complex types with array property
    *
-   * @param {ArrayModelPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property which is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class ArrayModel {
   /**
    * Put complex types with array property which is empty
    *
-   * @param {ArrayModelPutEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property while server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/arrayModel.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/arrayModel.ts
@@ -31,10 +31,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.ArrayModelGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetValidResponse>;
@@ -55,10 +51,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.ArrayModelPutValidOptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.ArrayModelGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetEmptyResponse>;
@@ -103,10 +91,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: Models.ArrayModelPutEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.ArrayModelGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetNotProvidedResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/arrayModel.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/arrayModel.ts
@@ -30,7 +30,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/basicOperations.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/basicOperations.ts
@@ -32,10 +32,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.BasicGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.BasicGetValidResponse>;
@@ -58,10 +54,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.Basic): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.Basic, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.BasicGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.BasicGetInvalidResponse>;
@@ -107,10 +95,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.BasicGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.BasicGetEmptyResponse>;
@@ -131,10 +115,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.BasicGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.BasicGetNullResponse>;
@@ -155,10 +135,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.BasicGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.BasicGetNotProvidedResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/basicOperations.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/basicOperations.ts
@@ -29,7 +29,7 @@ export class BasicOperations {
   /**
    * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,9 +53,9 @@ export class BasicOperations {
   /**
    * Please put {id: 2, name: 'abc', color: 'Magenta'}
    *
-   * @param {Basic} complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+   * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,7 +80,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type that is invalid for the local strong type
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,7 +104,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type that is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -128,7 +128,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type whose properties are null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -152,7 +152,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type while the server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/basicOperations.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/basicOperations.ts
@@ -31,7 +31,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -57,7 +57,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -130,7 +130,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -154,7 +154,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/dictionary.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/dictionary.ts
@@ -30,7 +30,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/dictionary.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/dictionary.ts
@@ -31,10 +31,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.DictionaryGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetValidResponse>;
@@ -55,10 +51,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.DictionaryPutValidOptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.DictionaryGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetEmptyResponse>;
@@ -103,10 +91,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: Models.DictionaryPutEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DictionaryGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNullResponse>;
@@ -151,10 +131,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.DictionaryGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNotProvidedResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/dictionary.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/dictionary.ts
@@ -28,7 +28,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Dictionary {
   /**
    * Put complex types with dictionary property
    *
-   * @param {DictionaryPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property which is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Dictionary {
   /**
    * Put complex types with dictionary property which is empty
    *
-   * @param {DictionaryPutEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property which is null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property while server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/flattencomplex.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/flattencomplex.ts
@@ -29,10 +29,6 @@ export class Flattencomplex {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.FlattencomplexGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.FlattencomplexGetValidResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/flattencomplex.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/flattencomplex.ts
@@ -28,7 +28,7 @@ export class Flattencomplex {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/flattencomplex.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/flattencomplex.ts
@@ -26,7 +26,7 @@ export class Flattencomplex {
   }
 
   /**
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/inheritance.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/inheritance.ts
@@ -30,7 +30,7 @@ export class Inheritance {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -58,7 +58,7 @@ export class Inheritance {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/inheritance.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/inheritance.ts
@@ -31,10 +31,6 @@ export class Inheritance {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.InheritanceGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.InheritanceGetValidResponse>;
@@ -59,10 +55,6 @@ export class Inheritance {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.Siamese): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.Siamese, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/inheritance.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/inheritance.ts
@@ -28,7 +28,7 @@ export class Inheritance {
   /**
    * Get complex types that extend others
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,11 +52,11 @@ export class Inheritance {
   /**
    * Put complex types that extend others
    *
-   * @param {Siamese} complexBody Please put a siamese with id=2, name="Siameee", color=green,
-   * breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and
-   * the 2nd one named "Tomato" with id=-1 and food="french fries".
+   * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+   * which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one
+   * named "Tomato" with id=-1 and food="french fries".
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/polymorphicrecursive.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/polymorphicrecursive.ts
@@ -31,10 +31,6 @@ export class Polymorphicrecursive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.PolymorphicrecursiveGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.PolymorphicrecursiveGetValidResponse>;
@@ -109,10 +105,6 @@ export class Polymorphicrecursive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/polymorphicrecursive.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/polymorphicrecursive.ts
@@ -30,7 +30,7 @@ export class Polymorphicrecursive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -108,7 +108,7 @@ export class Polymorphicrecursive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/polymorphicrecursive.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/polymorphicrecursive.ts
@@ -28,7 +28,7 @@ export class Polymorphicrecursive {
   /**
    * Get complex types that are polymorphic and have recursive references
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Polymorphicrecursive {
   /**
    * Put complex types that are polymorphic and have recursive references
    *
-   * @param {FishUnion} complexBody Please put a salmon that looks like this:
+   * @param complexBody Please put a salmon that looks like this:
    * {
    * "fishtype": "salmon",
    * "species": "king",
@@ -106,7 +106,7 @@ export class Polymorphicrecursive {
    * ]
    * }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/polymorphism.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/polymorphism.ts
@@ -30,7 +30,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -88,7 +88,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -114,7 +114,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -141,7 +141,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -168,7 +168,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/polymorphism.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/polymorphism.ts
@@ -31,10 +31,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.PolymorphismGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.PolymorphismGetValidResponse>;
@@ -89,10 +85,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -115,10 +107,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplicated(): Promise<Models.PolymorphismGetComplicatedResponse>;
   getComplicated(options: msRest.RequestOptionsBase): Promise<Models.PolymorphismGetComplicatedResponse>;
@@ -142,10 +130,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplicated(complexBody: Models.SalmonUnion): Promise<msRest.RestResponse>;
   putComplicated(complexBody: Models.SalmonUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -169,10 +153,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMissingDiscriminator(complexBody: Models.SalmonUnion): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
   putMissingDiscriminator(complexBody: Models.SalmonUnion, options: msRest.RequestOptionsBase): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
@@ -223,10 +203,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValidMissingRequired(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValidMissingRequired(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/polymorphism.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/polymorphism.ts
@@ -28,7 +28,7 @@ export class Polymorphism {
   /**
    * Get complex types that are polymorphic
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic
    *
-   * @param {FishUnion} complexBody Please put a salmon that looks like this:
+   * @param complexBody Please put a salmon that looks like this:
    * {
    * 'fishtype':'Salmon',
    * 'location':'alaska',
@@ -86,7 +86,7 @@ export class Polymorphism {
    * ]
    * };
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -112,7 +112,7 @@ export class Polymorphism {
    * Get complex types that are polymorphic, but not at the root of the hierarchy; also have
    * additional properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -137,9 +137,9 @@ export class Polymorphism {
    * Put complex types that are polymorphic, but not at the root of the hierarchy; also have
    * additional properties
    *
-   * @param {SalmonUnion} complexBody
+   * @param complexBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -164,9 +164,9 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic, omitting the discriminator
    *
-   * @param {SalmonUnion} complexBody
+   * @param complexBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -192,8 +192,8 @@ export class Polymorphism {
    * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the
    * request should not be allowed from the client
    *
-   * @param {FishUnion} complexBody Please attempt put a sawshark that looks like this, the client
-   * should not allow this data to be sent:
+   * @param complexBody Please attempt put a sawshark that looks like this, the client should not
+   * allow this data to be sent:
    * {
    * "fishtype": "sawshark",
    * "species": "snaggle toothed",
@@ -220,7 +220,7 @@ export class Polymorphism {
    * ]
    * }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/primitive.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/primitive.ts
@@ -31,10 +31,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInt(): Promise<Models.PrimitiveGetIntResponse>;
   getInt(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetIntResponse>;
@@ -57,10 +53,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putInt(complexBody: Models.IntWrapper): Promise<msRest.RestResponse>;
   putInt(complexBody: Models.IntWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -82,10 +74,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLong(): Promise<Models.PrimitiveGetLongResponse>;
   getLong(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetLongResponse>;
@@ -108,10 +96,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLong(complexBody: Models.LongWrapper): Promise<msRest.RestResponse>;
   putLong(complexBody: Models.LongWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -133,10 +117,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloat(): Promise<Models.PrimitiveGetFloatResponse>;
   getFloat(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetFloatResponse>;
@@ -159,10 +139,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFloat(complexBody: Models.FloatWrapper): Promise<msRest.RestResponse>;
   putFloat(complexBody: Models.FloatWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -184,10 +160,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDouble(): Promise<Models.PrimitiveGetDoubleResponse>;
   getDouble(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDoubleResponse>;
@@ -211,10 +183,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDouble(complexBody: Models.DoubleWrapper): Promise<msRest.RestResponse>;
   putDouble(complexBody: Models.DoubleWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -236,10 +204,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBool(): Promise<Models.PrimitiveGetBoolResponse>;
   getBool(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetBoolResponse>;
@@ -262,10 +226,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBool(complexBody: Models.BooleanWrapper): Promise<msRest.RestResponse>;
   putBool(complexBody: Models.BooleanWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -287,10 +247,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getString(): Promise<Models.PrimitiveGetStringResponse>;
   getString(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetStringResponse>;
@@ -313,10 +269,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putString(complexBody: Models.StringWrapper): Promise<msRest.RestResponse>;
   putString(complexBody: Models.StringWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -338,10 +290,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDate(): Promise<Models.PrimitiveGetDateResponse>;
   getDate(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateResponse>;
@@ -364,10 +312,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDate(complexBody: Models.DateWrapper): Promise<msRest.RestResponse>;
   putDate(complexBody: Models.DateWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -389,10 +333,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTime(): Promise<Models.PrimitiveGetDateTimeResponse>;
   getDateTime(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateTimeResponse>;
@@ -415,10 +355,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTime(complexBody: Models.DatetimeWrapper): Promise<msRest.RestResponse>;
   putDateTime(complexBody: Models.DatetimeWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -440,10 +376,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeRfc1123(): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
   getDateTimeRfc1123(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
@@ -467,10 +399,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeRfc1123(complexBody: Models.Datetimerfc1123Wrapper): Promise<msRest.RestResponse>;
   putDateTimeRfc1123(complexBody: Models.Datetimerfc1123Wrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -492,10 +420,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDuration(): Promise<Models.PrimitiveGetDurationResponse>;
   getDuration(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDurationResponse>;
@@ -516,10 +440,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDuration(): Promise<msRest.RestResponse>;
   putDuration(options: Models.PrimitivePutDurationOptionalParams): Promise<msRest.RestResponse>;
@@ -540,10 +460,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByte(): Promise<Models.PrimitiveGetByteResponse>;
   getByte(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetByteResponse>;
@@ -564,10 +480,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putByte(): Promise<msRest.RestResponse>;
   putByte(options: Models.PrimitivePutByteOptionalParams): Promise<msRest.RestResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/primitive.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/primitive.ts
@@ -28,7 +28,7 @@ export class Primitive {
   /**
    * Get complex types with integer properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,9 +52,9 @@ export class Primitive {
   /**
    * Put complex types with integer properties
    *
-   * @param {IntWrapper} complexBody Please put -1 and 2
+   * @param complexBody Please put -1 and 2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -79,7 +79,7 @@ export class Primitive {
   /**
    * Get complex types with long properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,9 +103,9 @@ export class Primitive {
   /**
    * Put complex types with long properties
    *
-   * @param {LongWrapper} complexBody Please put 1099511627775 and -999511627788
+   * @param complexBody Please put 1099511627775 and -999511627788
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -130,7 +130,7 @@ export class Primitive {
   /**
    * Get complex types with float properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -154,9 +154,9 @@ export class Primitive {
   /**
    * Put complex types with float properties
    *
-   * @param {FloatWrapper} complexBody Please put 1.05 and -0.003
+   * @param complexBody Please put 1.05 and -0.003
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -181,7 +181,7 @@ export class Primitive {
   /**
    * Get complex types with double properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -205,10 +205,10 @@ export class Primitive {
   /**
    * Put complex types with double properties
    *
-   * @param {DoubleWrapper} complexBody Please put 3e-100 and
+   * @param complexBody Please put 3e-100 and
    * -0.000000000000000000000000000000000000000000000000000000005
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -233,7 +233,7 @@ export class Primitive {
   /**
    * Get complex types with bool properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -257,9 +257,9 @@ export class Primitive {
   /**
    * Put complex types with bool properties
    *
-   * @param {BooleanWrapper} complexBody Please put true and false
+   * @param complexBody Please put true and false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -284,7 +284,7 @@ export class Primitive {
   /**
    * Get complex types with string properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -308,9 +308,9 @@ export class Primitive {
   /**
    * Put complex types with string properties
    *
-   * @param {StringWrapper} complexBody Please put 'goodrequest', '', and null
+   * @param complexBody Please put 'goodrequest', '', and null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -335,7 +335,7 @@ export class Primitive {
   /**
    * Get complex types with date properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -359,9 +359,9 @@ export class Primitive {
   /**
    * Put complex types with date properties
    *
-   * @param {DateWrapper} complexBody Please put '0001-01-01' and '2016-02-29'
+   * @param complexBody Please put '0001-01-01' and '2016-02-29'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -386,7 +386,7 @@ export class Primitive {
   /**
    * Get complex types with datetime properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -410,10 +410,9 @@ export class Primitive {
   /**
    * Put complex types with datetime properties
    *
-   * @param {DatetimeWrapper} complexBody Please put '0001-01-01T12:00:00-04:00' and
-   * '2015-05-18T11:38:00-08:00'
+   * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -438,7 +437,7 @@ export class Primitive {
   /**
    * Get complex types with datetimeRfc1123 properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -462,10 +461,10 @@ export class Primitive {
   /**
    * Put complex types with datetimeRfc1123 properties
    *
-   * @param {Datetimerfc1123Wrapper} complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon,
-   * 18 May 2015 11:38:00 GMT'
+   * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00
+   * GMT'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -490,7 +489,7 @@ export class Primitive {
   /**
    * Get complex types with duration properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -514,7 +513,7 @@ export class Primitive {
   /**
    * Put complex types with duration properties
    *
-   * @param {PrimitivePutDurationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -538,7 +537,7 @@ export class Primitive {
   /**
    * Get complex types with byte properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -562,7 +561,7 @@ export class Primitive {
   /**
    * Put complex types with byte properties
    *
-   * @param {PrimitivePutByteOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/primitive.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/primitive.ts
@@ -30,7 +30,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -81,7 +81,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -107,7 +107,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -132,7 +132,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -158,7 +158,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -183,7 +183,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -210,7 +210,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -235,7 +235,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -261,7 +261,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -286,7 +286,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -312,7 +312,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -337,7 +337,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -363,7 +363,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -388,7 +388,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -414,7 +414,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -439,7 +439,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -466,7 +466,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -491,7 +491,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -515,7 +515,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -539,7 +539,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -563,7 +563,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/readonlyproperty.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/readonlyproperty.ts
@@ -31,10 +31,6 @@ export class Readonlyproperty {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.ReadonlypropertyGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.ReadonlypropertyGetValidResponse>;
@@ -55,10 +51,6 @@ export class Readonlyproperty {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.ReadonlypropertyPutValidOptionalParams): Promise<msRest.RestResponse>;

--- a/test/metadata/generated/BodyComplex/lib/operations/readonlyproperty.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/readonlyproperty.ts
@@ -28,7 +28,7 @@ export class Readonlyproperty {
   /**
    * Get complex types that have readonly properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Readonlyproperty {
   /**
    * Put complex types that have readonly properties
    *
-   * @param {ReadonlypropertyPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/metadata/generated/BodyComplex/lib/operations/readonlyproperty.ts
+++ b/test/metadata/generated/BodyComplex/lib/operations/readonlyproperty.ts
@@ -30,7 +30,7 @@ export class Readonlyproperty {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Readonlyproperty {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClient.ts
+++ b/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClient.ts
@@ -18,10 +18,9 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
   /**
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     super(credentials, options);

--- a/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClientContext.ts
+++ b/test/multiapi/generated/2017-10-01/lib/autoRestParameterizedHostTestClientContext.ts
@@ -24,10 +24,9 @@ export class AutoRestParameterizedHostTestClientContext extends msRestAzure.Azur
   /**
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, options?: Models.AutoRestParameterizedHostTestClientOptions) {
     if (credentials == undefined) {

--- a/test/multiapi/generated/2017-10-01/lib/operations/paths.ts
+++ b/test/multiapi/generated/2017-10-01/lib/operations/paths.ts
@@ -29,10 +29,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(accountName: string): Promise<msRest.RestResponse>;
   getEmpty(accountName: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/multiapi/generated/2017-10-01/lib/operations/paths.ts
+++ b/test/multiapi/generated/2017-10-01/lib/operations/paths.ts
@@ -24,9 +24,9 @@ export class Paths {
   /**
    * Get a 200 to test a valid base uri
    *
-   * @param {string} accountName Account Name
+   * @param accountName Account Name
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/multiapi/generated/2017-10-01/lib/operations/paths.ts
+++ b/test/multiapi/generated/2017-10-01/lib/operations/paths.ts
@@ -28,7 +28,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClient.ts
@@ -18,12 +18,11 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
   /**
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId The subscription id with value 'test12'.
+   * @param subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     super(credentials, subscriptionId, options);

--- a/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClientContext.ts
+++ b/test/multiapi/generated/2018-02-01/lib/autoRestParameterizedCustomHostTestClientContext.ts
@@ -26,12 +26,11 @@ export class AutoRestParameterizedCustomHostTestClientContext extends msRestAzur
   /**
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
    *
-   * @param {msRest.ServiceClientCredentials} credentials Credentials needed for the client to
-   * connect to Azure.
+   * @param credentials Credentials needed for the client to connect to Azure.
    *
-   * @param {string} subscriptionId The subscription id with value 'test12'.
+   * @param subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(credentials: msRest.ServiceClientCredentials, subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     if (credentials == undefined) {

--- a/test/multiapi/generated/2018-02-01/lib/operations/paths.ts
+++ b/test/multiapi/generated/2018-02-01/lib/operations/paths.ts
@@ -34,10 +34,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(vault: string, secret: string, keyName: string): Promise<msRest.RestResponse>;
   getEmpty(vault: string, secret: string, keyName: string, options: Models.PathsGetEmptyOptionalParams): Promise<msRest.RestResponse>;

--- a/test/multiapi/generated/2018-02-01/lib/operations/paths.ts
+++ b/test/multiapi/generated/2018-02-01/lib/operations/paths.ts
@@ -25,13 +25,13 @@ export class Paths {
   /**
    * Get a 200 to test a valid base uri
    *
-   * @param {string} vault The vault name, e.g. https://myvault
+   * @param vault The vault name, e.g. https://myvault
    *
-   * @param {string} secret Secret value.
+   * @param secret Secret value.
    *
-   * @param {string} keyName The key name with value 'key1'.
+   * @param keyName The key name with value 'key1'.
    *
-   * @param {PathsGetEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/multiapi/generated/2018-02-01/lib/operations/paths.ts
+++ b/test/multiapi/generated/2018-02-01/lib/operations/paths.ts
@@ -33,7 +33,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
@@ -40,7 +40,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -71,7 +71,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -96,7 +96,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -119,7 +119,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
@@ -41,10 +41,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   validationOfMethodParameters(resourceGroupName: string, id: number): Promise<Models.ValidationOfMethodParametersResponse>;
   validationOfMethodParameters(resourceGroupName: string, id: number, options: msRest.RequestOptionsBase): Promise<Models.ValidationOfMethodParametersResponse>;
@@ -72,10 +68,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   validationOfBody(resourceGroupName: string, id: number): Promise<Models.ValidationOfBodyResponse>;
   validationOfBody(resourceGroupName: string, id: number, options: Models.AutoRestValidationTestValidationOfBodyOptionalParams): Promise<Models.ValidationOfBodyResponse>;
@@ -97,10 +89,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWithConstantInPath(): Promise<msRest.RestResponse>;
   getWithConstantInPath(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -120,10 +108,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postWithConstantInBody(): Promise<Models.PostWithConstantInBodyResponse>;
   postWithConstantInBody(options: Models.AutoRestValidationTestPostWithConstantInBodyOptionalParams): Promise<Models.PostWithConstantInBodyResponse>;

--- a/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTest.ts
@@ -18,13 +18,13 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * Initializes a new instance of the AutoRestValidationTest class.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
+   * @param apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(subscriptionId, apiVersion, baseUri, options);
@@ -34,12 +34,11 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * Validates input parameters on the method. See swagger for details.
    *
-   * @param {string} resourceGroupName Required string between 3 and 10 chars with pattern
-   * [a-zA-Z0-9]+.
+   * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
    *
-   * @param {number} id Required int multiple of 10 from 100 to 1000.
+   * @param id Required int multiple of 10 from 100 to 1000.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -66,12 +65,11 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * Validates body parameters on the method. See swagger for details.
    *
-   * @param {string} resourceGroupName Required string between 3 and 10 chars with pattern
-   * [a-zA-Z0-9]+.
+   * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
    *
-   * @param {number} id Required int multiple of 10 from 100 to 1000.
+   * @param id Required int multiple of 10 from 100 to 1000.
    *
-   * @param {AutoRestValidationTestValidationOfBodyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -96,7 +94,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   // methods on the client.
 
   /**
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -119,8 +117,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   // methods on the client.
 
   /**
-   * @param {AutoRestValidationTestPostWithConstantInBodyOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/no-client-validation/generated/Validation/autoRestValidationTestContext.ts
+++ b/test/no-client-validation/generated/Validation/autoRestValidationTestContext.ts
@@ -20,13 +20,13 @@ export class AutoRestValidationTestContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestValidationTestContext class.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
+   * @param apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     if (subscriptionId === null || subscriptionId === undefined) {

--- a/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
   /**
    * Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
+++ b/test/optional-response-headers/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATHeaderServiceContext extends msRest.ServiceClient
   /**
    * Initializes a new instance of the AutoRestSwaggerBATHeaderServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/optional-response-headers/generated/Header/operations/header.ts
+++ b/test/optional-response-headers/generated/Header/operations/header.ts
@@ -29,9 +29,9 @@ export class Header {
   /**
    * Send a post request with header value "User-Agent": "overwrite"
    *
-   * @param {string} userAgent Send a post request with header value "User-Agent": "overwrite"
+   * @param userAgent Send a post request with header value "User-Agent": "overwrite"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -56,7 +56,7 @@ export class Header {
   /**
    * Get a response with header value "User-Agent": "overwrite"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,9 +80,9 @@ export class Header {
   /**
    * Send a post request with header value "Content-Type": "text/html"
    *
-   * @param {string} contentType Send a post request with header value "Content-Type": "text/html"
+   * @param contentType Send a post request with header value "Content-Type": "text/html"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,7 +107,7 @@ export class Header {
   /**
    * Get a response with header value "Content-Type": "text/html"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -132,12 +132,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 1 or "scenario":
    * "negative", "value": -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 1 or -2
+   * @param value Send a post request with header values 1 or -2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -163,10 +162,9 @@ export class Header {
   /**
    * Get a response with header value "value": 1 or -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -192,12 +190,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 105 or "scenario":
    * "negative", "value": -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 105 or -2
+   * @param value Send a post request with header values 105 or -2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -223,10 +220,9 @@ export class Header {
   /**
    * Get a response with header value "value": 105 or -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -252,12 +248,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario":
    * "negative", "value": -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 0.07 or -3.0
+   * @param value Send a post request with header values 0.07 or -3.0
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -283,10 +278,9 @@ export class Header {
   /**
    * Get a response with header value "value": 0.07 or -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -312,12 +306,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario":
    * "negative", "value": -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 7e120 or -3.0
+   * @param value Send a post request with header values 7e120 or -3.0
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -343,10 +336,9 @@ export class Header {
   /**
    * Get a response with header value "value": 7e120 or -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -372,11 +364,11 @@ export class Header {
    * Send a post request with header values "scenario": "true", "value": true or "scenario": "false",
    * "value": false
    *
-   * @param {string} scenario Send a post request with header values "scenario": "true" or "false"
+   * @param scenario Send a post request with header values "scenario": "true" or "false"
    *
-   * @param {boolean} value Send a post request with header values true or false
+   * @param value Send a post request with header values true or false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -402,9 +394,9 @@ export class Header {
   /**
    * Get a response with header value "value": true or false
    *
-   * @param {string} scenario Send a post request with header values "scenario": "true" or "false"
+   * @param scenario Send a post request with header values "scenario": "true" or "false"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -430,10 +422,9 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps
    * over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {HeaderParamStringOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -458,10 +449,9 @@ export class Header {
   /**
    * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -487,11 +477,11 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario":
    * "min", "value": "0001-01-01"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {Date | string} value Send a post request with header values "2010-01-01" or "0001-01-01"
+   * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -517,9 +507,9 @@ export class Header {
   /**
    * Get a response with header values "2010-01-01" or "0001-01-01"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -545,12 +535,12 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or
    * "scenario": "min", "value": "0001-01-01T00:00:00Z"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {Date | string} value Send a post request with header values "2010-01-01T12:34:56Z" or
+   * @param value Send a post request with header values "2010-01-01T12:34:56Z" or
    * "0001-01-01T00:00:00Z"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -576,9 +566,9 @@ export class Header {
   /**
    * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -604,9 +594,9 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56
    * GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {HeaderParamDatetimeRfc1123OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -632,9 +622,9 @@ export class Header {
    * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
    * GMT"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -659,11 +649,11 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {string} value Send a post request with header values "P123DT22H14M12.011S"
+   * @param value Send a post request with header values "P123DT22H14M12.011S"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -689,9 +679,9 @@ export class Header {
   /**
    * Get a response with header values "P123DT22H14M12.011S"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -716,11 +706,11 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {Uint8Array} value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
+   * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -746,9 +736,9 @@ export class Header {
   /**
    * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -774,10 +764,9 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario":
    * "null", "value": null
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {HeaderParamEnumOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -802,10 +791,9 @@ export class Header {
   /**
    * Get a response with header values "GREY" or null
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -830,7 +818,7 @@ export class Header {
   /**
    * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/optional-response-headers/generated/Header/operations/header.ts
+++ b/test/optional-response-headers/generated/Header/operations/header.ts
@@ -33,7 +33,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -58,7 +58,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -84,7 +84,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -138,7 +138,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -166,7 +166,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -196,7 +196,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -224,7 +224,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -254,7 +254,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -282,7 +282,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -312,7 +312,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -340,7 +340,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -370,7 +370,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -398,7 +398,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -426,7 +426,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -453,7 +453,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -483,7 +483,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -511,7 +511,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -542,7 +542,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -570,7 +570,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -598,7 +598,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -626,7 +626,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -655,7 +655,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -683,7 +683,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -712,7 +712,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -740,7 +740,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -768,7 +768,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -795,7 +795,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -820,7 +820,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/optional-response-headers/generated/Header/operations/header.ts
+++ b/test/optional-response-headers/generated/Header/operations/header.ts
@@ -34,10 +34,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramExistingKey(userAgent: string): Promise<msRest.RestResponse>;
   paramExistingKey(userAgent: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -59,10 +55,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseExistingKey(): Promise<Models.HeaderResponseExistingKeyResponse>;
   responseExistingKey(options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseExistingKeyResponse>;
@@ -85,10 +77,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramProtectedKey(contentType: string): Promise<msRest.RestResponse>;
   paramProtectedKey(contentType: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -110,10 +98,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseProtectedKey(): Promise<Models.HeaderResponseProtectedKeyResponse>;
   responseProtectedKey(options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseProtectedKeyResponse>;
@@ -139,10 +123,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramInteger(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramInteger(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -167,10 +147,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseInteger(scenario: string): Promise<Models.HeaderResponseIntegerResponse>;
   responseInteger(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseIntegerResponse>;
@@ -197,10 +173,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramLong(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramLong(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -225,10 +197,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseLong(scenario: string): Promise<Models.HeaderResponseLongResponse>;
   responseLong(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseLongResponse>;
@@ -255,10 +223,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramFloat(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramFloat(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -283,10 +247,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseFloat(scenario: string): Promise<Models.HeaderResponseFloatResponse>;
   responseFloat(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseFloatResponse>;
@@ -313,10 +273,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDouble(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramDouble(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -341,10 +297,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDouble(scenario: string): Promise<Models.HeaderResponseDoubleResponse>;
   responseDouble(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDoubleResponse>;
@@ -371,10 +323,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramBool(scenario: string, value: boolean): Promise<msRest.RestResponse>;
   paramBool(scenario: string, value: boolean, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -399,10 +347,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseBool(scenario: string): Promise<Models.HeaderResponseBoolResponse>;
   responseBool(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseBoolResponse>;
@@ -427,10 +371,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramString(scenario: string): Promise<msRest.RestResponse>;
   paramString(scenario: string, options: Models.HeaderParamStringOptionalParams): Promise<msRest.RestResponse>;
@@ -454,10 +394,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseString(scenario: string): Promise<Models.HeaderResponseStringResponse>;
   responseString(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseStringResponse>;
@@ -484,10 +420,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDate(scenario: string, value: Date | string): Promise<msRest.RestResponse>;
   paramDate(scenario: string, value: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -512,10 +444,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDate(scenario: string): Promise<Models.HeaderResponseDateResponse>;
   responseDate(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDateResponse>;
@@ -543,10 +471,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDatetime(scenario: string, value: Date | string): Promise<msRest.RestResponse>;
   paramDatetime(scenario: string, value: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -571,10 +495,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDatetime(scenario: string): Promise<Models.HeaderResponseDatetimeResponse>;
   responseDatetime(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDatetimeResponse>;
@@ -599,10 +519,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDatetimeRfc1123(scenario: string): Promise<msRest.RestResponse>;
   paramDatetimeRfc1123(scenario: string, options: Models.HeaderParamDatetimeRfc1123OptionalParams): Promise<msRest.RestResponse>;
@@ -627,10 +543,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDatetimeRfc1123(scenario: string): Promise<Models.HeaderResponseDatetimeRfc1123Response>;
   responseDatetimeRfc1123(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDatetimeRfc1123Response>;
@@ -656,10 +568,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDuration(scenario: string, value: string): Promise<msRest.RestResponse>;
   paramDuration(scenario: string, value: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -684,10 +592,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDuration(scenario: string): Promise<Models.HeaderResponseDurationResponse>;
   responseDuration(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDurationResponse>;
@@ -713,10 +617,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramByte(scenario: string, value: Uint8Array): Promise<msRest.RestResponse>;
   paramByte(scenario: string, value: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -741,10 +641,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseByte(scenario: string): Promise<Models.HeaderResponseByteResponse>;
   responseByte(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseByteResponse>;
@@ -769,10 +665,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramEnum(scenario: string): Promise<msRest.RestResponse>;
   paramEnum(scenario: string, options: Models.HeaderParamEnumOptionalParams): Promise<msRest.RestResponse>;
@@ -796,10 +688,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseEnum(scenario: string): Promise<Models.HeaderResponseEnumResponse>;
   responseEnum(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseEnumResponse>;
@@ -821,10 +709,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   customRequestId(): Promise<msRest.RestResponse>;
   customRequestId(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
@@ -35,10 +35,6 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUsingOptional(): Promise<msRest.RestResponse>;
   getUsingOptional(options: Models.AutoRestRenameParameterTestServiceGetUsingOptionalOptionalParams): Promise<msRest.RestResponse>;
@@ -62,10 +58,6 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUsingRequired(timeout: string): Promise<msRest.RestResponse>;
   getUsingRequired(timeout: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -88,10 +80,6 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUsingClientOptional(): Promise<msRest.RestResponse>;
   getUsingClientOptional(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -113,10 +101,6 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUsingClientRequired(): Promise<msRest.RestResponse>;
   getUsingClientRequired(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
@@ -18,11 +18,11 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
   /**
    * Initializes a new instance of the AutoRestRenameParameterTestService class.
    *
-   * @param {string} noRetryPolicy A query parameter.
+   * @param noRetryPolicy A query parameter.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(noRetryPolicy: string, baseUri?: string, options?: Models.AutoRestRenameParameterTestServiceOptions) {
     super(noRetryPolicy, baseUri, options);
@@ -32,8 +32,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
   /**
    * GET with an optional query parameter
    *
-   * @param {AutoRestRenameParameterTestServiceGetUsingOptionalOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -58,9 +57,9 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
   /**
    * GET with a required query parameter
    *
-   * @param {string} timeout A query parameter.
+   * @param timeout A query parameter.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -86,7 +85,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
   /**
    * GET with an optional client query parameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -111,7 +110,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
   /**
    * GET with a required client query parameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestService.ts
@@ -34,7 +34,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -61,7 +61,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -87,7 +87,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -112,7 +112,7 @@ class AutoRestRenameParameterTestService extends AutoRestRenameParameterTestServ
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/rename-parameter/generated/lib/autoRestRenameParameterTestServiceContext.ts
+++ b/test/rename-parameter/generated/lib/autoRestRenameParameterTestServiceContext.ts
@@ -21,11 +21,11 @@ export class AutoRestRenameParameterTestServiceContext extends msRest.ServiceCli
   /**
    * Initializes a new instance of the AutoRestRenameParameterTestServiceContext class.
    *
-   * @param {string} noRetryPolicy A query parameter.
+   * @param noRetryPolicy A query parameter.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(noRetryPolicy: string, baseUri?: string, options?: Models.AutoRestRenameParameterTestServiceOptions) {
     if (noRetryPolicy === null || noRetryPolicy === undefined) {

--- a/test/vanilla/generated/AdditionalProperties/additionalPropertiesClient.ts
+++ b/test/vanilla/generated/AdditionalProperties/additionalPropertiesClient.ts
@@ -21,9 +21,9 @@ class AdditionalPropertiesClient extends AdditionalPropertiesClientContext {
   /**
    * Initializes a new instance of the AdditionalPropertiesClient class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/AdditionalProperties/additionalPropertiesClientContext.ts
+++ b/test/vanilla/generated/AdditionalProperties/additionalPropertiesClientContext.ts
@@ -18,9 +18,9 @@ export class AdditionalPropertiesClientContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AdditionalPropertiesClientContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/AdditionalProperties/operations/pets.ts
+++ b/test/vanilla/generated/AdditionalProperties/operations/pets.ts
@@ -33,10 +33,6 @@ export class Pets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   createAPTrue(createParameters: Models.PetAPTrue): Promise<Models.PetsCreateAPTrueResponse>;
   createAPTrue(createParameters: Models.PetAPTrue, options: msRest.RequestOptionsBase): Promise<Models.PetsCreateAPTrueResponse>;
@@ -60,10 +56,6 @@ export class Pets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   createCatAPTrue(createParameters: Models.CatAPTrue): Promise<Models.PetsCreateCatAPTrueResponse>;
   createCatAPTrue(createParameters: Models.CatAPTrue, options: msRest.RequestOptionsBase): Promise<Models.PetsCreateCatAPTrueResponse>;
@@ -87,10 +79,6 @@ export class Pets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   createAPObject(createParameters: Models.PetAPObject): Promise<Models.PetsCreateAPObjectResponse>;
   createAPObject(createParameters: Models.PetAPObject, options: msRest.RequestOptionsBase): Promise<Models.PetsCreateAPObjectResponse>;
@@ -114,10 +102,6 @@ export class Pets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   createAPString(createParameters: Models.PetAPString): Promise<Models.PetsCreateAPStringResponse>;
   createAPString(createParameters: Models.PetAPString, options: msRest.RequestOptionsBase): Promise<Models.PetsCreateAPStringResponse>;
@@ -141,10 +125,6 @@ export class Pets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   createAPInProperties(createParameters: Models.PetAPInProperties): Promise<Models.PetsCreateAPInPropertiesResponse>;
   createAPInProperties(createParameters: Models.PetAPInProperties, options: msRest.RequestOptionsBase): Promise<Models.PetsCreateAPInPropertiesResponse>;
@@ -168,10 +148,6 @@ export class Pets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   createAPInPropertiesWithAPString(createParameters: Models.PetAPInPropertiesWithAPString): Promise<Models.PetsCreateAPInPropertiesWithAPStringResponse>;
   createAPInPropertiesWithAPString(createParameters: Models.PetAPInPropertiesWithAPString, options: msRest.RequestOptionsBase): Promise<Models.PetsCreateAPInPropertiesWithAPStringResponse>;

--- a/test/vanilla/generated/AdditionalProperties/operations/pets.ts
+++ b/test/vanilla/generated/AdditionalProperties/operations/pets.ts
@@ -28,9 +28,9 @@ export class Pets {
   /**
    * Create a Pet which contains more properties than what is defined.
    *
-   * @param {PetAPTrue} createParameters
+   * @param createParameters
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -55,9 +55,9 @@ export class Pets {
   /**
    * Create a CatAPTrue which contains more properties than what is defined.
    *
-   * @param {CatAPTrue} createParameters
+   * @param createParameters
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -82,9 +82,9 @@ export class Pets {
   /**
    * Create a Pet which contains more properties than what is defined.
    *
-   * @param {PetAPObject} createParameters
+   * @param createParameters
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -109,9 +109,9 @@ export class Pets {
   /**
    * Create a Pet which contains more properties than what is defined.
    *
-   * @param {PetAPString} createParameters
+   * @param createParameters
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -136,9 +136,9 @@ export class Pets {
   /**
    * Create a Pet which contains more properties than what is defined.
    *
-   * @param {PetAPInProperties} createParameters
+   * @param createParameters
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -163,9 +163,9 @@ export class Pets {
   /**
    * Create a Pet which contains more properties than what is defined.
    *
-   * @param {PetAPInPropertiesWithAPString} createParameters
+   * @param createParameters
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/AdditionalProperties/operations/pets.ts
+++ b/test/vanilla/generated/AdditionalProperties/operations/pets.ts
@@ -32,7 +32,7 @@ export class Pets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -59,7 +59,7 @@ export class Pets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -86,7 +86,7 @@ export class Pets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -113,7 +113,7 @@ export class Pets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -140,7 +140,7 @@ export class Pets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -167,7 +167,7 @@ export class Pets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATArrayService extends AutoRestSwaggerBATArrayServiceConte
   /**
    * Initializes a new instance of the AutoRestSwaggerBATArrayService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayServiceContext.ts
+++ b/test/vanilla/generated/BodyArray/autoRestSwaggerBATArrayServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATArrayServiceContext extends msRest.ServiceClient 
   /**
    * Initializes a new instance of the AutoRestSwaggerBATArrayServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -31,10 +31,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.ArrayModelGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetNullResponse>;
@@ -55,10 +51,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.ArrayModelGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetInvalidResponse>;
@@ -79,10 +71,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.ArrayModelGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetEmptyResponse>;
@@ -105,10 +93,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(arrayBody: string[]): Promise<msRest.RestResponse>;
   putEmpty(arrayBody: string[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -130,10 +114,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanTfft(): Promise<Models.ArrayModelGetBooleanTfftResponse>;
   getBooleanTfft(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetBooleanTfftResponse>;
@@ -156,10 +136,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBooleanTfft(arrayBody: boolean[]): Promise<msRest.RestResponse>;
   putBooleanTfft(arrayBody: boolean[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -181,10 +157,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanInvalidNull(): Promise<Models.ArrayModelGetBooleanInvalidNullResponse>;
   getBooleanInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetBooleanInvalidNullResponse>;
@@ -205,10 +177,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanInvalidString(): Promise<Models.ArrayModelGetBooleanInvalidStringResponse>;
   getBooleanInvalidString(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetBooleanInvalidStringResponse>;
@@ -229,10 +197,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntegerValid(): Promise<Models.ArrayModelGetIntegerValidResponse>;
   getIntegerValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetIntegerValidResponse>;
@@ -255,10 +219,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putIntegerValid(arrayBody: number[]): Promise<msRest.RestResponse>;
   putIntegerValid(arrayBody: number[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -280,10 +240,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntInvalidNull(): Promise<Models.ArrayModelGetIntInvalidNullResponse>;
   getIntInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetIntInvalidNullResponse>;
@@ -304,10 +260,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntInvalidString(): Promise<Models.ArrayModelGetIntInvalidStringResponse>;
   getIntInvalidString(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetIntInvalidStringResponse>;
@@ -328,10 +280,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongValid(): Promise<Models.ArrayModelGetLongValidResponse>;
   getLongValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetLongValidResponse>;
@@ -354,10 +302,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLongValid(arrayBody: number[]): Promise<msRest.RestResponse>;
   putLongValid(arrayBody: number[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -379,10 +323,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongInvalidNull(): Promise<Models.ArrayModelGetLongInvalidNullResponse>;
   getLongInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetLongInvalidNullResponse>;
@@ -403,10 +343,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongInvalidString(): Promise<Models.ArrayModelGetLongInvalidStringResponse>;
   getLongInvalidString(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetLongInvalidStringResponse>;
@@ -427,10 +363,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloatValid(): Promise<Models.ArrayModelGetFloatValidResponse>;
   getFloatValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetFloatValidResponse>;
@@ -453,10 +385,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFloatValid(arrayBody: number[]): Promise<msRest.RestResponse>;
   putFloatValid(arrayBody: number[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -478,10 +406,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloatInvalidNull(): Promise<Models.ArrayModelGetFloatInvalidNullResponse>;
   getFloatInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetFloatInvalidNullResponse>;
@@ -502,10 +426,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloatInvalidString(): Promise<Models.ArrayModelGetFloatInvalidStringResponse>;
   getFloatInvalidString(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetFloatInvalidStringResponse>;
@@ -526,10 +446,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDoubleValid(): Promise<Models.ArrayModelGetDoubleValidResponse>;
   getDoubleValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDoubleValidResponse>;
@@ -552,10 +468,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDoubleValid(arrayBody: number[]): Promise<msRest.RestResponse>;
   putDoubleValid(arrayBody: number[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -577,10 +489,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDoubleInvalidNull(): Promise<Models.ArrayModelGetDoubleInvalidNullResponse>;
   getDoubleInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDoubleInvalidNullResponse>;
@@ -601,10 +509,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDoubleInvalidString(): Promise<Models.ArrayModelGetDoubleInvalidStringResponse>;
   getDoubleInvalidString(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDoubleInvalidStringResponse>;
@@ -625,10 +529,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringValid(): Promise<Models.ArrayModelGetStringValidResponse>;
   getStringValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetStringValidResponse>;
@@ -651,10 +551,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putStringValid(arrayBody: string[]): Promise<msRest.RestResponse>;
   putStringValid(arrayBody: string[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -676,10 +572,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEnumValid(): Promise<Models.ArrayModelGetEnumValidResponse>;
   getEnumValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetEnumValidResponse>;
@@ -702,10 +594,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEnumValid(arrayBody: Models.FooEnum[]): Promise<msRest.RestResponse>;
   putEnumValid(arrayBody: Models.FooEnum[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -727,10 +615,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringEnumValid(): Promise<Models.ArrayModelGetStringEnumValidResponse>;
   getStringEnumValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetStringEnumValidResponse>;
@@ -753,10 +637,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putStringEnumValid(arrayBody: string[]): Promise<msRest.RestResponse>;
   putStringEnumValid(arrayBody: string[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -778,10 +658,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringWithNull(): Promise<Models.ArrayModelGetStringWithNullResponse>;
   getStringWithNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetStringWithNullResponse>;
@@ -802,10 +678,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringWithInvalid(): Promise<Models.ArrayModelGetStringWithInvalidResponse>;
   getStringWithInvalid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetStringWithInvalidResponse>;
@@ -827,10 +699,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUuidValid(): Promise<Models.ArrayModelGetUuidValidResponse>;
   getUuidValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetUuidValidResponse>;
@@ -854,10 +722,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUuidValid(arrayBody: string[]): Promise<msRest.RestResponse>;
   putUuidValid(arrayBody: string[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -879,10 +743,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUuidInvalidChars(): Promise<Models.ArrayModelGetUuidInvalidCharsResponse>;
   getUuidInvalidChars(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetUuidInvalidCharsResponse>;
@@ -903,10 +763,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateValid(): Promise<Models.ArrayModelGetDateValidResponse>;
   getDateValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateValidResponse>;
@@ -929,10 +785,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateValid(arrayBody: Array<Date> | Array<string>): Promise<msRest.RestResponse>;
   putDateValid(arrayBody: Array<Date> | Array<string>, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -954,10 +806,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateInvalidNull(): Promise<Models.ArrayModelGetDateInvalidNullResponse>;
   getDateInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateInvalidNullResponse>;
@@ -978,10 +826,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateInvalidChars(): Promise<Models.ArrayModelGetDateInvalidCharsResponse>;
   getDateInvalidChars(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateInvalidCharsResponse>;
@@ -1003,10 +847,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeValid(): Promise<Models.ArrayModelGetDateTimeValidResponse>;
   getDateTimeValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateTimeValidResponse>;
@@ -1030,10 +870,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeValid(arrayBody: Array<Date> | Array<string>): Promise<msRest.RestResponse>;
   putDateTimeValid(arrayBody: Array<Date> | Array<string>, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1055,10 +891,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeInvalidNull(): Promise<Models.ArrayModelGetDateTimeInvalidNullResponse>;
   getDateTimeInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateTimeInvalidNullResponse>;
@@ -1079,10 +911,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeInvalidChars(): Promise<Models.ArrayModelGetDateTimeInvalidCharsResponse>;
   getDateTimeInvalidChars(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateTimeInvalidCharsResponse>;
@@ -1104,10 +932,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeRfc1123Valid(): Promise<Models.ArrayModelGetDateTimeRfc1123ValidResponse>;
   getDateTimeRfc1123Valid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDateTimeRfc1123ValidResponse>;
@@ -1131,10 +955,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeRfc1123Valid(arrayBody: Array<Date> | Array<string>): Promise<msRest.RestResponse>;
   putDateTimeRfc1123Valid(arrayBody: Array<Date> | Array<string>, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1156,10 +976,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDurationValid(): Promise<Models.ArrayModelGetDurationValidResponse>;
   getDurationValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDurationValidResponse>;
@@ -1182,10 +998,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDurationValid(arrayBody: string[]): Promise<msRest.RestResponse>;
   putDurationValid(arrayBody: string[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1208,10 +1020,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByteValid(): Promise<Models.ArrayModelGetByteValidResponse>;
   getByteValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetByteValidResponse>;
@@ -1235,10 +1043,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putByteValid(arrayBody: Uint8Array[]): Promise<msRest.RestResponse>;
   putByteValid(arrayBody: Uint8Array[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1260,10 +1064,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByteInvalidNull(): Promise<Models.ArrayModelGetByteInvalidNullResponse>;
   getByteInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetByteInvalidNullResponse>;
@@ -1285,10 +1085,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBase64Url(): Promise<Models.ArrayModelGetBase64UrlResponse>;
   getBase64Url(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetBase64UrlResponse>;
@@ -1309,10 +1105,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexNull(): Promise<Models.ArrayModelGetComplexNullResponse>;
   getComplexNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetComplexNullResponse>;
@@ -1333,10 +1125,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexEmpty(): Promise<Models.ArrayModelGetComplexEmptyResponse>;
   getComplexEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetComplexEmptyResponse>;
@@ -1358,10 +1146,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexItemNull(): Promise<Models.ArrayModelGetComplexItemNullResponse>;
   getComplexItemNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetComplexItemNullResponse>;
@@ -1383,10 +1167,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexItemEmpty(): Promise<Models.ArrayModelGetComplexItemEmptyResponse>;
   getComplexItemEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetComplexItemEmptyResponse>;
@@ -1408,10 +1188,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexValid(): Promise<Models.ArrayModelGetComplexValidResponse>;
   getComplexValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetComplexValidResponse>;
@@ -1435,10 +1211,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplexValid(arrayBody: Models.Product[]): Promise<msRest.RestResponse>;
   putComplexValid(arrayBody: Models.Product[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1460,10 +1232,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayNull(): Promise<Models.ArrayModelGetArrayNullResponse>;
   getArrayNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetArrayNullResponse>;
@@ -1484,10 +1252,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayEmpty(): Promise<Models.ArrayModelGetArrayEmptyResponse>;
   getArrayEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetArrayEmptyResponse>;
@@ -1508,10 +1272,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayItemNull(): Promise<Models.ArrayModelGetArrayItemNullResponse>;
   getArrayItemNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetArrayItemNullResponse>;
@@ -1532,10 +1292,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayItemEmpty(): Promise<Models.ArrayModelGetArrayItemEmptyResponse>;
   getArrayItemEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetArrayItemEmptyResponse>;
@@ -1556,10 +1312,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayValid(): Promise<Models.ArrayModelGetArrayValidResponse>;
   getArrayValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetArrayValidResponse>;
@@ -1582,10 +1334,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putArrayValid(arrayBody: string[][]): Promise<msRest.RestResponse>;
   putArrayValid(arrayBody: string[][], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1607,10 +1355,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryNull(): Promise<Models.ArrayModelGetDictionaryNullResponse>;
   getDictionaryNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDictionaryNullResponse>;
@@ -1631,10 +1375,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryEmpty(): Promise<Models.ArrayModelGetDictionaryEmptyResponse>;
   getDictionaryEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDictionaryEmptyResponse>;
@@ -1656,10 +1396,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryItemNull(): Promise<Models.ArrayModelGetDictionaryItemNullResponse>;
   getDictionaryItemNull(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDictionaryItemNullResponse>;
@@ -1681,10 +1417,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryItemEmpty(): Promise<Models.ArrayModelGetDictionaryItemEmptyResponse>;
   getDictionaryItemEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDictionaryItemEmptyResponse>;
@@ -1706,10 +1438,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryValid(): Promise<Models.ArrayModelGetDictionaryValidResponse>;
   getDictionaryValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetDictionaryValidResponse>;
@@ -1733,10 +1461,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDictionaryValid(arrayBody: { [propertyName: string]: string }[]): Promise<msRest.RestResponse>;
   putDictionaryValid(arrayBody: { [propertyName: string]: string }[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -30,7 +30,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -104,7 +104,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -129,7 +129,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -155,7 +155,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -180,7 +180,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -204,7 +204,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -228,7 +228,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -254,7 +254,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -279,7 +279,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -303,7 +303,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -327,7 +327,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -353,7 +353,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -378,7 +378,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -402,7 +402,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -426,7 +426,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -452,7 +452,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -477,7 +477,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -501,7 +501,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -525,7 +525,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -551,7 +551,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -576,7 +576,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -600,7 +600,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -624,7 +624,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -650,7 +650,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -675,7 +675,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -701,7 +701,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -726,7 +726,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -752,7 +752,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -777,7 +777,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -801,7 +801,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -826,7 +826,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -853,7 +853,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -878,7 +878,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -902,7 +902,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -928,7 +928,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -953,7 +953,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -977,7 +977,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1002,7 +1002,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1029,7 +1029,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1054,7 +1054,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1078,7 +1078,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1103,7 +1103,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1130,7 +1130,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1155,7 +1155,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1181,7 +1181,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1207,7 +1207,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1234,7 +1234,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1259,7 +1259,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1284,7 +1284,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1308,7 +1308,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1332,7 +1332,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1357,7 +1357,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1382,7 +1382,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1407,7 +1407,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1434,7 +1434,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1459,7 +1459,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1483,7 +1483,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1507,7 +1507,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1531,7 +1531,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1555,7 +1555,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1581,7 +1581,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1606,7 +1606,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1630,7 +1630,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1655,7 +1655,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1680,7 +1680,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1705,7 +1705,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1732,7 +1732,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyArray/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyArray/operations/arrayModel.ts
@@ -28,7 +28,7 @@ export class ArrayModel {
   /**
    * Get null array value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class ArrayModel {
   /**
    * Get invalid array [1, 2, 3
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class ArrayModel {
   /**
    * Get empty array value []
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,9 +100,9 @@ export class ArrayModel {
   /**
    * Set array value empty []
    *
-   * @param {string[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -127,7 +127,7 @@ export class ArrayModel {
   /**
    * Get boolean array value [true, false, false, true]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,9 +151,9 @@ export class ArrayModel {
   /**
    * Set array value empty [true, false, false, true]
    *
-   * @param {boolean[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -178,7 +178,7 @@ export class ArrayModel {
   /**
    * Get boolean array value [true, null, false]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -202,7 +202,7 @@ export class ArrayModel {
   /**
    * Get boolean array value [true, 'boolean', false]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,7 +226,7 @@ export class ArrayModel {
   /**
    * Get integer array value [1, -1, 3, 300]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -250,9 +250,9 @@ export class ArrayModel {
   /**
    * Set array value empty [1, -1, 3, 300]
    *
-   * @param {number[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -277,7 +277,7 @@ export class ArrayModel {
   /**
    * Get integer array value [1, null, 0]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -301,7 +301,7 @@ export class ArrayModel {
   /**
    * Get integer array value [1, 'integer', 0]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -325,7 +325,7 @@ export class ArrayModel {
   /**
    * Get integer array value [1, -1, 3, 300]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -349,9 +349,9 @@ export class ArrayModel {
   /**
    * Set array value empty [1, -1, 3, 300]
    *
-   * @param {number[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -376,7 +376,7 @@ export class ArrayModel {
   /**
    * Get long array value [1, null, 0]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -400,7 +400,7 @@ export class ArrayModel {
   /**
    * Get long array value [1, 'integer', 0]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -424,7 +424,7 @@ export class ArrayModel {
   /**
    * Get float array value [0, -0.01, 1.2e20]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -448,9 +448,9 @@ export class ArrayModel {
   /**
    * Set array value [0, -0.01, 1.2e20]
    *
-   * @param {number[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -475,7 +475,7 @@ export class ArrayModel {
   /**
    * Get float array value [0.0, null, -1.2e20]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -499,7 +499,7 @@ export class ArrayModel {
   /**
    * Get boolean array value [1.0, 'number', 0.0]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -523,7 +523,7 @@ export class ArrayModel {
   /**
    * Get float array value [0, -0.01, 1.2e20]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -547,9 +547,9 @@ export class ArrayModel {
   /**
    * Set array value [0, -0.01, 1.2e20]
    *
-   * @param {number[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -574,7 +574,7 @@ export class ArrayModel {
   /**
    * Get float array value [0.0, null, -1.2e20]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -598,7 +598,7 @@ export class ArrayModel {
   /**
    * Get boolean array value [1.0, 'number', 0.0]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -622,7 +622,7 @@ export class ArrayModel {
   /**
    * Get string array value ['foo1', 'foo2', 'foo3']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -646,9 +646,9 @@ export class ArrayModel {
   /**
    * Set array value ['foo1', 'foo2', 'foo3']
    *
-   * @param {string[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -673,7 +673,7 @@ export class ArrayModel {
   /**
    * Get enum array value ['foo1', 'foo2', 'foo3']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -697,9 +697,9 @@ export class ArrayModel {
   /**
    * Set array value ['foo1', 'foo2', 'foo3']
    *
-   * @param {FooEnum[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -724,7 +724,7 @@ export class ArrayModel {
   /**
    * Get enum array value ['foo1', 'foo2', 'foo3']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -748,9 +748,9 @@ export class ArrayModel {
   /**
    * Set array value ['foo1', 'foo2', 'foo3']
    *
-   * @param {string[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -775,7 +775,7 @@ export class ArrayModel {
   /**
    * Get string array value ['foo', null, 'foo2']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -799,7 +799,7 @@ export class ArrayModel {
   /**
    * Get string array value ['foo', 123, 'foo2']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -824,7 +824,7 @@ export class ArrayModel {
    * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652',
    * 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -849,9 +849,9 @@ export class ArrayModel {
    * Set array value  ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652',
    * 'd1399005-30f7-40d6-8da6-dd7c89ad34db', 'f42f6aa1-a5bc-4ddf-907e-5f915de43205']
    *
-   * @param {string[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -876,7 +876,7 @@ export class ArrayModel {
   /**
    * Get uuid array value ['6dcc7237-45fe-45c4-8a6b-3a8a3f625652', 'foo']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -900,7 +900,7 @@ export class ArrayModel {
   /**
    * Get integer array value ['2000-12-01', '1980-01-02', '1492-10-12']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -924,9 +924,9 @@ export class ArrayModel {
   /**
    * Set array value  ['2000-12-01', '1980-01-02', '1492-10-12']
    *
-   * @param {Array<Date> | Array<string>} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -951,7 +951,7 @@ export class ArrayModel {
   /**
    * Get date array value ['2012-01-01', null, '1776-07-04']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -975,7 +975,7 @@ export class ArrayModel {
   /**
    * Get date array value ['2011-03-22', 'date']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1000,7 +1000,7 @@ export class ArrayModel {
    * Get date-time array value ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00',
    * '1492-10-12T10:15:01-08:00']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1025,9 +1025,9 @@ export class ArrayModel {
    * Set array value  ['2000-12-01t00:00:01z', '1980-01-02T00:11:35+01:00',
    * '1492-10-12T10:15:01-08:00']
    *
-   * @param {Array<Date> | Array<string>} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1052,7 +1052,7 @@ export class ArrayModel {
   /**
    * Get date array value ['2000-12-01t00:00:01z', null]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1076,7 +1076,7 @@ export class ArrayModel {
   /**
    * Get date array value ['2000-12-01t00:00:01z', 'date-time']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1101,7 +1101,7 @@ export class ArrayModel {
    * Get date-time array value ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT',
    * 'Wed, 12 Oct 1492 10:15:01 GMT']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1126,9 +1126,9 @@ export class ArrayModel {
    * Set array value  ['Fri, 01 Dec 2000 00:00:01 GMT', 'Wed, 02 Jan 1980 00:11:35 GMT', 'Wed, 12 Oct
    * 1492 10:15:01 GMT']
    *
-   * @param {Array<Date> | Array<string>} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1153,7 +1153,7 @@ export class ArrayModel {
   /**
    * Get duration array value ['P123DT22H14M12.011S', 'P5DT1H0M0S']
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1177,9 +1177,9 @@ export class ArrayModel {
   /**
    * Set array value  ['P123DT22H14M12.011S', 'P5DT1H0M0S']
    *
-   * @param {string[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1205,7 +1205,7 @@ export class ArrayModel {
    * Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each item encoded
    * in base64
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1230,9 +1230,9 @@ export class ArrayModel {
    * Put the array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29, 43)] with each elementencoded
    * in base 64
    *
-   * @param {Uint8Array[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1257,7 +1257,7 @@ export class ArrayModel {
   /**
    * Get byte array value [hex(AB, AC, AD), null] with the first item base64 encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1282,7 +1282,7 @@ export class ArrayModel {
    * Get array value ['a string that gets encoded with base64url', 'test string' 'Lorem ipsum'] with
    * the items base64url encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1306,7 +1306,7 @@ export class ArrayModel {
   /**
    * Get array of complex type null value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1330,7 +1330,7 @@ export class ArrayModel {
   /**
    * Get empty array of complex type []
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1355,7 +1355,7 @@ export class ArrayModel {
    * Get array of complex type with null item [{'integer': 1 'string': '2'}, null, {'integer': 5,
    * 'string': '6'}]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1380,7 +1380,7 @@ export class ArrayModel {
    * Get array of complex type with empty item [{'integer': 1 'string': '2'}, {}, {'integer': 5,
    * 'string': '6'}]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1405,7 +1405,7 @@ export class ArrayModel {
    * Get array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'},
    * {'integer': 5, 'string': '6'}]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1430,9 +1430,9 @@ export class ArrayModel {
    * Put an array of complex type with values [{'integer': 1 'string': '2'}, {'integer': 3, 'string':
    * '4'}, {'integer': 5, 'string': '6'}]
    *
-   * @param {Product[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1457,7 +1457,7 @@ export class ArrayModel {
   /**
    * Get a null array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1481,7 +1481,7 @@ export class ArrayModel {
   /**
    * Get an empty array []
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1505,7 +1505,7 @@ export class ArrayModel {
   /**
    * Get an array of array of strings [['1', '2', '3'], null, ['7', '8', '9']]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1529,7 +1529,7 @@ export class ArrayModel {
   /**
    * Get an array of array of strings [['1', '2', '3'], [], ['7', '8', '9']]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1553,7 +1553,7 @@ export class ArrayModel {
   /**
    * Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1577,9 +1577,9 @@ export class ArrayModel {
   /**
    * Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'], ['7', '8', '9']]
    *
-   * @param {string[][]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1604,7 +1604,7 @@ export class ArrayModel {
   /**
    * Get an array of Dictionaries with value null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1628,7 +1628,7 @@ export class ArrayModel {
   /**
    * Get an array of Dictionaries of type <string, string> with value []
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1653,7 +1653,7 @@ export class ArrayModel {
    * Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3':
    * 'three'}, null, {'7': 'seven', '8': 'eight', '9': 'nine'}]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1678,7 +1678,7 @@ export class ArrayModel {
    * Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3':
    * 'three'}, {}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1703,7 +1703,7 @@ export class ArrayModel {
    * Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3':
    * 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1728,9 +1728,9 @@ export class ArrayModel {
    * Get an array of Dictionaries of type <string, string> with value [{'1': 'one', '2': 'two', '3':
    * 'three'}, {'4': 'four', '5': 'five', '6': 'six'}, {'7': 'seven', '8': 'eight', '9': 'nine'}]
    *
-   * @param {{ [propertyName: string]: string }[]} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestService.ts
@@ -21,9 +21,9 @@ class AutoRestBoolTestService extends AutoRestBoolTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestBoolTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyBoolean/autoRestBoolTestServiceContext.ts
+++ b/test/vanilla/generated/BodyBoolean/autoRestBoolTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestBoolTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestBoolTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -28,7 +28,7 @@ export class Bool {
   /**
    * Get true Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Bool {
   /**
    * Set Boolean value true
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Bool {
   /**
    * Get false Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Bool {
   /**
    * Set Boolean value false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class Bool {
   /**
    * Get null Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class Bool {
   /**
    * Get invalid Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -30,7 +30,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyBoolean/operations/bool.ts
+++ b/test/vanilla/generated/BodyBoolean/operations/bool.ts
@@ -31,10 +31,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getTrue(): Promise<Models.BoolGetTrueResponse>;
   getTrue(options: msRest.RequestOptionsBase): Promise<Models.BoolGetTrueResponse>;
@@ -55,10 +51,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putTrue(): Promise<msRest.RestResponse>;
   putTrue(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFalse(): Promise<Models.BoolGetFalseResponse>;
   getFalse(options: msRest.RequestOptionsBase): Promise<Models.BoolGetFalseResponse>;
@@ -103,10 +91,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFalse(): Promise<msRest.RestResponse>;
   putFalse(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.BoolGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.BoolGetNullResponse>;
@@ -151,10 +131,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.BoolGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.BoolGetInvalidResponse>;

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATByteService extends AutoRestSwaggerBATByteServiceContext
   /**
    * Initializes a new instance of the AutoRestSwaggerBATByteService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteServiceContext.ts
+++ b/test/vanilla/generated/BodyByte/autoRestSwaggerBATByteServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATByteServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATByteServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyByte/operations/byteModel.ts
+++ b/test/vanilla/generated/BodyByte/operations/byteModel.ts
@@ -31,10 +31,6 @@ export class ByteModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.ByteModelGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.ByteModelGetNullResponse>;
@@ -55,10 +51,6 @@ export class ByteModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.ByteModelGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.ByteModelGetEmptyResponse>;
@@ -79,10 +71,6 @@ export class ByteModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNonAscii(): Promise<Models.ByteModelGetNonAsciiResponse>;
   getNonAscii(options: msRest.RequestOptionsBase): Promise<Models.ByteModelGetNonAsciiResponse>;
@@ -105,10 +93,6 @@ export class ByteModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNonAscii(byteBody: Uint8Array): Promise<msRest.RestResponse>;
   putNonAscii(byteBody: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -130,10 +114,6 @@ export class ByteModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.ByteModelGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.ByteModelGetInvalidResponse>;

--- a/test/vanilla/generated/BodyByte/operations/byteModel.ts
+++ b/test/vanilla/generated/BodyByte/operations/byteModel.ts
@@ -28,7 +28,7 @@ export class ByteModel {
   /**
    * Get null byte value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class ByteModel {
   /**
    * Get empty byte value ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class ByteModel {
   /**
    * Get non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,10 +100,9 @@ export class ByteModel {
   /**
    * Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
    *
-   * @param {Uint8Array} byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7
-   * F6)
+   * @param byteBody Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -128,7 +127,7 @@ export class ByteModel {
   /**
    * Get invalid byte value ':::SWAGGER::::'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyByte/operations/byteModel.ts
+++ b/test/vanilla/generated/BodyByte/operations/byteModel.ts
@@ -30,7 +30,7 @@ export class ByteModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class ByteModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class ByteModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -104,7 +104,7 @@ export class ByteModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -129,7 +129,7 @@ export class ByteModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestService.ts
@@ -29,9 +29,9 @@ class AutoRestComplexTestService extends AutoRestComplexTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestComplexTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyComplex/autoRestComplexTestServiceContext.ts
+++ b/test/vanilla/generated/BodyComplex/autoRestComplexTestServiceContext.ts
@@ -19,9 +19,9 @@ export class AutoRestComplexTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestComplexTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
@@ -28,7 +28,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class ArrayModel {
   /**
    * Put complex types with array property
    *
-   * @param {ArrayModelPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property which is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class ArrayModel {
   /**
    * Put complex types with array property which is empty
    *
-   * @param {ArrayModelPutEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class ArrayModel {
   /**
    * Get complex types with array property while server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
@@ -31,10 +31,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.ArrayModelGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetValidResponse>;
@@ -55,10 +51,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.ArrayModelPutValidOptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.ArrayModelGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetEmptyResponse>;
@@ -103,10 +91,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: Models.ArrayModelPutEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class ArrayModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.ArrayModelGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.ArrayModelGetNotProvidedResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
+++ b/test/vanilla/generated/BodyComplex/operations/arrayModel.ts
@@ -30,7 +30,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class ArrayModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
+++ b/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
@@ -32,10 +32,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.BasicGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.BasicGetValidResponse>;
@@ -58,10 +54,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.Basic): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.Basic, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.BasicGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.BasicGetInvalidResponse>;
@@ -107,10 +95,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.BasicGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.BasicGetEmptyResponse>;
@@ -131,10 +115,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.BasicGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.BasicGetNullResponse>;
@@ -155,10 +135,6 @@ export class BasicOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.BasicGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.BasicGetNotProvidedResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
+++ b/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
@@ -29,7 +29,7 @@ export class BasicOperations {
   /**
    * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,9 +53,9 @@ export class BasicOperations {
   /**
    * Please put {id: 2, name: 'abc', color: 'Magenta'}
    *
-   * @param {Basic} complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
+   * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,7 +80,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type that is invalid for the local strong type
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,7 +104,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type that is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -128,7 +128,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type whose properties are null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -152,7 +152,7 @@ export class BasicOperations {
   /**
    * Get a basic complex type while the server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
+++ b/test/vanilla/generated/BodyComplex/operations/basicOperations.ts
@@ -31,7 +31,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -57,7 +57,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -130,7 +130,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -154,7 +154,7 @@ export class BasicOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyComplex/operations/dictionary.ts
@@ -30,7 +30,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyComplex/operations/dictionary.ts
@@ -31,10 +31,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.DictionaryGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetValidResponse>;
@@ -55,10 +51,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.DictionaryPutValidOptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.DictionaryGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetEmptyResponse>;
@@ -103,10 +91,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: Models.DictionaryPutEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DictionaryGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNullResponse>;
@@ -151,10 +131,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.DictionaryGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNotProvidedResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyComplex/operations/dictionary.ts
@@ -28,7 +28,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Dictionary {
   /**
    * Put complex types with dictionary property
    *
-   * @param {DictionaryPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property which is empty
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Dictionary {
   /**
    * Put complex types with dictionary property which is empty
    *
-   * @param {DictionaryPutEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property which is null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class Dictionary {
   /**
    * Get complex types with dictionary property while server doesn't provide a response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
+++ b/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
@@ -29,10 +29,6 @@ export class Flattencomplex {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.FlattencomplexGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.FlattencomplexGetValidResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
+++ b/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
@@ -28,7 +28,7 @@ export class Flattencomplex {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
+++ b/test/vanilla/generated/BodyComplex/operations/flattencomplex.ts
@@ -26,7 +26,7 @@ export class Flattencomplex {
   }
 
   /**
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/inheritance.ts
+++ b/test/vanilla/generated/BodyComplex/operations/inheritance.ts
@@ -30,7 +30,7 @@ export class Inheritance {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -58,7 +58,7 @@ export class Inheritance {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/inheritance.ts
+++ b/test/vanilla/generated/BodyComplex/operations/inheritance.ts
@@ -31,10 +31,6 @@ export class Inheritance {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.InheritanceGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.InheritanceGetValidResponse>;
@@ -59,10 +55,6 @@ export class Inheritance {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.Siamese): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.Siamese, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/inheritance.ts
+++ b/test/vanilla/generated/BodyComplex/operations/inheritance.ts
@@ -28,7 +28,7 @@ export class Inheritance {
   /**
    * Get complex types that extend others
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,11 +52,11 @@ export class Inheritance {
   /**
    * Put complex types that extend others
    *
-   * @param {Siamese} complexBody Please put a siamese with id=2, name="Siameee", color=green,
-   * breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and
-   * the 2nd one named "Tomato" with id=-1 and food="french fries".
+   * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+   * which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one
+   * named "Tomato" with id=-1 and food="french fries".
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
@@ -31,10 +31,6 @@ export class Polymorphicrecursive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.PolymorphicrecursiveGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.PolymorphicrecursiveGetValidResponse>;
@@ -109,10 +105,6 @@ export class Polymorphicrecursive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
@@ -30,7 +30,7 @@ export class Polymorphicrecursive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -108,7 +108,7 @@ export class Polymorphicrecursive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphicrecursive.ts
@@ -28,7 +28,7 @@ export class Polymorphicrecursive {
   /**
    * Get complex types that are polymorphic and have recursive references
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Polymorphicrecursive {
   /**
    * Put complex types that are polymorphic and have recursive references
    *
-   * @param {FishUnion} complexBody Please put a salmon that looks like this:
+   * @param complexBody Please put a salmon that looks like this:
    * {
    * "fishtype": "salmon",
    * "species": "king",
@@ -106,7 +106,7 @@ export class Polymorphicrecursive {
    * ]
    * }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
@@ -30,7 +30,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -88,7 +88,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -114,7 +114,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -141,7 +141,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -168,7 +168,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class Polymorphism {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
@@ -31,10 +31,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.PolymorphismGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.PolymorphismGetValidResponse>;
@@ -89,10 +85,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValid(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -115,10 +107,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplicated(): Promise<Models.PolymorphismGetComplicatedResponse>;
   getComplicated(options: msRest.RequestOptionsBase): Promise<Models.PolymorphismGetComplicatedResponse>;
@@ -142,10 +130,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplicated(complexBody: Models.SalmonUnion): Promise<msRest.RestResponse>;
   putComplicated(complexBody: Models.SalmonUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -169,10 +153,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMissingDiscriminator(complexBody: Models.SalmonUnion): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
   putMissingDiscriminator(complexBody: Models.SalmonUnion, options: msRest.RequestOptionsBase): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
@@ -223,10 +203,6 @@ export class Polymorphism {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValidMissingRequired(complexBody: Models.FishUnion): Promise<msRest.RestResponse>;
   putValidMissingRequired(complexBody: Models.FishUnion, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
+++ b/test/vanilla/generated/BodyComplex/operations/polymorphism.ts
@@ -28,7 +28,7 @@ export class Polymorphism {
   /**
    * Get complex types that are polymorphic
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic
    *
-   * @param {FishUnion} complexBody Please put a salmon that looks like this:
+   * @param complexBody Please put a salmon that looks like this:
    * {
    * 'fishtype':'Salmon',
    * 'location':'alaska',
@@ -86,7 +86,7 @@ export class Polymorphism {
    * ]
    * };
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -112,7 +112,7 @@ export class Polymorphism {
    * Get complex types that are polymorphic, but not at the root of the hierarchy; also have
    * additional properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -137,9 +137,9 @@ export class Polymorphism {
    * Put complex types that are polymorphic, but not at the root of the hierarchy; also have
    * additional properties
    *
-   * @param {SalmonUnion} complexBody
+   * @param complexBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -164,9 +164,9 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic, omitting the discriminator
    *
-   * @param {SalmonUnion} complexBody
+   * @param complexBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -192,8 +192,8 @@ export class Polymorphism {
    * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the
    * request should not be allowed from the client
    *
-   * @param {FishUnion} complexBody Please attempt put a sawshark that looks like this, the client
-   * should not allow this data to be sent:
+   * @param complexBody Please attempt put a sawshark that looks like this, the client should not
+   * allow this data to be sent:
    * {
    * "fishtype": "sawshark",
    * "species": "snaggle toothed",
@@ -220,7 +220,7 @@ export class Polymorphism {
    * ]
    * }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/primitive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/primitive.ts
@@ -31,10 +31,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInt(): Promise<Models.PrimitiveGetIntResponse>;
   getInt(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetIntResponse>;
@@ -57,10 +53,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putInt(complexBody: Models.IntWrapper): Promise<msRest.RestResponse>;
   putInt(complexBody: Models.IntWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -82,10 +74,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLong(): Promise<Models.PrimitiveGetLongResponse>;
   getLong(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetLongResponse>;
@@ -108,10 +96,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLong(complexBody: Models.LongWrapper): Promise<msRest.RestResponse>;
   putLong(complexBody: Models.LongWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -133,10 +117,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloat(): Promise<Models.PrimitiveGetFloatResponse>;
   getFloat(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetFloatResponse>;
@@ -159,10 +139,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFloat(complexBody: Models.FloatWrapper): Promise<msRest.RestResponse>;
   putFloat(complexBody: Models.FloatWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -184,10 +160,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDouble(): Promise<Models.PrimitiveGetDoubleResponse>;
   getDouble(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDoubleResponse>;
@@ -211,10 +183,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDouble(complexBody: Models.DoubleWrapper): Promise<msRest.RestResponse>;
   putDouble(complexBody: Models.DoubleWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -236,10 +204,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBool(): Promise<Models.PrimitiveGetBoolResponse>;
   getBool(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetBoolResponse>;
@@ -262,10 +226,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBool(complexBody: Models.BooleanWrapper): Promise<msRest.RestResponse>;
   putBool(complexBody: Models.BooleanWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -287,10 +247,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getString(): Promise<Models.PrimitiveGetStringResponse>;
   getString(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetStringResponse>;
@@ -313,10 +269,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putString(complexBody: Models.StringWrapper): Promise<msRest.RestResponse>;
   putString(complexBody: Models.StringWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -338,10 +290,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDate(): Promise<Models.PrimitiveGetDateResponse>;
   getDate(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateResponse>;
@@ -364,10 +312,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDate(complexBody: Models.DateWrapper): Promise<msRest.RestResponse>;
   putDate(complexBody: Models.DateWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -389,10 +333,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTime(): Promise<Models.PrimitiveGetDateTimeResponse>;
   getDateTime(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateTimeResponse>;
@@ -415,10 +355,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTime(complexBody: Models.DatetimeWrapper): Promise<msRest.RestResponse>;
   putDateTime(complexBody: Models.DatetimeWrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -440,10 +376,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeRfc1123(): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
   getDateTimeRfc1123(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
@@ -467,10 +399,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeRfc1123(complexBody: Models.Datetimerfc1123Wrapper): Promise<msRest.RestResponse>;
   putDateTimeRfc1123(complexBody: Models.Datetimerfc1123Wrapper, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -492,10 +420,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDuration(): Promise<Models.PrimitiveGetDurationResponse>;
   getDuration(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetDurationResponse>;
@@ -516,10 +440,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDuration(): Promise<msRest.RestResponse>;
   putDuration(options: Models.PrimitivePutDurationOptionalParams): Promise<msRest.RestResponse>;
@@ -540,10 +460,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByte(): Promise<Models.PrimitiveGetByteResponse>;
   getByte(options: msRest.RequestOptionsBase): Promise<Models.PrimitiveGetByteResponse>;
@@ -564,10 +480,6 @@ export class Primitive {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putByte(): Promise<msRest.RestResponse>;
   putByte(options: Models.PrimitivePutByteOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/primitive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/primitive.ts
@@ -28,7 +28,7 @@ export class Primitive {
   /**
    * Get complex types with integer properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,9 +52,9 @@ export class Primitive {
   /**
    * Put complex types with integer properties
    *
-   * @param {IntWrapper} complexBody Please put -1 and 2
+   * @param complexBody Please put -1 and 2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -79,7 +79,7 @@ export class Primitive {
   /**
    * Get complex types with long properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,9 +103,9 @@ export class Primitive {
   /**
    * Put complex types with long properties
    *
-   * @param {LongWrapper} complexBody Please put 1099511627775 and -999511627788
+   * @param complexBody Please put 1099511627775 and -999511627788
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -130,7 +130,7 @@ export class Primitive {
   /**
    * Get complex types with float properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -154,9 +154,9 @@ export class Primitive {
   /**
    * Put complex types with float properties
    *
-   * @param {FloatWrapper} complexBody Please put 1.05 and -0.003
+   * @param complexBody Please put 1.05 and -0.003
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -181,7 +181,7 @@ export class Primitive {
   /**
    * Get complex types with double properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -205,10 +205,10 @@ export class Primitive {
   /**
    * Put complex types with double properties
    *
-   * @param {DoubleWrapper} complexBody Please put 3e-100 and
+   * @param complexBody Please put 3e-100 and
    * -0.000000000000000000000000000000000000000000000000000000005
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -233,7 +233,7 @@ export class Primitive {
   /**
    * Get complex types with bool properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -257,9 +257,9 @@ export class Primitive {
   /**
    * Put complex types with bool properties
    *
-   * @param {BooleanWrapper} complexBody Please put true and false
+   * @param complexBody Please put true and false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -284,7 +284,7 @@ export class Primitive {
   /**
    * Get complex types with string properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -308,9 +308,9 @@ export class Primitive {
   /**
    * Put complex types with string properties
    *
-   * @param {StringWrapper} complexBody Please put 'goodrequest', '', and null
+   * @param complexBody Please put 'goodrequest', '', and null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -335,7 +335,7 @@ export class Primitive {
   /**
    * Get complex types with date properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -359,9 +359,9 @@ export class Primitive {
   /**
    * Put complex types with date properties
    *
-   * @param {DateWrapper} complexBody Please put '0001-01-01' and '2016-02-29'
+   * @param complexBody Please put '0001-01-01' and '2016-02-29'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -386,7 +386,7 @@ export class Primitive {
   /**
    * Get complex types with datetime properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -410,10 +410,9 @@ export class Primitive {
   /**
    * Put complex types with datetime properties
    *
-   * @param {DatetimeWrapper} complexBody Please put '0001-01-01T12:00:00-04:00' and
-   * '2015-05-18T11:38:00-08:00'
+   * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -438,7 +437,7 @@ export class Primitive {
   /**
    * Get complex types with datetimeRfc1123 properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -462,10 +461,10 @@ export class Primitive {
   /**
    * Put complex types with datetimeRfc1123 properties
    *
-   * @param {Datetimerfc1123Wrapper} complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon,
-   * 18 May 2015 11:38:00 GMT'
+   * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00
+   * GMT'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -490,7 +489,7 @@ export class Primitive {
   /**
    * Get complex types with duration properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -514,7 +513,7 @@ export class Primitive {
   /**
    * Put complex types with duration properties
    *
-   * @param {PrimitivePutDurationOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -538,7 +537,7 @@ export class Primitive {
   /**
    * Get complex types with byte properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -562,7 +561,7 @@ export class Primitive {
   /**
    * Put complex types with byte properties
    *
-   * @param {PrimitivePutByteOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/primitive.ts
+++ b/test/vanilla/generated/BodyComplex/operations/primitive.ts
@@ -30,7 +30,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -81,7 +81,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -107,7 +107,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -132,7 +132,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -158,7 +158,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -183,7 +183,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -210,7 +210,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -235,7 +235,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -261,7 +261,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -286,7 +286,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -312,7 +312,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -337,7 +337,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -363,7 +363,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -388,7 +388,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -414,7 +414,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -439,7 +439,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -466,7 +466,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -491,7 +491,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -515,7 +515,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -539,7 +539,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -563,7 +563,7 @@ export class Primitive {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
+++ b/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
@@ -31,10 +31,6 @@ export class Readonlyproperty {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getValid(): Promise<Models.ReadonlypropertyGetValidResponse>;
   getValid(options: msRest.RequestOptionsBase): Promise<Models.ReadonlypropertyGetValidResponse>;
@@ -55,10 +51,6 @@ export class Readonlyproperty {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putValid(): Promise<msRest.RestResponse>;
   putValid(options: Models.ReadonlypropertyPutValidOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
+++ b/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
@@ -28,7 +28,7 @@ export class Readonlyproperty {
   /**
    * Get complex types that have readonly properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Readonlyproperty {
   /**
    * Put complex types that have readonly properties
    *
-   * @param {ReadonlypropertyPutValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
+++ b/test/vanilla/generated/BodyComplex/operations/readonlyproperty.ts
@@ -30,7 +30,7 @@ export class Readonlyproperty {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Readonlyproperty {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestService.ts
@@ -21,9 +21,9 @@ class AutoRestDateTestService extends AutoRestDateTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestDateTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDate/autoRestDateTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDate/autoRestDateTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestDateTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestDateTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDate/operations/dateModel.ts
+++ b/test/vanilla/generated/BodyDate/operations/dateModel.ts
@@ -30,7 +30,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -179,7 +179,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -204,7 +204,7 @@ export class DateModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyDate/operations/dateModel.ts
+++ b/test/vanilla/generated/BodyDate/operations/dateModel.ts
@@ -28,7 +28,7 @@ export class DateModel {
   /**
    * Get null date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class DateModel {
   /**
    * Get invalid date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class DateModel {
   /**
    * Get overflow date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class DateModel {
   /**
    * Get underflow date value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,9 +124,9 @@ export class DateModel {
   /**
    * Put max date value 9999-12-31
    *
-   * @param {Date | string} dateBody
+   * @param dateBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class DateModel {
   /**
    * Get max date value 9999-12-31
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,9 +175,9 @@ export class DateModel {
   /**
    * Put min date value 0000-01-01
    *
-   * @param {Date | string} dateBody
+   * @param dateBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -202,7 +202,7 @@ export class DateModel {
   /**
    * Get min date value 0000-01-01
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyDate/operations/dateModel.ts
+++ b/test/vanilla/generated/BodyDate/operations/dateModel.ts
@@ -31,10 +31,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DateModelGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetNullResponse>;
@@ -55,10 +51,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidDate(): Promise<Models.DateModelGetInvalidDateResponse>;
   getInvalidDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetInvalidDateResponse>;
@@ -79,10 +71,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflowDate(): Promise<Models.DateModelGetOverflowDateResponse>;
   getOverflowDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetOverflowDateResponse>;
@@ -103,10 +91,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflowDate(): Promise<Models.DateModelGetUnderflowDateResponse>;
   getUnderflowDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetUnderflowDateResponse>;
@@ -129,10 +113,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMaxDate(dateBody: Date | string): Promise<msRest.RestResponse>;
   putMaxDate(dateBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -154,10 +134,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMaxDate(): Promise<Models.DateModelGetMaxDateResponse>;
   getMaxDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetMaxDateResponse>;
@@ -180,10 +156,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMinDate(dateBody: Date | string): Promise<msRest.RestResponse>;
   putMinDate(dateBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -205,10 +177,6 @@ export class DateModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMinDate(): Promise<Models.DateModelGetMinDateResponse>;
   getMinDate(options: msRest.RequestOptionsBase): Promise<Models.DateModelGetMinDateResponse>;

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestService.ts
@@ -21,9 +21,9 @@ class AutoRestDateTimeTestService extends AutoRestDateTimeTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestDateTimeTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDateTime/autoRestDateTimeTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestDateTimeTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestDateTimeTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDateTime/operations/datetime.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/datetime.ts
@@ -31,10 +31,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DatetimeGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetNullResponse>;
@@ -55,10 +51,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.DatetimeGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetInvalidResponse>;
@@ -79,10 +71,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflow(): Promise<Models.DatetimeGetOverflowResponse>;
   getOverflow(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetOverflowResponse>;
@@ -103,10 +91,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflow(): Promise<Models.DatetimeGetUnderflowResponse>;
   getUnderflow(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUnderflowResponse>;
@@ -129,10 +113,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMaxDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putUtcMaxDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -154,10 +134,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcLowercaseMaxDateTime(): Promise<Models.DatetimeGetUtcLowercaseMaxDateTimeResponse>;
   getUtcLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUtcLowercaseMaxDateTimeResponse>;
@@ -178,10 +154,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcUppercaseMaxDateTime(): Promise<Models.DatetimeGetUtcUppercaseMaxDateTimeResponse>;
   getUtcUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUtcUppercaseMaxDateTimeResponse>;
@@ -204,10 +176,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalPositiveOffsetMaxDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putLocalPositiveOffsetMaxDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -229,10 +197,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPositiveOffsetLowercaseMaxDateTime(): Promise<Models.DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse>;
   getLocalPositiveOffsetLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalPositiveOffsetLowercaseMaxDateTimeResponse>;
@@ -253,10 +217,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPositiveOffsetUppercaseMaxDateTime(): Promise<Models.DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse>;
   getLocalPositiveOffsetUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalPositiveOffsetUppercaseMaxDateTimeResponse>;
@@ -279,10 +239,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalNegativeOffsetMaxDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putLocalNegativeOffsetMaxDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -304,10 +260,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalNegativeOffsetUppercaseMaxDateTime(): Promise<Models.DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse>;
   getLocalNegativeOffsetUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalNegativeOffsetUppercaseMaxDateTimeResponse>;
@@ -328,10 +280,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalNegativeOffsetLowercaseMaxDateTime(): Promise<Models.DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse>;
   getLocalNegativeOffsetLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalNegativeOffsetLowercaseMaxDateTimeResponse>;
@@ -354,10 +302,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMinDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putUtcMinDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -379,10 +323,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcMinDateTime(): Promise<Models.DatetimeGetUtcMinDateTimeResponse>;
   getUtcMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetUtcMinDateTimeResponse>;
@@ -405,10 +345,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalPositiveOffsetMinDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putLocalPositiveOffsetMinDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -430,10 +366,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPositiveOffsetMinDateTime(): Promise<Models.DatetimeGetLocalPositiveOffsetMinDateTimeResponse>;
   getLocalPositiveOffsetMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalPositiveOffsetMinDateTimeResponse>;
@@ -456,10 +388,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLocalNegativeOffsetMinDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putLocalNegativeOffsetMinDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -481,10 +409,6 @@ export class Datetime {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalNegativeOffsetMinDateTime(): Promise<Models.DatetimeGetLocalNegativeOffsetMinDateTimeResponse>;
   getLocalNegativeOffsetMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.DatetimeGetLocalNegativeOffsetMinDateTimeResponse>;

--- a/test/vanilla/generated/BodyDateTime/operations/datetime.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/datetime.ts
@@ -28,7 +28,7 @@ export class Datetime {
   /**
    * Get null datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Datetime {
   /**
    * Get invalid datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Datetime {
   /**
    * Get overflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Datetime {
   /**
    * Get underflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,9 +124,9 @@ export class Datetime {
   /**
    * Put max datetime value 9999-12-31T23:59:59.9999999Z
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class Datetime {
   /**
    * Get max datetime value 9999-12-31t23:59:59.9999999z
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,7 +175,7 @@ export class Datetime {
   /**
    * Get max datetime value 9999-12-31T23:59:59.9999999Z
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -199,9 +199,9 @@ export class Datetime {
   /**
    * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999+14:00
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,7 +226,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999+14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -250,7 +250,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999+14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -274,9 +274,9 @@ export class Datetime {
   /**
    * Put max datetime value with positive numoffset 9999-12-31t23:59:59.9999999-14:00
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -301,7 +301,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31T23:59:59.9999999-14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -325,7 +325,7 @@ export class Datetime {
   /**
    * Get max datetime value with positive num offset 9999-12-31t23:59:59.9999999-14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -349,9 +349,9 @@ export class Datetime {
   /**
    * Put min datetime value 0001-01-01T00:00:00Z
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -376,7 +376,7 @@ export class Datetime {
   /**
    * Get min datetime value 0001-01-01T00:00:00Z
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -400,9 +400,9 @@ export class Datetime {
   /**
    * Put min datetime value 0001-01-01T00:00:00+14:00
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -427,7 +427,7 @@ export class Datetime {
   /**
    * Get min datetime value 0001-01-01T00:00:00+14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -451,9 +451,9 @@ export class Datetime {
   /**
    * Put min datetime value 0001-01-01T00:00:00-14:00
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -478,7 +478,7 @@ export class Datetime {
   /**
    * Get min datetime value 0001-01-01T00:00:00-14:00
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyDateTime/operations/datetime.ts
+++ b/test/vanilla/generated/BodyDateTime/operations/datetime.ts
@@ -30,7 +30,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -177,7 +177,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -228,7 +228,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -252,7 +252,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -278,7 +278,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -303,7 +303,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -327,7 +327,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -353,7 +353,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -378,7 +378,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -404,7 +404,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -429,7 +429,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -455,7 +455,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -480,7 +480,7 @@ export class Datetime {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.ts
@@ -21,9 +21,9 @@ class AutoRestRFC1123DateTimeTestService extends AutoRestRFC1123DateTimeTestServ
   /**
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestRFC1123DateTimeTestServiceContext extends msRest.ServiceCli
   /**
    * Initializes a new instance of the AutoRestRFC1123DateTimeTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -30,7 +30,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -177,7 +177,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -228,7 +228,7 @@ export class Datetimerfc1123 {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -28,7 +28,7 @@ export class Datetimerfc1123 {
   /**
    * Get null datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Datetimerfc1123 {
   /**
    * Get invalid datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Datetimerfc1123 {
   /**
    * Get overflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Datetimerfc1123 {
   /**
    * Get underflow datetime value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,9 +124,9 @@ export class Datetimerfc1123 {
   /**
    * Put max datetime value Fri, 31 Dec 9999 23:59:59 GMT
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class Datetimerfc1123 {
   /**
    * Get max datetime value fri, 31 dec 9999 23:59:59 gmt
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,7 +175,7 @@ export class Datetimerfc1123 {
   /**
    * Get max datetime value FRI, 31 DEC 9999 23:59:59 GMT
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -199,9 +199,9 @@ export class Datetimerfc1123 {
   /**
    * Put min datetime value Mon, 1 Jan 0001 00:00:00 GMT
    *
-   * @param {Date | string} datetimeBody
+   * @param datetimeBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,7 +226,7 @@ export class Datetimerfc1123 {
   /**
    * Get min datetime value Mon, 1 Jan 0001 00:00:00 GMT
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
+++ b/test/vanilla/generated/BodyDateTimeRfc1123/operations/datetimerfc1123.ts
@@ -31,10 +31,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.Datetimerfc1123GetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetNullResponse>;
@@ -55,10 +51,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.Datetimerfc1123GetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetInvalidResponse>;
@@ -79,10 +71,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflow(): Promise<Models.Datetimerfc1123GetOverflowResponse>;
   getOverflow(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetOverflowResponse>;
@@ -103,10 +91,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflow(): Promise<Models.Datetimerfc1123GetUnderflowResponse>;
   getUnderflow(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUnderflowResponse>;
@@ -129,10 +113,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMaxDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putUtcMaxDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -154,10 +134,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcLowercaseMaxDateTime(): Promise<Models.Datetimerfc1123GetUtcLowercaseMaxDateTimeResponse>;
   getUtcLowercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUtcLowercaseMaxDateTimeResponse>;
@@ -178,10 +154,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcUppercaseMaxDateTime(): Promise<Models.Datetimerfc1123GetUtcUppercaseMaxDateTimeResponse>;
   getUtcUppercaseMaxDateTime(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUtcUppercaseMaxDateTimeResponse>;
@@ -204,10 +176,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUtcMinDateTime(datetimeBody: Date | string): Promise<msRest.RestResponse>;
   putUtcMinDateTime(datetimeBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -229,10 +197,6 @@ export class Datetimerfc1123 {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUtcMinDateTime(): Promise<Models.Datetimerfc1123GetUtcMinDateTimeResponse>;
   getUtcMinDateTime(options: msRest.RequestOptionsBase): Promise<Models.Datetimerfc1123GetUtcMinDateTimeResponse>;

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATdictionaryService extends AutoRestSwaggerBATdictionarySe
   /**
    * Initializes a new instance of the AutoRestSwaggerBATdictionaryService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryServiceContext.ts
+++ b/test/vanilla/generated/BodyDictionary/autoRestSwaggerBATdictionaryServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATdictionaryServiceContext extends msRest.ServiceCl
   /**
    * Initializes a new instance of the AutoRestSwaggerBATdictionaryServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
@@ -31,10 +31,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DictionaryGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNullResponse>;
@@ -55,10 +51,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.DictionaryGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetEmptyResponse>;
@@ -81,10 +73,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(arrayBody: { [propertyName: string]: string }): Promise<msRest.RestResponse>;
   putEmpty(arrayBody: { [propertyName: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -106,10 +94,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNullValue(): Promise<Models.DictionaryGetNullValueResponse>;
   getNullValue(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNullValueResponse>;
@@ -130,10 +114,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNullKey(): Promise<Models.DictionaryGetNullKeyResponse>;
   getNullKey(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetNullKeyResponse>;
@@ -154,10 +134,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyStringKey(): Promise<Models.DictionaryGetEmptyStringKeyResponse>;
   getEmptyStringKey(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetEmptyStringKeyResponse>;
@@ -178,10 +154,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.DictionaryGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetInvalidResponse>;
@@ -202,10 +174,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanTfft(): Promise<Models.DictionaryGetBooleanTfftResponse>;
   getBooleanTfft(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetBooleanTfftResponse>;
@@ -228,10 +196,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBooleanTfft(arrayBody: { [propertyName: string]: boolean }): Promise<msRest.RestResponse>;
   putBooleanTfft(arrayBody: { [propertyName: string]: boolean }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -253,10 +217,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanInvalidNull(): Promise<Models.DictionaryGetBooleanInvalidNullResponse>;
   getBooleanInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetBooleanInvalidNullResponse>;
@@ -277,10 +237,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanInvalidString(): Promise<Models.DictionaryGetBooleanInvalidStringResponse>;
   getBooleanInvalidString(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetBooleanInvalidStringResponse>;
@@ -301,10 +257,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntegerValid(): Promise<Models.DictionaryGetIntegerValidResponse>;
   getIntegerValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetIntegerValidResponse>;
@@ -327,10 +279,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putIntegerValid(arrayBody: { [propertyName: string]: number }): Promise<msRest.RestResponse>;
   putIntegerValid(arrayBody: { [propertyName: string]: number }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -352,10 +300,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntInvalidNull(): Promise<Models.DictionaryGetIntInvalidNullResponse>;
   getIntInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetIntInvalidNullResponse>;
@@ -376,10 +320,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntInvalidString(): Promise<Models.DictionaryGetIntInvalidStringResponse>;
   getIntInvalidString(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetIntInvalidStringResponse>;
@@ -400,10 +340,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongValid(): Promise<Models.DictionaryGetLongValidResponse>;
   getLongValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetLongValidResponse>;
@@ -426,10 +362,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putLongValid(arrayBody: { [propertyName: string]: number }): Promise<msRest.RestResponse>;
   putLongValid(arrayBody: { [propertyName: string]: number }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -451,10 +383,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongInvalidNull(): Promise<Models.DictionaryGetLongInvalidNullResponse>;
   getLongInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetLongInvalidNullResponse>;
@@ -475,10 +403,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongInvalidString(): Promise<Models.DictionaryGetLongInvalidStringResponse>;
   getLongInvalidString(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetLongInvalidStringResponse>;
@@ -499,10 +423,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloatValid(): Promise<Models.DictionaryGetFloatValidResponse>;
   getFloatValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetFloatValidResponse>;
@@ -525,10 +445,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFloatValid(arrayBody: { [propertyName: string]: number }): Promise<msRest.RestResponse>;
   putFloatValid(arrayBody: { [propertyName: string]: number }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -550,10 +466,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloatInvalidNull(): Promise<Models.DictionaryGetFloatInvalidNullResponse>;
   getFloatInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetFloatInvalidNullResponse>;
@@ -574,10 +486,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFloatInvalidString(): Promise<Models.DictionaryGetFloatInvalidStringResponse>;
   getFloatInvalidString(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetFloatInvalidStringResponse>;
@@ -598,10 +506,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDoubleValid(): Promise<Models.DictionaryGetDoubleValidResponse>;
   getDoubleValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDoubleValidResponse>;
@@ -624,10 +528,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDoubleValid(arrayBody: { [propertyName: string]: number }): Promise<msRest.RestResponse>;
   putDoubleValid(arrayBody: { [propertyName: string]: number }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -649,10 +549,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDoubleInvalidNull(): Promise<Models.DictionaryGetDoubleInvalidNullResponse>;
   getDoubleInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDoubleInvalidNullResponse>;
@@ -673,10 +569,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDoubleInvalidString(): Promise<Models.DictionaryGetDoubleInvalidStringResponse>;
   getDoubleInvalidString(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDoubleInvalidStringResponse>;
@@ -697,10 +589,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringValid(): Promise<Models.DictionaryGetStringValidResponse>;
   getStringValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetStringValidResponse>;
@@ -723,10 +611,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putStringValid(arrayBody: { [propertyName: string]: string }): Promise<msRest.RestResponse>;
   putStringValid(arrayBody: { [propertyName: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -748,10 +632,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringWithNull(): Promise<Models.DictionaryGetStringWithNullResponse>;
   getStringWithNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetStringWithNullResponse>;
@@ -772,10 +652,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getStringWithInvalid(): Promise<Models.DictionaryGetStringWithInvalidResponse>;
   getStringWithInvalid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetStringWithInvalidResponse>;
@@ -796,10 +672,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateValid(): Promise<Models.DictionaryGetDateValidResponse>;
   getDateValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateValidResponse>;
@@ -822,10 +694,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateValid(arrayBody: { [key: string]: Date } | { [key: string]: string }): Promise<msRest.RestResponse>;
   putDateValid(arrayBody: { [key: string]: Date } | { [key: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -847,10 +715,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateInvalidNull(): Promise<Models.DictionaryGetDateInvalidNullResponse>;
   getDateInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateInvalidNullResponse>;
@@ -871,10 +735,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateInvalidChars(): Promise<Models.DictionaryGetDateInvalidCharsResponse>;
   getDateInvalidChars(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateInvalidCharsResponse>;
@@ -896,10 +756,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeValid(): Promise<Models.DictionaryGetDateTimeValidResponse>;
   getDateTimeValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateTimeValidResponse>;
@@ -923,10 +779,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeValid(arrayBody: { [key: string]: Date } | { [key: string]: string }): Promise<msRest.RestResponse>;
   putDateTimeValid(arrayBody: { [key: string]: Date } | { [key: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -948,10 +800,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeInvalidNull(): Promise<Models.DictionaryGetDateTimeInvalidNullResponse>;
   getDateTimeInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateTimeInvalidNullResponse>;
@@ -972,10 +820,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeInvalidChars(): Promise<Models.DictionaryGetDateTimeInvalidCharsResponse>;
   getDateTimeInvalidChars(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateTimeInvalidCharsResponse>;
@@ -997,10 +841,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDateTimeRfc1123Valid(): Promise<Models.DictionaryGetDateTimeRfc1123ValidResponse>;
   getDateTimeRfc1123Valid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDateTimeRfc1123ValidResponse>;
@@ -1024,10 +864,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDateTimeRfc1123Valid(arrayBody: { [key: string]: Date } | { [key: string]: string }): Promise<msRest.RestResponse>;
   putDateTimeRfc1123Valid(arrayBody: { [key: string]: Date } | { [key: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1049,10 +885,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDurationValid(): Promise<Models.DictionaryGetDurationValidResponse>;
   getDurationValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDurationValidResponse>;
@@ -1075,10 +907,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDurationValid(arrayBody: { [propertyName: string]: string }): Promise<msRest.RestResponse>;
   putDurationValid(arrayBody: { [propertyName: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1101,10 +929,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByteValid(): Promise<Models.DictionaryGetByteValidResponse>;
   getByteValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetByteValidResponse>;
@@ -1128,10 +952,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putByteValid(arrayBody: { [propertyName: string]: Uint8Array }): Promise<msRest.RestResponse>;
   putByteValid(arrayBody: { [propertyName: string]: Uint8Array }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1153,10 +973,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByteInvalidNull(): Promise<Models.DictionaryGetByteInvalidNullResponse>;
   getByteInvalidNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetByteInvalidNullResponse>;
@@ -1178,10 +994,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBase64Url(): Promise<Models.DictionaryGetBase64UrlResponse>;
   getBase64Url(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetBase64UrlResponse>;
@@ -1202,10 +1014,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexNull(): Promise<Models.DictionaryGetComplexNullResponse>;
   getComplexNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetComplexNullResponse>;
@@ -1226,10 +1034,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexEmpty(): Promise<Models.DictionaryGetComplexEmptyResponse>;
   getComplexEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetComplexEmptyResponse>;
@@ -1251,10 +1055,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexItemNull(): Promise<Models.DictionaryGetComplexItemNullResponse>;
   getComplexItemNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetComplexItemNullResponse>;
@@ -1276,10 +1076,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexItemEmpty(): Promise<Models.DictionaryGetComplexItemEmptyResponse>;
   getComplexItemEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetComplexItemEmptyResponse>;
@@ -1301,10 +1097,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexValid(): Promise<Models.DictionaryGetComplexValidResponse>;
   getComplexValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetComplexValidResponse>;
@@ -1328,10 +1120,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplexValid(arrayBody: { [propertyName: string]: Models.Widget }): Promise<msRest.RestResponse>;
   putComplexValid(arrayBody: { [propertyName: string]: Models.Widget }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1353,10 +1141,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayNull(): Promise<Models.DictionaryGetArrayNullResponse>;
   getArrayNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetArrayNullResponse>;
@@ -1377,10 +1161,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayEmpty(): Promise<Models.DictionaryGetArrayEmptyResponse>;
   getArrayEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetArrayEmptyResponse>;
@@ -1401,10 +1181,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayItemNull(): Promise<Models.DictionaryGetArrayItemNullResponse>;
   getArrayItemNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetArrayItemNullResponse>;
@@ -1425,10 +1201,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayItemEmpty(): Promise<Models.DictionaryGetArrayItemEmptyResponse>;
   getArrayItemEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetArrayItemEmptyResponse>;
@@ -1450,10 +1222,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArrayValid(): Promise<Models.DictionaryGetArrayValidResponse>;
   getArrayValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetArrayValidResponse>;
@@ -1477,10 +1245,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putArrayValid(arrayBody: { [propertyName: string]: string[] }): Promise<msRest.RestResponse>;
   putArrayValid(arrayBody: { [propertyName: string]: string[] }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -1502,10 +1266,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryNull(): Promise<Models.DictionaryGetDictionaryNullResponse>;
   getDictionaryNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDictionaryNullResponse>;
@@ -1526,10 +1286,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryEmpty(): Promise<Models.DictionaryGetDictionaryEmptyResponse>;
   getDictionaryEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDictionaryEmptyResponse>;
@@ -1551,10 +1307,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryItemNull(): Promise<Models.DictionaryGetDictionaryItemNullResponse>;
   getDictionaryItemNull(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDictionaryItemNullResponse>;
@@ -1576,10 +1328,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryItemEmpty(): Promise<Models.DictionaryGetDictionaryItemEmptyResponse>;
   getDictionaryItemEmpty(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDictionaryItemEmptyResponse>;
@@ -1602,10 +1350,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionaryValid(): Promise<Models.DictionaryGetDictionaryValidResponse>;
   getDictionaryValid(options: msRest.RequestOptionsBase): Promise<Models.DictionaryGetDictionaryValidResponse>;
@@ -1630,10 +1374,6 @@ export class Dictionary {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDictionaryValid(arrayBody: { [propertyName: string]: { [propertyName: string]: string } }): Promise<msRest.RestResponse>;
   putDictionaryValid(arrayBody: { [propertyName: string]: { [propertyName: string]: string } }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
@@ -28,7 +28,7 @@ export class Dictionary {
   /**
    * Get null dictionary value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Dictionary {
   /**
    * Get empty dictionary value {}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,9 +76,9 @@ export class Dictionary {
   /**
    * Set dictionary value empty {}
    *
-   * @param {{ [propertyName: string]: string }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,7 +103,7 @@ export class Dictionary {
   /**
    * Get Dictionary with null value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -127,7 +127,7 @@ export class Dictionary {
   /**
    * Get Dictionary with null key
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class Dictionary {
   /**
    * Get Dictionary with key as empty string
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,7 +175,7 @@ export class Dictionary {
   /**
    * Get invalid Dictionary value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -199,7 +199,7 @@ export class Dictionary {
   /**
    * Get boolean dictionary value {"0": true, "1": false, "2": false, "3": true }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -223,9 +223,9 @@ export class Dictionary {
   /**
    * Set dictionary value empty {"0": true, "1": false, "2": false, "3": true }
    *
-   * @param {{ [propertyName: string]: boolean }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -250,7 +250,7 @@ export class Dictionary {
   /**
    * Get boolean dictionary value {"0": true, "1": null, "2": false }
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -274,7 +274,7 @@ export class Dictionary {
   /**
    * Get boolean dictionary value '{"0": true, "1": "boolean", "2": false}'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -298,7 +298,7 @@ export class Dictionary {
   /**
    * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -322,9 +322,9 @@ export class Dictionary {
   /**
    * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
    *
-   * @param {{ [propertyName: string]: number }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -349,7 +349,7 @@ export class Dictionary {
   /**
    * Get integer dictionary value {"0": 1, "1": null, "2": 0}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -373,7 +373,7 @@ export class Dictionary {
   /**
    * Get integer dictionary value {"0": 1, "1": "integer", "2": 0}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -397,7 +397,7 @@ export class Dictionary {
   /**
    * Get integer dictionary value {"0": 1, "1": -1, "2": 3, "3": 300}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -421,9 +421,9 @@ export class Dictionary {
   /**
    * Set dictionary value empty {"0": 1, "1": -1, "2": 3, "3": 300}
    *
-   * @param {{ [propertyName: string]: number }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -448,7 +448,7 @@ export class Dictionary {
   /**
    * Get long dictionary value {"0": 1, "1": null, "2": 0}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -472,7 +472,7 @@ export class Dictionary {
   /**
    * Get long dictionary value {"0": 1, "1": "integer", "2": 0}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -496,7 +496,7 @@ export class Dictionary {
   /**
    * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -520,9 +520,9 @@ export class Dictionary {
   /**
    * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
    *
-   * @param {{ [propertyName: string]: number }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -547,7 +547,7 @@ export class Dictionary {
   /**
    * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -571,7 +571,7 @@ export class Dictionary {
   /**
    * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -595,7 +595,7 @@ export class Dictionary {
   /**
    * Get float dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -619,9 +619,9 @@ export class Dictionary {
   /**
    * Set dictionary value {"0": 0, "1": -0.01, "2": 1.2e20}
    *
-   * @param {{ [propertyName: string]: number }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -646,7 +646,7 @@ export class Dictionary {
   /**
    * Get float dictionary value {"0": 0.0, "1": null, "2": 1.2e20}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -670,7 +670,7 @@ export class Dictionary {
   /**
    * Get boolean dictionary value {"0": 1.0, "1": "number", "2": 0.0}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -694,7 +694,7 @@ export class Dictionary {
   /**
    * Get string dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -718,9 +718,9 @@ export class Dictionary {
   /**
    * Set dictionary value {"0": "foo1", "1": "foo2", "2": "foo3"}
    *
-   * @param {{ [propertyName: string]: string }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -745,7 +745,7 @@ export class Dictionary {
   /**
    * Get string dictionary value {"0": "foo", "1": null, "2": "foo2"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -769,7 +769,7 @@ export class Dictionary {
   /**
    * Get string dictionary value {"0": "foo", "1": 123, "2": "foo2"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -793,7 +793,7 @@ export class Dictionary {
   /**
    * Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -817,9 +817,9 @@ export class Dictionary {
   /**
    * Set dictionary value  {"0": "2000-12-01", "1": "1980-01-02", "2": "1492-10-12"}
    *
-   * @param {{ [key: string]: Date } | { [key: string]: string }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -844,7 +844,7 @@ export class Dictionary {
   /**
    * Get date dictionary value {"0": "2012-01-01", "1": null, "2": "1776-07-04"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -868,7 +868,7 @@ export class Dictionary {
   /**
    * Get date dictionary value {"0": "2011-03-22", "1": "date"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -893,7 +893,7 @@ export class Dictionary {
    * Get date-time dictionary value {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00",
    * "2": "1492-10-12T10:15:01-08:00"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -918,9 +918,9 @@ export class Dictionary {
    * Set dictionary value  {"0": "2000-12-01t00:00:01z", "1": "1980-01-02T00:11:35+01:00", "2":
    * "1492-10-12T10:15:01-08:00"}
    *
-   * @param {{ [key: string]: Date } | { [key: string]: string }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -945,7 +945,7 @@ export class Dictionary {
   /**
    * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": null}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -969,7 +969,7 @@ export class Dictionary {
   /**
    * Get date dictionary value {"0": "2000-12-01t00:00:01z", "1": "date-time"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -994,7 +994,7 @@ export class Dictionary {
    * Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan
    * 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1019,9 +1019,9 @@ export class Dictionary {
    * Set dictionary value empty {"0": "Fri, 01 Dec 2000 00:00:01 GMT", "1": "Wed, 02 Jan 1980
    * 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01 GMT"}
    *
-   * @param {{ [key: string]: Date } | { [key: string]: string }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1046,7 +1046,7 @@ export class Dictionary {
   /**
    * Get duration dictionary value {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1070,9 +1070,9 @@ export class Dictionary {
   /**
    * Set dictionary value  {"0": "P123DT22H14M12.011S", "1": "P5DT1H0M0S"}
    *
-   * @param {{ [propertyName: string]: string }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1098,7 +1098,7 @@ export class Dictionary {
    * Get byte dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)}
    * with each item encoded in base64
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1123,9 +1123,9 @@ export class Dictionary {
    * Put the dictionary value {"0": hex(FF FF FF FA), "1": hex(01 02 03), "2": hex (25, 29, 43)} with
    * each elementencoded in base 64
    *
-   * @param {{ [propertyName: string]: Uint8Array }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1150,7 +1150,7 @@ export class Dictionary {
   /**
    * Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first item base64 encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1175,7 +1175,7 @@ export class Dictionary {
    * Get base64url dictionary value {"0": "a string that gets encoded with base64url", "1": "test
    * string", "2": "Lorem ipsum"}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1199,7 +1199,7 @@ export class Dictionary {
   /**
    * Get dictionary of complex type null value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1223,7 +1223,7 @@ export class Dictionary {
   /**
    * Get empty dictionary of complex type {}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1248,7 +1248,7 @@ export class Dictionary {
    * Get dictionary of complex type with null item {"0": {"integer": 1, "string": "2"}, "1": null,
    * "2": {"integer": 5, "string": "6"}}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1273,7 +1273,7 @@ export class Dictionary {
    * Get dictionary of complex type with empty item {"0": {"integer": 1, "string": "2"}, "1:" {},
    * "2": {"integer": 5, "string": "6"}}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1298,7 +1298,7 @@ export class Dictionary {
    * Get dictionary of complex type with {"0": {"integer": 1, "string": "2"}, "1": {"integer": 3,
    * "string": "4"}, "2": {"integer": 5, "string": "6"}}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1323,9 +1323,9 @@ export class Dictionary {
    * Put an dictionary of complex type with values {"0": {"integer": 1, "string": "2"}, "1":
    * {"integer": 3, "string": "4"}, "2": {"integer": 5, "string": "6"}}
    *
-   * @param {{ [propertyName: string]: Widget }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1350,7 +1350,7 @@ export class Dictionary {
   /**
    * Get a null array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1374,7 +1374,7 @@ export class Dictionary {
   /**
    * Get an empty dictionary {}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1398,7 +1398,7 @@ export class Dictionary {
   /**
    * Get an dictionary of array of strings {"0": ["1", "2", "3"], "1": null, "2": ["7", "8", "9"]}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1422,7 +1422,7 @@ export class Dictionary {
   /**
    * Get an array of array of strings [{"0": ["1", "2", "3"], "1": [], "2": ["7", "8", "9"]}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1447,7 +1447,7 @@ export class Dictionary {
    * Get an array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8",
    * "9"]}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1472,9 +1472,9 @@ export class Dictionary {
    * Put An array of array of strings {"0": ["1", "2", "3"], "1": ["4", "5", "6"], "2": ["7", "8",
    * "9"]}
    *
-   * @param {{ [propertyName: string]: string[] }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1499,7 +1499,7 @@ export class Dictionary {
   /**
    * Get an dictionaries of dictionaries with value null
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1523,7 +1523,7 @@ export class Dictionary {
   /**
    * Get an dictionaries of dictionaries of type <string, string> with value {}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1548,7 +1548,7 @@ export class Dictionary {
    * Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2":
    * "two", "3": "three"}, "1": null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1573,7 +1573,7 @@ export class Dictionary {
    * Get an dictionaries of dictionaries of type <string, string> with value {"0": {"1": "one", "2":
    * "two", "3": "three"}, "1": {}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1599,7 +1599,7 @@ export class Dictionary {
    * "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8":
    * "eight", "9": "nine"}}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -1625,9 +1625,9 @@ export class Dictionary {
    * "two", "3": "three"}, "1": {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8":
    * "eight", "9": "nine"}}
    *
-   * @param {{ [propertyName: string]: { [propertyName: string]: string } }} arrayBody
+   * @param arrayBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
+++ b/test/vanilla/generated/BodyDictionary/operations/dictionary.ts
@@ -30,7 +30,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -80,7 +80,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -105,7 +105,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -129,7 +129,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -177,7 +177,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -201,7 +201,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -227,7 +227,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -252,7 +252,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -276,7 +276,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -300,7 +300,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -326,7 +326,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -351,7 +351,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -375,7 +375,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -399,7 +399,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -425,7 +425,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -450,7 +450,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -474,7 +474,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -498,7 +498,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -524,7 +524,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -549,7 +549,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -573,7 +573,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -597,7 +597,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -623,7 +623,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -648,7 +648,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -672,7 +672,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -696,7 +696,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -722,7 +722,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -747,7 +747,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -771,7 +771,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -795,7 +795,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -821,7 +821,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -846,7 +846,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -870,7 +870,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -895,7 +895,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -922,7 +922,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -947,7 +947,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -971,7 +971,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -996,7 +996,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1023,7 +1023,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1048,7 +1048,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1074,7 +1074,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1100,7 +1100,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1127,7 +1127,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1152,7 +1152,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1177,7 +1177,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1201,7 +1201,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1225,7 +1225,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1250,7 +1250,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1275,7 +1275,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1300,7 +1300,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1327,7 +1327,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1352,7 +1352,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1376,7 +1376,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1400,7 +1400,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1424,7 +1424,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1449,7 +1449,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1476,7 +1476,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1501,7 +1501,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1525,7 +1525,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1550,7 +1550,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1575,7 +1575,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1601,7 +1601,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -1629,7 +1629,7 @@ export class Dictionary {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestService.ts
@@ -21,9 +21,9 @@ class AutoRestDurationTestService extends AutoRestDurationTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestDurationTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyDuration/autoRestDurationTestServiceContext.ts
+++ b/test/vanilla/generated/BodyDuration/autoRestDurationTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestDurationTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestDurationTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyDuration/operations/duration.ts
+++ b/test/vanilla/generated/BodyDuration/operations/duration.ts
@@ -31,10 +31,6 @@ export class Duration {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.DurationGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.DurationGetNullResponse>;
@@ -57,10 +53,6 @@ export class Duration {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putPositiveDuration(durationBody: string): Promise<msRest.RestResponse>;
   putPositiveDuration(durationBody: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -82,10 +74,6 @@ export class Duration {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getPositiveDuration(): Promise<Models.DurationGetPositiveDurationResponse>;
   getPositiveDuration(options: msRest.RequestOptionsBase): Promise<Models.DurationGetPositiveDurationResponse>;
@@ -106,10 +94,6 @@ export class Duration {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.DurationGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.DurationGetInvalidResponse>;

--- a/test/vanilla/generated/BodyDuration/operations/duration.ts
+++ b/test/vanilla/generated/BodyDuration/operations/duration.ts
@@ -30,7 +30,7 @@ export class Duration {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class Duration {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -81,7 +81,7 @@ export class Duration {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -105,7 +105,7 @@ export class Duration {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyDuration/operations/duration.ts
+++ b/test/vanilla/generated/BodyDuration/operations/duration.ts
@@ -28,7 +28,7 @@ export class Duration {
   /**
    * Get null duration value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,9 +52,9 @@ export class Duration {
   /**
    * Put a positive duration value
    *
-   * @param {string} durationBody
+   * @param durationBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -79,7 +79,7 @@ export class Duration {
   /**
    * Get a positive duration value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,7 +103,7 @@ export class Duration {
   /**
    * Get an invalid duration value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATFileService extends AutoRestSwaggerBATFileServiceContext
   /**
    * Initializes a new instance of the AutoRestSwaggerBATFileService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileServiceContext.ts
+++ b/test/vanilla/generated/BodyFile/autoRestSwaggerBATFileServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATFileServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATFileServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyFile/operations/files.ts
+++ b/test/vanilla/generated/BodyFile/operations/files.ts
@@ -28,7 +28,7 @@ export class Files {
   /**
    * Get file
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Files {
   /**
    * Get a large file
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Files {
   /**
    * Get empty file
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyFile/operations/files.ts
+++ b/test/vanilla/generated/BodyFile/operations/files.ts
@@ -31,10 +31,6 @@ export class Files {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFile(): Promise<Models.FilesGetFileResponse>;
   getFile(options: msRest.RequestOptionsBase): Promise<Models.FilesGetFileResponse>;
@@ -55,10 +51,6 @@ export class Files {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFileLarge(): Promise<Models.FilesGetFileLargeResponse>;
   getFileLarge(options: msRest.RequestOptionsBase): Promise<Models.FilesGetFileLargeResponse>;
@@ -79,10 +71,6 @@ export class Files {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyFile(): Promise<Models.FilesGetEmptyFileResponse>;
   getEmptyFile(options: msRest.RequestOptionsBase): Promise<Models.FilesGetEmptyFileResponse>;

--- a/test/vanilla/generated/BodyFile/operations/files.ts
+++ b/test/vanilla/generated/BodyFile/operations/files.ts
@@ -30,7 +30,7 @@ export class Files {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Files {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Files {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATFormDataService extends AutoRestSwaggerBATFormDataServic
   /**
    * Initializes a new instance of the AutoRestSwaggerBATFormDataService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataServiceContext.ts
+++ b/test/vanilla/generated/BodyFormData/autoRestSwaggerBATFormDataServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATFormDataServiceContext extends msRest.ServiceClie
   /**
    * Initializes a new instance of the AutoRestSwaggerBATFormDataServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyFormData/operations/formdata.ts
+++ b/test/vanilla/generated/BodyFormData/operations/formdata.ts
@@ -29,11 +29,11 @@ export class Formdata {
   /**
    * Upload file
    *
-   * @param {msRest.HttpRequestBody} fileContent File to upload.
+   * @param fileContent File to upload.
    *
-   * @param {string} fileName File name to upload. Name has to be spelled exactly as written here.
+   * @param fileName File name to upload. Name has to be spelled exactly as written here.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -59,9 +59,9 @@ export class Formdata {
   /**
    * Upload file
    *
-   * @param {msRest.HttpRequestBody} fileContent File to upload.
+   * @param fileContent File to upload.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyFormData/operations/formdata.ts
+++ b/test/vanilla/generated/BodyFormData/operations/formdata.ts
@@ -36,10 +36,6 @@ export class Formdata {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   uploadFile(fileContent: msRest.HttpRequestBody, fileName: string): Promise<Models.FormdataUploadFileResponse>;
   uploadFile(fileContent: msRest.HttpRequestBody, fileName: string, options: msRest.RequestOptionsBase): Promise<Models.FormdataUploadFileResponse>;
@@ -64,10 +60,6 @@ export class Formdata {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   uploadFileViaBody(fileContent: msRest.HttpRequestBody): Promise<Models.FormdataUploadFileViaBodyResponse>;
   uploadFileViaBody(fileContent: msRest.HttpRequestBody, options: msRest.RequestOptionsBase): Promise<Models.FormdataUploadFileViaBodyResponse>;

--- a/test/vanilla/generated/BodyFormData/operations/formdata.ts
+++ b/test/vanilla/generated/BodyFormData/operations/formdata.ts
@@ -35,7 +35,7 @@ export class Formdata {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -63,7 +63,7 @@ export class Formdata {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestService.ts
@@ -21,9 +21,9 @@ class AutoRestIntegerTestService extends AutoRestIntegerTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestIntegerTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyInteger/autoRestIntegerTestServiceContext.ts
+++ b/test/vanilla/generated/BodyInteger/autoRestIntegerTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestIntegerTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestIntegerTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyInteger/operations/intModel.ts
+++ b/test/vanilla/generated/BodyInteger/operations/intModel.ts
@@ -31,10 +31,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.IntModelGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetNullResponse>;
@@ -55,10 +51,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.IntModelGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetInvalidResponse>;
@@ -79,10 +71,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflowInt32(): Promise<Models.IntModelGetOverflowInt32Response>;
   getOverflowInt32(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetOverflowInt32Response>;
@@ -103,10 +91,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflowInt32(): Promise<Models.IntModelGetUnderflowInt32Response>;
   getUnderflowInt32(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetUnderflowInt32Response>;
@@ -127,10 +111,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflowInt64(): Promise<Models.IntModelGetOverflowInt64Response>;
   getOverflowInt64(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetOverflowInt64Response>;
@@ -151,10 +131,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflowInt64(): Promise<Models.IntModelGetUnderflowInt64Response>;
   getUnderflowInt64(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetUnderflowInt64Response>;
@@ -177,10 +153,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMax32(intBody: number): Promise<msRest.RestResponse>;
   putMax32(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -204,10 +176,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMax64(intBody: number): Promise<msRest.RestResponse>;
   putMax64(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -231,10 +199,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMin32(intBody: number): Promise<msRest.RestResponse>;
   putMin32(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -258,10 +222,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMin64(intBody: number): Promise<msRest.RestResponse>;
   putMin64(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -283,10 +243,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnixTime(): Promise<Models.IntModelGetUnixTimeResponse>;
   getUnixTime(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetUnixTimeResponse>;
@@ -309,10 +265,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUnixTimeDate(intBody: Date | string): Promise<msRest.RestResponse>;
   putUnixTimeDate(intBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -334,10 +286,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidUnixTime(): Promise<Models.IntModelGetInvalidUnixTimeResponse>;
   getInvalidUnixTime(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetInvalidUnixTimeResponse>;
@@ -358,10 +306,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNullUnixTime(): Promise<Models.IntModelGetNullUnixTimeResponse>;
   getNullUnixTime(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetNullUnixTimeResponse>;

--- a/test/vanilla/generated/BodyInteger/operations/intModel.ts
+++ b/test/vanilla/generated/BodyInteger/operations/intModel.ts
@@ -28,7 +28,7 @@ export class IntModel {
   /**
    * Get null Int value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class IntModel {
   /**
    * Get invalid Int value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class IntModel {
   /**
    * Get overflow Int32 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class IntModel {
   /**
    * Get underflow Int32 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class IntModel {
   /**
    * Get overflow Int64 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class IntModel {
   /**
    * Get underflow Int64 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,9 +172,9 @@ export class IntModel {
   /**
    * Put max int32 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -199,9 +199,9 @@ export class IntModel {
   /**
    * Put max int64 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,9 +226,9 @@ export class IntModel {
   /**
    * Put min int32 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -253,9 +253,9 @@ export class IntModel {
   /**
    * Put min int64 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -280,7 +280,7 @@ export class IntModel {
   /**
    * Get datetime encoded as Unix time value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -304,9 +304,9 @@ export class IntModel {
   /**
    * Put datetime encoded as Unix time
    *
-   * @param {Date | string} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -331,7 +331,7 @@ export class IntModel {
   /**
    * Get invalid Unix time value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -355,7 +355,7 @@ export class IntModel {
   /**
    * Get null Unix time value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyInteger/operations/intModel.ts
+++ b/test/vanilla/generated/BodyInteger/operations/intModel.ts
@@ -30,7 +30,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -176,7 +176,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -230,7 +230,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -257,7 +257,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -282,7 +282,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -308,7 +308,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -333,7 +333,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -357,7 +357,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestService.ts
@@ -21,9 +21,9 @@ class AutoRestNumberTestService extends AutoRestNumberTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestNumberTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyNumber/autoRestNumberTestServiceContext.ts
+++ b/test/vanilla/generated/BodyNumber/autoRestNumberTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestNumberTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestNumberTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -28,7 +28,7 @@ export class Number {
   /**
    * Get null Number value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Number {
   /**
    * Get invalid float Number value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Number {
   /**
    * Get invalid double Number value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Number {
   /**
    * Get invalid decimal Number value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,9 +124,9 @@ export class Number {
   /**
    * Put big float value 3.402823e+20
    *
-   * @param {number} numberBody
+   * @param numberBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -151,7 +151,7 @@ export class Number {
   /**
    * Get big float value 3.402823e+20
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -175,9 +175,9 @@ export class Number {
   /**
    * Put big double value 2.5976931e+101
    *
-   * @param {number} numberBody
+   * @param numberBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -202,7 +202,7 @@ export class Number {
   /**
    * Get big double value 2.5976931e+101
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,7 +226,7 @@ export class Number {
   /**
    * Put big double value 99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -250,7 +250,7 @@ export class Number {
   /**
    * Get big double value 99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -274,7 +274,7 @@ export class Number {
   /**
    * Put big double value -99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -298,7 +298,7 @@ export class Number {
   /**
    * Get big double value -99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -322,9 +322,9 @@ export class Number {
   /**
    * Put big decimal value 2.5976931e+101
    *
-   * @param {number} numberBody
+   * @param numberBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -349,7 +349,7 @@ export class Number {
   /**
    * Get big decimal value 2.5976931e+101
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -373,7 +373,7 @@ export class Number {
   /**
    * Put big decimal value 99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -397,7 +397,7 @@ export class Number {
   /**
    * Get big decimal value 99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -421,7 +421,7 @@ export class Number {
   /**
    * Put big decimal value -99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -445,7 +445,7 @@ export class Number {
   /**
    * Get big decimal value -99999999.99
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -469,9 +469,9 @@ export class Number {
   /**
    * Put small float value 3.402823e-20
    *
-   * @param {number} numberBody
+   * @param numberBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -496,7 +496,7 @@ export class Number {
   /**
    * Get big double value 3.402823e-20
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -520,9 +520,9 @@ export class Number {
   /**
    * Put small double value 2.5976931e-101
    *
-   * @param {number} numberBody
+   * @param numberBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -547,7 +547,7 @@ export class Number {
   /**
    * Get big double value 2.5976931e-101
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -571,9 +571,9 @@ export class Number {
   /**
    * Put small decimal value 2.5976931e-101
    *
-   * @param {number} numberBody
+   * @param numberBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -598,7 +598,7 @@ export class Number {
   /**
    * Get small decimal value 2.5976931e-101
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -30,7 +30,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -128,7 +128,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -153,7 +153,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -179,7 +179,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -204,7 +204,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -228,7 +228,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -252,7 +252,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -276,7 +276,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -300,7 +300,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -326,7 +326,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -351,7 +351,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -375,7 +375,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -399,7 +399,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -423,7 +423,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -447,7 +447,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -473,7 +473,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -498,7 +498,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -524,7 +524,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -549,7 +549,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -575,7 +575,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -600,7 +600,7 @@ export class Number {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyNumber/operations/number.ts
+++ b/test/vanilla/generated/BodyNumber/operations/number.ts
@@ -31,10 +31,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.NumberGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.NumberGetNullResponse>;
@@ -55,10 +51,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidFloat(): Promise<Models.NumberGetInvalidFloatResponse>;
   getInvalidFloat(options: msRest.RequestOptionsBase): Promise<Models.NumberGetInvalidFloatResponse>;
@@ -79,10 +71,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidDouble(): Promise<Models.NumberGetInvalidDoubleResponse>;
   getInvalidDouble(options: msRest.RequestOptionsBase): Promise<Models.NumberGetInvalidDoubleResponse>;
@@ -103,10 +91,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidDecimal(): Promise<Models.NumberGetInvalidDecimalResponse>;
   getInvalidDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetInvalidDecimalResponse>;
@@ -129,10 +113,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigFloat(numberBody: number): Promise<msRest.RestResponse>;
   putBigFloat(numberBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -154,10 +134,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigFloat(): Promise<Models.NumberGetBigFloatResponse>;
   getBigFloat(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigFloatResponse>;
@@ -180,10 +156,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigDouble(numberBody: number): Promise<msRest.RestResponse>;
   putBigDouble(numberBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -205,10 +177,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigDouble(): Promise<Models.NumberGetBigDoubleResponse>;
   getBigDouble(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigDoubleResponse>;
@@ -229,10 +197,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigDoublePositiveDecimal(): Promise<msRest.RestResponse>;
   putBigDoublePositiveDecimal(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -253,10 +217,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigDoublePositiveDecimal(): Promise<Models.NumberGetBigDoublePositiveDecimalResponse>;
   getBigDoublePositiveDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigDoublePositiveDecimalResponse>;
@@ -277,10 +237,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigDoubleNegativeDecimal(): Promise<msRest.RestResponse>;
   putBigDoubleNegativeDecimal(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -301,10 +257,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigDoubleNegativeDecimal(): Promise<Models.NumberGetBigDoubleNegativeDecimalResponse>;
   getBigDoubleNegativeDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigDoubleNegativeDecimalResponse>;
@@ -327,10 +279,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigDecimal(numberBody: number): Promise<msRest.RestResponse>;
   putBigDecimal(numberBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -352,10 +300,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigDecimal(): Promise<Models.NumberGetBigDecimalResponse>;
   getBigDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigDecimalResponse>;
@@ -376,10 +320,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigDecimalPositiveDecimal(): Promise<msRest.RestResponse>;
   putBigDecimalPositiveDecimal(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -400,10 +340,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigDecimalPositiveDecimal(): Promise<Models.NumberGetBigDecimalPositiveDecimalResponse>;
   getBigDecimalPositiveDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigDecimalPositiveDecimalResponse>;
@@ -424,10 +360,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBigDecimalNegativeDecimal(): Promise<msRest.RestResponse>;
   putBigDecimalNegativeDecimal(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -448,10 +380,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBigDecimalNegativeDecimal(): Promise<Models.NumberGetBigDecimalNegativeDecimalResponse>;
   getBigDecimalNegativeDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetBigDecimalNegativeDecimalResponse>;
@@ -474,10 +402,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSmallFloat(numberBody: number): Promise<msRest.RestResponse>;
   putSmallFloat(numberBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -499,10 +423,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSmallFloat(): Promise<Models.NumberGetSmallFloatResponse>;
   getSmallFloat(options: msRest.RequestOptionsBase): Promise<Models.NumberGetSmallFloatResponse>;
@@ -525,10 +445,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSmallDouble(numberBody: number): Promise<msRest.RestResponse>;
   putSmallDouble(numberBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -550,10 +466,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSmallDouble(): Promise<Models.NumberGetSmallDoubleResponse>;
   getSmallDouble(options: msRest.RequestOptionsBase): Promise<Models.NumberGetSmallDoubleResponse>;
@@ -576,10 +488,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSmallDecimal(numberBody: number): Promise<msRest.RestResponse>;
   putSmallDecimal(numberBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -601,10 +509,6 @@ export class Number {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSmallDecimal(): Promise<Models.NumberGetSmallDecimalResponse>;
   getSmallDecimal(options: msRest.RequestOptionsBase): Promise<Models.NumberGetSmallDecimalResponse>;

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATService.ts
@@ -22,9 +22,9 @@ class AutoRestSwaggerBATService extends AutoRestSwaggerBATServiceContext {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/BodyString/autoRestSwaggerBATServiceContext.ts
+++ b/test/vanilla/generated/BodyString/autoRestSwaggerBATServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/BodyString/operations/enumModel.ts
+++ b/test/vanilla/generated/BodyString/operations/enumModel.ts
@@ -30,7 +30,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -56,7 +56,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -81,7 +81,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -107,7 +107,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -132,7 +132,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -156,7 +156,7 @@ export class EnumModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyString/operations/enumModel.ts
+++ b/test/vanilla/generated/BodyString/operations/enumModel.ts
@@ -28,7 +28,7 @@ export class EnumModel {
   /**
    * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,9 +52,9 @@ export class EnumModel {
   /**
    * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
    *
-   * @param {Colors} stringBody Possible values include: 'red color', 'green-color', 'blue_color'
+   * @param stringBody Possible values include: 'red color', 'green-color', 'blue_color'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -79,7 +79,7 @@ export class EnumModel {
   /**
    * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -103,9 +103,9 @@ export class EnumModel {
   /**
    * Sends value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'
    *
-   * @param {Colors} enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
+   * @param enumStringBody Possible values include: 'red color', 'green-color', 'blue_color'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -130,7 +130,7 @@ export class EnumModel {
   /**
    * Get value 'green-color' from the constant.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -154,7 +154,7 @@ export class EnumModel {
   /**
    * Sends value 'green-color' from a constant
    *
-   * @param {EnumModelPutReferencedConstantOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/BodyString/operations/enumModel.ts
+++ b/test/vanilla/generated/BodyString/operations/enumModel.ts
@@ -31,10 +31,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotExpandable(): Promise<Models.EnumModelGetNotExpandableResponse>;
   getNotExpandable(options: msRest.RequestOptionsBase): Promise<Models.EnumModelGetNotExpandableResponse>;
@@ -57,10 +53,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNotExpandable(stringBody: Models.Colors): Promise<msRest.RestResponse>;
   putNotExpandable(stringBody: Models.Colors, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -82,10 +74,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getReferenced(): Promise<Models.EnumModelGetReferencedResponse>;
   getReferenced(options: msRest.RequestOptionsBase): Promise<Models.EnumModelGetReferencedResponse>;
@@ -108,10 +96,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putReferenced(enumStringBody: Models.Colors): Promise<msRest.RestResponse>;
   putReferenced(enumStringBody: Models.Colors, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -133,10 +117,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getReferencedConstant(): Promise<Models.EnumModelGetReferencedConstantResponse>;
   getReferencedConstant(options: msRest.RequestOptionsBase): Promise<Models.EnumModelGetReferencedConstantResponse>;
@@ -157,10 +137,6 @@ export class EnumModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putReferencedConstant(): Promise<msRest.RestResponse>;
   putReferencedConstant(options: Models.EnumModelPutReferencedConstantOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -31,10 +31,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.StringGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.StringGetNullResponse>;
@@ -55,10 +51,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putNull(): Promise<msRest.RestResponse>;
   putNull(options: Models.StringPutNullOptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(): Promise<Models.StringGetEmptyResponse>;
   getEmpty(options: msRest.RequestOptionsBase): Promise<Models.StringGetEmptyResponse>;
@@ -103,10 +91,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmpty(): Promise<msRest.RestResponse>;
   putEmpty(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getMbcs(): Promise<Models.StringGetMbcsResponse>;
   getMbcs(options: msRest.RequestOptionsBase): Promise<Models.StringGetMbcsResponse>;
@@ -151,10 +131,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMbcs(): Promise<msRest.RestResponse>;
   putMbcs(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -176,10 +152,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWhitespace(): Promise<Models.StringGetWhitespaceResponse>;
   getWhitespace(options: msRest.RequestOptionsBase): Promise<Models.StringGetWhitespaceResponse>;
@@ -201,10 +173,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putWhitespace(): Promise<msRest.RestResponse>;
   putWhitespace(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -225,10 +193,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNotProvided(): Promise<Models.StringGetNotProvidedResponse>;
   getNotProvided(options: msRest.RequestOptionsBase): Promise<Models.StringGetNotProvidedResponse>;
@@ -249,10 +213,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBase64Encoded(): Promise<Models.StringGetBase64EncodedResponse>;
   getBase64Encoded(options: msRest.RequestOptionsBase): Promise<Models.StringGetBase64EncodedResponse>;
@@ -273,10 +233,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBase64UrlEncoded(): Promise<Models.StringGetBase64UrlEncodedResponse>;
   getBase64UrlEncoded(options: msRest.RequestOptionsBase): Promise<Models.StringGetBase64UrlEncodedResponse>;
@@ -299,10 +255,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putBase64UrlEncoded(stringBody: Uint8Array): Promise<msRest.RestResponse>;
   putBase64UrlEncoded(stringBody: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -324,10 +276,6 @@ export class String {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNullBase64UrlEncoded(): Promise<Models.StringGetNullBase64UrlEncodedResponse>;
   getNullBase64UrlEncoded(options: msRest.RequestOptionsBase): Promise<Models.StringGetNullBase64UrlEncodedResponse>;

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -30,7 +30,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -175,7 +175,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -200,7 +200,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -224,7 +224,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -248,7 +248,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -272,7 +272,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -298,7 +298,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -323,7 +323,7 @@ export class String {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/BodyString/operations/string.ts
+++ b/test/vanilla/generated/BodyString/operations/string.ts
@@ -28,7 +28,7 @@ export class String {
   /**
    * Get null string value value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class String {
   /**
    * Set string value null
    *
-   * @param {StringPutNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class String {
   /**
    * Get empty string value value ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class String {
   /**
    * Set string value empty ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class String {
   /**
    * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class String {
   /**
    * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -173,7 +173,7 @@ export class String {
    * Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for
    * all good men to come to the aid of their country<tab><space><space>'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -198,7 +198,7 @@ export class String {
    * Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for
    * all good men to come to the aid of their country<tab><space><space>'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -222,7 +222,7 @@ export class String {
   /**
    * Get String value when no string value is sent in response payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -246,7 +246,7 @@ export class String {
   /**
    * Get value that is base64 encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -270,7 +270,7 @@ export class String {
   /**
    * Get value that is base64url encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -294,9 +294,9 @@ export class String {
   /**
    * Put value that is base64url encoded
    *
-   * @param {Uint8Array} stringBody
+   * @param stringBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -321,7 +321,7 @@ export class String {
   /**
    * Get null value that is expected to be base64url encoded
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -38,7 +38,7 @@ class ComplexModelClient extends ComplexModelClientContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -70,7 +70,7 @@ class ComplexModelClient extends ComplexModelClientContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -103,7 +103,7 @@ class ComplexModelClient extends ComplexModelClientContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -18,9 +18,9 @@ class ComplexModelClient extends ComplexModelClientContext {
   /**
    * Initializes a new instance of the ComplexModelClient class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);
@@ -34,9 +34,9 @@ class ComplexModelClient extends ComplexModelClientContext {
    * The response includes the display name and other details about each product, and lists the
    * products in the proper display order.
    *
-   * @param {string} resourceGroupName Resource Group ID.
+   * @param resourceGroupName Resource Group ID.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -64,11 +64,11 @@ class ComplexModelClient extends ComplexModelClientContext {
    *
    * Resets products.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} resourceGroupName Resource Group ID.
+   * @param resourceGroupName Resource Group ID.
    *
-   * @param {ComplexModelClientCreateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -97,11 +97,11 @@ class ComplexModelClient extends ComplexModelClientContext {
    *
    * Resets products.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} resourceGroupName Resource Group ID.
+   * @param resourceGroupName Resource Group ID.
    *
-   * @param {ComplexModelClientUpdateOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClient.ts
@@ -28,21 +28,17 @@ class ComplexModelClient extends ComplexModelClientContext {
   // methods on the client.
 
   /**
-   * @summary Product Types
-   *
    * The Products endpoint returns information about the Uber products offered at a given location.
    * The response includes the display name and other details about each product, and lists the
    * products in the proper display order.
+   *
+   * @summary Product Types
    *
    * @param resourceGroupName Resource Group ID.
    *
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   list(resourceGroupName: string): Promise<Models.ListResponse>;
   list(resourceGroupName: string, options: msRest.RequestOptionsBase): Promise<Models.ListResponse>;
@@ -60,9 +56,9 @@ class ComplexModelClient extends ComplexModelClientContext {
   // methods on the client.
 
   /**
-   * @summary Create products
-   *
    * Resets products.
+   *
+   * @summary Create products
    *
    * @param subscriptionId Subscription ID.
    *
@@ -71,10 +67,6 @@ class ComplexModelClient extends ComplexModelClientContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   create(subscriptionId: string, resourceGroupName: string): Promise<Models.CreateResponse>;
   create(subscriptionId: string, resourceGroupName: string, options: Models.ComplexModelClientCreateOptionalParams): Promise<Models.CreateResponse>;
@@ -93,9 +85,9 @@ class ComplexModelClient extends ComplexModelClientContext {
   // methods on the client.
 
   /**
-   * @summary Update products
-   *
    * Resets products.
+   *
+   * @summary Update products
    *
    * @param subscriptionId Subscription ID.
    *
@@ -104,10 +96,6 @@ class ComplexModelClient extends ComplexModelClientContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   update(subscriptionId: string, resourceGroupName: string): Promise<Models.UpdateResponse>;
   update(subscriptionId: string, resourceGroupName: string, options: Models.ComplexModelClientUpdateOptionalParams): Promise<Models.UpdateResponse>;

--- a/test/vanilla/generated/ComplexModelClient/complexModelClientContext.ts
+++ b/test/vanilla/generated/ComplexModelClient/complexModelClientContext.ts
@@ -20,9 +20,9 @@ export class ComplexModelClientContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the ComplexModelClientContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolInt.ts
@@ -22,9 +22,9 @@ class CompositeBoolInt extends CompositeBoolIntContext {
   /**
    * Initializes a new instance of the CompositeBoolInt class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/CompositeBoolIntClient/compositeBoolIntContext.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/compositeBoolIntContext.ts
@@ -18,9 +18,9 @@ export class CompositeBoolIntContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the CompositeBoolIntContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -28,7 +28,7 @@ export class Bool {
   /**
    * Get true Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class Bool {
   /**
    * Set Boolean value true
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class Bool {
   /**
    * Get false Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class Bool {
   /**
    * Set Boolean value false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class Bool {
   /**
    * Get null Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class Bool {
   /**
    * Get invalid Boolean value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -30,7 +30,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class Bool {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/bool.ts
@@ -31,10 +31,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getTrue(): Promise<Models.BoolGetTrueResponse>;
   getTrue(options: msRest.RequestOptionsBase): Promise<Models.BoolGetTrueResponse>;
@@ -55,10 +51,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putTrue(): Promise<msRest.RestResponse>;
   putTrue(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getFalse(): Promise<Models.BoolGetFalseResponse>;
   getFalse(options: msRest.RequestOptionsBase): Promise<Models.BoolGetFalseResponse>;
@@ -103,10 +91,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putFalse(): Promise<msRest.RestResponse>;
   putFalse(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.BoolGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.BoolGetNullResponse>;
@@ -151,10 +131,6 @@ export class Bool {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.BoolGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.BoolGetInvalidResponse>;

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
@@ -31,10 +31,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNull(): Promise<Models.IntModelGetNullResponse>;
   getNull(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetNullResponse>;
@@ -55,10 +51,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalid(): Promise<Models.IntModelGetInvalidResponse>;
   getInvalid(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetInvalidResponse>;
@@ -79,10 +71,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflowInt32(): Promise<Models.IntModelGetOverflowInt32Response>;
   getOverflowInt32(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetOverflowInt32Response>;
@@ -103,10 +91,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflowInt32(): Promise<Models.IntModelGetUnderflowInt32Response>;
   getUnderflowInt32(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetUnderflowInt32Response>;
@@ -127,10 +111,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOverflowInt64(): Promise<Models.IntModelGetOverflowInt64Response>;
   getOverflowInt64(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetOverflowInt64Response>;
@@ -151,10 +131,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnderflowInt64(): Promise<Models.IntModelGetUnderflowInt64Response>;
   getUnderflowInt64(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetUnderflowInt64Response>;
@@ -177,10 +153,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMax32(intBody: number): Promise<msRest.RestResponse>;
   putMax32(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -204,10 +176,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMax64(intBody: number): Promise<msRest.RestResponse>;
   putMax64(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -231,10 +199,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMin32(intBody: number): Promise<msRest.RestResponse>;
   putMin32(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -258,10 +222,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putMin64(intBody: number): Promise<msRest.RestResponse>;
   putMin64(intBody: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -283,10 +243,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getUnixTime(): Promise<Models.IntModelGetUnixTimeResponse>;
   getUnixTime(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetUnixTimeResponse>;
@@ -309,10 +265,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putUnixTimeDate(intBody: Date | string): Promise<msRest.RestResponse>;
   putUnixTimeDate(intBody: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -334,10 +286,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getInvalidUnixTime(): Promise<Models.IntModelGetInvalidUnixTimeResponse>;
   getInvalidUnixTime(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetInvalidUnixTimeResponse>;
@@ -358,10 +306,6 @@ export class IntModel {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNullUnixTime(): Promise<Models.IntModelGetNullUnixTimeResponse>;
   getNullUnixTime(options: msRest.RequestOptionsBase): Promise<Models.IntModelGetNullUnixTimeResponse>;

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
@@ -28,7 +28,7 @@ export class IntModel {
   /**
    * Get null Int value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class IntModel {
   /**
    * Get invalid Int value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class IntModel {
   /**
    * Get overflow Int32 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class IntModel {
   /**
    * Get underflow Int32 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class IntModel {
   /**
    * Get overflow Int64 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class IntModel {
   /**
    * Get underflow Int64 value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,9 +172,9 @@ export class IntModel {
   /**
    * Put max int32 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -199,9 +199,9 @@ export class IntModel {
   /**
    * Put max int64 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -226,9 +226,9 @@ export class IntModel {
   /**
    * Put min int32 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -253,9 +253,9 @@ export class IntModel {
   /**
    * Put min int64 value
    *
-   * @param {number} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -280,7 +280,7 @@ export class IntModel {
   /**
    * Get datetime encoded as Unix time value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -304,9 +304,9 @@ export class IntModel {
   /**
    * Put datetime encoded as Unix time
    *
-   * @param {Date | string} intBody
+   * @param intBody
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -331,7 +331,7 @@ export class IntModel {
   /**
    * Get invalid Unix time value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -355,7 +355,7 @@ export class IntModel {
   /**
    * Get null Unix time value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
+++ b/test/vanilla/generated/CompositeBoolIntClient/operations/intModel.ts
@@ -30,7 +30,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -176,7 +176,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -203,7 +203,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -230,7 +230,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -257,7 +257,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -282,7 +282,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -308,7 +308,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -333,7 +333,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -357,7 +357,7 @@ export class IntModel {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClient.ts
@@ -20,7 +20,7 @@ class AutoRestParameterizedHostTestClient extends AutoRestParameterizedHostTestC
   /**
    * Initializes a new instance of the AutoRestParameterizedHostTestClient class.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(options?: Models.AutoRestParameterizedHostTestClientOptions) {
     super(options);

--- a/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
+++ b/test/vanilla/generated/CustomBaseUri/autoRestParameterizedHostTestClientContext.ts
@@ -20,7 +20,7 @@ export class AutoRestParameterizedHostTestClientContext extends msRest.ServiceCl
   /**
    * Initializes a new instance of the AutoRestParameterizedHostTestClientContext class.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(options?: Models.AutoRestParameterizedHostTestClientOptions) {
 

--- a/test/vanilla/generated/CustomBaseUri/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUri/operations/paths.ts
@@ -32,7 +32,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/CustomBaseUri/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUri/operations/paths.ts
@@ -28,9 +28,9 @@ export class Paths {
   /**
    * Get a 200 to test a valid base uri
    *
-   * @param {string} accountName Account Name
+   * @param accountName Account Name
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/CustomBaseUri/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUri/operations/paths.ts
@@ -33,10 +33,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(accountName: string): Promise<msRest.RestResponse>;
   getEmpty(accountName: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.ts
@@ -20,9 +20,9 @@ class AutoRestParameterizedCustomHostTestClient extends AutoRestParameterizedCus
   /**
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClient class.
    *
-   * @param {string} subscriptionId The subscription id with value 'test12'.
+   * @param subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     super(subscriptionId, options);

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClientContext.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClientContext.ts
@@ -21,9 +21,9 @@ export class AutoRestParameterizedCustomHostTestClientContext extends msRest.Ser
   /**
    * Initializes a new instance of the AutoRestParameterizedCustomHostTestClientContext class.
    *
-   * @param {string} subscriptionId The subscription id with value 'test12'.
+   * @param subscriptionId The subscription id with value 'test12'.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(subscriptionId: string, options?: Models.AutoRestParameterizedCustomHostTestClientOptions) {
     if (subscriptionId === null || subscriptionId === undefined) {

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
@@ -29,13 +29,13 @@ export class Paths {
   /**
    * Get a 200 to test a valid base uri
    *
-   * @param {string} vault The vault name, e.g. https://myvault
+   * @param vault The vault name, e.g. https://myvault
    *
-   * @param {string} secret Secret value.
+   * @param secret Secret value.
    *
-   * @param {string} keyName The key name with value 'key1'.
+   * @param keyName The key name with value 'key1'.
    *
-   * @param {PathsGetEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
@@ -37,7 +37,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
+++ b/test/vanilla/generated/CustomBaseUriMoreOptions/operations/paths.ts
@@ -38,10 +38,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmpty(vault: string, secret: string, keyName: string): Promise<msRest.RestResponse>;
   getEmpty(vault: string, secret: string, keyName: string, options: Models.PathsGetEmptyOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/ExtensibleEnum/operations/petOperations.ts
+++ b/test/vanilla/generated/ExtensibleEnum/operations/petOperations.ts
@@ -31,7 +31,7 @@ export class PetOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class PetOperations {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/ExtensibleEnum/operations/petOperations.ts
+++ b/test/vanilla/generated/ExtensibleEnum/operations/petOperations.ts
@@ -27,9 +27,9 @@ export class PetOperations {
   }
 
   /**
-   * @param {string} petId Pet id
+   * @param petId Pet id
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class PetOperations {
   }
 
   /**
-   * @param {PetAddPetOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/ExtensibleEnum/operations/petOperations.ts
+++ b/test/vanilla/generated/ExtensibleEnum/operations/petOperations.ts
@@ -32,10 +32,6 @@ export class PetOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getByPetId(petId: string): Promise<Models.PetGetByPetIdResponse>;
   getByPetId(petId: string, options: msRest.RequestOptionsBase): Promise<Models.PetGetByPetIdResponse>;
@@ -55,10 +51,6 @@ export class PetOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   addPet(): Promise<Models.PetAddPetResponse>;
   addPet(options: Models.PetAddPetOptionalParams): Promise<Models.PetAddPetResponse>;

--- a/test/vanilla/generated/ExtensibleEnum/petStoreInc.ts
+++ b/test/vanilla/generated/ExtensibleEnum/petStoreInc.ts
@@ -21,9 +21,9 @@ class PetStoreInc extends PetStoreIncContext {
   /**
    * Initializes a new instance of the PetStoreInc class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/ExtensibleEnum/petStoreIncContext.ts
+++ b/test/vanilla/generated/ExtensibleEnum/petStoreIncContext.ts
@@ -18,9 +18,9 @@ export class PetStoreIncContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the PetStoreIncContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATHeaderService extends AutoRestSwaggerBATHeaderServiceCon
   /**
    * Initializes a new instance of the AutoRestSwaggerBATHeaderService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
+++ b/test/vanilla/generated/Header/autoRestSwaggerBATHeaderServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATHeaderServiceContext extends msRest.ServiceClient
   /**
    * Initializes a new instance of the AutoRestSwaggerBATHeaderServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/Header/operations/header.ts
+++ b/test/vanilla/generated/Header/operations/header.ts
@@ -29,9 +29,9 @@ export class Header {
   /**
    * Send a post request with header value "User-Agent": "overwrite"
    *
-   * @param {string} userAgent Send a post request with header value "User-Agent": "overwrite"
+   * @param userAgent Send a post request with header value "User-Agent": "overwrite"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -56,7 +56,7 @@ export class Header {
   /**
    * Get a response with header value "User-Agent": "overwrite"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,9 +80,9 @@ export class Header {
   /**
    * Send a post request with header value "Content-Type": "text/html"
    *
-   * @param {string} contentType Send a post request with header value "Content-Type": "text/html"
+   * @param contentType Send a post request with header value "Content-Type": "text/html"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -107,7 +107,7 @@ export class Header {
   /**
    * Get a response with header value "Content-Type": "text/html"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -132,12 +132,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 1 or "scenario":
    * "negative", "value": -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 1 or -2
+   * @param value Send a post request with header values 1 or -2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -163,10 +162,9 @@ export class Header {
   /**
    * Get a response with header value "value": 1 or -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -192,12 +190,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 105 or "scenario":
    * "negative", "value": -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 105 or -2
+   * @param value Send a post request with header values 105 or -2
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -223,10 +220,9 @@ export class Header {
   /**
    * Get a response with header value "value": 105 or -2
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -252,12 +248,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 0.07 or "scenario":
    * "negative", "value": -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 0.07 or -3.0
+   * @param value Send a post request with header values 0.07 or -3.0
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -283,10 +278,9 @@ export class Header {
   /**
    * Get a response with header value "value": 0.07 or -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -312,12 +306,11 @@ export class Header {
    * Send a post request with header values "scenario": "positive", "value": 7e120 or "scenario":
    * "negative", "value": -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {number} value Send a post request with header values 7e120 or -3.0
+   * @param value Send a post request with header values 7e120 or -3.0
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -343,10 +336,9 @@ export class Header {
   /**
    * Get a response with header value "value": 7e120 or -3.0
    *
-   * @param {string} scenario Send a post request with header values "scenario": "positive" or
-   * "negative"
+   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -372,11 +364,11 @@ export class Header {
    * Send a post request with header values "scenario": "true", "value": true or "scenario": "false",
    * "value": false
    *
-   * @param {string} scenario Send a post request with header values "scenario": "true" or "false"
+   * @param scenario Send a post request with header values "scenario": "true" or "false"
    *
-   * @param {boolean} value Send a post request with header values true or false
+   * @param value Send a post request with header values true or false
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -402,9 +394,9 @@ export class Header {
   /**
    * Get a response with header value "value": true or false
    *
-   * @param {string} scenario Send a post request with header values "scenario": "true" or "false"
+   * @param scenario Send a post request with header values "scenario": "true" or "false"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -430,10 +422,9 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps
    * over the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {HeaderParamStringOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -458,10 +449,9 @@ export class Header {
   /**
    * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -487,11 +477,11 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario":
    * "min", "value": "0001-01-01"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {Date | string} value Send a post request with header values "2010-01-01" or "0001-01-01"
+   * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -517,9 +507,9 @@ export class Header {
   /**
    * Get a response with header values "2010-01-01" or "0001-01-01"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -545,12 +535,12 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or
    * "scenario": "min", "value": "0001-01-01T00:00:00Z"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {Date | string} value Send a post request with header values "2010-01-01T12:34:56Z" or
+   * @param value Send a post request with header values "2010-01-01T12:34:56Z" or
    * "0001-01-01T00:00:00Z"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -576,9 +566,9 @@ export class Header {
   /**
    * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -604,9 +594,9 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56
    * GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {HeaderParamDatetimeRfc1123OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -632,9 +622,9 @@ export class Header {
    * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00
    * GMT"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "min"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -659,11 +649,11 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {string} value Send a post request with header values "P123DT22H14M12.011S"
+   * @param value Send a post request with header values "P123DT22H14M12.011S"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -689,9 +679,9 @@ export class Header {
   /**
    * Get a response with header values "P123DT22H14M12.011S"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -716,11 +706,11 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {Uint8Array} value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
+   * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -746,9 +736,9 @@ export class Header {
   /**
    * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid"
+   * @param scenario Send a post request with header values "scenario": "valid"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -774,10 +764,9 @@ export class Header {
    * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario":
    * "null", "value": null
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {HeaderParamEnumOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -802,10 +791,9 @@ export class Header {
   /**
    * Get a response with header values "GREY" or null
    *
-   * @param {string} scenario Send a post request with header values "scenario": "valid" or "null" or
-   * "empty"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -830,7 +818,7 @@ export class Header {
   /**
    * Send x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 in the header of the request
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Header/operations/header.ts
+++ b/test/vanilla/generated/Header/operations/header.ts
@@ -33,7 +33,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -58,7 +58,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -84,7 +84,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -138,7 +138,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -166,7 +166,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -196,7 +196,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -224,7 +224,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -254,7 +254,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -282,7 +282,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -312,7 +312,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -340,7 +340,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -370,7 +370,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -398,7 +398,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -426,7 +426,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -453,7 +453,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -483,7 +483,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -511,7 +511,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -542,7 +542,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -570,7 +570,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -598,7 +598,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -626,7 +626,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -655,7 +655,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -683,7 +683,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -712,7 +712,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -740,7 +740,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -768,7 +768,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -795,7 +795,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -820,7 +820,7 @@ export class Header {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Header/operations/header.ts
+++ b/test/vanilla/generated/Header/operations/header.ts
@@ -34,10 +34,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramExistingKey(userAgent: string): Promise<msRest.RestResponse>;
   paramExistingKey(userAgent: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -59,10 +55,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseExistingKey(): Promise<Models.HeaderResponseExistingKeyResponse>;
   responseExistingKey(options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseExistingKeyResponse>;
@@ -85,10 +77,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramProtectedKey(contentType: string): Promise<msRest.RestResponse>;
   paramProtectedKey(contentType: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -110,10 +98,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseProtectedKey(): Promise<Models.HeaderResponseProtectedKeyResponse>;
   responseProtectedKey(options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseProtectedKeyResponse>;
@@ -139,10 +123,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramInteger(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramInteger(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -167,10 +147,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseInteger(scenario: string): Promise<Models.HeaderResponseIntegerResponse>;
   responseInteger(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseIntegerResponse>;
@@ -197,10 +173,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramLong(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramLong(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -225,10 +197,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseLong(scenario: string): Promise<Models.HeaderResponseLongResponse>;
   responseLong(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseLongResponse>;
@@ -255,10 +223,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramFloat(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramFloat(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -283,10 +247,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseFloat(scenario: string): Promise<Models.HeaderResponseFloatResponse>;
   responseFloat(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseFloatResponse>;
@@ -313,10 +273,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDouble(scenario: string, value: number): Promise<msRest.RestResponse>;
   paramDouble(scenario: string, value: number, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -341,10 +297,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDouble(scenario: string): Promise<Models.HeaderResponseDoubleResponse>;
   responseDouble(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDoubleResponse>;
@@ -371,10 +323,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramBool(scenario: string, value: boolean): Promise<msRest.RestResponse>;
   paramBool(scenario: string, value: boolean, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -399,10 +347,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseBool(scenario: string): Promise<Models.HeaderResponseBoolResponse>;
   responseBool(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseBoolResponse>;
@@ -427,10 +371,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramString(scenario: string): Promise<msRest.RestResponse>;
   paramString(scenario: string, options: Models.HeaderParamStringOptionalParams): Promise<msRest.RestResponse>;
@@ -454,10 +394,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseString(scenario: string): Promise<Models.HeaderResponseStringResponse>;
   responseString(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseStringResponse>;
@@ -484,10 +420,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDate(scenario: string, value: Date | string): Promise<msRest.RestResponse>;
   paramDate(scenario: string, value: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -512,10 +444,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDate(scenario: string): Promise<Models.HeaderResponseDateResponse>;
   responseDate(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDateResponse>;
@@ -543,10 +471,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDatetime(scenario: string, value: Date | string): Promise<msRest.RestResponse>;
   paramDatetime(scenario: string, value: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -571,10 +495,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDatetime(scenario: string): Promise<Models.HeaderResponseDatetimeResponse>;
   responseDatetime(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDatetimeResponse>;
@@ -599,10 +519,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDatetimeRfc1123(scenario: string): Promise<msRest.RestResponse>;
   paramDatetimeRfc1123(scenario: string, options: Models.HeaderParamDatetimeRfc1123OptionalParams): Promise<msRest.RestResponse>;
@@ -627,10 +543,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDatetimeRfc1123(scenario: string): Promise<Models.HeaderResponseDatetimeRfc1123Response>;
   responseDatetimeRfc1123(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDatetimeRfc1123Response>;
@@ -656,10 +568,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramDuration(scenario: string, value: string): Promise<msRest.RestResponse>;
   paramDuration(scenario: string, value: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -684,10 +592,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseDuration(scenario: string): Promise<Models.HeaderResponseDurationResponse>;
   responseDuration(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseDurationResponse>;
@@ -713,10 +617,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramByte(scenario: string, value: Uint8Array): Promise<msRest.RestResponse>;
   paramByte(scenario: string, value: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -741,10 +641,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseByte(scenario: string): Promise<Models.HeaderResponseByteResponse>;
   responseByte(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseByteResponse>;
@@ -769,10 +665,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   paramEnum(scenario: string): Promise<msRest.RestResponse>;
   paramEnum(scenario: string, options: Models.HeaderParamEnumOptionalParams): Promise<msRest.RestResponse>;
@@ -796,10 +688,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   responseEnum(scenario: string): Promise<Models.HeaderResponseEnumResponse>;
   responseEnum(scenario: string, options: msRest.RequestOptionsBase): Promise<Models.HeaderResponseEnumResponse>;
@@ -821,10 +709,6 @@ export class Header {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   customRequestId(): Promise<msRest.RestResponse>;
   customRequestId(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestService.ts
@@ -27,9 +27,9 @@ class AutoRestHttpInfrastructureTestService extends AutoRestHttpInfrastructureTe
   /**
    * Initializes a new instance of the AutoRestHttpInfrastructureTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/Http/autoRestHttpInfrastructureTestServiceContext.ts
+++ b/test/vanilla/generated/Http/autoRestHttpInfrastructureTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestHttpInfrastructureTestServiceContext extends msRest.Service
   /**
    * Initializes a new instance of the AutoRestHttpInfrastructureTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/Http/operations/httpClientFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpClientFailure.ts
@@ -31,10 +31,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head400(): Promise<Models.HttpClientFailureHead400Response>;
   head400(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureHead400Response>;
@@ -55,10 +51,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get400(): Promise<Models.HttpClientFailureGet400Response>;
   get400(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureGet400Response>;
@@ -79,10 +71,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put400(): Promise<Models.HttpClientFailurePut400Response>;
   put400(options: Models.HttpClientFailurePut400OptionalParams): Promise<Models.HttpClientFailurePut400Response>;
@@ -103,10 +91,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch400(): Promise<Models.HttpClientFailurePatch400Response>;
   patch400(options: Models.HttpClientFailurePatch400OptionalParams): Promise<Models.HttpClientFailurePatch400Response>;
@@ -127,10 +111,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post400(): Promise<Models.HttpClientFailurePost400Response>;
   post400(options: Models.HttpClientFailurePost400OptionalParams): Promise<Models.HttpClientFailurePost400Response>;
@@ -151,10 +131,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete400(): Promise<Models.HttpClientFailureDelete400Response>;
   delete400(options: Models.HttpClientFailureDelete400OptionalParams): Promise<Models.HttpClientFailureDelete400Response>;
@@ -175,10 +151,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head401(): Promise<Models.HttpClientFailureHead401Response>;
   head401(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureHead401Response>;
@@ -199,10 +171,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get402(): Promise<Models.HttpClientFailureGet402Response>;
   get402(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureGet402Response>;
@@ -223,10 +191,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get403(): Promise<Models.HttpClientFailureGet403Response>;
   get403(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureGet403Response>;
@@ -247,10 +211,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put404(): Promise<Models.HttpClientFailurePut404Response>;
   put404(options: Models.HttpClientFailurePut404OptionalParams): Promise<Models.HttpClientFailurePut404Response>;
@@ -271,10 +231,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch405(): Promise<Models.HttpClientFailurePatch405Response>;
   patch405(options: Models.HttpClientFailurePatch405OptionalParams): Promise<Models.HttpClientFailurePatch405Response>;
@@ -295,10 +251,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post406(): Promise<Models.HttpClientFailurePost406Response>;
   post406(options: Models.HttpClientFailurePost406OptionalParams): Promise<Models.HttpClientFailurePost406Response>;
@@ -319,10 +271,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete407(): Promise<Models.HttpClientFailureDelete407Response>;
   delete407(options: Models.HttpClientFailureDelete407OptionalParams): Promise<Models.HttpClientFailureDelete407Response>;
@@ -343,10 +291,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put409(): Promise<Models.HttpClientFailurePut409Response>;
   put409(options: Models.HttpClientFailurePut409OptionalParams): Promise<Models.HttpClientFailurePut409Response>;
@@ -367,10 +311,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head410(): Promise<Models.HttpClientFailureHead410Response>;
   head410(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureHead410Response>;
@@ -391,10 +331,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get411(): Promise<Models.HttpClientFailureGet411Response>;
   get411(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureGet411Response>;
@@ -415,10 +351,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get412(): Promise<Models.HttpClientFailureGet412Response>;
   get412(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureGet412Response>;
@@ -439,10 +371,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put413(): Promise<Models.HttpClientFailurePut413Response>;
   put413(options: Models.HttpClientFailurePut413OptionalParams): Promise<Models.HttpClientFailurePut413Response>;
@@ -463,10 +391,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch414(): Promise<Models.HttpClientFailurePatch414Response>;
   patch414(options: Models.HttpClientFailurePatch414OptionalParams): Promise<Models.HttpClientFailurePatch414Response>;
@@ -487,10 +411,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post415(): Promise<Models.HttpClientFailurePost415Response>;
   post415(options: Models.HttpClientFailurePost415OptionalParams): Promise<Models.HttpClientFailurePost415Response>;
@@ -511,10 +431,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get416(): Promise<Models.HttpClientFailureGet416Response>;
   get416(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureGet416Response>;
@@ -535,10 +451,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete417(): Promise<Models.HttpClientFailureDelete417Response>;
   delete417(options: Models.HttpClientFailureDelete417OptionalParams): Promise<Models.HttpClientFailureDelete417Response>;
@@ -559,10 +471,6 @@ export class HttpClientFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head429(): Promise<Models.HttpClientFailureHead429Response>;
   head429(options: msRest.RequestOptionsBase): Promise<Models.HttpClientFailureHead429Response>;

--- a/test/vanilla/generated/Http/operations/httpClientFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpClientFailure.ts
@@ -30,7 +30,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -174,7 +174,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -198,7 +198,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -246,7 +246,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -270,7 +270,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -294,7 +294,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -318,7 +318,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -342,7 +342,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -366,7 +366,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -390,7 +390,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -414,7 +414,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -438,7 +438,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -462,7 +462,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -486,7 +486,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -510,7 +510,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -534,7 +534,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -558,7 +558,7 @@ export class HttpClientFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/httpClientFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpClientFailure.ts
@@ -28,7 +28,7 @@ export class HttpClientFailure {
   /**
    * Return 400 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HttpClientFailure {
   /**
    * Return 400 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HttpClientFailure {
   /**
    * Return 400 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePut400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class HttpClientFailure {
   /**
    * Return 400 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePatch400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class HttpClientFailure {
   /**
    * Return 400 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePost400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class HttpClientFailure {
   /**
    * Return 400 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailureDelete400OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,7 +172,7 @@ export class HttpClientFailure {
   /**
    * Return 401 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -196,7 +196,7 @@ export class HttpClientFailure {
   /**
    * Return 402 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -220,7 +220,7 @@ export class HttpClientFailure {
   /**
    * Return 403 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -244,7 +244,7 @@ export class HttpClientFailure {
   /**
    * Return 404 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePut404OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -268,7 +268,7 @@ export class HttpClientFailure {
   /**
    * Return 405 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePatch405OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -292,7 +292,7 @@ export class HttpClientFailure {
   /**
    * Return 406 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePost406OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -316,7 +316,7 @@ export class HttpClientFailure {
   /**
    * Return 407 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailureDelete407OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -340,7 +340,7 @@ export class HttpClientFailure {
   /**
    * Return 409 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePut409OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -364,7 +364,7 @@ export class HttpClientFailure {
   /**
    * Return 410 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -388,7 +388,7 @@ export class HttpClientFailure {
   /**
    * Return 411 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -412,7 +412,7 @@ export class HttpClientFailure {
   /**
    * Return 412 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -436,7 +436,7 @@ export class HttpClientFailure {
   /**
    * Return 413 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePut413OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -460,7 +460,7 @@ export class HttpClientFailure {
   /**
    * Return 414 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePatch414OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -484,7 +484,7 @@ export class HttpClientFailure {
   /**
    * Return 415 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailurePost415OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -508,7 +508,7 @@ export class HttpClientFailure {
   /**
    * Return 416 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -532,7 +532,7 @@ export class HttpClientFailure {
   /**
    * Return 417 status code - should be represented in the client as an error
    *
-   * @param {HttpClientFailureDelete417OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -556,7 +556,7 @@ export class HttpClientFailure {
   /**
    * Return 429 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Http/operations/httpFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpFailure.ts
@@ -31,10 +31,6 @@ export class HttpFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyError(): Promise<Models.HttpFailureGetEmptyErrorResponse>;
   getEmptyError(options: msRest.RequestOptionsBase): Promise<Models.HttpFailureGetEmptyErrorResponse>;
@@ -55,10 +51,6 @@ export class HttpFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNoModelError(): Promise<Models.HttpFailureGetNoModelErrorResponse>;
   getNoModelError(options: msRest.RequestOptionsBase): Promise<Models.HttpFailureGetNoModelErrorResponse>;
@@ -79,10 +71,6 @@ export class HttpFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNoModelEmpty(): Promise<Models.HttpFailureGetNoModelEmptyResponse>;
   getNoModelEmpty(options: msRest.RequestOptionsBase): Promise<Models.HttpFailureGetNoModelEmptyResponse>;

--- a/test/vanilla/generated/Http/operations/httpFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpFailure.ts
@@ -30,7 +30,7 @@ export class HttpFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HttpFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HttpFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/httpFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpFailure.ts
@@ -28,7 +28,7 @@ export class HttpFailure {
   /**
    * Get empty error form server
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HttpFailure {
   /**
    * Get empty error form server
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HttpFailure {
   /**
    * Get empty response from server
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Http/operations/httpRedirects.ts
+++ b/test/vanilla/generated/Http/operations/httpRedirects.ts
@@ -28,7 +28,7 @@ export class HttpRedirects {
   /**
    * Return 300 status code and redirect to /http/success/200
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HttpRedirects {
   /**
    * Return 300 status code and redirect to /http/success/200
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HttpRedirects {
   /**
    * Return 301 status code and redirect to /http/success/200
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class HttpRedirects {
   /**
    * Return 301 status code and redirect to /http/success/200
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class HttpRedirects {
    * Put true Boolean value in request returns 301.  This request should not be automatically
    * redirected, but should return the received 301 to the caller for evaluation
    *
-   * @param {HttpRedirectsPut301OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -149,7 +149,7 @@ export class HttpRedirects {
   /**
    * Return 302 status code and redirect to /http/success/200
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -173,7 +173,7 @@ export class HttpRedirects {
   /**
    * Return 302 status code and redirect to /http/success/200
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -198,7 +198,7 @@ export class HttpRedirects {
    * Patch true Boolean value in request returns 302.  This request should not be automatically
    * redirected, but should return the received 302 to the caller for evaluation
    *
-   * @param {HttpRedirectsPatch302OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -223,7 +223,7 @@ export class HttpRedirects {
    * Post true Boolean value in request returns 303.  This request should be automatically redirected
    * usign a get, ultimately returning a 200 status code
    *
-   * @param {HttpRedirectsPost303OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -247,7 +247,7 @@ export class HttpRedirects {
   /**
    * Redirect with 307, resulting in a 200 success
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -271,7 +271,7 @@ export class HttpRedirects {
   /**
    * Redirect get with 307, resulting in a 200 success
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -295,7 +295,7 @@ export class HttpRedirects {
   /**
    * Put redirected with 307, resulting in a 200 after redirect
    *
-   * @param {HttpRedirectsPut307OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -319,7 +319,7 @@ export class HttpRedirects {
   /**
    * Patch redirected with 307, resulting in a 200 after redirect
    *
-   * @param {HttpRedirectsPatch307OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -343,7 +343,7 @@ export class HttpRedirects {
   /**
    * Post redirected with 307, resulting in a 200 after redirect
    *
-   * @param {HttpRedirectsPost307OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -367,7 +367,7 @@ export class HttpRedirects {
   /**
    * Delete redirected with 307, resulting in a 200 after redirect
    *
-   * @param {HttpRedirectsDelete307OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Http/operations/httpRedirects.ts
+++ b/test/vanilla/generated/Http/operations/httpRedirects.ts
@@ -30,7 +30,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -151,7 +151,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -175,7 +175,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -200,7 +200,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -225,7 +225,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -249,7 +249,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -273,7 +273,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -297,7 +297,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -321,7 +321,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -345,7 +345,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -369,7 +369,7 @@ export class HttpRedirects {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/httpRedirects.ts
+++ b/test/vanilla/generated/Http/operations/httpRedirects.ts
@@ -31,10 +31,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head300(): Promise<Models.HttpRedirectsHead300Response>;
   head300(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsHead300Response>;
@@ -55,10 +51,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get300(): Promise<Models.HttpRedirectsGet300Response>;
   get300(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsGet300Response>;
@@ -79,10 +71,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head301(): Promise<Models.HttpRedirectsHead301Response>;
   head301(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsHead301Response>;
@@ -103,10 +91,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get301(): Promise<Models.HttpRedirectsGet301Response>;
   get301(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsGet301Response>;
@@ -128,10 +112,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put301(): Promise<Models.HttpRedirectsPut301Response>;
   put301(options: Models.HttpRedirectsPut301OptionalParams): Promise<Models.HttpRedirectsPut301Response>;
@@ -152,10 +132,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head302(): Promise<Models.HttpRedirectsHead302Response>;
   head302(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsHead302Response>;
@@ -176,10 +152,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get302(): Promise<Models.HttpRedirectsGet302Response>;
   get302(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsGet302Response>;
@@ -201,10 +173,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch302(): Promise<Models.HttpRedirectsPatch302Response>;
   patch302(options: Models.HttpRedirectsPatch302OptionalParams): Promise<Models.HttpRedirectsPatch302Response>;
@@ -226,10 +194,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post303(): Promise<Models.HttpRedirectsPost303Response>;
   post303(options: Models.HttpRedirectsPost303OptionalParams): Promise<Models.HttpRedirectsPost303Response>;
@@ -250,10 +214,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head307(): Promise<Models.HttpRedirectsHead307Response>;
   head307(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsHead307Response>;
@@ -274,10 +234,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get307(): Promise<Models.HttpRedirectsGet307Response>;
   get307(options: msRest.RequestOptionsBase): Promise<Models.HttpRedirectsGet307Response>;
@@ -298,10 +254,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put307(): Promise<Models.HttpRedirectsPut307Response>;
   put307(options: Models.HttpRedirectsPut307OptionalParams): Promise<Models.HttpRedirectsPut307Response>;
@@ -322,10 +274,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch307(): Promise<Models.HttpRedirectsPatch307Response>;
   patch307(options: Models.HttpRedirectsPatch307OptionalParams): Promise<Models.HttpRedirectsPatch307Response>;
@@ -346,10 +294,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post307(): Promise<Models.HttpRedirectsPost307Response>;
   post307(options: Models.HttpRedirectsPost307OptionalParams): Promise<Models.HttpRedirectsPost307Response>;
@@ -370,10 +314,6 @@ export class HttpRedirects {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete307(): Promise<Models.HttpRedirectsDelete307Response>;
   delete307(options: Models.HttpRedirectsDelete307OptionalParams): Promise<Models.HttpRedirectsDelete307Response>;

--- a/test/vanilla/generated/Http/operations/httpRetry.ts
+++ b/test/vanilla/generated/Http/operations/httpRetry.ts
@@ -30,7 +30,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -174,7 +174,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -198,7 +198,7 @@ export class HttpRetry {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/httpRetry.ts
+++ b/test/vanilla/generated/Http/operations/httpRetry.ts
@@ -28,7 +28,7 @@ export class HttpRetry {
   /**
    * Return 408 status code, then 200 after retry
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HttpRetry {
   /**
    * Return 500 status code, then 200 after retry
    *
-   * @param {HttpRetryPut500OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HttpRetry {
   /**
    * Return 500 status code, then 200 after retry
    *
-   * @param {HttpRetryPatch500OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class HttpRetry {
   /**
    * Return 502 status code, then 200 after retry
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class HttpRetry {
   /**
    * Return 503 status code, then 200 after retry
    *
-   * @param {HttpRetryPost503OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class HttpRetry {
   /**
    * Return 503 status code, then 200 after retry
    *
-   * @param {HttpRetryDelete503OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,7 +172,7 @@ export class HttpRetry {
   /**
    * Return 504 status code, then 200 after retry
    *
-   * @param {HttpRetryPut504OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -196,7 +196,7 @@ export class HttpRetry {
   /**
    * Return 504 status code, then 200 after retry
    *
-   * @param {HttpRetryPatch504OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Http/operations/httpRetry.ts
+++ b/test/vanilla/generated/Http/operations/httpRetry.ts
@@ -31,10 +31,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head408(): Promise<msRest.RestResponse>;
   head408(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -55,10 +51,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put500(): Promise<msRest.RestResponse>;
   put500(options: Models.HttpRetryPut500OptionalParams): Promise<msRest.RestResponse>;
@@ -79,10 +71,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch500(): Promise<msRest.RestResponse>;
   patch500(options: Models.HttpRetryPatch500OptionalParams): Promise<msRest.RestResponse>;
@@ -103,10 +91,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get502(): Promise<msRest.RestResponse>;
   get502(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post503(): Promise<msRest.RestResponse>;
   post503(options: Models.HttpRetryPost503OptionalParams): Promise<msRest.RestResponse>;
@@ -151,10 +131,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete503(): Promise<msRest.RestResponse>;
   delete503(options: Models.HttpRetryDelete503OptionalParams): Promise<msRest.RestResponse>;
@@ -175,10 +151,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put504(): Promise<msRest.RestResponse>;
   put504(options: Models.HttpRetryPut504OptionalParams): Promise<msRest.RestResponse>;
@@ -199,10 +171,6 @@ export class HttpRetry {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch504(): Promise<msRest.RestResponse>;
   patch504(options: Models.HttpRetryPatch504OptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/Http/operations/httpServerFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpServerFailure.ts
@@ -28,7 +28,7 @@ export class HttpServerFailure {
   /**
    * Return 501 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HttpServerFailure {
   /**
    * Return 501 status code - should be represented in the client as an error
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HttpServerFailure {
   /**
    * Return 505 status code - should be represented in the client as an error
    *
-   * @param {HttpServerFailurePost505OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class HttpServerFailure {
   /**
    * Return 505 status code - should be represented in the client as an error
    *
-   * @param {HttpServerFailureDelete505OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Http/operations/httpServerFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpServerFailure.ts
@@ -30,7 +30,7 @@ export class HttpServerFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HttpServerFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HttpServerFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class HttpServerFailure {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/httpServerFailure.ts
+++ b/test/vanilla/generated/Http/operations/httpServerFailure.ts
@@ -31,10 +31,6 @@ export class HttpServerFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head501(): Promise<Models.HttpServerFailureHead501Response>;
   head501(options: msRest.RequestOptionsBase): Promise<Models.HttpServerFailureHead501Response>;
@@ -55,10 +51,6 @@ export class HttpServerFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get501(): Promise<Models.HttpServerFailureGet501Response>;
   get501(options: msRest.RequestOptionsBase): Promise<Models.HttpServerFailureGet501Response>;
@@ -79,10 +71,6 @@ export class HttpServerFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post505(): Promise<Models.HttpServerFailurePost505Response>;
   post505(options: Models.HttpServerFailurePost505OptionalParams): Promise<Models.HttpServerFailurePost505Response>;
@@ -103,10 +91,6 @@ export class HttpServerFailure {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete505(): Promise<Models.HttpServerFailureDelete505Response>;
   delete505(options: Models.HttpServerFailureDelete505OptionalParams): Promise<Models.HttpServerFailureDelete505Response>;

--- a/test/vanilla/generated/Http/operations/httpSuccess.ts
+++ b/test/vanilla/generated/Http/operations/httpSuccess.ts
@@ -30,7 +30,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -174,7 +174,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -198,7 +198,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -246,7 +246,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -270,7 +270,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -294,7 +294,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -318,7 +318,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -342,7 +342,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -366,7 +366,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -390,7 +390,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -414,7 +414,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -438,7 +438,7 @@ export class HttpSuccess {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/httpSuccess.ts
+++ b/test/vanilla/generated/Http/operations/httpSuccess.ts
@@ -28,7 +28,7 @@ export class HttpSuccess {
   /**
    * Return 200 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class HttpSuccess {
   /**
    * Get 200 success
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class HttpSuccess {
   /**
    * Put boolean value true returning 200 success
    *
-   * @param {HttpSuccessPut200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class HttpSuccess {
   /**
    * Patch true Boolean value in request returning 200
    *
-   * @param {HttpSuccessPatch200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class HttpSuccess {
   /**
    * Post bollean value true in request that returns a 200
    *
-   * @param {HttpSuccessPost200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class HttpSuccess {
   /**
    * Delete simple boolean value true returns 200
    *
-   * @param {HttpSuccessDelete200OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,7 +172,7 @@ export class HttpSuccess {
   /**
    * Put true Boolean value in request returns 201
    *
-   * @param {HttpSuccessPut201OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -196,7 +196,7 @@ export class HttpSuccess {
   /**
    * Post true Boolean value in request returns 201 (Created)
    *
-   * @param {HttpSuccessPost201OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -220,7 +220,7 @@ export class HttpSuccess {
   /**
    * Put true Boolean value in request returns 202 (Accepted)
    *
-   * @param {HttpSuccessPut202OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -244,7 +244,7 @@ export class HttpSuccess {
   /**
    * Patch true Boolean value in request returns 202
    *
-   * @param {HttpSuccessPatch202OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -268,7 +268,7 @@ export class HttpSuccess {
   /**
    * Post true Boolean value in request returns 202 (Accepted)
    *
-   * @param {HttpSuccessPost202OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -292,7 +292,7 @@ export class HttpSuccess {
   /**
    * Delete true Boolean value in request returns 202 (accepted)
    *
-   * @param {HttpSuccessDelete202OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -316,7 +316,7 @@ export class HttpSuccess {
   /**
    * Return 204 status code if successful
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -340,7 +340,7 @@ export class HttpSuccess {
   /**
    * Put true Boolean value in request returns 204 (no content)
    *
-   * @param {HttpSuccessPut204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -364,7 +364,7 @@ export class HttpSuccess {
   /**
    * Patch true Boolean value in request returns 204 (no content)
    *
-   * @param {HttpSuccessPatch204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -388,7 +388,7 @@ export class HttpSuccess {
   /**
    * Post true Boolean value in request returns 204 (no content)
    *
-   * @param {HttpSuccessPost204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -412,7 +412,7 @@ export class HttpSuccess {
   /**
    * Delete true Boolean value in request returns 204 (no content)
    *
-   * @param {HttpSuccessDelete204OptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -436,7 +436,7 @@ export class HttpSuccess {
   /**
    * Return 404 status code
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Http/operations/httpSuccess.ts
+++ b/test/vanilla/generated/Http/operations/httpSuccess.ts
@@ -31,10 +31,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head200(): Promise<msRest.RestResponse>;
   head200(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -55,10 +51,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200(): Promise<Models.HttpSuccessGet200Response>;
   get200(options: msRest.RequestOptionsBase): Promise<Models.HttpSuccessGet200Response>;
@@ -79,10 +71,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put200(): Promise<msRest.RestResponse>;
   put200(options: Models.HttpSuccessPut200OptionalParams): Promise<msRest.RestResponse>;
@@ -103,10 +91,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch200(): Promise<msRest.RestResponse>;
   patch200(options: Models.HttpSuccessPatch200OptionalParams): Promise<msRest.RestResponse>;
@@ -127,10 +111,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post200(): Promise<msRest.RestResponse>;
   post200(options: Models.HttpSuccessPost200OptionalParams): Promise<msRest.RestResponse>;
@@ -151,10 +131,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete200(): Promise<msRest.RestResponse>;
   delete200(options: Models.HttpSuccessDelete200OptionalParams): Promise<msRest.RestResponse>;
@@ -175,10 +151,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put201(): Promise<msRest.RestResponse>;
   put201(options: Models.HttpSuccessPut201OptionalParams): Promise<msRest.RestResponse>;
@@ -199,10 +171,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post201(): Promise<msRest.RestResponse>;
   post201(options: Models.HttpSuccessPost201OptionalParams): Promise<msRest.RestResponse>;
@@ -223,10 +191,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put202(): Promise<msRest.RestResponse>;
   put202(options: Models.HttpSuccessPut202OptionalParams): Promise<msRest.RestResponse>;
@@ -247,10 +211,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch202(): Promise<msRest.RestResponse>;
   patch202(options: Models.HttpSuccessPatch202OptionalParams): Promise<msRest.RestResponse>;
@@ -271,10 +231,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post202(): Promise<msRest.RestResponse>;
   post202(options: Models.HttpSuccessPost202OptionalParams): Promise<msRest.RestResponse>;
@@ -295,10 +251,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete202(): Promise<msRest.RestResponse>;
   delete202(options: Models.HttpSuccessDelete202OptionalParams): Promise<msRest.RestResponse>;
@@ -319,10 +271,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head204(): Promise<msRest.RestResponse>;
   head204(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -343,10 +291,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   put204(): Promise<msRest.RestResponse>;
   put204(options: Models.HttpSuccessPut204OptionalParams): Promise<msRest.RestResponse>;
@@ -367,10 +311,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   patch204(): Promise<msRest.RestResponse>;
   patch204(options: Models.HttpSuccessPatch204OptionalParams): Promise<msRest.RestResponse>;
@@ -391,10 +331,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   post204(): Promise<msRest.RestResponse>;
   post204(options: Models.HttpSuccessPost204OptionalParams): Promise<msRest.RestResponse>;
@@ -415,10 +351,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   delete204(): Promise<msRest.RestResponse>;
   delete204(options: Models.HttpSuccessDelete204OptionalParams): Promise<msRest.RestResponse>;
@@ -439,10 +371,6 @@ export class HttpSuccess {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   head404(): Promise<msRest.RestResponse>;
   head404(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/Http/operations/multipleResponses.ts
+++ b/test/vanilla/generated/Http/operations/multipleResponses.ts
@@ -30,7 +30,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -54,7 +54,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -78,7 +78,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -102,7 +102,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -126,7 +126,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -150,7 +150,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -174,7 +174,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -198,7 +198,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -222,7 +222,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -246,7 +246,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -270,7 +270,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -294,7 +294,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -318,7 +318,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -342,7 +342,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -366,7 +366,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -390,7 +390,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -414,7 +414,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -438,7 +438,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -462,7 +462,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -486,7 +486,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -510,7 +510,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -534,7 +534,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -558,7 +558,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -582,7 +582,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -606,7 +606,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -630,7 +630,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -654,7 +654,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -679,7 +679,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -703,7 +703,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -727,7 +727,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -751,7 +751,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -775,7 +775,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -799,7 +799,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -823,7 +823,7 @@ export class MultipleResponses {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Http/operations/multipleResponses.ts
+++ b/test/vanilla/generated/Http/operations/multipleResponses.ts
@@ -31,10 +31,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model204NoModelDefaultError200Valid(): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse>;
   get200Model204NoModelDefaultError200Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError200ValidResponse>;
@@ -55,10 +51,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model204NoModelDefaultError204Valid(): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse>;
   get200Model204NoModelDefaultError204Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError204ValidResponse>;
@@ -79,10 +71,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model204NoModelDefaultError201Invalid(): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse>;
   get200Model204NoModelDefaultError201Invalid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError201InvalidResponse>;
@@ -103,10 +91,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model204NoModelDefaultError202None(): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse>;
   get200Model204NoModelDefaultError202None(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError202NoneResponse>;
@@ -127,10 +111,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model204NoModelDefaultError400Valid(): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse>;
   get200Model204NoModelDefaultError400Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model204NoModelDefaultError400ValidResponse>;
@@ -151,10 +131,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model201ModelDefaultError200Valid(): Promise<Models.MultipleResponsesGet200Model201ModelDefaultError200ValidResponse>;
   get200Model201ModelDefaultError200Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model201ModelDefaultError200ValidResponse>;
@@ -175,10 +151,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model201ModelDefaultError201Valid(): Promise<Models.MultipleResponsesGet200Model201ModelDefaultError201ValidResponse>;
   get200Model201ModelDefaultError201Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model201ModelDefaultError201ValidResponse>;
@@ -199,10 +171,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200Model201ModelDefaultError400Valid(): Promise<Models.MultipleResponsesGet200Model201ModelDefaultError400ValidResponse>;
   get200Model201ModelDefaultError400Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200Model201ModelDefaultError400ValidResponse>;
@@ -223,10 +191,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA201ModelC404ModelDDefaultError200Valid(): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse>;
   get200ModelA201ModelC404ModelDDefaultError200Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError200ValidResponse>;
@@ -247,10 +211,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA201ModelC404ModelDDefaultError201Valid(): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse>;
   get200ModelA201ModelC404ModelDDefaultError201Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError201ValidResponse>;
@@ -271,10 +231,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA201ModelC404ModelDDefaultError404Valid(): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse>;
   get200ModelA201ModelC404ModelDDefaultError404Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError404ValidResponse>;
@@ -295,10 +251,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA201ModelC404ModelDDefaultError400Valid(): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse>;
   get200ModelA201ModelC404ModelDDefaultError400Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA201ModelC404ModelDDefaultError400ValidResponse>;
@@ -319,10 +271,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultError202None(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultError202None(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -343,10 +291,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultError204None(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultError204None(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -367,10 +311,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultError400Valid(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultError400Valid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -391,10 +331,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultNone202Invalid(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultNone202Invalid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -415,10 +351,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultNone204None(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultNone204None(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -439,10 +371,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultNone400None(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultNone400None(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -463,10 +391,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get202None204NoneDefaultNone400Invalid(): Promise<msRest.RestResponse>;
   get202None204NoneDefaultNone400Invalid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -487,10 +411,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultModelA200Valid(): Promise<Models.MultipleResponsesGetDefaultModelA200ValidResponse>;
   getDefaultModelA200Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGetDefaultModelA200ValidResponse>;
@@ -511,10 +431,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultModelA200None(): Promise<Models.MultipleResponsesGetDefaultModelA200NoneResponse>;
   getDefaultModelA200None(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGetDefaultModelA200NoneResponse>;
@@ -535,10 +451,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultModelA400Valid(): Promise<Models.MultipleResponsesGetDefaultModelA400ValidResponse>;
   getDefaultModelA400Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGetDefaultModelA400ValidResponse>;
@@ -559,10 +471,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultModelA400None(): Promise<Models.MultipleResponsesGetDefaultModelA400NoneResponse>;
   getDefaultModelA400None(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGetDefaultModelA400NoneResponse>;
@@ -583,10 +491,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultNone200Invalid(): Promise<msRest.RestResponse>;
   getDefaultNone200Invalid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -607,10 +511,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultNone200None(): Promise<msRest.RestResponse>;
   getDefaultNone200None(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -631,10 +531,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultNone400Invalid(): Promise<msRest.RestResponse>;
   getDefaultNone400Invalid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -655,10 +551,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDefaultNone400None(): Promise<msRest.RestResponse>;
   getDefaultNone400None(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -680,10 +572,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA200None(): Promise<Models.MultipleResponsesGet200ModelA200NoneResponse>;
   get200ModelA200None(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA200NoneResponse>;
@@ -704,10 +592,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA200Valid(): Promise<Models.MultipleResponsesGet200ModelA200ValidResponse>;
   get200ModelA200Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA200ValidResponse>;
@@ -728,10 +612,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA200Invalid(): Promise<Models.MultipleResponsesGet200ModelA200InvalidResponse>;
   get200ModelA200Invalid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA200InvalidResponse>;
@@ -752,10 +632,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA400None(): Promise<Models.MultipleResponsesGet200ModelA400NoneResponse>;
   get200ModelA400None(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA400NoneResponse>;
@@ -776,10 +652,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA400Valid(): Promise<Models.MultipleResponsesGet200ModelA400ValidResponse>;
   get200ModelA400Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA400ValidResponse>;
@@ -800,10 +672,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA400Invalid(): Promise<Models.MultipleResponsesGet200ModelA400InvalidResponse>;
   get200ModelA400Invalid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA400InvalidResponse>;
@@ -824,10 +692,6 @@ export class MultipleResponses {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   get200ModelA202Valid(): Promise<Models.MultipleResponsesGet200ModelA202ValidResponse>;
   get200ModelA202Valid(options: msRest.RequestOptionsBase): Promise<Models.MultipleResponsesGet200ModelA202ValidResponse>;

--- a/test/vanilla/generated/Http/operations/multipleResponses.ts
+++ b/test/vanilla/generated/Http/operations/multipleResponses.ts
@@ -28,7 +28,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with valid payload: {'statusCode': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -52,7 +52,7 @@ export class MultipleResponses {
   /**
    * Send a 204 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -76,7 +76,7 @@ export class MultipleResponses {
   /**
    * Send a 201 response with valid payload: {'statusCode': '201'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -100,7 +100,7 @@ export class MultipleResponses {
   /**
    * Send a 202 response with no payload:
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -124,7 +124,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with valid error payload: {'status': 400, 'message': 'client error'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -148,7 +148,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with valid payload: {'statusCode': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -172,7 +172,7 @@ export class MultipleResponses {
   /**
    * Send a 201 response with valid payload: {'statusCode': '201', 'textStatusCode': 'Created'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -196,7 +196,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -220,7 +220,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with valid payload: {'statusCode': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -244,7 +244,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with valid payload: {'httpCode': '201'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -268,7 +268,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with valid payload: {'httpStatusCode': '404'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -292,7 +292,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -316,7 +316,7 @@ export class MultipleResponses {
   /**
    * Send a 202 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -340,7 +340,7 @@ export class MultipleResponses {
   /**
    * Send a 204 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -364,7 +364,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with valid payload: {'code': '400', 'message': 'client error'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -388,7 +388,7 @@ export class MultipleResponses {
   /**
    * Send a 202 response with an unexpected payload {'property': 'value'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -412,7 +412,7 @@ export class MultipleResponses {
   /**
    * Send a 204 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -436,7 +436,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -460,7 +460,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with an unexpected payload {'property': 'value'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -484,7 +484,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with valid payload: {'statusCode': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -508,7 +508,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -532,7 +532,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with valid payload: {'statusCode': '400'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -556,7 +556,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -580,7 +580,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with invalid payload: {'statusCode': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -604,7 +604,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -628,7 +628,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with valid payload: {'statusCode': '400'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -652,7 +652,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with no payload
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -677,7 +677,7 @@ export class MultipleResponses {
    * Send a 200 response with no payload, when a payload is expected - client should return a null
    * object of thde type for model A
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -701,7 +701,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with payload {'statusCode': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -725,7 +725,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with invalid payload {'statusCodeInvalid': '200'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -749,7 +749,7 @@ export class MultipleResponses {
   /**
    * Send a 400 response with no payload client should treat as an http error with no error model
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -773,7 +773,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with payload {'statusCode': '400'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -797,7 +797,7 @@ export class MultipleResponses {
   /**
    * Send a 200 response with invalid payload {'statusCodeInvalid': '400'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -821,7 +821,7 @@ export class MultipleResponses {
   /**
    * Send a 202 response with payload {'statusCode': '202'}
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -32,7 +32,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -57,7 +57,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -83,7 +83,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -109,7 +109,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -134,7 +134,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -159,7 +159,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -184,7 +184,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -209,7 +209,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -234,7 +234,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -265,7 +265,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -294,7 +294,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -33,10 +33,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putArray(): Promise<msRest.RestResponse>;
   putArray(options: Models.AutoRestResourceFlatteningTestServicePutArrayOptionalParams): Promise<msRest.RestResponse>;
@@ -58,10 +54,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getArray(): Promise<Models.GetArrayResponse>;
   getArray(options: msRest.RequestOptionsBase): Promise<Models.GetArrayResponse>;
@@ -84,10 +76,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putWrappedArray(): Promise<msRest.RestResponse>;
   putWrappedArray(options: Models.AutoRestResourceFlatteningTestServicePutWrappedArrayOptionalParams): Promise<msRest.RestResponse>;
@@ -110,10 +98,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWrappedArray(): Promise<Models.GetWrappedArrayResponse>;
   getWrappedArray(options: msRest.RequestOptionsBase): Promise<Models.GetWrappedArrayResponse>;
@@ -135,10 +119,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putDictionary(): Promise<msRest.RestResponse>;
   putDictionary(options: Models.AutoRestResourceFlatteningTestServicePutDictionaryOptionalParams): Promise<msRest.RestResponse>;
@@ -160,10 +140,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getDictionary(): Promise<Models.GetDictionaryResponse>;
   getDictionary(options: msRest.RequestOptionsBase): Promise<Models.GetDictionaryResponse>;
@@ -185,10 +161,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putResourceCollection(): Promise<msRest.RestResponse>;
   putResourceCollection(options: Models.AutoRestResourceFlatteningTestServicePutResourceCollectionOptionalParams): Promise<msRest.RestResponse>;
@@ -210,10 +182,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getResourceCollection(): Promise<Models.GetResourceCollectionResponse>;
   getResourceCollection(options: msRest.RequestOptionsBase): Promise<Models.GetResourceCollectionResponse>;
@@ -235,10 +203,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSimpleProduct(): Promise<Models.PutSimpleProductResponse>;
   putSimpleProduct(options: Models.AutoRestResourceFlatteningTestServicePutSimpleProductOptionalParams): Promise<Models.PutSimpleProductResponse>;
@@ -266,10 +230,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postFlattenedSimpleProduct(productId: string, maxProductDisplayName: string): Promise<Models.PostFlattenedSimpleProductResponse>;
   postFlattenedSimpleProduct(productId: string, maxProductDisplayName: string, options: Models.AutoRestResourceFlatteningTestServicePostFlattenedSimpleProductOptionalParams): Promise<Models.PostFlattenedSimpleProductResponse>;
@@ -295,10 +255,6 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSimpleProductWithGrouping(flattenParameterGroup: Models.FlattenParameterGroup): Promise<Models.PutSimpleProductWithGroupingResponse>;
   putSimpleProductWithGrouping(flattenParameterGroup: Models.FlattenParameterGroup, options: msRest.RequestOptionsBase): Promise<Models.PutSimpleProductWithGroupingResponse>;

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestService.ts
@@ -18,9 +18,9 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Initializes a new instance of the AutoRestResourceFlatteningTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);
@@ -30,8 +30,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put External Resource as an Array
    *
-   * @param {AutoRestResourceFlatteningTestServicePutArrayOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -56,7 +55,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Get External Resource as an Array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -82,8 +81,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * No need to have a route in Express server for this operation. Used to verify the type flattened
    * is not removed if it's referenced in an array
    *
-   * @param {AutoRestResourceFlatteningTestServicePutWrappedArrayOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -109,7 +107,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
    * No need to have a route in Express server for this operation. Used to verify the type flattened
    * is not removed if it's referenced in an array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -134,8 +132,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put External Resource as a Dictionary
    *
-   * @param {AutoRestResourceFlatteningTestServicePutDictionaryOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -160,7 +157,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Get External Resource as a Dictionary
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -185,8 +182,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put External Resource as a ResourceCollection
    *
-   * @param {AutoRestResourceFlatteningTestServicePutResourceCollectionOptionalParams} [options]
-   * Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -211,7 +207,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Get External Resource as a ResourceCollection
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -236,8 +232,7 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put Simple Product with client flattening true on the model
    *
-   * @param {AutoRestResourceFlatteningTestServicePutSimpleProductOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -262,14 +257,13 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put Flattened Simple Product with client flattening true on the parameter
    *
-   * @param {string} productId Unique identifier representing a specific product for a given latitude
-   * & longitude. For example, uberX in San Francisco will have a different product_id than uberX in
+   * @param productId Unique identifier representing a specific product for a given latitude &
+   * longitude. For example, uberX in San Francisco will have a different product_id than uberX in
    * Los Angeles.
    *
-   * @param {string} maxProductDisplayName Display name of product.
+   * @param maxProductDisplayName Display name of product.
    *
-   * @param {AutoRestResourceFlatteningTestServicePostFlattenedSimpleProductOptionalParams} [options]
-   * Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -296,9 +290,9 @@ class AutoRestResourceFlatteningTestService extends AutoRestResourceFlatteningTe
   /**
    * Put Simple Product with client flattening true on the model
    *
-   * @param {FlattenParameterGroup} flattenParameterGroup Additional parameters for the operation
+   * @param flattenParameterGroup Additional parameters for the operation
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestServiceContext.ts
+++ b/test/vanilla/generated/ModelFlattening/autoRestResourceFlatteningTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestResourceFlatteningTestServiceContext extends msRest.Service
   /**
    * Initializes a new instance of the AutoRestResourceFlatteningTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlattening.ts
@@ -21,9 +21,9 @@ class AutoRestParameterFlattening extends AutoRestParameterFlatteningContext {
   /**
    * Initializes a new instance of the AutoRestParameterFlattening class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/ParameterFlattening/autoRestParameterFlatteningContext.ts
+++ b/test/vanilla/generated/ParameterFlattening/autoRestParameterFlatteningContext.ts
@@ -18,9 +18,9 @@ export class AutoRestParameterFlatteningContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestParameterFlatteningContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
@@ -36,7 +36,7 @@ export class AvailabilitySets {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
@@ -37,10 +37,6 @@ export class AvailabilitySets {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   update(resourceGroupName: string, avset: string, tags: { [propertyName: string]: string }): Promise<msRest.RestResponse>;
   update(resourceGroupName: string, avset: string, tags: { [propertyName: string]: string }, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
+++ b/test/vanilla/generated/ParameterFlattening/operations/availabilitySets.ts
@@ -28,14 +28,13 @@ export class AvailabilitySets {
   /**
    * Updates the tags for an availability set.
    *
-   * @param {string} resourceGroupName The name of the resource group.
+   * @param resourceGroupName The name of the resource group.
    *
-   * @param {string} avset The name of the storage availability set.
+   * @param avset The name of the storage availability set.
    *
-   * @param {{ [propertyName: string]: string }} tags A set of tags. A description about the set of
-   * tags.
+   * @param tags A set of tags. A description about the set of tags.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -32,7 +32,7 @@ class AutoRestReportService extends AutoRestReportServiceContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -18,9 +18,9 @@ class AutoRestReportService extends AutoRestReportServiceContext {
   /**
    * Initializes a new instance of the AutoRestReportService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);
@@ -30,7 +30,7 @@ class AutoRestReportService extends AutoRestReportServiceContext {
   /**
    * Get test coverage report
    *
-   * @param {AutoRestReportServiceGetReportOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Report/autoRestReportService.ts
+++ b/test/vanilla/generated/Report/autoRestReportService.ts
@@ -33,10 +33,6 @@ class AutoRestReportService extends AutoRestReportServiceContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getReport(): Promise<Models.GetReportResponse>;
   getReport(options: Models.AutoRestReportServiceGetReportOptionalParams): Promise<Models.GetReportResponse>;

--- a/test/vanilla/generated/Report/autoRestReportServiceContext.ts
+++ b/test/vanilla/generated/Report/autoRestReportServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestReportServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestReportServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestService.ts
@@ -21,13 +21,13 @@ class AutoRestRequiredOptionalTestService extends AutoRestRequiredOptionalTestSe
   /**
    * Initializes a new instance of the AutoRestRequiredOptionalTestService class.
    *
-   * @param {string} requiredGlobalPath number of items to skip
+   * @param requiredGlobalPath number of items to skip
    *
-   * @param {string} requiredGlobalQuery number of items to skip
+   * @param requiredGlobalQuery number of items to skip
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(requiredGlobalPath: string, requiredGlobalQuery: string, baseUri?: string, options?: Models.AutoRestRequiredOptionalTestServiceOptions) {
     super(requiredGlobalPath, requiredGlobalQuery, baseUri, options);

--- a/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestServiceContext.ts
+++ b/test/vanilla/generated/RequiredOptional/autoRestRequiredOptionalTestServiceContext.ts
@@ -22,13 +22,13 @@ export class AutoRestRequiredOptionalTestServiceContext extends msRest.ServiceCl
   /**
    * Initializes a new instance of the AutoRestRequiredOptionalTestServiceContext class.
    *
-   * @param {string} requiredGlobalPath number of items to skip
+   * @param requiredGlobalPath number of items to skip
    *
-   * @param {string} requiredGlobalQuery number of items to skip
+   * @param requiredGlobalQuery number of items to skip
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(requiredGlobalPath: string, requiredGlobalQuery: string, baseUri?: string, options?: Models.AutoRestRequiredOptionalTestServiceOptions) {
     if (requiredGlobalPath === null || requiredGlobalPath === undefined) {

--- a/test/vanilla/generated/RequiredOptional/operations/explicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/explicit.ts
@@ -35,10 +35,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredIntegerParameter(bodyParameter: number): Promise<Models.ExplicitPostRequiredIntegerParameterResponse>;
   postRequiredIntegerParameter(bodyParameter: number, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredIntegerParameterResponse>;
@@ -60,10 +56,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalIntegerParameter(): Promise<msRest.RestResponse>;
   postOptionalIntegerParameter(options: Models.ExplicitPostOptionalIntegerParameterOptionalParams): Promise<msRest.RestResponse>;
@@ -87,10 +79,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredIntegerProperty(value: number): Promise<Models.ExplicitPostRequiredIntegerPropertyResponse>;
   postRequiredIntegerProperty(value: number, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredIntegerPropertyResponse>;
@@ -112,10 +100,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalIntegerProperty(): Promise<msRest.RestResponse>;
   postOptionalIntegerProperty(options: Models.ExplicitPostOptionalIntegerPropertyOptionalParams): Promise<msRest.RestResponse>;
@@ -139,10 +123,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredIntegerHeader(headerParameter: number): Promise<Models.ExplicitPostRequiredIntegerHeaderResponse>;
   postRequiredIntegerHeader(headerParameter: number, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredIntegerHeaderResponse>;
@@ -164,10 +144,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalIntegerHeader(): Promise<msRest.RestResponse>;
   postOptionalIntegerHeader(options: Models.ExplicitPostOptionalIntegerHeaderOptionalParams): Promise<msRest.RestResponse>;
@@ -191,10 +167,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredStringParameter(bodyParameter: string): Promise<Models.ExplicitPostRequiredStringParameterResponse>;
   postRequiredStringParameter(bodyParameter: string, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredStringParameterResponse>;
@@ -216,10 +188,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalStringParameter(): Promise<msRest.RestResponse>;
   postOptionalStringParameter(options: Models.ExplicitPostOptionalStringParameterOptionalParams): Promise<msRest.RestResponse>;
@@ -243,10 +211,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredStringProperty(value: string): Promise<Models.ExplicitPostRequiredStringPropertyResponse>;
   postRequiredStringProperty(value: string, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredStringPropertyResponse>;
@@ -268,10 +232,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalStringProperty(): Promise<msRest.RestResponse>;
   postOptionalStringProperty(options: Models.ExplicitPostOptionalStringPropertyOptionalParams): Promise<msRest.RestResponse>;
@@ -295,10 +255,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredStringHeader(headerParameter: string): Promise<Models.ExplicitPostRequiredStringHeaderResponse>;
   postRequiredStringHeader(headerParameter: string, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredStringHeaderResponse>;
@@ -320,10 +276,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalStringHeader(): Promise<msRest.RestResponse>;
   postOptionalStringHeader(options: Models.ExplicitPostOptionalStringHeaderOptionalParams): Promise<msRest.RestResponse>;
@@ -347,10 +299,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredClassParameter(bodyParameter: Models.Product): Promise<Models.ExplicitPostRequiredClassParameterResponse>;
   postRequiredClassParameter(bodyParameter: Models.Product, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredClassParameterResponse>;
@@ -372,10 +320,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalClassParameter(): Promise<msRest.RestResponse>;
   postOptionalClassParameter(options: Models.ExplicitPostOptionalClassParameterOptionalParams): Promise<msRest.RestResponse>;
@@ -399,10 +343,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredClassProperty(value: Models.Product): Promise<Models.ExplicitPostRequiredClassPropertyResponse>;
   postRequiredClassProperty(value: Models.Product, options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredClassPropertyResponse>;
@@ -424,10 +364,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalClassProperty(): Promise<msRest.RestResponse>;
   postOptionalClassProperty(options: Models.ExplicitPostOptionalClassPropertyOptionalParams): Promise<msRest.RestResponse>;
@@ -451,10 +387,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredArrayParameter(bodyParameter: string[]): Promise<Models.ExplicitPostRequiredArrayParameterResponse>;
   postRequiredArrayParameter(bodyParameter: string[], options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredArrayParameterResponse>;
@@ -476,10 +408,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalArrayParameter(): Promise<msRest.RestResponse>;
   postOptionalArrayParameter(options: Models.ExplicitPostOptionalArrayParameterOptionalParams): Promise<msRest.RestResponse>;
@@ -503,10 +431,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredArrayProperty(value: string[]): Promise<Models.ExplicitPostRequiredArrayPropertyResponse>;
   postRequiredArrayProperty(value: string[], options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredArrayPropertyResponse>;
@@ -528,10 +452,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalArrayProperty(): Promise<msRest.RestResponse>;
   postOptionalArrayProperty(options: Models.ExplicitPostOptionalArrayPropertyOptionalParams): Promise<msRest.RestResponse>;
@@ -555,10 +475,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postRequiredArrayHeader(headerParameter: string[]): Promise<Models.ExplicitPostRequiredArrayHeaderResponse>;
   postRequiredArrayHeader(headerParameter: string[], options: msRest.RequestOptionsBase): Promise<Models.ExplicitPostRequiredArrayHeaderResponse>;
@@ -580,10 +496,6 @@ export class Explicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postOptionalArrayHeader(): Promise<msRest.RestResponse>;
   postOptionalArrayHeader(options: Models.ExplicitPostOptionalArrayHeaderOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/RequiredOptional/operations/explicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/explicit.ts
@@ -30,9 +30,9 @@ export class Explicit {
    * Test explicitly required integer. Please put null and the client library should throw before the
    * request is sent.
    *
-   * @param {number} bodyParameter
+   * @param bodyParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -57,7 +57,7 @@ export class Explicit {
   /**
    * Test explicitly optional integer. Please put null.
    *
-   * @param {ExplicitPostOptionalIntegerParameterOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -82,9 +82,9 @@ export class Explicit {
    * Test explicitly required integer. Please put a valid int-wrapper with 'value' = null and the
    * client library should throw before the request is sent.
    *
-   * @param {number} value
+   * @param value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -109,7 +109,7 @@ export class Explicit {
   /**
    * Test explicitly optional integer. Please put a valid int-wrapper with 'value' = null.
    *
-   * @param {ExplicitPostOptionalIntegerPropertyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -134,9 +134,9 @@ export class Explicit {
    * Test explicitly required integer. Please put a header 'headerParameter' => null and the client
    * library should throw before the request is sent.
    *
-   * @param {number} headerParameter
+   * @param headerParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -161,7 +161,7 @@ export class Explicit {
   /**
    * Test explicitly optional integer. Please put a header 'headerParameter' => null.
    *
-   * @param {ExplicitPostOptionalIntegerHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -186,9 +186,9 @@ export class Explicit {
    * Test explicitly required string. Please put null and the client library should throw before the
    * request is sent.
    *
-   * @param {string} bodyParameter
+   * @param bodyParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -213,7 +213,7 @@ export class Explicit {
   /**
    * Test explicitly optional string. Please put null.
    *
-   * @param {ExplicitPostOptionalStringParameterOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -238,9 +238,9 @@ export class Explicit {
    * Test explicitly required string. Please put a valid string-wrapper with 'value' = null and the
    * client library should throw before the request is sent.
    *
-   * @param {string} value
+   * @param value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -265,7 +265,7 @@ export class Explicit {
   /**
    * Test explicitly optional integer. Please put a valid string-wrapper with 'value' = null.
    *
-   * @param {ExplicitPostOptionalStringPropertyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -290,9 +290,9 @@ export class Explicit {
    * Test explicitly required string. Please put a header 'headerParameter' => null and the client
    * library should throw before the request is sent.
    *
-   * @param {string} headerParameter
+   * @param headerParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -317,7 +317,7 @@ export class Explicit {
   /**
    * Test explicitly optional string. Please put a header 'headerParameter' => null.
    *
-   * @param {ExplicitPostOptionalStringHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -342,9 +342,9 @@ export class Explicit {
    * Test explicitly required complex object. Please put null and the client library should throw
    * before the request is sent.
    *
-   * @param {Product} bodyParameter
+   * @param bodyParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -369,7 +369,7 @@ export class Explicit {
   /**
    * Test explicitly optional complex object. Please put null.
    *
-   * @param {ExplicitPostOptionalClassParameterOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -394,9 +394,9 @@ export class Explicit {
    * Test explicitly required complex object. Please put a valid class-wrapper with 'value' = null
    * and the client library should throw before the request is sent.
    *
-   * @param {Product} value
+   * @param value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -421,7 +421,7 @@ export class Explicit {
   /**
    * Test explicitly optional complex object. Please put a valid class-wrapper with 'value' = null.
    *
-   * @param {ExplicitPostOptionalClassPropertyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -446,9 +446,9 @@ export class Explicit {
    * Test explicitly required array. Please put null and the client library should throw before the
    * request is sent.
    *
-   * @param {string[]} bodyParameter
+   * @param bodyParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -473,7 +473,7 @@ export class Explicit {
   /**
    * Test explicitly optional array. Please put null.
    *
-   * @param {ExplicitPostOptionalArrayParameterOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -498,9 +498,9 @@ export class Explicit {
    * Test explicitly required array. Please put a valid array-wrapper with 'value' = null and the
    * client library should throw before the request is sent.
    *
-   * @param {string[]} value
+   * @param value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -525,7 +525,7 @@ export class Explicit {
   /**
    * Test explicitly optional array. Please put a valid array-wrapper with 'value' = null.
    *
-   * @param {ExplicitPostOptionalArrayPropertyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -550,9 +550,9 @@ export class Explicit {
    * Test explicitly required array. Please put a header 'headerParameter' => null and the client
    * library should throw before the request is sent.
    *
-   * @param {string[]} headerParameter
+   * @param headerParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -577,7 +577,7 @@ export class Explicit {
   /**
    * Test explicitly optional integer. Please put a header 'headerParameter' => null.
    *
-   * @param {ExplicitPostOptionalArrayHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/RequiredOptional/operations/explicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/explicit.ts
@@ -34,7 +34,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -59,7 +59,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -86,7 +86,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -111,7 +111,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -138,7 +138,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -163,7 +163,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -190,7 +190,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -215,7 +215,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -242,7 +242,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -267,7 +267,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -294,7 +294,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -319,7 +319,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -346,7 +346,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -371,7 +371,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -398,7 +398,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -423,7 +423,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -450,7 +450,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -475,7 +475,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -502,7 +502,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -527,7 +527,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -554,7 +554,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -579,7 +579,7 @@ export class Explicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/RequiredOptional/operations/implicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/implicit.ts
@@ -29,9 +29,9 @@ export class Implicit {
   /**
    * Test implicitly required path parameter
    *
-   * @param {string} pathParameter
+   * @param pathParameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -56,7 +56,7 @@ export class Implicit {
   /**
    * Test implicitly optional query parameter
    *
-   * @param {ImplicitPutOptionalQueryOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,7 +80,7 @@ export class Implicit {
   /**
    * Test implicitly optional header parameter
    *
-   * @param {ImplicitPutOptionalHeaderOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,7 +104,7 @@ export class Implicit {
   /**
    * Test implicitly optional body parameter
    *
-   * @param {ImplicitPutOptionalBodyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -128,7 +128,7 @@ export class Implicit {
   /**
    * Test implicitly required path parameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -152,7 +152,7 @@ export class Implicit {
   /**
    * Test implicitly required query parameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -176,7 +176,7 @@ export class Implicit {
   /**
    * Test implicitly optional query parameter
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/RequiredOptional/operations/implicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/implicit.ts
@@ -33,7 +33,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -58,7 +58,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -106,7 +106,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -130,7 +130,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -154,7 +154,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -178,7 +178,7 @@ export class Implicit {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/RequiredOptional/operations/implicit.ts
+++ b/test/vanilla/generated/RequiredOptional/operations/implicit.ts
@@ -34,10 +34,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getRequiredPath(pathParameter: string): Promise<Models.ImplicitGetRequiredPathResponse>;
   getRequiredPath(pathParameter: string, options: msRest.RequestOptionsBase): Promise<Models.ImplicitGetRequiredPathResponse>;
@@ -59,10 +55,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putOptionalQuery(): Promise<msRest.RestResponse>;
   putOptionalQuery(options: Models.ImplicitPutOptionalQueryOptionalParams): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putOptionalHeader(): Promise<msRest.RestResponse>;
   putOptionalHeader(options: Models.ImplicitPutOptionalHeaderOptionalParams): Promise<msRest.RestResponse>;
@@ -107,10 +95,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putOptionalBody(): Promise<msRest.RestResponse>;
   putOptionalBody(options: Models.ImplicitPutOptionalBodyOptionalParams): Promise<msRest.RestResponse>;
@@ -131,10 +115,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getRequiredGlobalPath(): Promise<Models.ImplicitGetRequiredGlobalPathResponse>;
   getRequiredGlobalPath(options: msRest.RequestOptionsBase): Promise<Models.ImplicitGetRequiredGlobalPathResponse>;
@@ -155,10 +135,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getRequiredGlobalQuery(): Promise<Models.ImplicitGetRequiredGlobalQueryResponse>;
   getRequiredGlobalQuery(options: msRest.RequestOptionsBase): Promise<Models.ImplicitGetRequiredGlobalQueryResponse>;
@@ -179,10 +155,6 @@ export class Implicit {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getOptionalGlobalQuery(): Promise<Models.ImplicitGetOptionalGlobalQueryResponse>;
   getOptionalGlobalQuery(options: msRest.RequestOptionsBase): Promise<Models.ImplicitGetOptionalGlobalQueryResponse>;

--- a/test/vanilla/generated/Url/autoRestUrlTestService.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestService.ts
@@ -22,11 +22,11 @@ class AutoRestUrlTestService extends AutoRestUrlTestServiceContext {
   /**
    * Initializes a new instance of the AutoRestUrlTestService class.
    *
-   * @param {string} globalStringPath A string value 'globalItemStringPath' that appears in the path
+   * @param globalStringPath A string value 'globalItemStringPath' that appears in the path
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(globalStringPath: string, baseUri?: string, options?: Models.AutoRestUrlTestServiceOptions) {
     super(globalStringPath, baseUri, options);

--- a/test/vanilla/generated/Url/autoRestUrlTestServiceContext.ts
+++ b/test/vanilla/generated/Url/autoRestUrlTestServiceContext.ts
@@ -21,11 +21,11 @@ export class AutoRestUrlTestServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestUrlTestServiceContext class.
    *
-   * @param {string} globalStringPath A string value 'globalItemStringPath' that appears in the path
+   * @param globalStringPath A string value 'globalItemStringPath' that appears in the path
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(globalStringPath: string, baseUri?: string, options?: Models.AutoRestUrlTestServiceOptions) {
     if (globalStringPath === null || globalStringPath === undefined) {

--- a/test/vanilla/generated/Url/operations/pathItems.ts
+++ b/test/vanilla/generated/Url/operations/pathItems.ts
@@ -37,7 +37,7 @@ export class PathItems {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -69,7 +69,7 @@ export class PathItems {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -101,7 +101,7 @@ export class PathItems {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -133,7 +133,7 @@ export class PathItems {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Url/operations/pathItems.ts
+++ b/test/vanilla/generated/Url/operations/pathItems.ts
@@ -31,11 +31,11 @@ export class PathItems {
    * localStringPath='localStringPath', globalStringQuery='globalStringQuery',
    * pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
    *
-   * @param {string} localStringPath should contain value 'localStringPath'
+   * @param localStringPath should contain value 'localStringPath'
    *
-   * @param {string} pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    *
-   * @param {PathItemsGetAllWithValuesOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -63,11 +63,11 @@ export class PathItems {
    * localStringPath='localStringPath', globalStringQuery=null,
    * pathItemStringQuery='pathItemStringQuery', localStringQuery='localStringQuery'
    *
-   * @param {string} localStringPath should contain value 'localStringPath'
+   * @param localStringPath should contain value 'localStringPath'
    *
-   * @param {string} pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    *
-   * @param {PathItemsGetGlobalQueryNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -95,11 +95,11 @@ export class PathItems {
    * localStringPath='localStringPath', globalStringQuery=null,
    * pathItemStringQuery='pathItemStringQuery', localStringQuery=null
    *
-   * @param {string} localStringPath should contain value 'localStringPath'
+   * @param localStringPath should contain value 'localStringPath'
    *
-   * @param {string} pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    *
-   * @param {PathItemsGetGlobalAndLocalQueryNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -127,11 +127,11 @@ export class PathItems {
    * localStringPath='localStringPath', globalStringQuery='globalStringQuery',
    * pathItemStringQuery=null, localStringQuery=null
    *
-   * @param {string} localStringPath should contain value 'localStringPath'
+   * @param localStringPath should contain value 'localStringPath'
    *
-   * @param {string} pathItemStringPath A string value 'pathItemStringPath' that appears in the path
+   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    *
-   * @param {PathItemsGetLocalPathItemQueryNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Url/operations/pathItems.ts
+++ b/test/vanilla/generated/Url/operations/pathItems.ts
@@ -38,10 +38,6 @@ export class PathItems {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getAllWithValues(localStringPath: string, pathItemStringPath: string): Promise<msRest.RestResponse>;
   getAllWithValues(localStringPath: string, pathItemStringPath: string, options: Models.PathItemsGetAllWithValuesOptionalParams): Promise<msRest.RestResponse>;
@@ -70,10 +66,6 @@ export class PathItems {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getGlobalQueryNull(localStringPath: string, pathItemStringPath: string): Promise<msRest.RestResponse>;
   getGlobalQueryNull(localStringPath: string, pathItemStringPath: string, options: Models.PathItemsGetGlobalQueryNullOptionalParams): Promise<msRest.RestResponse>;
@@ -102,10 +94,6 @@ export class PathItems {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getGlobalAndLocalQueryNull(localStringPath: string, pathItemStringPath: string): Promise<msRest.RestResponse>;
   getGlobalAndLocalQueryNull(localStringPath: string, pathItemStringPath: string, options: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams): Promise<msRest.RestResponse>;
@@ -134,10 +122,6 @@ export class PathItems {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLocalPathItemQueryNull(localStringPath: string, pathItemStringPath: string): Promise<msRest.RestResponse>;
   getLocalPathItemQueryNull(localStringPath: string, pathItemStringPath: string, options: Models.PathItemsGetLocalPathItemQueryNullOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/Url/operations/paths.ts
+++ b/test/vanilla/generated/Url/operations/paths.ts
@@ -29,7 +29,7 @@ export class Paths {
   /**
    * Get true Boolean value on path
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Paths {
   /**
    * Get false Boolean value on path
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -77,7 +77,7 @@ export class Paths {
   /**
    * Get '1000000' integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -101,7 +101,7 @@ export class Paths {
   /**
    * Get '-1000000' integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class Paths {
   /**
    * Get '10000000000' 64 bit integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -149,7 +149,7 @@ export class Paths {
   /**
    * Get '-10000000000' 64 bit integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -173,7 +173,7 @@ export class Paths {
   /**
    * Get '1.034E+20' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -197,7 +197,7 @@ export class Paths {
   /**
    * Get '-1.034E-20' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -221,7 +221,7 @@ export class Paths {
   /**
    * Get '9999999.999' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -245,7 +245,7 @@ export class Paths {
   /**
    * Get '-9999999.999' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -269,7 +269,7 @@ export class Paths {
   /**
    * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -293,7 +293,7 @@ export class Paths {
   /**
    * Get 'begin!*'();:@ &=+$,/?#[]end
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -317,7 +317,7 @@ export class Paths {
   /**
    * Get ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -341,9 +341,9 @@ export class Paths {
   /**
    * Get null (should throw)
    *
-   * @param {string} stringPath null string value
+   * @param stringPath null string value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -368,10 +368,10 @@ export class Paths {
   /**
    * Get using uri with 'green color' in path parameter
    *
-   * @param {UriColor} enumPath send the value green. Possible values include: 'red color', 'green
-   * color', 'blue color'
+   * @param enumPath send the value green. Possible values include: 'red color', 'green color', 'blue
+   * color'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -396,10 +396,10 @@ export class Paths {
   /**
    * Get null (should throw on the client before the request is sent on wire)
    *
-   * @param {UriColor} enumPath send null should throw. Possible values include: 'red color', 'green
-   * color', 'blue color'
+   * @param enumPath send null should throw. Possible values include: 'red color', 'green color',
+   * 'blue color'
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -424,9 +424,9 @@ export class Paths {
   /**
    * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    *
-   * @param {Uint8Array} bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+   * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -451,7 +451,7 @@ export class Paths {
   /**
    * Get '' as byte array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -475,9 +475,9 @@ export class Paths {
   /**
    * Get null as byte array (should throw)
    *
-   * @param {Uint8Array} bytePath null as byte array (should throw)
+   * @param bytePath null as byte array (should throw)
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -502,7 +502,7 @@ export class Paths {
   /**
    * Get '2012-01-01' as date
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -527,9 +527,9 @@ export class Paths {
    * Get null as date - this should throw or be unusable on the client side, depending on date
    * representation
    *
-   * @param {Date | string} datePath null as date (should throw)
+   * @param datePath null as date (should throw)
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -554,7 +554,7 @@ export class Paths {
   /**
    * Get '2012-01-01T01:01:01Z' as date-time
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -578,9 +578,9 @@ export class Paths {
   /**
    * Get null as date-time, should be disallowed or throw depending on representation of date-time
    *
-   * @param {Date | string} dateTimePath null as date-time
+   * @param dateTimePath null as date-time
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -605,9 +605,9 @@ export class Paths {
   /**
    * Get 'lorem' encoded value as 'bG9yZW0' (base64url)
    *
-   * @param {Uint8Array} base64UrlPath base64url encoded value
+   * @param base64UrlPath base64url encoded value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -633,10 +633,10 @@ export class Paths {
    * Get an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
    * csv-array format
    *
-   * @param {string[]} arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' ,
-   * null, ''] using the csv-array format
+   * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, '']
+   * using the csv-array format
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -661,9 +661,9 @@ export class Paths {
   /**
    * Get the date 2016-04-13 encoded value as '1460505600' (Unix time)
    *
-   * @param {Date | string} unixTimeUrlPath Unix time encoded value
+   * @param unixTimeUrlPath Unix time encoded value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Url/operations/paths.ts
+++ b/test/vanilla/generated/Url/operations/paths.ts
@@ -31,7 +31,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -79,7 +79,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -103,7 +103,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -151,7 +151,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -175,7 +175,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -199,7 +199,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -223,7 +223,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -247,7 +247,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -271,7 +271,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -295,7 +295,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -319,7 +319,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -345,7 +345,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -373,7 +373,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -401,7 +401,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -428,7 +428,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -453,7 +453,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -479,7 +479,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -504,7 +504,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -531,7 +531,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -556,7 +556,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -582,7 +582,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -609,7 +609,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -638,7 +638,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -665,7 +665,7 @@ export class Paths {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Url/operations/paths.ts
+++ b/test/vanilla/generated/Url/operations/paths.ts
@@ -32,10 +32,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanTrue(): Promise<msRest.RestResponse>;
   getBooleanTrue(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -56,10 +52,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanFalse(): Promise<msRest.RestResponse>;
   getBooleanFalse(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -80,10 +72,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntOneMillion(): Promise<msRest.RestResponse>;
   getIntOneMillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -104,10 +92,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntNegativeOneMillion(): Promise<msRest.RestResponse>;
   getIntNegativeOneMillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -128,10 +112,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getTenBillion(): Promise<msRest.RestResponse>;
   getTenBillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -152,10 +132,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNegativeTenBillion(): Promise<msRest.RestResponse>;
   getNegativeTenBillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -176,10 +152,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   floatScientificPositive(): Promise<msRest.RestResponse>;
   floatScientificPositive(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -200,10 +172,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   floatScientificNegative(): Promise<msRest.RestResponse>;
   floatScientificNegative(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -224,10 +192,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   doubleDecimalPositive(): Promise<msRest.RestResponse>;
   doubleDecimalPositive(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -248,10 +212,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   doubleDecimalNegative(): Promise<msRest.RestResponse>;
   doubleDecimalNegative(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -272,10 +232,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringUnicode(): Promise<msRest.RestResponse>;
   stringUnicode(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -296,10 +252,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringUrlEncoded(): Promise<msRest.RestResponse>;
   stringUrlEncoded(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -320,10 +272,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringEmpty(): Promise<msRest.RestResponse>;
   stringEmpty(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -346,10 +294,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringNull(stringPath: string): Promise<msRest.RestResponse>;
   stringNull(stringPath: string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -374,10 +318,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   enumValid(enumPath: Models.UriColor): Promise<msRest.RestResponse>;
   enumValid(enumPath: Models.UriColor, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -402,10 +342,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   enumNull(enumPath: Models.UriColor): Promise<msRest.RestResponse>;
   enumNull(enumPath: Models.UriColor, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -429,10 +365,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   byteMultiByte(bytePath: Uint8Array): Promise<msRest.RestResponse>;
   byteMultiByte(bytePath: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -454,10 +386,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   byteEmpty(): Promise<msRest.RestResponse>;
   byteEmpty(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -480,10 +408,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   byteNull(bytePath: Uint8Array): Promise<msRest.RestResponse>;
   byteNull(bytePath: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -505,10 +429,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateValid(): Promise<msRest.RestResponse>;
   dateValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -532,10 +452,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateNull(datePath: Date | string): Promise<msRest.RestResponse>;
   dateNull(datePath: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -557,10 +473,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateTimeValid(): Promise<msRest.RestResponse>;
   dateTimeValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -583,10 +495,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateTimeNull(dateTimePath: Date | string): Promise<msRest.RestResponse>;
   dateTimeNull(dateTimePath: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -610,10 +518,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   base64Url(base64UrlPath: Uint8Array): Promise<msRest.RestResponse>;
   base64Url(base64UrlPath: Uint8Array, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -639,10 +543,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayCsvInPath(arrayPath: string[]): Promise<msRest.RestResponse>;
   arrayCsvInPath(arrayPath: string[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -666,10 +566,6 @@ export class Paths {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   unixTimeUrl(unixTimeUrlPath: Date | string): Promise<msRest.RestResponse>;
   unixTimeUrl(unixTimeUrlPath: Date | string, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/Url/operations/queries.ts
+++ b/test/vanilla/generated/Url/operations/queries.ts
@@ -31,7 +31,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -79,7 +79,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -103,7 +103,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -127,7 +127,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -151,7 +151,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -175,7 +175,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -199,7 +199,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -223,7 +223,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -247,7 +247,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -271,7 +271,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -295,7 +295,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -319,7 +319,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -343,7 +343,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -367,7 +367,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -391,7 +391,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -415,7 +415,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -439,7 +439,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -463,7 +463,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -487,7 +487,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -511,7 +511,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -535,7 +535,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -559,7 +559,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -583,7 +583,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -607,7 +607,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -631,7 +631,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -655,7 +655,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -679,7 +679,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -704,7 +704,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -728,7 +728,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -752,7 +752,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -777,7 +777,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -802,7 +802,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -827,7 +827,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Url/operations/queries.ts
+++ b/test/vanilla/generated/Url/operations/queries.ts
@@ -32,10 +32,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanTrue(): Promise<msRest.RestResponse>;
   getBooleanTrue(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -56,10 +52,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanFalse(): Promise<msRest.RestResponse>;
   getBooleanFalse(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -80,10 +72,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getBooleanNull(): Promise<msRest.RestResponse>;
   getBooleanNull(options: Models.QueriesGetBooleanNullOptionalParams): Promise<msRest.RestResponse>;
@@ -104,10 +92,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntOneMillion(): Promise<msRest.RestResponse>;
   getIntOneMillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -128,10 +112,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntNegativeOneMillion(): Promise<msRest.RestResponse>;
   getIntNegativeOneMillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -152,10 +132,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getIntNull(): Promise<msRest.RestResponse>;
   getIntNull(options: Models.QueriesGetIntNullOptionalParams): Promise<msRest.RestResponse>;
@@ -176,10 +152,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getTenBillion(): Promise<msRest.RestResponse>;
   getTenBillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -200,10 +172,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getNegativeTenBillion(): Promise<msRest.RestResponse>;
   getNegativeTenBillion(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -224,10 +192,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getLongNull(): Promise<msRest.RestResponse>;
   getLongNull(options: Models.QueriesGetLongNullOptionalParams): Promise<msRest.RestResponse>;
@@ -248,10 +212,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   floatScientificPositive(): Promise<msRest.RestResponse>;
   floatScientificPositive(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -272,10 +232,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   floatScientificNegative(): Promise<msRest.RestResponse>;
   floatScientificNegative(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -296,10 +252,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   floatNull(): Promise<msRest.RestResponse>;
   floatNull(options: Models.QueriesFloatNullOptionalParams): Promise<msRest.RestResponse>;
@@ -320,10 +272,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   doubleDecimalPositive(): Promise<msRest.RestResponse>;
   doubleDecimalPositive(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -344,10 +292,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   doubleDecimalNegative(): Promise<msRest.RestResponse>;
   doubleDecimalNegative(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -368,10 +312,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   doubleNull(): Promise<msRest.RestResponse>;
   doubleNull(options: Models.QueriesDoubleNullOptionalParams): Promise<msRest.RestResponse>;
@@ -392,10 +332,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringUnicode(): Promise<msRest.RestResponse>;
   stringUnicode(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -416,10 +352,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringUrlEncoded(): Promise<msRest.RestResponse>;
   stringUrlEncoded(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -440,10 +372,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringEmpty(): Promise<msRest.RestResponse>;
   stringEmpty(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -464,10 +392,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   stringNull(): Promise<msRest.RestResponse>;
   stringNull(options: Models.QueriesStringNullOptionalParams): Promise<msRest.RestResponse>;
@@ -488,10 +412,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   enumValid(): Promise<msRest.RestResponse>;
   enumValid(options: Models.QueriesEnumValidOptionalParams): Promise<msRest.RestResponse>;
@@ -512,10 +432,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   enumNull(): Promise<msRest.RestResponse>;
   enumNull(options: Models.QueriesEnumNullOptionalParams): Promise<msRest.RestResponse>;
@@ -536,10 +452,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   byteMultiByte(): Promise<msRest.RestResponse>;
   byteMultiByte(options: Models.QueriesByteMultiByteOptionalParams): Promise<msRest.RestResponse>;
@@ -560,10 +472,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   byteEmpty(): Promise<msRest.RestResponse>;
   byteEmpty(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -584,10 +492,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   byteNull(): Promise<msRest.RestResponse>;
   byteNull(options: Models.QueriesByteNullOptionalParams): Promise<msRest.RestResponse>;
@@ -608,10 +512,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateValid(): Promise<msRest.RestResponse>;
   dateValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -632,10 +532,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateNull(): Promise<msRest.RestResponse>;
   dateNull(options: Models.QueriesDateNullOptionalParams): Promise<msRest.RestResponse>;
@@ -656,10 +552,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateTimeValid(): Promise<msRest.RestResponse>;
   dateTimeValid(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -680,10 +572,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   dateTimeNull(): Promise<msRest.RestResponse>;
   dateTimeNull(options: Models.QueriesDateTimeNullOptionalParams): Promise<msRest.RestResponse>;
@@ -705,10 +593,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringCsvValid(): Promise<msRest.RestResponse>;
   arrayStringCsvValid(options: Models.QueriesArrayStringCsvValidOptionalParams): Promise<msRest.RestResponse>;
@@ -729,10 +613,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringCsvNull(): Promise<msRest.RestResponse>;
   arrayStringCsvNull(options: Models.QueriesArrayStringCsvNullOptionalParams): Promise<msRest.RestResponse>;
@@ -753,10 +633,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringCsvEmpty(): Promise<msRest.RestResponse>;
   arrayStringCsvEmpty(options: Models.QueriesArrayStringCsvEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -778,10 +654,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringSsvValid(): Promise<msRest.RestResponse>;
   arrayStringSsvValid(options: Models.QueriesArrayStringSsvValidOptionalParams): Promise<msRest.RestResponse>;
@@ -803,10 +675,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringTsvValid(): Promise<msRest.RestResponse>;
   arrayStringTsvValid(options: Models.QueriesArrayStringTsvValidOptionalParams): Promise<msRest.RestResponse>;
@@ -828,10 +696,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringPipesValid(): Promise<msRest.RestResponse>;
   arrayStringPipesValid(options: Models.QueriesArrayStringPipesValidOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/Url/operations/queries.ts
+++ b/test/vanilla/generated/Url/operations/queries.ts
@@ -29,7 +29,7 @@ export class Queries {
   /**
    * Get true Boolean value on path
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Queries {
   /**
    * Get false Boolean value on path
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -77,7 +77,7 @@ export class Queries {
   /**
    * Get null Boolean value on query (query string should be absent)
    *
-   * @param {QueriesGetBooleanNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -101,7 +101,7 @@ export class Queries {
   /**
    * Get '1000000' integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -125,7 +125,7 @@ export class Queries {
   /**
    * Get '-1000000' integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -149,7 +149,7 @@ export class Queries {
   /**
    * Get null integer value (no query parameter)
    *
-   * @param {QueriesGetIntNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -173,7 +173,7 @@ export class Queries {
   /**
    * Get '10000000000' 64 bit integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -197,7 +197,7 @@ export class Queries {
   /**
    * Get '-10000000000' 64 bit integer value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -221,7 +221,7 @@ export class Queries {
   /**
    * Get 'null 64 bit integer value (no query param in uri)
    *
-   * @param {QueriesGetLongNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -245,7 +245,7 @@ export class Queries {
   /**
    * Get '1.034E+20' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -269,7 +269,7 @@ export class Queries {
   /**
    * Get '-1.034E-20' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -293,7 +293,7 @@ export class Queries {
   /**
    * Get null numeric value (no query parameter)
    *
-   * @param {QueriesFloatNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -317,7 +317,7 @@ export class Queries {
   /**
    * Get '9999999.999' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -341,7 +341,7 @@ export class Queries {
   /**
    * Get '-9999999.999' numeric value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -365,7 +365,7 @@ export class Queries {
   /**
    * Get null numeric value (no query parameter)
    *
-   * @param {QueriesDoubleNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -389,7 +389,7 @@ export class Queries {
   /**
    * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -413,7 +413,7 @@ export class Queries {
   /**
    * Get 'begin!*'();:@ &=+$,/?#[]end
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -437,7 +437,7 @@ export class Queries {
   /**
    * Get ''
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -461,7 +461,7 @@ export class Queries {
   /**
    * Get null (no query parameter in url)
    *
-   * @param {QueriesStringNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -485,7 +485,7 @@ export class Queries {
   /**
    * Get using uri with query parameter 'green color'
    *
-   * @param {QueriesEnumValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -509,7 +509,7 @@ export class Queries {
   /**
    * Get null (no query parameter in url)
    *
-   * @param {QueriesEnumNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -533,7 +533,7 @@ export class Queries {
   /**
    * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    *
-   * @param {QueriesByteMultiByteOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -557,7 +557,7 @@ export class Queries {
   /**
    * Get '' as byte array
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -581,7 +581,7 @@ export class Queries {
   /**
    * Get null as byte array (no query parameters in uri)
    *
-   * @param {QueriesByteNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -605,7 +605,7 @@ export class Queries {
   /**
    * Get '2012-01-01' as date
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -629,7 +629,7 @@ export class Queries {
   /**
    * Get null as date - this should result in no query parameters in uri
    *
-   * @param {QueriesDateNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -653,7 +653,7 @@ export class Queries {
   /**
    * Get '2012-01-01T01:01:01Z' as date-time
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -677,7 +677,7 @@ export class Queries {
   /**
    * Get null as date-time, should result in no query parameters in uri
    *
-   * @param {QueriesDateTimeNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -702,7 +702,7 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
    * csv-array format
    *
-   * @param {QueriesArrayStringCsvValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -726,7 +726,7 @@ export class Queries {
   /**
    * Get a null array of string using the csv-array format
    *
-   * @param {QueriesArrayStringCsvNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -750,7 +750,7 @@ export class Queries {
   /**
    * Get an empty array [] of string using the csv-array format
    *
-   * @param {QueriesArrayStringCsvEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -775,7 +775,7 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
    * ssv-array format
    *
-   * @param {QueriesArrayStringSsvValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -800,7 +800,7 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
    * tsv-array format
    *
-   * @param {QueriesArrayStringTsvValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -825,7 +825,7 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
    * pipes-array format
    *
-   * @param {QueriesArrayStringPipesValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestService.ts
@@ -21,9 +21,9 @@ class AutoRestUrlMutliCollectionFormatTestService extends AutoRestUrlMutliCollec
   /**
    * Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestServiceContext.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/autoRestUrlMutliCollectionFormatTestServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestUrlMutliCollectionFormatTestServiceContext extends msRest.S
   /**
    * Initializes a new instance of the AutoRestUrlMutliCollectionFormatTestServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
@@ -32,10 +32,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringMultiNull(): Promise<msRest.RestResponse>;
   arrayStringMultiNull(options: Models.QueriesArrayStringMultiNullOptionalParams): Promise<msRest.RestResponse>;
@@ -56,10 +52,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringMultiEmpty(): Promise<msRest.RestResponse>;
   arrayStringMultiEmpty(options: Models.QueriesArrayStringMultiEmptyOptionalParams): Promise<msRest.RestResponse>;
@@ -81,10 +73,6 @@ export class Queries {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   arrayStringMultiValid(): Promise<msRest.RestResponse>;
   arrayStringMultiValid(options: Models.QueriesArrayStringMultiValidOptionalParams): Promise<msRest.RestResponse>;

--- a/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
@@ -31,7 +31,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -55,7 +55,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -80,7 +80,7 @@ export class Queries {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
+++ b/test/vanilla/generated/UrlMultiCollectionFormat/operations/queries.ts
@@ -29,7 +29,7 @@ export class Queries {
   /**
    * Get a null array of string using the multi-array format
    *
-   * @param {QueriesArrayStringMultiNullOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,7 +53,7 @@ export class Queries {
   /**
    * Get an empty array [] of string using the multi-array format
    *
-   * @param {QueriesArrayStringMultiEmptyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -78,7 +78,7 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the
    * mult-array format
    *
-   * @param {QueriesArrayStringMultiValidOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -40,7 +40,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -71,7 +71,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -96,7 +96,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -119,7 +119,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -41,10 +41,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   validationOfMethodParameters(resourceGroupName: string, id: number): Promise<Models.ValidationOfMethodParametersResponse>;
   validationOfMethodParameters(resourceGroupName: string, id: number, options: msRest.RequestOptionsBase): Promise<Models.ValidationOfMethodParametersResponse>;
@@ -72,10 +68,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   validationOfBody(resourceGroupName: string, id: number): Promise<Models.ValidationOfBodyResponse>;
   validationOfBody(resourceGroupName: string, id: number, options: Models.AutoRestValidationTestValidationOfBodyOptionalParams): Promise<Models.ValidationOfBodyResponse>;
@@ -97,10 +89,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWithConstantInPath(): Promise<msRest.RestResponse>;
   getWithConstantInPath(options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -120,10 +108,6 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   postWithConstantInBody(): Promise<Models.PostWithConstantInBodyResponse>;
   postWithConstantInBody(options: Models.AutoRestValidationTestPostWithConstantInBodyOptionalParams): Promise<Models.PostWithConstantInBodyResponse>;

--- a/test/vanilla/generated/Validation/autoRestValidationTest.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTest.ts
@@ -18,13 +18,13 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * Initializes a new instance of the AutoRestValidationTest class.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
+   * @param apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(subscriptionId, apiVersion, baseUri, options);
@@ -34,12 +34,11 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * Validates input parameters on the method. See swagger for details.
    *
-   * @param {string} resourceGroupName Required string between 3 and 10 chars with pattern
-   * [a-zA-Z0-9]+.
+   * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
    *
-   * @param {number} id Required int multiple of 10 from 100 to 1000.
+   * @param id Required int multiple of 10 from 100 to 1000.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -66,12 +65,11 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   /**
    * Validates body parameters on the method. See swagger for details.
    *
-   * @param {string} resourceGroupName Required string between 3 and 10 chars with pattern
-   * [a-zA-Z0-9]+.
+   * @param resourceGroupName Required string between 3 and 10 chars with pattern [a-zA-Z0-9]+.
    *
-   * @param {number} id Required int multiple of 10 from 100 to 1000.
+   * @param id Required int multiple of 10 from 100 to 1000.
    *
-   * @param {AutoRestValidationTestValidationOfBodyOptionalParams} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -96,7 +94,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   // methods on the client.
 
   /**
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -119,8 +117,7 @@ class AutoRestValidationTest extends AutoRestValidationTestContext {
   // methods on the client.
 
   /**
-   * @param {AutoRestValidationTestPostWithConstantInBodyOptionalParams} [options] Optional
-   * Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/Validation/autoRestValidationTestContext.ts
+++ b/test/vanilla/generated/Validation/autoRestValidationTestContext.ts
@@ -20,13 +20,13 @@ export class AutoRestValidationTestContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestValidationTestContext class.
    *
-   * @param {string} subscriptionId Subscription ID.
+   * @param subscriptionId Subscription ID.
    *
-   * @param {string} apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
+   * @param apiVersion Required string following pattern \d{2}-\d{2}-\d{4}
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(subscriptionId: string, apiVersion: string, baseUri?: string, options?: msRest.ServiceClientOptions) {
     if (subscriptionId === null || subscriptionId === undefined) {

--- a/test/vanilla/generated/XMSErrorResponses/operations/petOperations.ts
+++ b/test/vanilla/generated/XMSErrorResponses/operations/petOperations.ts
@@ -34,10 +34,6 @@ export class PetOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getPetById(petId: string): Promise<Models.PetGetPetByIdResponse>;
   getPetById(petId: string, options: msRest.RequestOptionsBase): Promise<Models.PetGetPetByIdResponse>;
@@ -61,10 +57,6 @@ export class PetOperations {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   doSomething(whatAction: string): Promise<Models.PetDoSomethingResponse>;
   doSomething(whatAction: string, options: msRest.RequestOptionsBase): Promise<Models.PetDoSomethingResponse>;

--- a/test/vanilla/generated/XMSErrorResponses/operations/petOperations.ts
+++ b/test/vanilla/generated/XMSErrorResponses/operations/petOperations.ts
@@ -29,9 +29,9 @@ export class PetOperations {
   /**
    * Gets pets by id.
    *
-   * @param {string} petId pet id
+   * @param petId pet id
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -56,9 +56,9 @@ export class PetOperations {
   /**
    * Asks pet to do something
    *
-   * @param {string} whatAction what action the pet should do
+   * @param whatAction what action the pet should do
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/vanilla/generated/XMSErrorResponses/operations/petOperations.ts
+++ b/test/vanilla/generated/XMSErrorResponses/operations/petOperations.ts
@@ -33,7 +33,7 @@ export class PetOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -60,7 +60,7 @@ export class PetOperations {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *

--- a/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensions.ts
+++ b/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensions.ts
@@ -21,9 +21,9 @@ class XMSErrorResponseExtensions extends XMSErrorResponseExtensionsContext {
   /**
    * Initializes a new instance of the XMSErrorResponseExtensions class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensionsContext.ts
+++ b/test/vanilla/generated/XMSErrorResponses/xMSErrorResponseExtensionsContext.ts
@@ -18,9 +18,9 @@ export class XMSErrorResponseExtensionsContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the XMSErrorResponseExtensionsContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLService.ts
@@ -21,9 +21,9 @@ class AutoRestSwaggerBATXMLService extends AutoRestSwaggerBATXMLServiceContext {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATXMLService class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
     super(baseUri, options);

--- a/test/xml/generated/Xml/autoRestSwaggerBATXMLServiceContext.ts
+++ b/test/xml/generated/Xml/autoRestSwaggerBATXMLServiceContext.ts
@@ -18,9 +18,9 @@ export class AutoRestSwaggerBATXMLServiceContext extends msRest.ServiceClient {
   /**
    * Initializes a new instance of the AutoRestSwaggerBATXMLServiceContext class.
    *
-   * @param {string} [baseUri] The base URI of the service.
+   * @param [baseUri] The base URI of the service.
    *
-   * @param {object} [options] The parameter options
+   * @param [options] The parameter options
    */
   constructor(baseUri?: string, options?: msRest.ServiceClientOptions) {
 

--- a/test/xml/generated/Xml/operations/xml.ts
+++ b/test/xml/generated/Xml/operations/xml.ts
@@ -29,7 +29,7 @@ export class Xml {
   /**
    * Get a complex type that has a ref to a complex type with no XML node
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -53,9 +53,9 @@ export class Xml {
   /**
    * Puts a complex type that has a ref to a complex type with no XML node
    *
-   * @param {RootWithRefAndNoMeta} model
+   * @param model
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -80,7 +80,7 @@ export class Xml {
   /**
    * Get a complex type that has a ref to a complex type with XML node
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -104,9 +104,9 @@ export class Xml {
   /**
    * Puts a complex type that has a ref to a complex type with XML node
    *
-   * @param {RootWithRefAndMeta} model
+   * @param model
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -131,7 +131,7 @@ export class Xml {
   /**
    * Get a simple XML document
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -155,9 +155,9 @@ export class Xml {
   /**
    * Put a simple XML document
    *
-   * @param {Slideshow} slideshow
+   * @param slideshow
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -182,7 +182,7 @@ export class Xml {
   /**
    * Get an XML document with multiple wrapped lists
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -206,9 +206,9 @@ export class Xml {
   /**
    * Put an XML document with multiple wrapped lists
    *
-   * @param {AppleBarrel} wrappedLists
+   * @param wrappedLists
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -233,7 +233,7 @@ export class Xml {
   /**
    * Get strongly-typed response headers.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -257,7 +257,7 @@ export class Xml {
   /**
    * Get an empty list.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -281,9 +281,9 @@ export class Xml {
   /**
    * Puts an empty list.
    *
-   * @param {Slideshow} slideshow
+   * @param slideshow
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -308,7 +308,7 @@ export class Xml {
   /**
    * Gets some empty wrapped lists.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -332,9 +332,9 @@ export class Xml {
   /**
    * Puts some empty wrapped lists.
    *
-   * @param {AppleBarrel} appleBarrel
+   * @param appleBarrel
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -359,7 +359,7 @@ export class Xml {
   /**
    * Gets a list as the root element.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -383,9 +383,9 @@ export class Xml {
   /**
    * Puts a list as the root element.
    *
-   * @param {Banana[]} bananas
+   * @param bananas
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -410,7 +410,7 @@ export class Xml {
   /**
    * Gets a list with a single item.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -434,9 +434,9 @@ export class Xml {
   /**
    * Puts a list with a single item.
    *
-   * @param {Banana[]} bananas
+   * @param bananas
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -461,7 +461,7 @@ export class Xml {
   /**
    * Gets an empty list as the root element.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -485,9 +485,9 @@ export class Xml {
   /**
    * Puts an empty list as the root element.
    *
-   * @param {Banana[]} bananas
+   * @param bananas
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -512,7 +512,7 @@ export class Xml {
   /**
    * Gets an XML document with an empty child element.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -536,9 +536,9 @@ export class Xml {
   /**
    * Puts a value with an empty child element.
    *
-   * @param {Banana} banana
+   * @param banana
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -563,7 +563,7 @@ export class Xml {
   /**
    * Lists containers in a storage account.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -587,7 +587,7 @@ export class Xml {
   /**
    * Gets storage service properties.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -611,9 +611,9 @@ export class Xml {
   /**
    * Puts storage service properties.
    *
-   * @param {StorageServiceProperties} properties
+   * @param properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -638,7 +638,7 @@ export class Xml {
   /**
    * Gets storage ACLs for a container.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -662,9 +662,9 @@ export class Xml {
   /**
    * Puts storage ACLs for a container.
    *
-   * @param {SignedIdentifier[]} properties
+   * @param properties
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *
@@ -689,7 +689,7 @@ export class Xml {
   /**
    * Lists blobs in a storage container.
    *
-   * @param {RequestOptionsBase} [options] Optional Parameters.
+   * @param [options] Optional Parameters.
    *
    * @returns {Promise} A promise is returned
    *

--- a/test/xml/generated/Xml/operations/xml.ts
+++ b/test/xml/generated/Xml/operations/xml.ts
@@ -32,10 +32,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexTypeRefNoMeta(): Promise<Models.XmlGetComplexTypeRefNoMetaResponse>;
   getComplexTypeRefNoMeta(options: msRest.RequestOptionsBase): Promise<Models.XmlGetComplexTypeRefNoMetaResponse>;
@@ -58,10 +54,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplexTypeRefNoMeta(model: Models.RootWithRefAndNoMeta): Promise<msRest.RestResponse>;
   putComplexTypeRefNoMeta(model: Models.RootWithRefAndNoMeta, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -83,10 +75,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getComplexTypeRefWithMeta(): Promise<Models.XmlGetComplexTypeRefWithMetaResponse>;
   getComplexTypeRefWithMeta(options: msRest.RequestOptionsBase): Promise<Models.XmlGetComplexTypeRefWithMetaResponse>;
@@ -109,10 +97,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putComplexTypeRefWithMeta(model: Models.RootWithRefAndMeta): Promise<msRest.RestResponse>;
   putComplexTypeRefWithMeta(model: Models.RootWithRefAndMeta, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -134,10 +118,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getSimple(): Promise<Models.XmlGetSimpleResponse>;
   getSimple(options: msRest.RequestOptionsBase): Promise<Models.XmlGetSimpleResponse>;
@@ -160,10 +140,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putSimple(slideshow: Models.Slideshow): Promise<msRest.RestResponse>;
   putSimple(slideshow: Models.Slideshow, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -185,10 +161,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getWrappedLists(): Promise<Models.XmlGetWrappedListsResponse>;
   getWrappedLists(options: msRest.RequestOptionsBase): Promise<Models.XmlGetWrappedListsResponse>;
@@ -211,10 +183,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putWrappedLists(wrappedLists: Models.AppleBarrel): Promise<msRest.RestResponse>;
   putWrappedLists(wrappedLists: Models.AppleBarrel, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -236,10 +204,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getHeaders(): Promise<Models.XmlGetHeadersResponse>;
   getHeaders(options: msRest.RequestOptionsBase): Promise<Models.XmlGetHeadersResponse>;
@@ -260,10 +224,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyList(): Promise<Models.XmlGetEmptyListResponse>;
   getEmptyList(options: msRest.RequestOptionsBase): Promise<Models.XmlGetEmptyListResponse>;
@@ -286,10 +246,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmptyList(slideshow: Models.Slideshow): Promise<msRest.RestResponse>;
   putEmptyList(slideshow: Models.Slideshow, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -311,10 +267,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyWrappedLists(): Promise<Models.XmlGetEmptyWrappedListsResponse>;
   getEmptyWrappedLists(options: msRest.RequestOptionsBase): Promise<Models.XmlGetEmptyWrappedListsResponse>;
@@ -337,10 +289,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmptyWrappedLists(appleBarrel: Models.AppleBarrel): Promise<msRest.RestResponse>;
   putEmptyWrappedLists(appleBarrel: Models.AppleBarrel, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -362,10 +310,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getRootList(): Promise<Models.XmlGetRootListResponse>;
   getRootList(options: msRest.RequestOptionsBase): Promise<Models.XmlGetRootListResponse>;
@@ -388,10 +332,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putRootList(bananas: Models.Banana[]): Promise<msRest.RestResponse>;
   putRootList(bananas: Models.Banana[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -413,10 +353,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getRootListSingleItem(): Promise<Models.XmlGetRootListSingleItemResponse>;
   getRootListSingleItem(options: msRest.RequestOptionsBase): Promise<Models.XmlGetRootListSingleItemResponse>;
@@ -439,10 +375,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putRootListSingleItem(bananas: Models.Banana[]): Promise<msRest.RestResponse>;
   putRootListSingleItem(bananas: Models.Banana[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -464,10 +396,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyRootList(): Promise<Models.XmlGetEmptyRootListResponse>;
   getEmptyRootList(options: msRest.RequestOptionsBase): Promise<Models.XmlGetEmptyRootListResponse>;
@@ -490,10 +418,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmptyRootList(bananas: Models.Banana[]): Promise<msRest.RestResponse>;
   putEmptyRootList(bananas: Models.Banana[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -515,10 +439,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getEmptyChildElement(): Promise<Models.XmlGetEmptyChildElementResponse>;
   getEmptyChildElement(options: msRest.RequestOptionsBase): Promise<Models.XmlGetEmptyChildElementResponse>;
@@ -541,10 +461,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putEmptyChildElement(banana: Models.Banana): Promise<msRest.RestResponse>;
   putEmptyChildElement(banana: Models.Banana, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -566,10 +482,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   listContainers(): Promise<Models.XmlListContainersResponse>;
   listContainers(options: msRest.RequestOptionsBase): Promise<Models.XmlListContainersResponse>;
@@ -590,10 +502,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getServiceProperties(): Promise<Models.XmlGetServicePropertiesResponse>;
   getServiceProperties(options: msRest.RequestOptionsBase): Promise<Models.XmlGetServicePropertiesResponse>;
@@ -616,10 +524,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putServiceProperties(properties: Models.StorageServiceProperties): Promise<msRest.RestResponse>;
   putServiceProperties(properties: Models.StorageServiceProperties, options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -641,10 +545,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   getAcls(): Promise<Models.XmlGetAclsResponse>;
   getAcls(options: msRest.RequestOptionsBase): Promise<Models.XmlGetAclsResponse>;
@@ -667,10 +567,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   putAcls(properties: Models.SignedIdentifier[]): Promise<msRest.RestResponse>;
   putAcls(properties: Models.SignedIdentifier[], options: msRest.RequestOptionsBase): Promise<msRest.RestResponse>;
@@ -692,10 +588,6 @@ export class Xml {
    * @param [options] Optional Parameters.
    *
    * @returns A promise is returned
-   *
-   * @resolve {HttpOperationResponse} The deserialized result object.
-   *
-   * @reject {Error|ServiceError} The error object.
    */
   listBlobs(): Promise<Models.XmlListBlobsResponse>;
   listBlobs(options: msRest.RequestOptionsBase): Promise<Models.XmlListBlobsResponse>;

--- a/test/xml/generated/Xml/operations/xml.ts
+++ b/test/xml/generated/Xml/operations/xml.ts
@@ -31,7 +31,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -57,7 +57,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -82,7 +82,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -108,7 +108,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -133,7 +133,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -159,7 +159,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -184,7 +184,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -210,7 +210,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -235,7 +235,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -259,7 +259,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -285,7 +285,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -310,7 +310,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -336,7 +336,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -361,7 +361,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -387,7 +387,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -412,7 +412,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -438,7 +438,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -463,7 +463,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -489,7 +489,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -514,7 +514,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -540,7 +540,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -565,7 +565,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -589,7 +589,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -615,7 +615,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -640,7 +640,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -666,7 +666,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *
@@ -691,7 +691,7 @@ export class Xml {
    *
    * @param [options] Optional Parameters.
    *
-   * @returns {Promise} A promise is returned
+   * @returns A promise is returned
    *
    * @resolve {HttpOperationResponse} The deserialized result object.
    *


### PR DESCRIPTION
Also move `@summary` tags after the description and remove `@resolve` and `@reject` tags.

Resolves https://github.com/Azure/autorest.typescript/issues/304.
Resolves https://github.com/Azure/autorest.typescript/issues/300.