### PR TITLE
Add --use-azure-core flag to enable use of @azure/core-http

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "The typescript extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/src/azure/Model/CodeModelTSa.cs
+++ b/src/azure/Model/CodeModelTSa.cs
@@ -64,12 +64,12 @@ namespace AutoRest.TypeScript.Azure.Model
             {
                 imports.Add("AzureServiceClientOptions");
             }
-            builder.Import(imports, "@azure/ms-rest-azure-js");
+            builder.Import(imports, MsRestAzureLibName);
         }
 
         public override void PackageDependencies(JSONObject dependencies)
         {
-            dependencies.StringProperty("@azure/ms-rest-azure-js", "^1.3.2");
+            dependencies.StringProperty(MsRestAzureLibName, MsRestAzureDependencyVersion);
             base.PackageDependencies(dependencies);
         }
 
@@ -77,12 +77,12 @@ namespace AutoRest.TypeScript.Azure.Model
         {
             TSBuilder builder = new TSBuilder();
 
-            builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+            builder.ImportAllAs(MsRestModuleName, MsRestLibName);
 
             bool usesAzureOptionsType = OptionalParameterTypeForClientConstructor == "AzureServiceClientOptions";
             if (usesAzureOptionsType || MethodTemplateModels.Any((MethodTS method) => method.IsLongRunningOperation))
             {
-                builder.ImportAllAs("msRestAzure", "@azure/ms-rest-azure-js");
+                builder.ImportAllAs(MsRestAzureModuleName, MsRestAzureLibName);
             }
 
             if (CodeGeneratorTS.ShouldWriteModelsFiles(this))
@@ -121,7 +121,7 @@ namespace AutoRest.TypeScript.Azure.Model
 
             CompositeTypeTS[] orderedMapperTemplateModels = OrderedMapperTemplateModels.ToArray();
 
-            builder.Import(new[] { "CloudErrorMapper", "BaseResourceMapper" }, "@azure/ms-rest-azure-js");
+            builder.Import(new[] { "CloudErrorMapper", "BaseResourceMapper" }, MsRestAzureLibName);
 
             ImportMsRestForMappers(builder, orderedMapperTemplateModels);
 
@@ -146,7 +146,7 @@ namespace AutoRest.TypeScript.Azure.Model
         protected override void GenerateNodeSampleImports(TSBuilder builder)
         {
             GenerateNodeSampleMsRestJsImport(builder);
-            builder.ImportAllAs("msRestAzure", "@azure/ms-rest-azure-js");
+            builder.ImportAllAs(MsRestAzureModuleName, MsRestAzureLibName);
             GenerateNodeSampleMsRestNodeAuthImport(builder);
             GenerateNodeSampleClientImport(builder);
         }
@@ -165,7 +165,7 @@ namespace AutoRest.TypeScript.Azure.Model
             builder.Line(ConstructRuntimeImportForModelIndex());
             if (ContainsDurationPropertyInModels() || IsAnyModelInheritingFromRequestOptionsBase() || MethodsWithCustomResponseType.Any())
             {
-                builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+                builder.ImportAllAs(MsRestModuleName, MsRestLibName);
             }
             builder.Line();
             builder.Export("BaseResource", "CloudError");
@@ -192,6 +192,11 @@ namespace AutoRest.TypeScript.Azure.Model
         protected override string GetServiceClientOptionsName()
         {
             return "Azure" + base.GetServiceClientOptionsName();
+        }
+
+        protected override string GetServiceClientOptionsModuleName()
+        {
+            return MsRestAzureModuleName;
         }
     }
 }

--- a/src/azure/Templates/AzureServiceClientContextTemplate.cshtml
+++ b/src/azure/Templates/AzureServiceClientContextTemplate.cshtml
@@ -14,8 +14,8 @@ if (usesCustomOptionsType)
 @:import * as Models from "./models";
 }
 }
