### PR TITLE
Collect property types within an error body type

### DIFF
--- a/src/vanilla/Model/MethodGroupTS.cs
+++ b/src/vanilla/Model/MethodGroupTS.cs
@@ -48,11 +48,7 @@ namespace AutoRest.TypeScript.Model
                     }
                     if (method.DefaultResponse != null)
                     {
-                        // We don't want to collect types contained within the error type
-                        if (method.DefaultResponse.Body is CompositeType)
-                        {
-                            modelNames.Add(method.DefaultResponse.Body.Name);
-                        }
+                        CollectReferencedModelNames(modelNames, method.DefaultResponse.Body);
                         CollectReferencedModelNames(modelNames, method.DefaultResponse.Headers);
                     }
                 }


### PR DESCRIPTION
Resolves #302 

I'm not sure why I decided we shouldn't do this in the first place. It doesn't break any of the test fixtures.