### PR TITLE
Rename to @autorest/typescript and prepare for dev releases

### DIFF
--- a/.scripts/publish-dev-release.yml
+++ b/.scripts/publish-dev-release.yml
@@ -1,7 +1,8 @@
 # Publishes a development release of @autorest/typescript for
 # any commit to the master branch.
 
-trigger: master
+trigger:
+  - v6
 
 pool:
   vmImage: 'ubuntu-latest'

--- a/.scripts/publish-dev-release.yml
+++ b/.scripts/publish-dev-release.yml
@@ -1,0 +1,25 @@
+# Publishes a development release of @autorest/typescript for
+# any commit to the master branch.
+
+trigger: master
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.x'
+  displayName: 'Install Node.js'
+
+- script: |
+    npm install
+    npm run build
+  displayName: 'npm install and build'
+
+- script: |
+    export DEV_VERSION= $(node -p -e "require('./package.json').version")-dev.$BUILD_BUILD_NUMBER
+    npm version --no-git-tag-version $(node -p -e "require('./package.json').version")-dev.$BUILD_BUILD_NUMBER
+    npm pack
+    npx publish-release --token $(Github-azuresdkci-personalaccesstoken) --repo autorest.typescript --owner azure --name v$DEV_VERSION --tag v$DEV_VERSION --notes='prerelease build' --prerelease --editRelease false --assets autorest-typescript-$DEV_VERSION.tgz --target_commitish $(Build.SourceBranchName)
+  displayName: 'Publish to GitHub'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@microsoft.azure/autorest.typescript",
-  "version": "6.0.0-preview.1",
+  "name": "@autorest/typescript",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-    "name": "@microsoft.azure/autorest.typescript",
-    "version": "6.0.0-preview.1",
+    "name": "@autorest/typescript",
+    "version": "6.0.0",
+    "private": true,
     "scripts": {
         "build": "tsc -p .",
         "start": "node ./dist/src/main.js",
@@ -18,6 +19,11 @@
         "generate-bodycomplex": "npm run build && autorest-beta --version:3.0.6179 --use:@autorest/modelerfour@4.2.99 --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
         "generate-url": "npm run build && autorest-beta --version:3.0.6179 --use:@autorest/modelerfour@4.2.99 --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
     },
+    "files": [
+        "dist/**",
+        "README.md",
+        "LICENSE"
+    ],
     "dependencies": {
         "@autorest/autorest": "^3.0.6146",
         "@azure-tools/async-io": "3.0.203",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/typescript",
-    "version": "6.0.0",
+    "version": "0.1.0",
     "private": true,
     "scripts": {
         "build": "tsc -p .",


### PR DESCRIPTION
This change renames `@microsoft.azure/autorest.typescript` to `@autorest/typescript` and prepares the repo for shipping development releases to GitHub Releases on every successful commit to `master`.  

The advantage of this release automation is that it allows us to run pre-release versions of `@autorest/typescript` with the regression testing tool against `@autorest/core` and `@autorest/modelerfour`, ensuring that changes to the pipeline or modeler don't break our code generator.  This script is *not hooked up yet*; I'll do that after this PR is merged.

We'll only be publishing dev builds to GitHub Releases (for now) because AutoRest v3 can easily pull a specific version of a version from there without a corresponding npm release.  It will keep our npm page free of confusing version cruft.

**TODO**
- [x] Decide whether we should reset the version to `1.0.0` or forge ahead with `6.0.0`
- [ ] Test the release automation (after merging since I don't want to publish anything until we've agreed on the version!)