-import * as msRest from "@@azure/ms-rest-js";
-import * as msRestAzure from "@@azure/ms-rest-azure-js";
+import * as msRest from "@Model.MsRestLibName";
+import * as msRestAzure from "@Model.MsRestAzureLibName";
 @EmptyLine
 const packageName = "@Model.Settings.PackageName";
 const packageVersion = "@Model.Settings.PackageVersion";

--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -87,7 +87,10 @@ namespace AutoRest.TypeScript
             else if (primary.KnownPrimaryType == KnownPrimaryType.TimeSpan)
                 return "string";
             else if (primary.KnownPrimaryType == KnownPrimaryType.Credentials)
-                return "msRest.ServiceClientCredentials"; //TODO: test this, add include for it
+                return "msRest.ServiceClientCredentials" + //TODO: test this, add include for it
+                    ((Singleton<GeneratorSettingsTS>.Instance).UseAzureCore ?? false
+                        ? " | msRest.TokenCredential"
+                        : string.Empty); 
             else {
                 throw new NotImplementedException($"Type '{primary}' not implemented");
             }

--- a/src/vanilla/GeneratorSettingsTS.cs
+++ b/src/vanilla/GeneratorSettingsTS.cs
@@ -165,6 +165,13 @@ namespace AutoRest.TypeScript
         }
 
         /// <summary>
+        /// If true, the generated source will use @azure/core-http and @azure/core-lro
+        /// as dependencies instead of @azure/ms-rest-js and @azure/ms-rest-azure-js,
+        /// respectively.
+        /// </summary>
+        public bool? UseAzureCore { get; set; }
+
+        /// <summary>
         /// If true, adds "autoPublish" property to package's package.json.
         /// The property is used to determine if package can be publish automatically.
         /// </summary>

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -80,6 +80,58 @@ namespace AutoRest.TypeScript.Model
             }
         }
 
+        public string MsRestLibName
+        {
+            get
+            {
+                return Settings.UseAzureCore ?? false
+                    ? "@azure/core-http"
+                    : "@azure/ms-rest-js";
+            }
+        }
+
+        public string MsRestModuleName
+        {
+            get
+            {
+                return "msRest";
+            }
+        }
+
+        public string MsRestDependencyVersion
+        {
+            get
+            {
+                return "^1.8.1";
+            }
+        }
+
+        public string MsRestAzureLibName
+        {
+            get
+            {
+                return Settings.UseAzureCore ?? false
+                    ? "@azure/core-lro"
+                    : "@azure/ms-rest-azure-js";
+            }
+        }
+
+        public string MsRestAzureModuleName
+        {
+            get
+            {
+                return "msRestAzure";
+            }
+        }
+
+        public string MsRestAzureDependencyVersion
+        {
+            get
+            {
+                return "^1.3.2";
+            }
+        }
+
         private bool _computedRequestContentType;
         private string _requestContentType;
         public string RequestContentType
@@ -410,9 +462,9 @@ namespace AutoRest.TypeScript.Model
         {
             TSBuilder builder = new TSBuilder();
             var clientOptionType = OptionalParameterTypeForClientConstructor == GetServiceClientOptionsName()
-                ? "msRest." + GetServiceClientOptionsName()
+                ? $"{GetServiceClientOptionsModuleName()}.{GetServiceClientOptionsName()}"
                 : OptionalParameterTypeForClientConstructor;
-
+                
             string parameterList = (!string.IsNullOrEmpty(RequiredConstructorParametersTS) ? RequiredConstructorParametersTS + ", " : "") + "options?: " + clientOptionType;
 
             builder.Constructor(parameterList, superArgumentList, guardChecks, implementation);
@@ -502,6 +554,11 @@ namespace AutoRest.TypeScript.Model
             return ServiceClientOptions;
         }
 
