### PR TITLE
Fix missing msRest import

### DIFF
--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -595,7 +595,7 @@ namespace AutoRest.TypeScript.Model
         {
             TSBuilder builder = new TSBuilder();
 
-            if (MethodTemplateModels.Any() || OptionalParameterTypeForClientConstructor == ServiceClientOptions)
+            if (MethodTemplateModels.Any() || OptionalParameterTypeForClientConstructor == ServiceClientOptions || RequiredConstructorParametersTS.Contains("msRest."))
             {
                 builder.ImportAllAs("msRest", "ms-rest-js");
             }


### PR DESCRIPTION
Fixes service clients without any operations but importing objects (credentials) from ms-rest-js package.