+        protected virtual string GetServiceClientOptionsModuleName()
+        {
+            return MsRestModuleName;
+        }
+
         private void GenerateOperationGroupInitialization(TSBlock block)
         {
             foreach (var methodGroup in MethodGroupModels)
@@ -576,13 +633,13 @@ namespace AutoRest.TypeScript.Model
         {
             if (OptionalParameterTypeForClientConstructor != ServiceClientOptions)
             {
-                builder.Import(new string[] { ServiceClientOptions }, "@azure/ms-rest-js");
+                builder.Import(new string[] { ServiceClientOptions }, MsRestLibName);
             }
         }
 
         public virtual void PackageDependencies(JSONObject dependencies)
         {
-            dependencies.StringProperty("@azure/ms-rest-js", "^1.8.1");
+            dependencies.StringProperty(MsRestLibName, MsRestDependencyVersion);
             dependencies.StringProperty("tslib", "^1.9.3");
             if (Settings.MultiapiLatest)
             {
@@ -718,7 +775,7 @@ namespace AutoRest.TypeScript.Model
 
             if (MethodTemplateModels.Any() || OptionalParameterTypeForClientConstructor == ServiceClientOptions || RequiredConstructorParametersTS.Contains("msRest."))
             {
-                builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+                builder.ImportAllAs(MsRestModuleName, MsRestLibName);
             }
 
             if (CodeGeneratorTS.ShouldWriteModelsFiles(this))
@@ -826,7 +883,7 @@ namespace AutoRest.TypeScript.Model
         {
             if (orderedMapperModels.Any())
             {
-                builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+                builder.ImportAllAs(MsRestModuleName, MsRestLibName);
             }
         }
 
@@ -857,7 +914,7 @@ namespace AutoRest.TypeScript.Model
 
         protected void GenerateNodeSampleMsRestJsImport(TSBuilder builder)
         {
-            builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+            builder.ImportAllAs(MsRestModuleName, MsRestLibName);
         }
 
         protected void GenerateNodeSampleMsRestNodeAuthImport(TSBuilder builder)
@@ -1143,7 +1200,7 @@ namespace AutoRest.TypeScript.Model
             {
                 string inputFilePath = $"./esm/{(Settings.MultiapiLatest ? "index" : Name.ToCamelCase())}.js";
                 config.QuotedStringProperty($"input", inputFilePath);
-                config.QuotedStringArrayProperty("external", new[] { "@azure/ms-rest-js", "@azure/ms-rest-azure-js" });
+                config.QuotedStringArrayProperty("external", new[] { MsRestLibName, MsRestAzureLibName });
                 config.ObjectProperty("output", output =>
                 {
                     output.QuotedStringProperty("file", $"./dist/{BundleFilename}.js");
@@ -1152,8 +1209,8 @@ namespace AutoRest.TypeScript.Model
                     output.BooleanProperty("sourcemap", true);
                     output.ObjectProperty("globals", globals =>
                     {
-                        globals.QuotedStringProperty("@azure/ms-rest-js", "msRest");
-                        globals.QuotedStringProperty("@azure/ms-rest-azure-js", "msRestAzure");
+                        globals.QuotedStringProperty(MsRestLibName, MsRestModuleName);
+                        globals.QuotedStringProperty(MsRestAzureLibName, MsRestAzureModuleName);
                     });
 
                     JSBuilder banner = new JSBuilder();
@@ -1283,7 +1340,7 @@ namespace AutoRest.TypeScript.Model
             builder.Line(ConstructRuntimeImportForModelIndex());
             if (ContainsDurationPropertyInModels() || IsAnyModelInheritingFromRequestOptionsBase() || MethodsWithCustomResponseType.Any())
             {
-                builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+                builder.ImportAllAs(MsRestModuleName, MsRestLibName);
             }
             foreach (CompositeTypeTS model in OrderedModelTemplateModels)
             {

--- a/src/vanilla/Model/MethodGroupTS.cs
+++ b/src/vanilla/Model/MethodGroupTS.cs
@@ -168,14 +168,13 @@ namespace AutoRest.TypeScript.Model
         public string GenerateMethodGroupImports()
         {
             TSBuilder builder = new TSBuilder();
+            CodeModelTS codeModel = CodeModelTS;
 
-            builder.ImportAllAs("msRest", "@azure/ms-rest-js");
+            builder.ImportAllAs(codeModel.MsRestModuleName, codeModel.MsRestLibName);
             if (MethodTemplateModels.Any((MethodTS method) => method.IsLongRunningOperation))
             {
-                builder.ImportAllAs("msRestAzure", "@azure/ms-rest-azure-js");
+                builder.ImportAllAs(codeModel.MsRestAzureModuleName, codeModel.MsRestAzureLibName);
             }
-
-            CodeModelTS codeModel = CodeModelTS;
 
             if (CodeGeneratorTS.ShouldWriteModelsFiles(codeModel))
             {

--- a/src/vanilla/Model/PrimaryTypeTS.cs
+++ b/src/vanilla/Model/PrimaryTypeTS.cs
@@ -58,7 +58,10 @@ namespace AutoRest.TypeScript.Model
                         return "Object";
 
                     case KnownPrimaryType.Credentials:
-                        return "msRest.ServiceClientCredentials";
+                        return "msRest.ServiceClientCredentials" + 
+                            ((CodeModel as CodeModelTS).Settings.UseAzureCore ?? false
+                                ? " | msRest.TokenCredential"
+                                : string.Empty);
                 }
                 throw new NotImplementedException($"Primary type {KnownPrimaryType} is not implemented in {GetType().Name}");
             }

--- a/src/vanilla/Templates/ParameterTemplate.cshtml
+++ b/src/vanilla/Templates/ParameterTemplate.cshtml
@@ -7,7 +7,7 @@
  */
 @EmptyLine
 
-import * as msRest from "@@azure/ms-rest-js";
+import * as msRest from "@Model.MsRestLibName";
 @EmptyLine
 
 @Model.GenerateParameterMappers()

--- a/src/vanilla/Templates/ServiceClientContextTemplate.cshtml
+++ b/src/vanilla/Templates/ServiceClientContextTemplate.cshtml
@@ -6,7 +6,7 @@
 @Header(" * ")
  */
 @EmptyLine
-import * as msRest from "@@azure/ms-rest-js";
+import * as msRest from "@Model.MsRestLibName";
 @{
 bool usesCustomOptionsType = Model.OptionalParameterTypeForClientConstructor != "ServiceClientOptions";
 if (usesCustomOptionsType)

--- a/unittests/vanilla/Model/CodeModelTSTests.cs
+++ b/unittests/vanilla/Model/CodeModelTSTests.cs
@@ -101,6 +101,21 @@ namespace AutoRest.TypeScript.Model
         }
 
         [TestMethod]
+        public void GenerateServiceClientImportsWithAzureCore()
+        {
+            CodeModelTS codeModel = CreateCodeModel();
+            codeModel.Settings.UseAzureCore = true;
+
+            AssertEx.EqualLines(
+                new[]
+                {
+                    "import * as msRest from \"@azure/core-http\";",
+                    "import { Context } from \"./context\";"
+                },
+                codeModel.GenerateServiceClientImports());
+        }
+
+        [TestMethod]
         public void GenerateClassFieldsGeneratesProperlyOptionalPropertyDeclaration()
         {
             PropertyTS property = Models.Property("property", new PrimaryTypeTS(KnownPrimaryType.String));


### PR DESCRIPTION
This change adds a new `--use-azure-core` flag that will cause `@azure/ms-rest-js` and `@azure/ms-rest-azure-js` to be replaced by `@azure/core-http` and `@azure/core-lro` (https://github.com/Azure/azure-sdk-for-js/pull/3584) in the generated output.

I didn't change every hard-coded usage of `msRestJs` and `msRestAzureJs` with the new variables because it would require far too many changes than necessary to use the different library names.

Please let me know if there's anything else I need to change!

/cc @kpajdzik @daschult @amarzavery 