### PR TITLE
Generate models types for Operation Requests and Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ More information about these can be found [here](https://github.com/Azure/autore
 
 ```yaml
 use-extension:
-  "@autorest/modelerfour": "4.2.75"
+  "@autorest/modelerfour": "4.2.108"
 
 pipeline:
   typescript: # <- name of plugin

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ More information about these can be found [here](https://github.com/Azure/autore
 3. Hook up plugins into the AutoRest pipeline DAG, e.g.
 
 ```yaml
+version: 3.0.6185
 use-extension:
-  "@autorest/modelerfour": "4.2.108"
+  "@autorest/modelerfour": "4.3.121"
 
 pipeline:
   typescript: # <- name of plugin

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ More information about these can be found [here](https://github.com/Azure/autore
 3. Hook up plugins into the AutoRest pipeline DAG, e.g.
 
 ```yaml
-version: 3.0.6185
+version: 3.0.6189
 use-extension:
-  "@autorest/modelerfour": "4.3.121"
+  "@autorest/modelerfour": "4.3.142"
 
 pipeline:
   typescript: # <- name of plugin

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/typescript",
-  "version": "6.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -235,9 +235,9 @@
       }
     },
     "@microsoft.azure/autorest.testserver": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.testserver/-/autorest.testserver-2.10.7.tgz",
-      "integrity": "sha512-hvYdyBq8+rwaIXqo8kiDIffVi+JKRX2z0AD5Xi3jUCJfYC/yzLZUyyUvjKKJOu6O8S4gn0dERi828HI6cRclfg==",
+      "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.testserver/-/autorest.testserver-2.10.9.tgz",
+      "integrity": "sha512-YGxzxNU3UyR0W/aelw9TmHaJ80x437oRQerIjvGWWBqi8uYnrLskowZMca3oFnw4j+Ny39G8V7BJzh0ibakELw==",
       "dev": true,
       "requires": {
         "azure-storage": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -235,13 +235,15 @@
       }
     },
     "@microsoft.azure/autorest.testserver": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.testserver/-/autorest.testserver-2.7.1.tgz",
-      "integrity": "sha512-j4E9Wx3WVwzc2rfl5OutsW3lOtVsd2lEaLUh1k/uJj0qhwUHmQI0ObLW4fxikfA3k8I5sWqBkakoHjuB93TwUg==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@microsoft.azure/autorest.testserver/-/autorest.testserver-2.10.7.tgz",
+      "integrity": "sha512-hvYdyBq8+rwaIXqo8kiDIffVi+JKRX2z0AD5Xi3jUCJfYC/yzLZUyyUvjKKJOu6O8S4gn0dERi828HI6cRclfg==",
+      "dev": true,
       "requires": {
         "azure-storage": "^2.4.0",
         "body-parser": "^1.18.3",
         "busboy": "*",
+        "chalk": "3.0.0",
         "cookie-parser": "^1.4.3",
         "cors": "^2.8.4",
         "debug": "^3.1.0",
@@ -254,7 +256,20 @@
         "socket.io": "^2.1.1",
         "socket.io-client": "^2.1.1",
         "underscore": "*",
+        "wiremock": "2.25.0",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {
@@ -349,12 +364,14 @@
     "@types/babel-types": {
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
-      "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ=="
+      "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
+      "dev": true
     },
     "@types/babylon": {
       "version": "6.16.5",
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
+      "dev": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -368,6 +385,12 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/connect": {
       "version": "3.4.33",
@@ -594,6 +617,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
@@ -602,12 +626,14 @@
     "acorn": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true
     },
     "acorn-globals": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
+      "dev": true,
       "requires": {
         "acorn": "^4.0.4"
       },
@@ -615,7 +641,8 @@
         "acorn": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
         }
       }
     },
@@ -628,12 +655,14 @@
     "after": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+      "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -645,6 +674,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -663,6 +693,33 @@
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
+    "ansi-styles": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+      "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+      "dev": true,
+      "requires": {
+        "@types/color-name": "^1.1.1",
+        "color-convert": "^2.0.1"
+      },
+      "dependencies": {
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "arg": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
@@ -680,22 +737,26 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+      "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog==",
+      "dev": true
     },
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -703,7 +764,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -712,9 +774,10 @@
       "dev": true
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -724,17 +787,20 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+      "dev": true
     },
     "azure-storage": {
       "version": "2.10.3",
       "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.3.tgz",
       "integrity": "sha512-IGLs5Xj6kO8Ii90KerQrrwuJKexLgSwYC4oLWmc11mzKe7Jt2E5IVg+ZQ8K53YWZACtVTMBNO3iGuA+4ipjJxQ==",
+      "dev": true,
       "requires": {
         "browserify-mime": "~1.2.9",
         "extend": "^3.0.2",
@@ -752,17 +818,20 @@
         "sax": {
           "version": "0.5.8",
           "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
-          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE="
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
+          "dev": true
         },
         "underscore": {
           "version": "1.8.3",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
+          "dev": true
         },
         "xml2js": {
           "version": "0.2.8",
           "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
           "integrity": "sha1-m4FpCTFjH/CdGVdUn69U9PmAs8I=",
+          "dev": true,
           "requires": {
             "sax": "0.5.x"
           }
@@ -773,6 +842,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -782,6 +852,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "^6.26.0",
         "esutils": "^2.0.2",
@@ -792,12 +863,14 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "backo2": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
+      "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -807,17 +880,20 @@
     "base64-arraybuffer": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+      "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+      "dev": true
     },
     "base64id": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true
     },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
       "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -826,6 +902,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -834,6 +911,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
       "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+      "dev": true,
       "requires": {
         "callsite": "1.0.0"
       }
@@ -841,7 +919,8 @@
     "blob": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
+      "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig==",
+      "dev": true
     },
     "bluebird": {
       "version": "3.7.1",
@@ -853,6 +932,7 @@
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
       "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
+      "dev": true,
       "requires": {
         "bytes": "3.1.0",
         "content-type": "~1.0.4",
@@ -870,6 +950,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -877,7 +958,8 @@
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
         }
       }
     },
@@ -899,7 +981,8 @@
     "browserify-mime": {
       "version": "1.2.9",
       "resolved": "https://registry.npmjs.org/browserify-mime/-/browserify-mime-1.2.9.tgz",
-      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8="
+      "integrity": "sha1-rrGvKN5sDXpqLOQK22j/GEIq8x8=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -910,6 +993,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.1.tgz",
       "integrity": "sha512-y7tTxhGKXcyBxRKAni+awqx8uqaJKrSFSNFSeRG5CsWNdmy2BIK+6VGWEW7TZnIO/533mtMEA4rOevQV815YJw==",
+      "dev": true,
       "requires": {
         "dicer": "0.3.0"
       }
@@ -917,12 +1001,14 @@
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg=="
+      "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
+      "dev": true
     },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+      "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+      "dev": true
     },
     "callsites": {
       "version": "3.1.0",
@@ -933,17 +1019,20 @@
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
       "requires": {
         "align-text": "^0.1.3",
         "lazy-cache": "^1.0.3"
@@ -992,6 +1081,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
       "integrity": "sha1-x84o821LzZdE5f/CxfzeHHMmH8A=",
+      "dev": true,
       "requires": {
         "is-regex": "^1.0.3"
       }
@@ -1012,6 +1102,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
       "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
       "requires": {
         "source-map": "~0.6.0"
       }
@@ -1035,6 +1126,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+      "dev": true,
       "requires": {
         "center-align": "^0.1.1",
         "right-align": "^0.1.1",
@@ -1078,17 +1170,20 @@
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+      "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+      "dev": true
     },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+      "dev": true
     },
     "component-inherit": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
+      "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1099,6 +1194,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
+      "dev": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -1110,6 +1206,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -1117,17 +1214,20 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
     },
     "cookie": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
     },
     "cookie-parser": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
       "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "dev": true,
       "requires": {
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6"
@@ -1136,22 +1236,26 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
     },
     "core-js": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
       "requires": {
         "object-assign": "^4",
         "vary": "^1"
@@ -1174,22 +1278,33 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
     },
     "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1214,17 +1329,20 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "dicer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
       "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
+      "dev": true,
       "requires": {
         "streamsearch": "0.1.2"
       }
@@ -1262,7 +1380,8 @@
     "doctypes": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk="
+      "integrity": "sha1-6oCxBqh1OHdOijpKWv4pPeSJ4Kk=",
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
@@ -1274,6 +1393,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -1282,7 +1402,8 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -1293,7 +1414,8 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -1308,6 +1430,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.0.tgz",
       "integrity": "sha512-XCyYVWzcHnK5cMz7G4VTu2W7zJS7SM1QkcelghyIk/FmobWBtXE7fwhBusEKvCSqc3bMh8fNFMlUkCKTFRxH2w==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
@@ -1321,6 +1444,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1328,7 +1452,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -1336,6 +1461,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.0.tgz",
       "integrity": "sha512-a4J5QO2k99CM2a0b12IznnyQndoEvtA4UAldhGzKqnHf42I3Qs2W5SPnDvatZRcMaNZs4IevVicBPayxYt6FwA==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -1354,6 +1480,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1361,12 +1488,14 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "ws": {
           "version": "6.1.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
           "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
           }
@@ -1377,6 +1506,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
       "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+      "dev": true,
       "requires": {
         "after": "0.8.2",
         "arraybuffer.slice": "~0.0.7",
@@ -1426,7 +1556,8 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1624,12 +1755,14 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
     },
     "event-stream": {
       "version": "3.3.4",
@@ -1665,6 +1798,7 @@
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
       "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.7",
         "array-flatten": "1.1.1",
@@ -1701,12 +1835,14 @@
         "cookie": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
-          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+          "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1714,14 +1850,16 @@
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
-          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+          "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+          "dev": true
         }
       }
     },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -1737,12 +1875,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-glob": {
       "version": "3.1.1",
@@ -1807,7 +1947,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1845,6 +1986,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
@@ -1859,6 +2001,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -1903,12 +2046,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -1918,12 +2063,14 @@
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
     },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
     },
     "from": {
       "version": "0.1.7",
@@ -1956,7 +2103,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -1983,6 +2131,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -2041,12 +2190,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -2056,6 +2207,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -2064,6 +2216,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
       "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+      "dev": true,
       "requires": {
         "isarray": "2.0.1"
       },
@@ -2071,14 +2224,16 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         }
       }
     },
     "has-cors": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+      "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -2096,6 +2251,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
       "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -2117,6 +2273,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -2129,6 +2286,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -2139,6 +2297,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
@@ -2175,7 +2334,8 @@
     "indexof": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -2249,7 +2409,8 @@
     "ipaddr.js": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
+      "dev": true
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -2288,6 +2449,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-3.0.0.tgz",
       "integrity": "sha1-Oayqa+f9HzRx3ELHQW5hwkMXrJ8=",
+      "dev": true,
       "requires": {
         "acorn": "~4.0.2",
         "object-assign": "^4.0.1"
@@ -2296,7 +2458,8 @@
         "acorn": {
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
         }
       }
     },
@@ -2327,12 +2490,14 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -2363,7 +2528,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-unc-path": {
       "version": "1.0.0",
@@ -2381,7 +2547,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -2392,12 +2559,14 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "js-stringify": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds="
+      "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -2411,12 +2580,14 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "json-edm-parser": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/json-edm-parser/-/json-edm-parser-0.1.2.tgz",
       "integrity": "sha1-HmCw/vG8CvZ7wNFG393lSGzWFbQ=",
+      "dev": true,
       "requires": {
         "jsonparse": "~1.2.0"
       }
@@ -2430,12 +2601,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2446,7 +2619,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -2459,12 +2633,14 @@
     "jsonparse": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.2.0.tgz",
-      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70="
+      "integrity": "sha1-XAxWhRBxYOcv50ib3eoLRMK8Z70=",
+      "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -2476,6 +2652,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
       "integrity": "sha1-7Yvwkh4vPx7U1cGkT2hwntJHIsM=",
+      "dev": true,
       "requires": {
         "is-promise": "^2.0.0",
         "promise": "^7.0.1"
@@ -2485,6 +2662,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "^1.1.5"
       },
@@ -2492,7 +2670,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
         }
       }
     },
@@ -2505,7 +2684,8 @@
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true
     },
     "lcid": {
       "version": "2.0.0",
@@ -2579,7 +2759,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "make-error": {
       "version": "1.3.5",
@@ -2606,6 +2787,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+      "dev": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -2614,7 +2796,8 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
     },
     "mem": {
       "version": "4.3.0",
@@ -2636,7 +2819,8 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -2652,12 +2836,14 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.40.0",
@@ -3006,6 +3192,7 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
       "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "dev": true,
       "requires": {
         "basic-auth": "~2.0.0",
         "debug": "2.6.9",
@@ -3018,6 +3205,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3027,7 +3215,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -3044,7 +3233,8 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -3131,17 +3321,20 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-component": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
-      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+      "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
@@ -3181,6 +3374,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -3188,7 +3382,8 @@
     "on-headers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -3311,6 +3506,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
       "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+      "dev": true,
       "requires": {
         "better-assert": "~1.0.0"
       }
@@ -3319,6 +3515,7 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
       "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+      "dev": true,
       "requires": {
         "better-assert": "~1.0.0"
       }
@@ -3326,7 +3523,8 @@
     "parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -3348,12 +3546,14 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
     },
     "path-type": {
       "version": "3.0.0",
@@ -3376,7 +3576,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "picomatch": {
       "version": "2.1.1",
@@ -3414,7 +3615,8 @@
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -3426,6 +3628,7 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -3443,6 +3646,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
       "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
+      "dev": true,
       "requires": {
         "forwarded": "~0.1.2",
         "ipaddr.js": "1.9.0"
@@ -3466,6 +3670,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pug/-/pug-2.0.4.tgz",
       "integrity": "sha512-XhoaDlvi6NIzL49nu094R2NA6P37ijtgMDuWE+ofekDChvfKnzFal60bhSdiy8y2PBO6fmz3oMEIcfpBVRUdvw==",
+      "dev": true,
       "requires": {
         "pug-code-gen": "^2.0.2",
         "pug-filters": "^3.1.1",
@@ -3481,6 +3686,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-2.0.4.tgz",
       "integrity": "sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==",
+      "dev": true,
       "requires": {
         "constantinople": "^3.0.1",
         "js-stringify": "^1.0.1",
@@ -3491,6 +3697,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
       "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
+      "dev": true,
       "requires": {
         "constantinople": "^3.1.2",
         "doctypes": "^1.1.0",
@@ -3505,12 +3712,14 @@
     "pug-error": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.3.tgz",
-      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ=="
+      "integrity": "sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==",
+      "dev": true
     },
     "pug-filters": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-3.1.1.tgz",
       "integrity": "sha512-lFfjNyGEyVWC4BwX0WyvkoWLapI5xHSM3xZJFUhx4JM4XyyRdO8Aucc6pCygnqV2uSgJFaJWW3Ft1wCWSoQkQg==",
+      "dev": true,
       "requires": {
         "clean-css": "^4.1.11",
         "constantinople": "^3.0.1",
@@ -3525,6 +3734,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-4.1.0.tgz",
       "integrity": "sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==",
+      "dev": true,
       "requires": {
         "character-parser": "^2.1.1",
         "is-expression": "^3.0.0",
@@ -3535,6 +3745,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-3.0.6.tgz",
       "integrity": "sha512-bagfuHttfQOpANGy1Y6NJ+0mNb7dD2MswFG2ZKj22s8g0wVsojpRlqveEQHmgXXcfROB2RT6oqbPYr9EN2ZWzg==",
+      "dev": true,
       "requires": {
         "pug-error": "^1.3.3",
         "pug-walk": "^1.1.8"
@@ -3544,6 +3755,7 @@
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-2.0.12.tgz",
       "integrity": "sha512-UqpgGpyyXRYgJs/X60sE6SIf8UBsmcHYKNaOccyVLEuT6OPBIMo6xMPhoJnqtB3Q3BbO4Z3Bjz5qDsUWh4rXsg==",
+      "dev": true,
       "requires": {
         "object-assign": "^4.1.0",
         "pug-walk": "^1.1.8"
@@ -3553,6 +3765,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-5.0.1.tgz",
       "integrity": "sha512-nGHqK+w07p5/PsPIyzkTQfzlYfuqoiGjaoqHv1LjOv2ZLXmGX1O+4Vcvps+P4LhxZ3drYSljjq4b+Naid126wA==",
+      "dev": true,
       "requires": {
         "pug-error": "^1.3.3",
         "token-stream": "0.0.1"
@@ -3561,12 +3774,14 @@
     "pug-runtime": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.5.tgz",
-      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw=="
+      "integrity": "sha512-P+rXKn9un4fQY77wtpcuFyvFaBww7/91f3jHa154qU26qFAnOe6SW1CbIDcxiG5lLK9HazYrMCCuDvNgDQNptw==",
+      "dev": true
     },
     "pug-strip-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-1.0.4.tgz",
       "integrity": "sha512-i5j/9CS4yFhSxHp5iKPHwigaig/VV9g+FgReLJWWHEHbvKsbqL0oP/K5ubuLco6Wu3Kan5p7u7qk8A4oLLh6vw==",
+      "dev": true,
       "requires": {
         "pug-error": "^1.3.3"
       }
@@ -3574,7 +3789,8 @@
     "pug-walk": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.8.tgz",
-      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA=="
+      "integrity": "sha512-GMu3M5nUL3fju4/egXwZO0XLi6fW/K3T3VTgFQ14GxNi8btlxgT5qZL//JwZFm/2Fa64J/PNS8AZeys3wiMkVA==",
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -3594,17 +3810,20 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true
     },
     "raw-body": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
       "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
+      "dev": true,
       "requires": {
         "bytes": "3.1.0",
         "http-errors": "1.7.2",
@@ -3627,6 +3846,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
       "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -3648,7 +3868,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regexpp": {
       "version": "2.0.1",
@@ -3659,12 +3880,14 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -3691,12 +3914,14 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -3708,21 +3933,16 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
       "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-        }
       }
     },
     "request-promise-native": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
       "integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
+      "dev": true,
       "requires": {
         "request-promise-core": "1.1.3",
         "stealthy-require": "^1.1.1",
@@ -3745,6 +3965,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -3773,6 +3994,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
       "requires": {
         "align-text": "^0.1.1"
       }
@@ -3818,7 +4040,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-eval": {
       "version": "0.3.0",
@@ -3828,7 +4051,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sax": {
       "version": "1.2.4",
@@ -3844,6 +4068,7 @@
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
       "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
+      "dev": true,
       "requires": {
         "debug": "2.6.9",
         "depd": "~1.1.2",
@@ -3864,6 +4089,7 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           },
@@ -3871,14 +4097,16 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -3886,6 +4114,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
       "integrity": "sha1-k10kDN/g9YBTB/3+ln2IlCosvPA=",
+      "dev": true,
       "requires": {
         "etag": "~1.8.1",
         "fresh": "0.5.2",
@@ -3897,12 +4126,14 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "dev": true
         }
       }
     },
@@ -3910,6 +4141,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
       "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
+      "dev": true,
       "requires": {
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -3926,7 +4158,8 @@
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -3981,6 +4214,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.3.0.tgz",
       "integrity": "sha512-2A892lrj0GcgR/9Qk81EaY2gYhCBxurV0PfmmESO6p27QPrUK1J3zdns+5QPqvUYK2q657nSj0guoIil9+7eFg==",
+      "dev": true,
       "requires": {
         "debug": "~4.1.0",
         "engine.io": "~3.4.0",
@@ -3994,6 +4228,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4001,19 +4236,22 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
     "socket.io-adapter": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
-      "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
+      "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==",
+      "dev": true
     },
     "socket.io-client": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
       "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
+      "dev": true,
       "requires": {
         "backo2": "1.0.2",
         "base64-arraybuffer": "0.1.5",
@@ -4035,6 +4273,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4042,17 +4281,20 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         },
         "socket.io-parser": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
           "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+          "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
             "debug": "~3.1.0",
@@ -4063,6 +4305,7 @@
               "version": "3.1.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4070,7 +4313,8 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "dev": true
             }
           }
         }
@@ -4080,6 +4324,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
       "integrity": "sha512-/G/VOI+3DBp0+DJKW4KesGnQkQPFmUCbA/oO2QGT6CWxU7hLGWqU3tyuzeSK/dqcyeHsQg1vTe9jiZI8GU9SCQ==",
+      "dev": true,
       "requires": {
         "component-emitter": "1.2.1",
         "debug": "~4.1.0",
@@ -4090,6 +4335,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4097,12 +4343,14 @@
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+          "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -4170,6 +4418,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4314,12 +4563,14 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stream-combiner": {
       "version": "0.0.4",
@@ -4333,7 +4584,8 @@
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "dev": true
     },
     "string-width": {
       "version": "2.1.1",
@@ -4379,7 +4631,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -4407,6 +4660,23 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
+    },
+    "supports-color": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+      "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        }
+      }
     },
     "table": {
       "version": "5.4.6",
@@ -4484,27 +4754,32 @@
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
+      "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+      "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+      "dev": true
     },
     "token-stream": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-0.0.1.tgz",
-      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo="
+      "integrity": "sha1-zu78cXp2xDFvEm0LnbqlXX598Bo=",
+      "dev": true
     },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -4555,6 +4830,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -4562,7 +4838,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -4577,6 +4854,7 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -4592,6 +4870,7 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
       "requires": {
         "source-map": "~0.5.1",
         "uglify-to-browserify": "~1.0.0",
@@ -4601,18 +4880,8 @@
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "requires": {
-            "camelcase": "^1.0.2",
-            "cliui": "^2.1.0",
-            "decamelize": "^1.0.0",
-            "window-size": "0.1.0"
-          }
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
         }
       }
     },
@@ -4620,6 +4889,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
       "optional": true
     },
     "unc-path-regex": {
@@ -4628,9 +4898,10 @@
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
     "underscore": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -4640,12 +4911,14 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -4653,12 +4926,14 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
     },
     "uuid": {
       "version": "3.3.2",
@@ -4684,17 +4959,20 @@
     "validator": {
       "version": "9.4.1",
       "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA=="
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA==",
+      "dev": true
     },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -4704,7 +4982,8 @@
     "void-elements": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
+      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+      "dev": true
     },
     "vscode-jsonrpc": {
       "version": "3.6.2",
@@ -4793,7 +5072,8 @@
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true
     },
     "wiremock": {
       "version": "2.25.0",
@@ -4821,6 +5101,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/with/-/with-5.1.1.tgz",
       "integrity": "sha1-+k2qktrzLE6pTtRTyB8EaGtXXf4=",
+      "dev": true,
       "requires": {
         "acorn": "^3.1.0",
         "acorn-globals": "^3.0.0"
@@ -4835,7 +5116,8 @@
     "wordwrap": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
+      "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -4899,12 +5181,10 @@
       }
     },
     "ws": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
-      "integrity": "sha512-+SqNqFbwTm/0DC18KYzIsMTnEWpLwJsiasW/O17la4iDRRIO9uaHbvKiAS3AHgTiuuWerK/brj4O6MYZkei9xg==",
-      "requires": {
-        "async-limiter": "^1.0.0"
-      }
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
+      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A==",
+      "dev": true
     },
     "xml2js": {
       "version": "0.4.19",
@@ -4923,13 +5203,26 @@
     "xmlhttprequest-ssl": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
     },
     "yargs-unparser": {
       "version": "1.6.0",
@@ -5050,7 +5343,8 @@
     "yeast": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
         "start-test-server:v1": "ts-node test/integration/testserver-v1/index.ts",
         "stop-test-server": "stop-autorest-testserver",
         "debug": "node --inspect-brk ./dist/src/main.js",
-        "generate-bodystring": "autorest-beta --typescript --output-folder=./test/integration/generated/bodyString --use=. --title=BodyStringClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-string.json --package-name=bodyString --package-version=1.0.0-preview1",
-        "generate-bodycomplex": "autorest-beta --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
-        "generate-url": "autorest-beta --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
+        "generate-bodystring": "autorest-beta --pipeline-model:v3 --typescript --output-folder=./test/integration/generated/bodyString --use=. --title=BodyStringClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-string.json --package-name=bodyString --package-version=1.0.0-preview1",
+        "generate-bodycomplex": "autorest-beta --pipeline-model:v3 --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
+        "generate-url": "autorest-beta --pipeline-model:v3 --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
     },
     "files": [
         "dist/**",
@@ -41,7 +41,7 @@
     },
     "devDependencies": {
         "@autorest/test-server": "^3.0.26",
-        "@microsoft.azure/autorest.testserver": "^2.10.7",
+        "@microsoft.azure/autorest.testserver": "^2.10.9",
         "@types/express": "^4.17.2",
         "@types/js-yaml": "3.12.1",
         "@types/mocha": "5.2.7",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
         "start-test-server:v1": "ts-node test/integration/testserver-v1/index.ts",
         "stop-test-server": "stop-autorest-testserver",
         "debug": "node --inspect-brk ./dist/src/main.js",
-        "generate-bodystring": "autorest-beta --version:3.0.6184 --use:@autorest/modelerfour@4.2.108 --typescript --output-folder=./test/integration/generated/bodyString --use=. --title=BodyStringClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-string.json --package-name=bodyString --package-version=1.0.0-preview1",
-        "generate-bodycomplex": "autorest-beta --version:3.0.6184 --use:@autorest/modelerfour@4.2.108 --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
-        "generate-url": "autorest-beta --version:3.0.6184 --use:@autorest/modelerfour@4.2.108 --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
+        "generate-bodystring": "autorest-beta --typescript --output-folder=./test/integration/generated/bodyString --use=. --title=BodyStringClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-string.json --package-name=bodyString --package-version=1.0.0-preview1",
+        "generate-bodycomplex": "autorest-beta --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
+        "generate-url": "autorest-beta --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
     },
     "files": [
         "dist/**",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
         "start-test-server:v1": "ts-node test/integration/testserver-v1/index.ts",
         "stop-test-server": "stop-autorest-testserver",
         "debug": "node --inspect-brk ./dist/src/main.js",
-        "generate-bodystring": "autorest-beta --version:3.0.6179 --use:@autorest/modelerfour@4.2.99 --typescript --output-folder=./test/integration/generated/bodyString --use=. --title=BodyStringClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-string.json --package-name=bodyString --package-version=1.0.0-preview1",
-        "generate-bodycomplex": "autorest-beta --version:3.0.6179 --use:@autorest/modelerfour@4.2.99 --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
-        "generate-url": "autorest-beta --version:3.0.6179 --use:@autorest/modelerfour@4.2.99 --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
+        "generate-bodystring": "autorest-beta --version:3.0.6184 --use:@autorest/modelerfour@4.2.108 --typescript --output-folder=./test/integration/generated/bodyString --use=. --title=BodyStringClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-string.json --package-name=bodyString --package-version=1.0.0-preview1",
+        "generate-bodycomplex": "autorest-beta --version:3.0.6184 --use:@autorest/modelerfour@4.2.108 --typescript --output-folder=./test/integration/generated/bodyComplex --use=. --title=BodyComplexClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/body-complex.json --package-name=bodyString --package-version=1.0.0-preview1",
+        "generate-url": "autorest-beta --version:3.0.6184 --use:@autorest/modelerfour@4.2.108 --typescript --output-folder=./test/integration/generated/url --use=. --title=UrlClient --input-file=node_modules/@microsoft.azure/autorest.testserver/swagger/url.json --package-name=url --package-version=1.0.0-preview1"
     },
     "files": [
         "dist/**",
@@ -33,7 +33,6 @@
         "@azure-tools/linq": "3.1.206",
         "@azure-tools/openapi": "3.0.209",
         "@azure/core-http": "^1.0.0",
-        "@microsoft.azure/autorest.testserver": "^2.10.3",
         "@types/lodash": "^4.14.149",
         "lodash": "^4.17.15",
         "prettier": "^1.19.1",
@@ -42,6 +41,7 @@
     },
     "devDependencies": {
         "@autorest/test-server": "^3.0.26",
+        "@microsoft.azure/autorest.testserver": "^2.10.7",
         "@types/express": "^4.17.2",
         "@types/js-yaml": "3.12.1",
         "@types/mocha": "5.2.7",

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -7,6 +7,10 @@ import { ClientDetails } from "../models/clientDetails";
 import { PackageDetails } from "../models/packageDetails";
 import { ParameterDetails } from "../models/parameterDetails";
 import { ImplementationLocation } from "@azure-tools/codemodel";
+import {
+  getCredentialsCheck,
+  getCredentialsParameter
+} from "./utils/parameterUtils";
 
 export function generateClientContext(
   clientDetails: ClientDetails,
@@ -64,13 +68,14 @@ export function generateClientContext(
       };
     })
   );
-
+  const hasCredentials = !!clientDetails.options.addCredentials;
   const classConstructor = contextClass.addConstructor({
     docs: [
       `Initializes a new instance of the ${clientContextClassName} class.\n
 @param options The parameter options`
     ],
     parameters: [
+      ...getCredentialsParameter(hasCredentials),
       ...requiredGlobals.map(p => ({
         name: p.name,
         type: p.typeDetails.typeName
@@ -86,6 +91,7 @@ export function generateClientContext(
   // This could all be expressed as one string template, but we may need to
   // optionally skip some segments based on generation options
   classConstructor.addStatements([
+    getCredentialsCheck(hasCredentials),
     ...getRequiredParamChecks(requiredGlobals),
     `if (!options) {
        options = {};

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -6,6 +6,7 @@ import { normalizeName, NameType } from "../utils/nameUtils";
 import { ClientDetails } from "../models/clientDetails";
 import { PackageDetails } from "../models/packageDetails";
 import { ParameterDetails } from "../models/parameterDetails";
+import { ImplementationLocation } from "@azure-tools/codemodel";
 
 export function generateClientContext(
   clientDetails: ClientDetails,
@@ -48,7 +49,9 @@ export function generateClientContext(
     isExported: true
   });
 
-  const globalParams = clientDetails.parameters.filter(param => param.isGlobal);
+  const globalParams = clientDetails.parameters.filter(
+    param => param.implementationLocation === ImplementationLocation.Client
+  );
   const requiredGlobals = globalParams.filter(p => p.required);
   const optionalGlobals = globalParams.filter(p => !p.required);
 
@@ -56,7 +59,7 @@ export function generateClientContext(
     globalParams.map(param => {
       return {
         name: param.name,
-        type: "any", // TODO use actual type
+        type: param.typeDetails.typeName,
         hasQuestionToken: !param.required
       };
     })
@@ -68,11 +71,14 @@ export function generateClientContext(
 @param options The parameter options`
     ],
     parameters: [
-      ...requiredGlobals.map(p => ({ name: p.name, type: "any" })), //TODO: Use actual type
+      ...requiredGlobals.map(p => ({
+        name: p.name,
+        type: p.typeDetails.typeName
+      })),
       {
         name: "options",
         hasQuestionToken: true,
-        type: "any" // TODO: Use the correct type from models `Models.${clientDetails.className}Options`
+        type: `coreHttp.ServiceClientOptions`
       }
     ]
   });

--- a/src/generators/clientFileGenerator.ts
+++ b/src/generators/clientFileGenerator.ts
@@ -10,7 +10,7 @@ import {
   NameType
 } from "../utils/nameUtils";
 import { ParameterDetails } from "../models/parameterDetails";
-import { ImplementationLocation } from "@azure-tools/codemodel";
+import { ImplementationLocation, SchemaType } from "@azure-tools/codemodel";
 import { getCredentialsParameter } from "./utils/parameterUtils";
 
 export function generateClient(clientDetails: ClientDetails, project: Project) {
@@ -73,7 +73,11 @@ export function generateClient(clientDetails: ClientDetails, project: Project) {
   );
   const hasCredentials = !!clientDetails.options.addCredentials;
   const requiredParams = clientDetails.parameters.filter(
-    param => param.implementationLocation === ImplementationLocation.Client
+    param =>
+      param.required &&
+      param.implementationLocation === ImplementationLocation.Client &&
+      !param.defaultValue &&
+      param.schemaType !== SchemaType.Constant
   );
 
   const clientConstructor = clientClass.addConstructor({
@@ -91,7 +95,7 @@ export function generateClient(clientDetails: ClientDetails, project: Project) {
       {
         name: "options",
         hasQuestionToken: true,
-        type: `coreHttp.ServiceClientOptions`
+        type: `any`
       }
     ]
   });

--- a/src/generators/clientFileGenerator.ts
+++ b/src/generators/clientFileGenerator.ts
@@ -42,11 +42,6 @@ export function generateClient(clientDetails: ClientDetails, project: Project) {
   });
 
   clientFile.addImportDeclaration({
-    namespaceImport: "coreHttp",
-    moduleSpecifier: "@azure/core-http"
-  });
-
-  clientFile.addImportDeclaration({
     namedImports: [clientContextClassName],
     moduleSpecifier: `./${clientDetails.sourceFileName}Context`
   });

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -2,7 +2,28 @@
 // Licensed under the MIT License.
 
 import { ClientDetails } from "../models/clientDetails";
-import { Project, PropertySignatureStructure, StructureKind } from "ts-morph";
+import {
+  Project,
+  PropertySignatureStructure,
+  StructureKind,
+  SourceFile,
+  Writers,
+  WriterFunction,
+  OptionalKind
+} from "ts-morph";
+import { keys } from "lodash";
+import {
+  ObjectKind,
+  PolymorphicObjectDetails,
+  ObjectDetails,
+  PropertyDetails,
+  PropertyKind,
+  TypeDetails
+} from "../models/modelDetails";
+import { normalizeName, NameType } from "../utils/nameUtils";
+import { filterOperationParameters } from "./utils/parameterUtils";
+import { OperationDetails } from "../models/operationDetails";
+import { ParameterDetails } from "../models/parameterDetails";
 
 export function generateModels(clientDetails: ClientDetails, project: Project) {
   const modelsIndexFile = project.createSourceFile(
@@ -16,31 +37,332 @@ export function generateModels(clientDetails: ClientDetails, project: Project) {
     moduleSpecifier: "@azure/core-http"
   });
 
-  for (const model of clientDetails.models) {
+  writeUniontypes(clientDetails, modelsIndexFile);
+  writeObjects(clientDetails, modelsIndexFile);
+  writeChoices(clientDetails, modelsIndexFile);
+  writeOperationModels(clientDetails, modelsIndexFile);
+}
+
+const writeOperationModels = (
+  clientDetails: ClientDetails,
+  modelsIndexFile: SourceFile
+) =>
+  clientDetails.operationGroups.forEach(operationGroup => {
+    operationGroup.operations.forEach(operation => {
+      // Add interfaces for operation optional parameters
+      const operationGroupName = normalizeName(
+        operationGroup.name,
+        NameType.Interface
+      );
+      const optionalParams = filterOperationParameters(
+        clientDetails.parameters,
+        operation,
+        { includeOptional: true }
+      ).filter(p => !p.required);
+
+      const operationName = normalizeName(operation.name, NameType.Interface);
+      writeOptionalParameters(
+        operationGroupName,
+        operationName,
+        optionalParams,
+        modelsIndexFile
+      );
+      writeResponseTypes(operation, modelsIndexFile);
+    });
+  });
+
+function writeResponseTypes(
+  { responses, name, typeDetails: operationType }: OperationDetails,
+  modelsIndexFile: SourceFile
+) {
+  const responseName = `${operationType.typeName}Response`;
+
+  responses
+    .filter(r => !r.isError && !!r.bodyMapper)
+    .forEach(response => {
+      // Define possible values for response
+      const responseType = response.typeDetails || {
+        typeName: "string",
+        kind: PropertyKind.Primitive
+      };
+
+      response.typeDetails.typeName;
+      const responseValueType = responseType.typeName;
+
+      if (responseType.isConstant) {
+        if (responseType.defaultValue === undefined) {
+          throw new Error(
+            `OperationResponse type does not have a defaultValue (operation: ${name})`
+          );
+        }
+
+        if (responseType.typeName === undefined) {
+          throw new Error(
+            `OperationResponse type does not have a modelTypeName (operation: ${name})`
+          );
+        }
+
+        let defaultValue = responseType.defaultValue;
+
+        // Get quoted value for string
+        if (responseType.typeName === "string" && defaultValue !== "null") {
+          defaultValue = `"${defaultValue}"`;
+        }
+
+        modelsIndexFile.addTypeAlias({
+          name: responseValueType,
+          docs: [`Defines values for ${responseType.typeName}.`],
+          isExported: true,
+          type: defaultValue,
+          leadingTrivia: writer => writer.blankLine()
+        });
+      }
+
+      modelsIndexFile.addTypeAlias({
+        name: responseName,
+        docs: [`Contains response data for the ${name} operation.`],
+        isExported: true,
+        type: generateResponseType(responseValueType, responseType),
+        leadingTrivia: writer => writer.blankLine()
+      });
+    });
+}
+
+function generateResponseType(
+  bodyType: string,
+  typeDetails: TypeDetails
+): WriterFunction {
+  const bodyName = normalizeName(bodyType, NameType.Interface);
+  const bodyTypeName = bodyName;
+  const bodyProperty: OptionalKind<PropertySignatureStructure> = {
+    name: "body",
+    type: bodyTypeName,
+    docs: ["The parsed response body."]
+  };
+
+  // TODO: These will change based on whether the response has
+  // a body, headers, etc
+  const responseProperties: OptionalKind<PropertySignatureStructure>[] = [
+    {
+      name: "bodyAsText",
+      docs: ["The response body as text (string format)"],
+      type: "string",
+      leadingTrivia: writer => writer.blankLine()
+    },
+    {
+      name: "parsedBody",
+      docs: ["The response body as parsed JSON or XML"],
+      type: bodyTypeName,
+      leadingTrivia: writer => writer.blankLine()
+    }
+  ];
+
+  const isComposite = typeDetails.kind === PropertyKind.Composite;
+
+  const innerTypeWriter = Writers.objectType({
+    properties: [
+      ...(isComposite ? [] : [bodyProperty]),
+      {
+        name: "_response",
+        docs: ["The underlying HTTP response."],
+        type: Writers.intersectionType(
+          "coreHttp.HttpResponse",
+          Writers.objectType({
+            properties: responseProperties
+          })
+        ),
+        leadingTrivia: writer => writer.blankLine()
+      }
+    ]
+  });
+
+  return isComposite
+    ? Writers.intersectionType(bodyTypeName, innerTypeWriter)
+    : innerTypeWriter;
+}
+
+const writeChoices = (
+  clientDetails: ClientDetails,
+  modelsIndexFile: SourceFile
+) =>
+  clientDetails.unions.forEach(choice => {
+    modelsIndexFile.addTypeAlias({
+      name: choice.name,
+      docs: [choice.description],
+      isExported: true,
+      type: choice.values.join(" | "),
+      trailingTrivia: writer => writer.newLine()
+    });
+  });
+
+const writeObjects = (
+  clientDetails: ClientDetails,
+  modelsIndexFile: SourceFile
+) => clientDetails.objects.forEach(writeObjectSignature(modelsIndexFile));
+
+const writeObjectSignature = (modelsIndexFile: SourceFile) => (
+  model: ObjectDetails
+) => {
+  const properties = getPropertiesSignatures(model);
+  const parents = model.parents.map(p => p.name).join(" & ");
+
+  if (parents) {
+    modelsIndexFile.addTypeAlias({
+      name: model.name,
+      docs: [model.description],
+      isExported: true,
+      type: Writers.intersectionType(
+        parents,
+        Writers.objectType({ properties })
+      ),
+      leadingTrivia: writer => writer.blankLine()
+    });
+  } else {
     modelsIndexFile.addInterface({
       name: model.name,
       docs: [model.description],
       isExported: true,
-      properties: model.properties
-        .filter(p => !p.isConstant)
-        .map<PropertySignatureStructure>(p => ({
-          name: p.name,
-          hasQuestionToken: !p.required,
-          isReadonly: p.readOnly,
-          type: p.type,
-          docs: p.description ? [p.description] : undefined,
-          kind: StructureKind.PropertySignature
-        }))
+      properties,
+      leadingTrivia: writer => writer.blankLine()
     });
+  }
+};
+
+/**
+ * This function writes all UnionTypes, these types represent the optios a request can use for a Polymorphic parameter
+ */
+function writeUniontypes({ objects }: ClientDetails, modelsFile: SourceFile) {
+  objects
+    .filter(
+      obj => obj.kind === ObjectKind.Polymorphic && obj.children.length > 0
+    )
+    .forEach(obj => {
+      const polymorphicObject = obj as PolymorphicObjectDetails;
+      const childrenNames = [
+        obj.name,
+        ...polymorphicObject.children.map(c => {
+          return c.schema.children && c.schema.children.immediate.length
+            ? `${c.name}Union`
+            : c.name;
+        })
+      ];
+      modelsFile.addTypeAlias({
+        name: `${obj.name}Union`,
+        isExported: true,
+        type: childrenNames.join(" | "),
+        trailingTrivia: writer => writer.newLine()
+      });
+    });
+}
+
+function writeOptionalParameters(
+  operationGroupName: string,
+  operationName: string,
+  optionalParams: ParameterDetails[],
+  modelsIndexFile: SourceFile
+) {
+  if (!optionalParams || !optionalParams.length) {
+    return;
   }
 
-  for (const union of clientDetails.unions) {
-    modelsIndexFile.addTypeAlias({
-      name: union.name,
-      docs: [union.description],
-      isExported: true,
-      type: union.values.join(" | "),
-      trailingTrivia: writer => writer.newLine()
-    });
-  }
+  modelsIndexFile.addInterface({
+    name: `${operationGroupName}${operationName}OptionalParams`,
+    docs: ["Optional parameters."],
+    isExported: true,
+    extends: ["coreHttp.RequestOptionsBase"],
+    properties: optionalParams.map<PropertySignatureStructure>(p => ({
+      name: p.name,
+      hasQuestionToken: !p.required,
+      type: p.typeDetails.typeName || "TODO NO TYPE",
+      docs: p.description ? [p.description] : undefined,
+      kind: StructureKind.PropertySignature
+    }))
+  });
 }
+
+/**
+ * Extracts all properties from ObjectDetails and returns a list of PropertySignatureStructure
+ * @param objectDetails Object description
+ */
+function getProperties(
+  objectDetails: ObjectDetails
+): PropertySignatureStructure[] {
+  const { properties } = objectDetails;
+  const getTypename = (property: PropertyDetails) =>
+    property.name === "siblings"
+      ? `${(objectDetails as PolymorphicObjectDetails).unionName}[]`
+      : property.type;
+
+  return properties
+    .filter(property => !property.isConstant && !property.isDiscriminator)
+    .map<PropertySignatureStructure>(property => ({
+      name: property.name,
+      hasQuestionToken: !property.required,
+      isReadonly: property.readOnly,
+      type: getTypename(property),
+      docs: property.description ? [property.description] : undefined,
+      kind: StructureKind.PropertySignature
+    }));
+}
+
+/**
+ * This function enahnces a list of PropertySignatures with the Polymorphic discriminator property if needed
+ * @param model ObjectDetails
+ * @param properties Properties to enhance
+ */
+function withDiscriminator(
+  model: ObjectDetails,
+  properties: PropertySignatureStructure[]
+): PropertySignatureStructure[] {
+  const discriminator = (model as PolymorphicObjectDetails).discriminator;
+  if (!discriminator) {
+    return properties;
+  }
+
+  const discProps = keys(discriminator).map<PropertySignatureStructure>(
+    key => ({
+      docs: [`Polymorphic discriminator`],
+      name: key,
+      type: discriminator[key].map(disc => `"${disc}"`).join(" | "),
+      kind: StructureKind.PropertySignature
+    })
+  );
+
+  return [...discProps, ...properties];
+}
+
+/**
+ * This function enahnces a list of PropertySignatures with the additional Properties property if needed
+ * @param model ObjectDetails
+ * @param properties Properties to enhance
+ */
+function withAdditionalProperties(
+  model: ObjectDetails,
+  properties: PropertySignatureStructure[]
+): PropertySignatureStructure[] {
+  if (!model.hasAdditionalProperties) {
+    return properties;
+  }
+
+  return [
+    {
+      docs: [
+        `Describes unknown properties. The value of an unknown property can be of "any" type.`
+      ],
+      name: "[property: string]",
+      type: "any",
+      kind: StructureKind.PropertySignature
+    },
+    ...properties
+  ];
+}
+
+/**
+ * Gets an enhanced list of Properties to construct an Object signature
+ * @param objectDetails Object description
+ */
+const getPropertiesSignatures = (objectDetails: ObjectDetails) =>
+  withDiscriminator(
+    objectDetails,
+    withAdditionalProperties(objectDetails, getProperties(objectDetails))
+  );

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -229,7 +229,7 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
 };
 
 /**
- * This function writes all UnionTypes, these types represent the optios a request can use for a Polymorphic parameter
+ * This function writes all UnionTypes, these types represent the options a request can use for a Polymorphic parameter
  */
 function writeUniontypes({ objects }: ClientDetails, modelsFile: SourceFile) {
   objects
@@ -273,7 +273,7 @@ function writeOptionalParameters(
     properties: optionalParams.map<PropertySignatureStructure>(p => ({
       name: p.name,
       hasQuestionToken: !p.required,
-      type: p.typeDetails.typeName || "TODO NO TYPE",
+      type: p.typeDetails.typeName,
       docs: p.description ? [p.description] : undefined,
       kind: StructureKind.PropertySignature
     }))
@@ -321,7 +321,9 @@ function withDiscriminator(
 
   const discProps = keys(discriminator).map<PropertySignatureStructure>(
     key => ({
-      docs: [`Polymorphic discriminator`],
+      docs: [
+        `Polymorphic discriminator, which specifies the different types this object can be`
+      ],
       name: key,
       type: discriminator[key].map(disc => `"${disc}"`).join(" | "),
       kind: StructureKind.PropertySignature

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -247,9 +247,7 @@ function addOperations(
     "Uint8Array"
   ];
   operationGroupDetails.operations.forEach(operation => {
-    const params = filterOperationParameters(parameters, operation, {
-      includeOptional: true
-    }).map<ParameterWithDescription>(param => {
+    const params = filterOperationParameters(parameters, operation).map<ParameterWithDescription>(param => {
       const typeName = param.modelType || "any";
       const type =
         primitiveTypes.indexOf(typeName) > -1

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -23,6 +23,7 @@ import {
 } from "../models/operationDetails";
 import { isString } from "util";
 import { ParameterDetails } from "../models/parameterDetails";
+import { filterOperationParameters } from "./utils/parameterUtils";
 
 /**
  * Function that writes the code for all the operations.
@@ -228,21 +229,6 @@ type ParameterWithDescription = OptionalKind<
   ParameterDeclarationStructure & { description: string }
 >;
 
-function filterOperationParameters(
-  parameters: ParameterDetails[],
-  operation: OperationDetails
-) {
-  return parameters.filter(
-    param =>
-      !param.isGlobal &&
-      param.operationsIn &&
-      param.operationsIn.includes(operation.fullName) &&
-      param.location !== ParameterLocation.Uri &&
-      param.required &&
-      param.parameter.schema.type !== SchemaType.Constant
-  );
-}
-
 /**
  * Add all the required operations  whith their overloads,
  * extracted from OperationGroupDetails, to the generated file
@@ -261,9 +247,9 @@ function addOperations(
     "Uint8Array"
   ];
   operationGroupDetails.operations.forEach(operation => {
-    const params = filterOperationParameters(parameters, operation).map<
-      ParameterWithDescription
-    >(param => {
+    const params = filterOperationParameters(parameters, operation, {
+      includeOptional: true
+    }).map<ParameterWithDescription>(param => {
       const typeName = param.modelType || "any";
       const type =
         primitiveTypes.indexOf(typeName) > -1

--- a/src/generators/static/packageFileGenerator.ts
+++ b/src/generators/static/packageFileGenerator.ts
@@ -18,7 +18,6 @@ export function generatePackageJson(
       `A generated SDK for ${clientDetails.name}.`,
     version: packageDetails.version,
     dependencies: {
-      "@azure/core-arm": "^1.0.0",
       "@azure/core-http": "^1.0.0",
       tslib: "^1.9.3"
     },

--- a/src/generators/static/tsConfigFileGenerator.ts
+++ b/src/generators/static/tsConfigFileGenerator.ts
@@ -15,7 +15,7 @@ export function generateTsConfig(project: Project) {
       esModuleInterop: true,
       allowSyntheticDefaultImports: true,
       forceConsistentCasingInFileNames: true,
-      lib: ["es6"],
+      lib: ["es6", "dom"],
       declaration: true,
       outDir: "./esm",
       importHelpers: true

--- a/src/generators/utils/parameterUtils.ts
+++ b/src/generators/utils/parameterUtils.ts
@@ -4,6 +4,7 @@
 import { ParameterDetails } from "../../models/parameterDetails";
 import { OperationDetails } from "../../models/operationDetails";
 import { ImplementationLocation, SchemaType } from "@azure-tools/codemodel";
+import { StructureKind, ParameterDeclarationStructure } from "ts-morph";
 
 interface ParameterFilterOptions {
   includeOptional?: boolean;
@@ -56,4 +57,26 @@ export function filterOperationParameters(
       constantFilter(param) &&
       clientParamFilter(param)
   );
+}
+
+export function getCredentialsParameter(
+  hasCredentials: boolean
+): ParameterDeclarationStructure[] {
+  return hasCredentials
+    ? [
+        {
+          name: "credentials",
+          type: `coreHttp.TokenCredential | coreHttp.ServiceClientCredentials`,
+          kind: StructureKind.Parameter
+        }
+      ]
+    : [];
+}
+
+export function getCredentialsCheck(hasCredentials: boolean): string {
+  return hasCredentials
+    ? `if (credentials == undefined) {
+    throw new Error("'credentials' cannot be null.");
+  }`
+    : ``;
 }

--- a/src/generators/utils/parameterUtils.ts
+++ b/src/generators/utils/parameterUtils.ts
@@ -1,0 +1,56 @@
+import { ParameterDetails } from "../../models/parameterDetails";
+import { OperationDetails } from "../../models/operationDetails";
+import { ImplementationLocation, SchemaType } from "@azure-tools/codemodel";
+
+interface ParameterFilterOptions {
+  includeOptional?: boolean;
+  includeClientParams?: boolean;
+  includeUriParameters?: boolean;
+  includeGlobalParameters?: boolean;
+  includeConstantParameters?: boolean;
+}
+
+/**
+ * Helper function to filter pre-processed parameters, to be used to find matching parameters
+ * within an operation
+ * @param parameters original list of parameters to filter
+ * @param operation operation to look up the parameter in
+ * @param param2 Object with filtering options
+ */
+export function filterOperationParameters(
+  parameters: ParameterDetails[],
+  operation: OperationDetails,
+  {
+    includeOptional,
+    includeClientParams,
+    includeGlobalParameters,
+    includeConstantParameters
+  }: ParameterFilterOptions = {}
+) {
+  const optionalFilter = (param: ParameterDetails) =>
+    !!(includeOptional || param.required);
+
+  const constantFilter = (param: ParameterDetails) =>
+    !!(includeConstantParameters || param.schemaType !== SchemaType.Constant);
+
+  const clientParamFilter = (param: ParameterDetails) =>
+    !!(
+      includeClientParams ||
+      param.implementationLocation !== ImplementationLocation.Client
+    );
+
+  const globalFilter = (param: ParameterDetails) =>
+    !!(includeGlobalParameters || !param.isGlobal);
+
+  const isInOperation = (param: ParameterDetails) =>
+    !!(param.operationsIn && param.operationsIn.includes(operation.fullName));
+
+  return parameters.filter(
+    param =>
+      globalFilter(param) &&
+      isInOperation(param) &&
+      optionalFilter(param) &&
+      constantFilter(param) &&
+      clientParamFilter(param)
+  );
+}

--- a/src/generators/utils/parameterUtils.ts
+++ b/src/generators/utils/parameterUtils.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 import { ParameterDetails } from "../../models/parameterDetails";
 import { OperationDetails } from "../../models/operationDetails";
 import { ImplementationLocation, SchemaType } from "@azure-tools/codemodel";

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,8 +16,9 @@ export async function processRequest(host: Host) {
       undefined,
       codeModelSchema
     );
-
+    const start = Date.now();
     await generateTypeScriptLibrary(session.model, host);
+    session.log(`Autorest.Typescript took ${Date.now() - start}ms`, "");
   } catch (err) {
     console.error("An error was encountered while handling a request:", err);
     throw err;

--- a/src/models/clientDetails.ts
+++ b/src/models/clientDetails.ts
@@ -7,6 +7,11 @@ import { Mapper } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";
 import { ObjectDetails } from "./modelDetails";
 
+export interface ClientOptions {
+  azureArm?: boolean;
+  addCredentials?: boolean;
+}
+
 export interface ClientDetails {
   name: string;
   className: string;
@@ -17,4 +22,5 @@ export interface ClientDetails {
   unions: UnionDetails[];
   operationGroups: OperationGroupDetails[];
   parameters: ParameterDetails[];
+  options: ClientOptions;
 }

--- a/src/models/clientDetails.ts
+++ b/src/models/clientDetails.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ModelDetails } from "./modelDetails";
 import { UnionDetails } from "./unionDetails";
 import { OperationGroupDetails } from "./operationDetails";
 import { Mapper } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";
+import { ObjectDetails } from "./modelDetails";
 
 export interface ClientDetails {
   name: string;
   className: string;
   description?: string;
   sourceFileName: string;
-  models: ModelDetails[];
+  objects: ObjectDetails[];
   mappers: Mapper[];
   unions: UnionDetails[];
   operationGroups: OperationGroupDetails[];

--- a/src/models/modelDetails.ts
+++ b/src/models/modelDetails.ts
@@ -12,15 +12,16 @@ export interface PropertyDetails {
   type: string;
   required: boolean;
   readOnly: boolean;
-  isConstant: boolean;
+  isConstant?: boolean;
+  typeDetails: TypeDetails;
 }
 
 /**
  * Details of a property's type
  */
-export interface PropertyTypeDetails {
+export interface TypeDetails {
   typeName: string;
-  isConstant: boolean;
+  isConstant?: boolean;
   defaultValue?: string;
   kind: PropertyKind;
 }

--- a/src/models/modelDetails.ts
+++ b/src/models/modelDetails.ts
@@ -1,6 +1,59 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { ObjectSchema } from "@azure-tools/codemodel";
+
+export type ObjectDetails =
+  | BasicObjectDetails
+  | ComposedObjectDetails
+  | PolymorphicObjectDetails;
+
+export enum ObjectKind {
+  Basic,
+  Extended,
+  Polymorphic
+}
+
+/**
+ * Details of a model, transformed from ObjectSchema.
+ */
+export interface BasicObjectDetails {
+  name: string;
+  description: string;
+  serializedName: string;
+  properties: PropertyDetails[];
+  kind: ObjectKind;
+  children: ObjectDetails[];
+  parents: ObjectDetails[];
+  schema: ObjectSchema;
+  hasAdditionalProperties: boolean;
+}
+
+/**
+ * Type that represents an object which inherits
+ */
+export type ComposedObjectDetails = BasicObjectDetails & {
+  /**
+   * Parents from which the object inherits properties
+   */
+  parentNames: string[];
+};
+
+/**
+ * Type for representing polymorphism of an Object
+ */
+export type PolymorphicObjectDetails = BasicObjectDetails & {
+  /**
+   * Polymorphic discriminator
+   */
+  discriminator: { [key: string]: string[] };
+  /**
+   * Name of the union type which represents
+   * the polymorphic options
+   */
+  unionName: string;
+};
+
 /**
  * Details of a model's property, transformed from Property.
  */
@@ -14,6 +67,7 @@ export interface PropertyDetails {
   readOnly: boolean;
   isConstant?: boolean;
   typeDetails: TypeDetails;
+  isDiscriminator: boolean;
 }
 
 /**
@@ -24,16 +78,6 @@ export interface TypeDetails {
   isConstant?: boolean;
   defaultValue?: string;
   kind: PropertyKind;
-}
-
-/**
- * Details of a model, transformed from ObjectSchema.
- */
-export interface ModelDetails {
-  name: string;
-  description: string;
-  serializedName: string;
-  properties: PropertyDetails[];
 }
 
 /**

--- a/src/models/modelDetails.ts
+++ b/src/models/modelDetails.ts
@@ -22,6 +22,7 @@ export interface PropertyTypeDetails {
   typeName: string;
   isConstant: boolean;
   defaultValue?: string;
+  kind: PropertyKind;
 }
 
 /**
@@ -32,4 +33,13 @@ export interface ModelDetails {
   description: string;
   serializedName: string;
   properties: PropertyDetails[];
+}
+
+/**
+ * Details what the kind of property for handling
+ */
+export enum PropertyKind {
+  Primitive,
+  Enum,
+  Composite
 }

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -5,6 +5,7 @@ import { ParameterLocation, HttpMethod } from "@azure-tools/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper, OperationQueryParameter } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";
+import { TypeDetails } from "./modelDetails";
 
 /**
  * Details of an operation request, transformed from Request.
@@ -20,9 +21,9 @@ export interface OperationRequestDetails {
  */
 export interface OperationResponseDetails {
   statusCodes: string[]; // Can be a status code number or "default"
-  modelType?: string; // Could be a primitive or actual model type
   mediaType?: KnownMediaType;
   bodyMapper?: Mapper | string;
+  typeDetails: TypeDetails;
 }
 
 /**
@@ -35,6 +36,7 @@ export interface OperationDetails {
   apiVersions: string[];
   request: OperationRequestDetails;
   responses: OperationResponseDetails[];
+  typeDetails: TypeDetails;
 }
 
 /**

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ParameterLocation, HttpMethod } from "@azure-tools/codemodel";
+import { HttpMethod } from "@azure-tools/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
-import { Mapper, OperationQueryParameter } from "@azure/core-http";
+import { Mapper } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";
 import { TypeDetails } from "./modelDetails";
 
@@ -24,6 +24,7 @@ export interface OperationResponseDetails {
   mediaType?: KnownMediaType;
   bodyMapper?: Mapper | string;
   typeDetails: TypeDetails;
+  isError?: boolean;
 }
 
 /**

--- a/src/models/parameterDetails.ts
+++ b/src/models/parameterDetails.ts
@@ -5,9 +5,11 @@ import {
   Parameter,
   ParameterLocation,
   AllSchemaTypes,
-  ImplementationLocation
+  ImplementationLocation,
+  SchemaType
 } from "@azure-tools/codemodel";
 import { Mapper } from "@azure/core-http";
+import { TypeDetails } from "./modelDetails";
 
 export interface ParameterDetails {
   nameRef: string;
@@ -21,8 +23,8 @@ export interface ParameterDetails {
   isGlobal: boolean;
   parameter: Parameter;
   operationsIn?: string[];
-  modelType: string;
   collectionFormat?: string;
   schemaType: AllSchemaTypes;
   implementationLocation?: ImplementationLocation;
+  typeDetails: TypeDetails;
 }

--- a/src/models/parameterDetails.ts
+++ b/src/models/parameterDetails.ts
@@ -13,6 +13,7 @@ import { TypeDetails } from "./modelDetails";
 
 export interface ParameterDetails {
   nameRef: string;
+  defaultValue?: any;
   description: string;
   name: string;
   serializedName: string;

--- a/src/models/parameterDetails.ts
+++ b/src/models/parameterDetails.ts
@@ -1,7 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Parameter, ParameterLocation } from "@azure-tools/codemodel";
+import {
+  Parameter,
+  ParameterLocation,
+  AllSchemaTypes,
+  ImplementationLocation
+} from "@azure-tools/codemodel";
 import { Mapper } from "@azure/core-http";
 
 export interface ParameterDetails {
@@ -18,4 +23,6 @@ export interface ParameterDetails {
   operationsIn?: string[];
   modelType: string;
   collectionFormat?: string;
+  schemaType: AllSchemaTypes;
+  implementationLocation?: ImplementationLocation;
 }

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -14,7 +14,8 @@ import {
   Property,
   ArraySchema,
   DictionarySchema,
-  DateTimeSchema
+  DateTimeSchema,
+  CodeModel
 } from "@azure-tools/codemodel";
 import {
   BaseMapper,
@@ -62,6 +63,18 @@ export interface EntityOptions {
 export interface MapperInput {
   schema: Schema;
   options?: EntityOptions;
+}
+
+export async function transformMappers(
+  codeModel: CodeModel
+): Promise<Mapper[]> {
+  if (!codeModel.schemas.objects) {
+    return [];
+  }
+
+  return codeModel.schemas.objects.map(objectSchema =>
+    transformMapper({ schema: objectSchema })
+  );
 }
 
 /**

--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -225,9 +225,8 @@ function transformPolymorphicObject(
   let discriminator: { [key: string]: string[] } = {};
 
   if (schema === uberParent && schema.children) {
-    const discriminatorProperty = getLanguageMetadata(
-      uberParent.discriminator!.property.language
-    ).name;
+    const discriminatorProperty = uberParent.discriminator!.property
+      .serializedName;
 
     const children = schema.children.all;
     const childDiscriminators = children

--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -1,0 +1,255 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  CodeModel,
+  ObjectSchema,
+  ComplexSchema,
+  SchemaType,
+  Property
+} from "@azure-tools/codemodel";
+import {
+  ObjectDetails,
+  ObjectKind,
+  PolymorphicObjectDetails,
+  ComposedObjectDetails
+} from "../models/modelDetails";
+import { getLanguageMetadata } from "../utils/languageHelpers";
+import { normalizeName, NameType } from "../utils/nameUtils";
+import { PropertyDetails } from "../models/modelDetails";
+import { getTypeForSchema } from "../utils/schemaHelpers";
+
+export function transformObjects(
+  codeModel: CodeModel,
+  uberParents: ObjectDetails[]
+): ObjectDetails[] {
+  const objectDetails = (codeModel.schemas.objects || []).map(object =>
+    transformObject(object, uberParents)
+  );
+
+  return getObjectDetailsWithHierarchy(objectDetails);
+}
+
+export function transformObject(
+  schema: ObjectSchema,
+  uberParents: ObjectDetails[]
+): ObjectDetails {
+  const metadata = getLanguageMetadata(schema.language);
+  let name = normalizeName(metadata.name, NameType.Class);
+  const kind = getObjectKind(schema);
+
+  let objectDetails: ObjectDetails = {
+    children: [],
+    parents: [],
+    hasAdditionalProperties: false,
+    kind,
+    name,
+    serializedName: metadata.serializedName,
+    description: `An interface representing ${metadata.name}.`,
+    schema,
+    properties: schema.properties
+      ? schema.properties.map(prop => transformProperty(prop))
+      : []
+  };
+
+  return getAdditionalObjectDetails(objectDetails, schema, uberParents);
+}
+
+export function transformProperty(property: Property): PropertyDetails {
+  const metadata = getLanguageMetadata(property.language);
+  const { typeName, isConstant, defaultValue } = getTypeForSchema(
+    property.schema
+  );
+  const typeDetails = getTypeForSchema(property.schema);
+
+  return {
+    name: normalizeName(metadata.name, NameType.Property),
+    description: !metadata.description.startsWith("MISSING")
+      ? metadata.description
+      : undefined,
+    serializedName: property.serializedName,
+    type: typeName,
+    required: !!property.required,
+    readOnly: !!property.readOnly,
+    isConstant,
+    defaultValue,
+    typeDetails,
+    isDiscriminator: false
+  };
+}
+
+function getObjectKind(schema: ObjectSchema): ObjectKind {
+  if (schema.discriminator || schema.discriminatorValue) {
+    return ObjectKind.Polymorphic;
+  }
+
+  if (schema.parents && schema.parents.immediate.length) {
+    return ObjectKind.Extended;
+  }
+
+  return ObjectKind.Basic;
+}
+
+function getObjectDetailsWithHierarchy(
+  objectsDetails: ObjectDetails[]
+): ObjectDetails[] {
+  return objectsDetails.map(current => {
+    const parentsSchema =
+      current.schema.parents && current.schema.parents.immediate;
+    const childrenSchema =
+      current.schema.children && current.schema.children.immediate;
+    let parents: ObjectDetails[] = extractHierarchy(
+      parentsSchema,
+      objectsDetails,
+      current
+    );
+    let children: ObjectDetails[] = extractHierarchy(
+      childrenSchema,
+      objectsDetails,
+      current
+    );
+    const hasAdditionalProperties =
+      !!parentsSchema &&
+      parentsSchema.some(p => p.type === SchemaType.Dictionary);
+
+    return {
+      ...current,
+      parents,
+      children,
+      hasAdditionalProperties
+    };
+  });
+}
+
+function extractHierarchy(
+  schemas: ComplexSchema[] | undefined,
+  objectsDetails: ObjectDetails[],
+  current: ObjectDetails
+): ObjectDetails[] {
+  if (!schemas || !schemas.length) {
+    return [];
+  }
+
+  return schemas
+    .filter(s => s.type === SchemaType.Object)
+    .map(r => {
+      const relativeName = normalizeName(
+        getLanguageMetadata(r.language).name,
+        NameType.Interface
+      );
+      const relative = objectsDetails.find(o => o.name === relativeName);
+
+      if (!relative) {
+        throw new Error(
+          `Expected relative ${relativeName} of ${current.name} but couldn't find it in transformed objects`
+        );
+      }
+      return relative;
+    });
+}
+
+function getAdditionalObjectDetails(
+  objectDetails: ObjectDetails,
+  schema: ObjectSchema,
+  uberParents: ObjectDetails[]
+): ObjectDetails {
+  switch (objectDetails.kind) {
+    case ObjectKind.Basic:
+      return objectDetails;
+    case ObjectKind.Polymorphic:
+      return transformPolymorphicObject(
+        objectDetails as PolymorphicObjectDetails,
+        schema,
+        uberParents
+      );
+    case ObjectKind.Extended:
+      return transformComposedObject(objectDetails, schema);
+    default:
+      throw new Error(`Unexpected ObjectKind ${objectDetails.kind}`);
+  }
+}
+
+function transformComposedObject(
+  objectDetails: ObjectDetails,
+  schema: ObjectSchema
+): ComposedObjectDetails {
+  if (!schema.parents) {
+    throw new Error(`Expected object ${objectDetails.name} to have parents`);
+  }
+
+  const parentNames = schema.parents.immediate.map(parent => {
+    const name = getLanguageMetadata(parent.language).name;
+    return `${normalizeName(name, NameType.Interface)}`;
+  });
+
+  return {
+    ...objectDetails,
+    parentNames
+  };
+}
+
+function transformPolymorphicObject(
+  objectDetails: PolymorphicObjectDetails,
+  schema: ObjectSchema,
+  uberParents: ObjectDetails[]
+): PolymorphicObjectDetails {
+  let uberParent: ObjectSchema | undefined = schema;
+  const allParents = schema.parents && schema.parents.all;
+  if (allParents && allParents.length) {
+    const uberParentSchema = allParents.find(p => {
+      // TODO: Reconsider names to reduce issues with normalization, can we switch to serialized?
+      const name = normalizeName(
+        getLanguageMetadata(p.language).name,
+        NameType.Interface
+      );
+      return uberParents.some(up => up.name === name);
+    });
+
+    if (!uberParentSchema) {
+      const upn = uberParents.map(u => u.name);
+      throw new Error(
+        `Could not determine uberParent for Object ${
+          objectDetails.name
+        }. Make sure that swagger defines polymorphism correctly; UberParents: ${JSON.stringify(
+          upn
+        )}`
+      );
+    }
+
+    uberParent = uberParentSchema as ObjectSchema;
+  }
+
+  const uberParentName = getLanguageMetadata(uberParent.language).name;
+  const unionName = `${normalizeName(uberParentName, NameType.Interface)}Union`;
+
+  let discriminator: { [key: string]: string[] } = {};
+
+  if (schema === uberParent && schema.children) {
+    const discriminatorProperty = getLanguageMetadata(
+      uberParent.discriminator!.property.language
+    ).name;
+
+    const children = schema.children.all;
+    const childDiscriminators = children
+      .map(c => (c as ObjectSchema).discriminatorValue)
+      .filter(c => !!c) as string[];
+
+    const propertyToMark = objectDetails.properties.find(
+      p => p.name === discriminatorProperty
+    );
+
+    if (propertyToMark) {
+      propertyToMark.isDiscriminator = true;
+    }
+
+    discriminator = !childDiscriminators.length
+      ? {}
+      : { [`"${discriminatorProperty}"`]: childDiscriminators };
+  }
+
+  return {
+    discriminator,
+    unionName,
+    ...objectDetails
+  } as PolymorphicObjectDetails;
+}

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -12,7 +12,8 @@ import {
   ChoiceSchema,
   OperationGroup,
   ParameterLocation,
-  ConstantSchema
+  ConstantSchema,
+  CodeModel
 } from "@azure-tools/codemodel";
 import { normalizeName, NameType } from "../utils/nameUtils";
 import {
@@ -241,6 +242,10 @@ export function transformOperation(
       transformOperationResponse(response as SchemaResponse)
     )
   };
+}
+
+export async function transformOperationGroups(codeModel: CodeModel) {
+  return codeModel.operationGroups.map(transformOperationGroup);
 }
 
 export function transformOperationGroup(

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -247,7 +247,8 @@ export function transformOperationGroup(
   operationGroup: OperationGroup
 ): OperationGroupDetails {
   const metadata = getLanguageMetadata(operationGroup.language);
-  const name = normalizeName(metadata.name, NameType.Property);
+  // TODO: Probably want to inline operations in client when there is only one operation group (#551)
+  const name = normalizeName(metadata.name || "operations", NameType.Property);
   return {
     name,
     key: operationGroup.$key,

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-  HttpMethods,
-  Mapper,
-  MapperType,
-  CompositeMapper,
-  OperationQueryParameter
-} from "@azure/core-http";
+import { HttpMethods, Mapper, MapperType } from "@azure/core-http";
 import {
   Operation,
   Request,
@@ -18,7 +12,6 @@ import {
   ChoiceSchema,
   OperationGroup,
   ParameterLocation,
-  Parameter,
   ConstantSchema
 } from "@azure-tools/codemodel";
 import { normalizeName, NameType } from "../utils/nameUtils";
@@ -34,6 +27,7 @@ import { getLanguageMetadata } from "../utils/languageHelpers";
 import { getTypeForSchema } from "../utils/schemaHelpers";
 import { getMapperTypeFromSchema } from "./mapperTransforms";
 import { ParameterDetails } from "../models/parameterDetails";
+import { PropertyTypeDetails, PropertyKind } from "../models/modelDetails";
 
 export function transformOperationSpec(
   operationDetails: OperationDetails,
@@ -176,12 +170,13 @@ export function transformOperationRequest(
 export function transformOperationResponse(
   response: Response | SchemaResponse
 ): OperationResponseDetails {
-  let modelType: string | undefined = undefined;
+  let modelTypeName: string | undefined = undefined;
+  let responseType: PropertyTypeDetails | undefined = undefined;
   let bodyMapper: Mapper | string | undefined = undefined;
 
   if ((response as SchemaResponse).schema) {
     const schemaResponse = response as SchemaResponse;
-    modelType = getTypeForSchema(schemaResponse.schema).typeName;
+    responseType = getTypeForSchema(schemaResponse.schema);
     bodyMapper = getBodyMapperFromSchema(schemaResponse.schema);
   }
 
@@ -189,7 +184,7 @@ export function transformOperationResponse(
     return {
       statusCodes: response.protocol.http.statusCodes,
       mediaType: response.protocol.http.knownMediaType,
-      modelType,
+      modelType: modelTypeName,
       bodyMapper
     };
   } else {

--- a/src/transforms/optionsTransforms.ts
+++ b/src/transforms/optionsTransforms.ts
@@ -1,0 +1,10 @@
+import { Host } from "@azure-tools/autorest-extension-base";
+import { ClientOptions } from "../models/clientDetails";
+
+export async function transformOptions(host: Host): Promise<ClientOptions> {
+  const addCredentials = await host.GetValue("add-credentials");
+
+  return {
+    addCredentials
+  };
+}

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -75,6 +75,7 @@ export function populateOperationParameters(
   if (!sameNameParams.length) {
     const name = normalizeName(parameterSerializedName, NameType.Property);
     const collectionFormat = getCollectionFormat(parameter);
+    const typeDetails = getTypeForSchema(parameter.schema);
     const paramDetails: ParameterDetails = {
       nameRef: name,
       description,
@@ -85,7 +86,6 @@ export function populateOperationParameters(
       required: parameter.required,
       schemaType: parameter.schema.type,
       parameterPath: getParameterPath(parameter),
-      modelType: getTypeForSchema(parameter.schema).typeName,
       mapper: getMapperOrRef(
         parameter.schema,
         parameterSerializedName,
@@ -94,7 +94,8 @@ export function populateOperationParameters(
       isGlobal: getIsGlobal(parameter),
       parameter,
       collectionFormat,
-      implementationLocation: parameter.implementation
+      implementationLocation: parameter.implementation,
+      typeDetails
     };
     operationParameters.push(paramDetails);
 
@@ -220,6 +221,7 @@ export function disambiguateParameter(
     const nameRef = `${name}${sameNameParams.length}`;
     const collectionFormat = getCollectionFormat(parameter);
     const description = getLanguageMetadata(parameter.language).description;
+    const typeDetails = getTypeForSchema(parameter.schema);
 
     operationParameters.push({
       nameRef,
@@ -236,7 +238,7 @@ export function disambiguateParameter(
         serializedName,
         parameter.required
       ),
-      modelType: getTypeForSchema(parameter.schema).typeName,
+      typeDetails,
       isGlobal: getIsGlobal(parameter),
       parameter,
       collectionFormat,

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -83,6 +83,7 @@ export function populateOperationParameters(
       operationsIn: [operationName],
       location: getParameterLocation(parameter),
       required: parameter.required,
+      schemaType: parameter.schema.type,
       parameterPath: getParameterPath(parameter),
       modelType: getTypeForSchema(parameter.schema).typeName,
       mapper: getMapperOrRef(
@@ -92,9 +93,11 @@ export function populateOperationParameters(
       ),
       isGlobal: getIsGlobal(parameter),
       parameter,
-      collectionFormat
+      collectionFormat,
+      implementationLocation: parameter.implementation
     };
     operationParameters.push(paramDetails);
+
     return;
   }
 
@@ -225,6 +228,7 @@ export function disambiguateParameter(
       serializedName,
       operationsIn: [operationName],
       required: parameter.required,
+      schemaType: parameter.schema.type,
       parameterPath: getParameterPath(parameter),
       location: getParameterLocation(parameter),
       mapper: getMapperOrRef(
@@ -235,7 +239,8 @@ export function disambiguateParameter(
       modelType: getTypeForSchema(parameter.schema).typeName,
       isGlobal: getIsGlobal(parameter),
       parameter,
-      collectionFormat
+      collectionFormat,
+      implementationLocation: parameter.implementation
     });
   }
 }

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -38,7 +38,8 @@ export function transformParameters(codeModel: CodeModel): ParameterDetails[] {
 
 const extractOperationParameters = (codeModel: CodeModel) =>
   codeModel.operationGroups.reduce<OperationParameterDetails[]>((acc, og) => {
-    const groupName = getLanguageMetadata(og.language).name;
+    // TODO: Probably want to inline operations in client when there is only one operation group (#551)
+    const groupName = getLanguageMetadata(og.language).name || "operations";
     return [
       ...acc,
       ...og.operations.reduce<OperationParameterDetails[]>(

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -29,6 +29,7 @@ export function transformProperty(property: Property): PropertyDetails {
   const { typeName, isConstant, defaultValue } = getTypeForSchema(
     property.schema
   );
+  const typeDetails = getTypeForSchema(property.schema);
 
   return {
     name: normalizeName(metadata.name, NameType.Property),
@@ -40,7 +41,8 @@ export function transformProperty(property: Property): PropertyDetails {
     required: !!property.required,
     readOnly: !!property.readOnly,
     isConstant,
-    defaultValue
+    defaultValue,
+    typeDetails
   };
 }
 

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -49,7 +49,7 @@ export async function generateTypeScriptLibrary(
     }
   });
 
-  const clientDetails = transformCodeModel(codeModel);
+  const clientDetails = await transformCodeModel(codeModel, host);
   const packageName = await host.GetValue("package-name");
   const packageNameParts = packageName.match(/(^@(.*)\/)?(.*)/);
   const packageDetails: PackageDetails = {

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -9,8 +9,9 @@ export enum CasingConvention {
 
 export enum NameType {
   Class,
-  Property,
-  File
+  File,
+  Interface,
+  Property
 }
 
 export function guardReservedNames(name: string): string {
@@ -44,6 +45,7 @@ export function getMappersName(title: string): string {
 function getCasingConvention(nameType: NameType) {
   switch (nameType) {
     case NameType.Class:
+    case NameType.Interface:
       return CasingConvention.Pascal;
     case NameType.File:
     case NameType.Property:

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -15,6 +15,10 @@ import { getStringForValue } from "./valueHelpers";
 import { getLanguageMetadata } from "./languageHelpers";
 import { normalizeName, NameType } from "./nameUtils";
 
+/**
+ * Helper function which given a schema returns type information for useful for generating Typescript code
+ * @param schema schema to extract type information from
+ */
 export function getTypeForSchema(schema: Schema): PropertyTypeDetails {
   let typeName: string = "";
   let defaultValue: string = "";

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -1,51 +1,106 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { PropertyTypeDetails } from "../models/modelDetails";
+import { PropertyTypeDetails, PropertyKind } from "../models/modelDetails";
 
-import { Schema, SchemaType, ConstantSchema } from "@azure-tools/codemodel";
+import {
+  Schema,
+  SchemaType,
+  ConstantSchema,
+  ObjectSchema,
+  ArraySchema,
+  DictionarySchema
+} from "@azure-tools/codemodel";
 import { getStringForValue } from "./valueHelpers";
 import { getLanguageMetadata } from "./languageHelpers";
+import { normalizeName, NameType } from "./nameUtils";
 
 export function getTypeForSchema(schema: Schema): PropertyTypeDetails {
   let typeName: string = "";
   let defaultValue: string = "";
+  let kind: PropertyKind = PropertyKind.Primitive;
 
   switch (schema.type) {
-    case SchemaType.String:
-      typeName = "string";
+    case SchemaType.Array:
+      const arraySchema = schema as ArraySchema;
+      const itemsType = getTypeForSchema(arraySchema.elementType);
+      const itemsName = getElementTypeName(itemsType);
+      kind = itemsType.kind;
+      typeName = `${itemsName}[]`;
       break;
-    case SchemaType.Number:
-    case SchemaType.Integer:
-      typeName = "number";
-      break;
-    case SchemaType.Constant:
-      const constantSchema = schema as ConstantSchema;
-      const constantType = getTypeForSchema(constantSchema.valueType);
-      typeName = constantType.typeName;
-      defaultValue = getStringForValue(
-        constantSchema.value.value,
-        constantSchema.valueType,
-        false
-      );
+    case SchemaType.Boolean:
+      typeName = "boolean";
       break;
     case SchemaType.ByteArray:
       typeName = "Uint8Array";
       break;
     case SchemaType.Choice:
     case SchemaType.SealedChoice:
+      const { name: choiceName } = getLanguageMetadata(schema.language);
+      typeName = choiceName;
+      kind = PropertyKind.Enum;
+      break;
+    case SchemaType.Constant:
+      const constantSchema = schema as ConstantSchema;
+      const constantType = getTypeForSchema(constantSchema.valueType);
+      typeName = constantType.typeName;
+      kind = constantType.kind;
+      defaultValue = getStringForValue(
+        constantSchema.value.value,
+        constantSchema.valueType,
+        false
+      );
+      break;
+    case SchemaType.DateTime:
+    case SchemaType.Date:
+    case SchemaType.UnixTime:
+      typeName = "Date";
+      break;
+    case SchemaType.Duration:
+      typeName = "string";
+      break;
+    case SchemaType.Dictionary:
+      const dictionarySchema = schema as DictionarySchema;
+      const elementType = getTypeForSchema(dictionarySchema.elementType);
+      const elementTypeName = getElementTypeName(elementType);
+      typeName = `{[propertyName: string]: ${elementTypeName}}`;
+      break;
+    case SchemaType.Number:
+    case SchemaType.Integer:
+      typeName = "number";
+      break;
+
     case SchemaType.Object:
+      const objSchema = schema as ObjectSchema;
       const { name } = getLanguageMetadata(schema.language);
-      typeName = name;
+
+      // Polymorphic objects with children will get a union type as type
+      // since they can take different shapes
+      const isUnionType =
+        !!(objSchema.discriminator || objSchema.discriminatorValue) &&
+        !!objSchema.children &&
+        !!objSchema.children.immediate.length;
+
+      typeName = isUnionType ? `${name}Union` : name;
+      kind = PropertyKind.Composite;
+      break;
+    case SchemaType.String:
+      typeName = "string";
       break;
     default:
-      typeName = "any";
-      break;
+      throw new Error(`Handling of ${schema.type} hasn't been implemented yet`);
   }
 
   return {
     typeName,
+    kind,
     isConstant: schema.type === SchemaType.Constant,
     ...(defaultValue && { defaultValue })
   };
+}
+
+function getElementTypeName(elementType: PropertyTypeDetails) {
+  return elementType.kind === PropertyKind.Primitive
+    ? elementType.typeName
+    : normalizeName(elementType.typeName, NameType.Interface);
 }

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { PropertyTypeDetails, PropertyKind } from "../models/modelDetails";
+import { TypeDetails, PropertyKind } from "../models/modelDetails";
 
 import {
   Schema,
@@ -19,7 +19,7 @@ import { normalizeName, NameType } from "./nameUtils";
  * Helper function which given a schema returns type information for useful for generating Typescript code
  * @param schema schema to extract type information from
  */
-export function getTypeForSchema(schema: Schema): PropertyTypeDetails {
+export function getTypeForSchema(schema: Schema): TypeDetails {
   let typeName: string = "";
   let defaultValue: string = "";
   let kind: PropertyKind = PropertyKind.Primitive;
@@ -103,7 +103,7 @@ export function getTypeForSchema(schema: Schema): PropertyTypeDetails {
   };
 }
 
-function getElementTypeName(elementType: PropertyTypeDetails) {
+function getElementTypeName(elementType: TypeDetails) {
   return elementType.kind === PropertyKind.Primitive
     ? elementType.typeName
     : normalizeName(elementType.typeName, NameType.Interface);

--- a/test/integration/bodyComplex.spec.ts
+++ b/test/integration/bodyComplex.spec.ts
@@ -31,11 +31,14 @@ describe("typescript", function() {
         assert.equal(result.id, 2);
         assert.equal(result.name, "abc");
         assert.equal(result.color, "YELLOW");
-        await testClient.basic.putValid({
+
+        const putResult = await testClient.basic.putValid({
           id: 2,
           name: "abc",
           color: "Magenta"
         });
+
+        assert.equal(putResult._response.status, 200);
       });
 
       it("should get null basic type properties", async function() {
@@ -44,29 +47,21 @@ describe("typescript", function() {
         assert.equal(null, result.name);
       });
 
-      it("should get empty basic type properties", function(done) {
-        testClient.basic.getEmpty(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.id, undefined);
-          assert.equal(result.name, undefined);
-          done();
-        });
+      it("should get empty basic type properties", async () => {
+        const result = await testClient.basic.getEmpty();
+        assert.equal(result.id, undefined);
+        assert.equal(result.name, undefined);
       });
 
-      it("should get basic type properties when the payload is empty", function(done) {
-        testClient.basic.getNotProvided(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result, undefined);
-          done();
-        });
+      it("should get basic type properties when the payload is empty", async () => {
+        await testClient.basic.getNotProvided();
+        assert.ok("Request succeeded with no errors");
       });
 
-      it("should deserialize invalid basic types without throwing", function(done) {
-        testClient.basic.getInvalid(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(!!result, true);
-          done();
-        });
+      it("should deserialize invalid basic types without throwing", async () => {
+        // TODO double check
+        const result = await testClient.basic.getInvalid();
+        assert.ok("Deserialized invalid basic types without throwing");
       });
     });
 
@@ -75,112 +70,91 @@ describe("typescript", function() {
       beforeEach(() => {
         testClient = new BodyComplexClient(clientOptions);
       });
-      it("should get and put valid int properties", function(done) {
-        testClient.primitive.getInt(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.field1, -1);
-          assert.equal(result.field2, 2);
-          testClient.primitive.putInt({ field1: -1, field2: 2 }, function(
-            error
-          ) {
-            assert.equal(error, undefined);
-            done();
-          });
+      it("should get and put valid int properties", async () => {
+        const result = await testClient.primitive.getInt();
+        assert.equal(result.field1, -1);
+        assert.equal(result.field2, 2);
+
+        const putResult = await testClient.primitive.putInt({
+          field1: -1,
+          field2: 2
         });
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get and put valid long properties", function(done) {
-        testClient.primitive.getLong(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.field1, 1099511627775);
-          assert.equal(result.field2, -999511627788);
-          testClient.primitive.putLong(
-            { field1: 1099511627775, field2: -999511627788 },
-            function(error) {
-              assert.equal(error, undefined);
-              done();
-            }
-          );
+      it("should get and put valid long properties", async () => {
+        const result = await testClient.primitive.getLong();
+        assert.equal(result.field1, 1099511627775);
+        assert.equal(result.field2, -999511627788);
+
+        const putResult = await testClient.primitive.putLong({
+          field1: 1099511627775,
+          field2: -999511627788
         });
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get and put valid float properties", function(done) {
-        testClient.primitive.getFloat(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.field1, 1.05);
-          assert.equal(result.field2, -0.003);
-          testClient.primitive.putFloat(
-            { field1: 1.05, field2: -0.003 },
-            function(error) {
-              assert.equal(error, undefined);
-              done();
-            }
-          );
+      it("should get and put valid float properties", async () => {
+        const result = await testClient.primitive.getFloat();
+        assert.equal(result.field1, 1.05);
+        assert.equal(result.field2, -0.003);
+
+        const putResult = await testClient.primitive.putFloat({
+          field1: 1.05,
+          field2: -0.003
         });
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get and put valid bool properties", function(done) {
-        testClient.primitive.getBool(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.fieldTrue, true);
-          assert.equal(result.fieldFalse, false);
-          testClient.primitive.putBool(
-            { fieldTrue: true, fieldFalse: false },
-            function(error) {
-              assert.equal(error, undefined);
-              done();
-            }
-          );
+      it("should get and put valid bool properties", async () => {
+        const result = await testClient.primitive.getBool();
+        assert.equal(result.fieldTrue, true);
+        assert.equal(result.fieldFalse, false);
+
+        const putResult = await testClient.primitive.putBool({
+          fieldTrue: true,
+          fieldFalse: false
         });
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get and put valid string properties", function(done) {
-        testClient.primitive.getString(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.field, "goodrequest");
-          assert.equal(result.empty, "");
-          assert.equal(result["nullProperty"], undefined);
-          testClient.primitive.putString(
-            { field: "goodrequest", empty: "" },
-            function(error) {
-              assert.equal(error, undefined);
-              done();
-            }
-          );
+      it("should get and put valid string properties", async () => {
+        const result = await testClient.primitive.getString();
+        assert.equal(result.field, "goodrequest");
+        assert.equal(result.empty, "");
+        assert.equal((result as any)["nullProperty"], undefined);
+
+        const putResult = await testClient.primitive.putString({
+          field: "goodrequest",
+          empty: ""
         });
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get and put valid date properties", function(done) {
-        testClient.primitive.getDate(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result.field, new Date("0001-01-01"));
-          assert.deepEqual(result.leap, new Date("2016-02-29"));
-          const complexBody = <BodyComplexModels.DateWrapper>{
-            field: new Date("0001-01-01"),
-            leap: new Date("2016-02-29")
-          };
-          testClient.primitive.putDate(complexBody, function(error) {
-            assert.equal(error, undefined);
-            done();
-          });
-        });
+      it("should get and put valid date properties", async () => {
+        const result = await testClient.primitive.getDate();
+        assert.deepEqual(result.field, new Date("0001-01-01"));
+        assert.deepEqual(result.leap, new Date("2016-02-29"));
+
+        const complexBody = <BodyComplexModels.DateWrapper>{
+          field: new Date("0001-01-01"),
+          leap: new Date("2016-02-29")
+        };
+
+        const putResult = await testClient.primitive.putDate(complexBody);
+        assert.equal(putResult._response.status, 200);
       });
-      it("should get and put valid date-time properties", function(done) {
-        testClient.primitive.getDateTime(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result.field, new Date("0001-01-01T00:00:00Z"));
-          assert.deepEqual(result.now, new Date("2015-05-18T18:38:00Z"));
-          testClient.primitive.putDateTime(
-            {
-              field: new Date("0001-01-01T00:00:00Z"),
-              now: new Date("2015-05-18T18:38:00Z")
-            },
-            function(error) {
-              assert.equal(error, undefined);
-              done();
-            }
-          );
+
+      it("should get and put valid date-time properties", async () => {
+        const result = await testClient.primitive.getDateTime();
+        assert.deepEqual(result.field, new Date("0001-01-01T00:00:00Z"));
+        assert.deepEqual(result.now, new Date("2015-05-18T18:38:00Z"));
+
+        const putResult = await testClient.primitive.putDateTime({
+          field: new Date("0001-01-01T00:00:00Z"),
+          now: new Date("2015-05-18T18:38:00Z")
         });
+        assert.equal(putResult._response.status, 200);
       });
 
       it("should get and put valid date-time-rfc1123 properties", async () => {
@@ -193,20 +167,26 @@ describe("typescript", function() {
 
         const dateFormat = "ddd, DD MMM YYYY HH:mm:ss";
         const fieldDate = moment.utc(timeStringOne, dateFormat).toDate();
-        await testClient.primitive.putDateTimeRfc1123({
+        const putResult = await testClient.primitive.putDateTimeRfc1123({
           field: fieldDate,
           now: new Date(timeStringTwo)
         });
+
+        assert.equal(putResult._response.status, 200);
       });
 
       it("should get and put valid duration properties", async function() {
         const durationString = "P123DT22H14M12.011S";
         const result = await testClient.primitive.getDuration();
         assert.equal(result.field, durationString);
-        await testClient.primitive.putDuration({ field: durationString });
+
+        const putResult = await testClient.primitive.putDuration({
+          field: durationString
+        });
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get and put valid byte properties", function(done) {
+      it("should get and put valid byte properties", async () => {
         const byteBuffer = new Uint8Array([
           255,
           254,
@@ -219,17 +199,16 @@ describe("typescript", function() {
           247,
           246
         ]);
-        testClient.primitive.getByte(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(
-            [].slice.apply(result.field),
-            [].slice.apply(byteBuffer)
-          );
-          testClient.primitive.putByte({ field: byteBuffer }, function(error) {
-            assert.equal(error, undefined);
-            done();
-          });
+        const result = await testClient.primitive.getByte();
+        assert.deepEqual(
+          [].slice.apply(result.field),
+          [].slice.apply(byteBuffer)
+        );
+
+        const putResult = await testClient.primitive.putByte({
+          field: byteBuffer
         });
+        assert.equal(putResult._response.status, 200);
       });
     });
 
@@ -238,7 +217,7 @@ describe("typescript", function() {
       beforeEach(() => {
         testClient = new BodyComplexClient(clientOptions);
       });
-      it("should get valid array type properties", function(done) {
+      it("should get valid array type properties", async () => {
         const testArray: string[] = [
           "1, 2, 3, 4",
           "",
@@ -247,33 +226,23 @@ describe("typescript", function() {
           "The quick brown fox jumps over the lazy dog"
         ];
         const wrapper: ArrayWrapper = { array: testArray };
-        testClient.array.getValid(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result.array, testArray);
-          testClient.array.putValid(wrapper, function(error) {
-            assert.equal(error, undefined);
-            done();
-          });
-        });
-      }).timeout(20000);
+        const result = await testClient.array.getValid();
+        assert.deepEqual(result.array, testArray);
 
-      it("should get and put empty array type properties", function(done) {
-        testClient.array.getEmpty(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result.array, []);
-          testClient.array.putEmpty({ array: [] }, function(error) {
-            assert.equal(error, undefined);
-            done();
-          });
-        });
+        const putResult = await testClient.array.putValid(wrapper);
+        assert.equal(putResult._response.status, 200);
       });
 
-      it("should get array type properties when the payload is empty", function(done) {
-        testClient.array.getNotProvided(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.array, undefined);
-          done();
-        });
+      it("should get and put empty array type properties", async () => {
+        const result = await testClient.array.getEmpty();
+        assert.deepEqual(result.array, []);
+        await testClient.array.putEmpty({ array: [] });
+        assert.ok("putEmpty succeeded");
+      });
+
+      it("should get array type properties when the payload is empty", async () => {
+        const result = await testClient.array.getNotProvided();
+        assert.equal(result.array, undefined);
       });
     });
 
@@ -283,7 +252,7 @@ describe("typescript", function() {
         testClient = new BodyComplexClient(clientOptions);
       });
 
-      it("should get and put valid dictionary type properties", function(done) {
+      it("should get and put valid dictionary type properties", async () => {
         const testDictionary: { [propertyName: string]: any } = {
           txt: "notepad",
           bmp: "mspaint",
@@ -291,46 +260,31 @@ describe("typescript", function() {
           exe: "",
           "": null
         };
-        testClient.dictionary.getValid(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result.defaultProgram, testDictionary);
-          testClient.dictionary.putValid(
-            { defaultProgram: testDictionary },
-            function(error: Error) {
-              assert.equal(error, undefined);
-              done();
-            }
-          );
+        const result = await testClient.dictionary.getValid();
+        assert.deepEqual(result.defaultProgram, testDictionary);
+
+        await testClient.dictionary.putValid({
+          defaultProgram: testDictionary
         });
+
+        assert.ok("putValid succeeded");
       });
 
-      it("should get and put empty dictionary type properties", function(done) {
-        testClient.dictionary.getEmpty(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result.defaultProgram, {});
-          testClient.dictionary.putEmpty({ defaultProgram: {} }, function(
-            error
-          ) {
-            assert.equal(error, undefined);
-            done();
-          });
-        });
+      it("should get and put empty dictionary type properties", async () => {
+        const result = await testClient.dictionary.getEmpty();
+        assert.deepEqual(result.defaultProgram, {});
+        await testClient.dictionary.putEmpty({ defaultProgram: {} });
+        assert.ok("putEmpty Dictionary succeeded");
       });
 
-      it("should get null dictionary type properties", function(done) {
-        testClient.dictionary.getNull(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.defaultProgram, undefined);
-          done();
-        });
+      it("should get null dictionary type properties", async () => {
+        const result = await testClient.dictionary.getNull();
+        assert.equal(result.defaultProgram, undefined);
       });
 
-      it("should get dictionary type properties when the payload is empty", function(done) {
-        testClient.dictionary.getNotProvided(function(error, result) {
-          assert.equal(error, undefined);
-          assert.equal(result.defaultProgram, undefined);
-          done();
-        });
+      it("should get dictionary type properties when the payload is empty", async () => {
+        const result = await testClient.dictionary.getNotProvided();
+        assert.equal(result.defaultProgram, undefined);
       });
     });
 
@@ -346,18 +300,16 @@ describe("typescript", function() {
         name: "Siameeee"
       };
       let testClient: BodyComplexClient;
+
       beforeEach(() => {
         testClient = new BodyComplexClient(clientOptions);
       });
-      it("should get valid basic type properties", function(done) {
-        testClient.inheritance.getValid(function(error, result) {
-          assert.equal(error, undefined);
-          assert.deepEqual(result, siamese);
-          testClient.inheritance.putValid(siamese, function(error) {
-            assert.equal(error, undefined);
-            done();
-          });
-        });
+
+      it("should get valid basic type properties", async () => {
+        const result = await testClient.inheritance.getValid();
+        assert.deepEqual(result, siamese);
+        await testClient.inheritance.putValid(siamese);
+        assert.ok("putValid succeeded");
       });
     });
 
@@ -366,19 +318,11 @@ describe("typescript", function() {
       beforeEach(() => {
         testClient = new BodyComplexClient(clientOptions);
       });
-      it("should get and put complex types with readonly properties", function(done) {
-        testClient.readonlyproperty.getValid(function(
-          error,
-          result: any /** TODO: Wire types */
-        ) {
-          assert.equal(error, undefined);
-          testClient.readonlyproperty.putValid(result, function(
-            error: Error | RestError
-          ) {
-            assert.equal(error, undefined);
-            done();
-          });
-        });
+      it("should get and put complex types with readonly properties", async () => {
+        const result = await testClient.readonlyproperty.getValid();
+        // TODO verify result properties?
+        await testClient.readonlyproperty.putValid(result);
+        assert.ok("putComplex succeeded");
       });
     });
 

--- a/test/integration/bodyComplex.spec.ts
+++ b/test/integration/bodyComplex.spec.ts
@@ -5,7 +5,14 @@ import {
   BodyComplexClient,
   BodyComplexModels
 } from "./generated/bodyComplex/src/bodyComplexClient";
-import { Sawshark } from "./generated/bodyComplex/src/models";
+import {
+  Sawshark,
+  Salmon,
+  ArrayWrapper,
+  Shark,
+  Goblinshark,
+  FishUnion
+} from "./generated/bodyComplex/src/models";
 import { RestError } from "@azure/core-http";
 
 const clientOptions = {
@@ -74,8 +81,7 @@ describe("typescript", function() {
           assert.equal(result.field1, -1);
           assert.equal(result.field2, 2);
           testClient.primitive.putInt({ field1: -1, field2: 2 }, function(
-            error,
-            result
+            error
           ) {
             assert.equal(error, undefined);
             done();
@@ -90,7 +96,7 @@ describe("typescript", function() {
           assert.equal(result.field2, -999511627788);
           testClient.primitive.putLong(
             { field1: 1099511627775, field2: -999511627788 },
-            function(error, result) {
+            function(error) {
               assert.equal(error, undefined);
               done();
             }
@@ -105,7 +111,7 @@ describe("typescript", function() {
           assert.equal(result.field2, -0.003);
           testClient.primitive.putFloat(
             { field1: 1.05, field2: -0.003 },
-            function(error, result) {
+            function(error) {
               assert.equal(error, undefined);
               done();
             }
@@ -120,7 +126,7 @@ describe("typescript", function() {
           assert.equal(result.fieldFalse, false);
           testClient.primitive.putBool(
             { fieldTrue: true, fieldFalse: false },
-            function(error, result) {
+            function(error) {
               assert.equal(error, undefined);
               done();
             }
@@ -136,7 +142,7 @@ describe("typescript", function() {
           assert.equal(result["nullProperty"], undefined);
           testClient.primitive.putString(
             { field: "goodrequest", empty: "" },
-            function(error, result) {
+            function(error) {
               assert.equal(error, undefined);
               done();
             }
@@ -153,7 +159,7 @@ describe("typescript", function() {
             field: new Date("0001-01-01"),
             leap: new Date("2016-02-29")
           };
-          testClient.primitive.putDate(complexBody, function(error, result) {
+          testClient.primitive.putDate(complexBody, function(error) {
             assert.equal(error, undefined);
             done();
           });
@@ -169,7 +175,7 @@ describe("typescript", function() {
               field: new Date("0001-01-01T00:00:00Z"),
               now: new Date("2015-05-18T18:38:00Z")
             },
-            function(error, result) {
+            function(error) {
               assert.equal(error, undefined);
               done();
             }
@@ -219,10 +225,7 @@ describe("typescript", function() {
             [].slice.apply(result.field),
             [].slice.apply(byteBuffer)
           );
-          testClient.primitive.putByte({ field: byteBuffer }, function(
-            error,
-            result
-          ) {
+          testClient.primitive.putByte({ field: byteBuffer }, function(error) {
             assert.equal(error, undefined);
             done();
           });
@@ -236,20 +239,18 @@ describe("typescript", function() {
         testClient = new BodyComplexClient(clientOptions);
       });
       it("should get valid array type properties", function(done) {
-        const testArray = [
+        const testArray: string[] = [
           "1, 2, 3, 4",
           "",
-          null,
+          null as any,
           "&S#$(*Y",
           "The quick brown fox jumps over the lazy dog"
         ];
+        const wrapper: ArrayWrapper = { array: testArray };
         testClient.array.getValid(function(error, result) {
           assert.equal(error, undefined);
           assert.deepEqual(result.array, testArray);
-          testClient.array.putValid({ array: testArray }, function(
-            error,
-            result
-          ) {
+          testClient.array.putValid(wrapper, function(error) {
             assert.equal(error, undefined);
             done();
           });
@@ -260,7 +261,7 @@ describe("typescript", function() {
         testClient.array.getEmpty(function(error, result) {
           assert.equal(error, undefined);
           assert.deepEqual(result.array, []);
-          testClient.array.putEmpty({ array: [] }, function(error, result) {
+          testClient.array.putEmpty({ array: [] }, function(error) {
             assert.equal(error, undefined);
             done();
           });
@@ -295,7 +296,7 @@ describe("typescript", function() {
           assert.deepEqual(result.defaultProgram, testDictionary);
           testClient.dictionary.putValid(
             { defaultProgram: testDictionary },
-            function(error, result) {
+            function(error: Error) {
               assert.equal(error, undefined);
               done();
             }
@@ -308,8 +309,7 @@ describe("typescript", function() {
           assert.equal(error, undefined);
           assert.deepEqual(result.defaultProgram, {});
           testClient.dictionary.putEmpty({ defaultProgram: {} }, function(
-            error,
-            result
+            error
           ) {
             assert.equal(error, undefined);
             done();
@@ -353,7 +353,7 @@ describe("typescript", function() {
         testClient.inheritance.getValid(function(error, result) {
           assert.equal(error, undefined);
           assert.deepEqual(result, siamese);
-          testClient.inheritance.putValid(siamese, function(error, result) {
+          testClient.inheritance.putValid(siamese, function(error) {
             assert.equal(error, undefined);
             done();
           });
@@ -383,7 +383,7 @@ describe("typescript", function() {
     });
 
     describe("Complex Types with Polymorphism Operations", function() {
-      const getFish = () => ({
+      const getFish = (): Salmon => ({
         fishtype: "salmon",
         location: "alaska",
         iswild: true,
@@ -396,7 +396,7 @@ describe("typescript", function() {
             birthday: new Date("2012-01-05T01:00:00Z"),
             length: 20.0,
             species: "predator"
-          },
+          } as Shark,
           {
             fishtype: "sawshark",
             age: 105,
@@ -404,7 +404,7 @@ describe("typescript", function() {
             length: 10.0,
             picture: new Uint8Array([255, 255, 255, 255, 254]),
             species: "dangerous"
-          },
+          } as Sawshark,
           {
             fishtype: "goblin",
             color: "pinkish-gray" as BodyComplexModels.GoblinSharkColor,
@@ -413,7 +413,7 @@ describe("typescript", function() {
             species: "scary",
             birthday: new Date("2015-08-08T00:00:00Z"),
             jawsize: 5
-          }
+          } as Goblinshark
         ]
       });
       let testClient: BodyComplexClient;
@@ -422,25 +422,25 @@ describe("typescript", function() {
       });
       it("should get valid polymorphic properties", async function() {
         const getResult = await testClient.polymorphism.getValid();
-
-        const actualBytes = getResult.siblings[1].picture;
+        const actualBytes = (getResult.siblings![1] as Sawshark)!.picture;
         assert.equal(!!actualBytes, true);
-        assert.equal(actualBytes.length, 5);
-        assert.equal(actualBytes[0], 255);
-        assert.equal(actualBytes[1], 255);
-        assert.equal(actualBytes[2], 255);
-        assert.equal(actualBytes[3], 255);
-        assert.equal(actualBytes[4], 254);
+        assert.equal(actualBytes!.length, 5);
+        assert.equal(actualBytes![0], 255);
+        assert.equal(actualBytes![1], 255);
+        assert.equal(actualBytes![2], 255);
+        assert.equal(actualBytes![3], 255);
+        assert.equal(actualBytes![4], 254);
 
         // Working around the fact that Uint8Array doesn't work with deepEqual
-        delete (getResult.siblings[1] as BodyComplexModels.Sawshark).picture;
+        delete (getResult.siblings![1] as BodyComplexModels.Sawshark).picture;
         const expectedFish = getFish();
-        delete (expectedFish.siblings[1] as BodyComplexModels.Sawshark).picture;
+        delete (expectedFish.siblings![1] as BodyComplexModels.Sawshark)
+          .picture;
         assert.deepEqual(getResult, expectedFish);
 
         await testClient.polymorphism.putValid(getFish());
       });
-      const getBadfish = () => ({
+      const getBadfish = (): FishUnion => ({
         fishtype: "sawshark",
         species: "snaggle toothed",
         length: 18.5,
@@ -455,14 +455,14 @@ describe("typescript", function() {
             birthday: new Date("2012-01-05T01:00:00Z"),
             length: 20,
             age: 6
-          },
+          } as Shark,
           {
             fishtype: "sawshark",
             species: "dangerous",
             picture: new Uint8Array([255, 255, 255, 255, 254]),
             length: 10,
             age: 105
-          }
+          } as Sawshark
         ]
       });
       it("should throw when required fields are omitted from polymorphic types", async function() {
@@ -476,7 +476,8 @@ describe("typescript", function() {
         }
       });
 
-      const getRawSalmon = () => ({
+      // TODO: Handle additionalProperties
+      const getRawSalmon = (): any => ({
         fishtype: "smart_salmon",
         location: "alaska",
         iswild: true,
@@ -517,9 +518,8 @@ describe("typescript", function() {
 
       it("should get complicated polymorphic types", async function() {
         const result = await testClient.polymorphism.getComplicated();
-
         const picture =
-          (result.siblings[1] as BodyComplexModels.Sawshark).picture || [];
+          (result.siblings![1] as BodyComplexModels.Sawshark)!.picture || [];
         assert.equal(!!picture, true);
         assert.equal(picture.length, 5);
         assert.equal(picture[0], 255);
@@ -527,10 +527,10 @@ describe("typescript", function() {
         assert.equal(picture[2], 255);
         assert.equal(picture[3], 255);
         assert.equal(picture[4], 254);
-        delete (result.siblings[1] as BodyComplexModels.Sawshark).picture;
+        delete (result.siblings![1] as BodyComplexModels.Sawshark).picture;
 
         const rawSalmon = getRawSalmon();
-        delete (rawSalmon.siblings[1] as BodyComplexModels.Sawshark).picture;
+        delete (rawSalmon.siblings![1] as BodyComplexModels.Sawshark).picture;
 
         assert.deepEqual(result, rawSalmon);
       });
@@ -548,8 +548,8 @@ describe("typescript", function() {
         );
 
         const picture =
-          (response.siblings[1] as BodyComplexModels.Sawshark).picture || [];
-        delete (response.siblings[1] as BodyComplexModels.Sawshark).picture;
+          (response.siblings![1] as BodyComplexModels.Sawshark).picture || [];
+        delete (response.siblings![1] as BodyComplexModels.Sawshark).picture;
         assert.equal(!!picture, true);
         assert.equal(picture.length, 5);
         assert.equal(picture[0], 255);
@@ -559,14 +559,14 @@ describe("typescript", function() {
         assert.equal(picture[4], 254);
 
         const expected = getFish();
-        delete (expected.siblings[1] as BodyComplexModels.Sawshark).picture;
+        delete (expected.siblings![1] as BodyComplexModels.Sawshark).picture;
 
         assert.deepStrictEqual(response, expected);
       });
     });
 
     describe("Complex Types with recursive definitions", function() {
-      const getBigfish = () => ({
+      const getBigfish = (): FishUnion => ({
         fishtype: "salmon",
         location: "alaska",
         iswild: true,
@@ -648,16 +648,18 @@ describe("typescript", function() {
           delete sawshark.picture;
         }
 
-        checkSawshark(result.siblings[0].siblings[0].siblings[1]);
-        checkSawshark(result.siblings[0].siblings[1]);
-        checkSawshark(result.siblings[1]);
+        checkSawshark(
+          result.siblings![0].siblings![0].siblings![1] as Sawshark
+        );
+        checkSawshark(result.siblings![0].siblings![1] as Sawshark);
+        checkSawshark(result.siblings![1] as Sawshark);
 
         const bigfish = getBigfish();
-        delete ((bigfish.siblings[0] as any).siblings[0]
+        delete ((bigfish.siblings![0] as any).siblings[0]
           .siblings[1] as BodyComplexModels.Sawshark).picture;
-        delete ((bigfish.siblings[0] as any)
+        delete ((bigfish.siblings![0] as any)
           .siblings[1] as BodyComplexModels.Sawshark).picture;
-        delete (bigfish.siblings[1] as BodyComplexModels.Sawshark).picture;
+        delete (bigfish.siblings![1] as BodyComplexModels.Sawshark).picture;
 
         assert.deepEqual(result, bigfish);
         await testClient.polymorphicrecursive.putValid(getBigfish());

--- a/test/integration/bodyString.spec.ts
+++ b/test/integration/bodyString.spec.ts
@@ -58,39 +58,28 @@ describe("Integration tests for BodyString", () => {
 
     it("should correctly deserialize base64 encoded string", async function() {
       const result = await client.string.getBase64Encoded();
-      ok(!!result);
       ok(!!result.body);
 
       const expected = "a string that gets encoded with base64";
       strictEqual((result.body as Buffer).toString("utf8"), expected);
     });
 
-    it("should correctly handle null base64url encoded string", function(done) {
-      client.string.getNullBase64UrlEncoded(function(error, result) {
-        ok(!error, "response should not contain errors");
-        ok(!result, "response should not contain result");
-        done();
-      });
+    it("should correctly handle null base64url encoded string", async () => {
+      const result = await client.string.getNullBase64UrlEncoded();
+      ok(!result.body, "response should not contain result");
     });
 
-    // TODO: Reenable after investigating why the following error is thrown:
-    // test/utils/stringToByteArray.ts:6:16 - error TS2304: Cannot find name 'TextEncoder'.
-    it("should correctly serialize and deserialize base64url encoded string", function(done) {
-      client.string.getBase64UrlEncoded(function(error, result) {
-        ok(!error, "response should not contain errors");
-        ok(!!result, "response should contain a result");
+    it("should correctly serialize and deserialize base64url encoded string", async () => {
+      const result = await client.string.getBase64UrlEncoded();
+      ok(!!result.body, "response should contain a result");
 
-        const decodedString = "a string that gets encoded with base64url";
-        strictEqual((result as Buffer).toString("utf8"), decodedString);
-        client.string.putBase64UrlEncoded(
-          Buffer.from(decodedString, "utf-8"),
-          function(error, result) {
-            ok(!error, "response should not contain errors");
-            ok(!result, "response should not contain result");
-            done();
-          }
-        );
-      });
+      const decodedString = "a string that gets encoded with base64url";
+      strictEqual((result.body as Buffer).toString("utf8"), decodedString);
+      const result2 = await client.string.putBase64UrlEncoded(
+        Buffer.from(decodedString, "utf-8")
+      );
+
+      ok(!result2.body, "response should not contain result");
     });
 
     it("should getEnumReferenced", async function() {

--- a/test/integration/generated/bodyComplex/package.json
+++ b/test/integration/generated/bodyComplex/package.json
@@ -3,11 +3,7 @@
   "author": "Microsoft Corporation",
   "description": "Test Infrastructure for AutoRest",
   "version": "1.0.0-preview1",
-  "dependencies": {
-    "@azure/core-arm": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
-    "tslib": "^1.9.3"
-  },
+  "dependencies": { "@azure/core-http": "^1.0.0", "tslib": "^1.9.3" },
   "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "./dist/bodyString.js",

--- a/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
@@ -13,6 +13,9 @@ const packageName = "bodyString";
 const packageVersion = "1.0.0-preview1";
 
 export class BodyComplexClientContext extends coreHttp.ServiceClient {
+  $host: string;
+  apiVersion: string;
+
   /**
    * Initializes a new instance of the BodyComplexClientContext class.
    *
@@ -32,5 +35,7 @@ export class BodyComplexClientContext extends coreHttp.ServiceClient {
 
     this.baseUri = options.baseUri || this.baseUri || "http://localhost:3000";
     this.requestContentType = "application/json; charset=utf-8";
+    this.$host = "http://localhost:3000";
+    this.apiVersion = "2016-02-29";
   }
 }

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -67,8 +67,8 @@ export interface DoubleWrapper {
  * An interface representing boolean-wrapper.
  */
 export interface BooleanWrapper {
-  fieldTrue?: any;
-  fieldFalse?: any;
+  fieldTrue?: boolean;
+  fieldFalse?: boolean;
 }
 
 /**
@@ -84,31 +84,31 @@ export interface StringWrapper {
  * An interface representing date-wrapper.
  */
 export interface DateWrapper {
-  field?: any;
-  leap?: any;
+  field?: Date;
+  leap?: Date;
 }
 
 /**
  * An interface representing datetime-wrapper.
  */
 export interface DatetimeWrapper {
-  field?: any;
-  now?: any;
+  field?: Date;
+  now?: Date;
 }
 
 /**
  * An interface representing datetimerfc1123-wrapper.
  */
 export interface Datetimerfc1123Wrapper {
-  field?: any;
-  now?: any;
+  field?: Date;
+  now?: Date;
 }
 
 /**
  * An interface representing duration-wrapper.
  */
 export interface DurationWrapper {
-  field?: any;
+  field?: string;
 }
 
 /**
@@ -122,7 +122,7 @@ export interface ByteWrapper {
  * An interface representing array-wrapper.
  */
 export interface ArrayWrapper {
-  array?: any;
+  array?: string[];
 }
 
 /**
@@ -132,7 +132,7 @@ export interface DictionaryWrapper {
   /**
    * Dictionary of <components·schemas·dictionary_wrapper·properties·defaultprogram·additionalproperties>
    */
-  defaultProgram?: any;
+  defaultProgram?: { [propertyName: string]: string };
 }
 
 /**
@@ -148,7 +148,7 @@ export interface Pet {
  */
 export interface Cat {
   color?: string;
-  hates?: any;
+  hates?: Dog[];
 }
 
 /**
@@ -172,7 +172,7 @@ export interface Fish {
   fishtype: string;
   species?: string;
   length: number;
-  siblings?: any;
+  siblings?: FishUnion[];
 }
 
 /**
@@ -188,9 +188,9 @@ export interface DotFish {
  */
 export interface DotFishMarket {
   sampleSalmon?: DotSalmon;
-  salmons?: any;
-  sampleFish?: DotFish;
-  fishes?: any;
+  salmons?: DotSalmon[];
+  sampleFish?: DotFishUnion;
+  fishes?: DotFishUnion[];
 }
 
 /**
@@ -198,7 +198,7 @@ export interface DotFishMarket {
  */
 export interface DotSalmon {
   location?: string;
-  iswild?: any;
+  iswild?: boolean;
 }
 
 /**
@@ -206,7 +206,7 @@ export interface DotSalmon {
  */
 export interface Salmon {
   location?: string;
-  iswild?: any;
+  iswild?: boolean;
 }
 
 /**
@@ -244,7 +244,7 @@ export interface SmartSalmon {
  */
 export interface Shark {
   age?: number;
-  birthday: any;
+  birthday: Date;
 }
 
 /**

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -8,6 +8,12 @@
 
 import * as coreHttp from "@azure/core-http";
 
+export type FishUnion = Fish | SalmonUnion | SharkUnion;
+export type DotFishUnion = DotFish | DotSalmon;
+export type SalmonUnion = Salmon | SmartSalmon;
+export type MyBaseTypeUnion = MyBaseType | MyDerivedType;
+export type SharkUnion = Shark | Sawshark | Goblinshark | Cookiecuttershark;
+
 /**
  * An interface representing basic.
  */
@@ -146,30 +152,39 @@ export interface Pet {
 /**
  * An interface representing cat.
  */
-export interface Cat {
+export type Cat = Pet & {
   color?: string;
   hates?: Dog[];
-}
+};
 
 /**
  * An interface representing dog.
  */
-export interface Dog {
+export type Dog = Pet & {
   food?: string;
-}
+};
 
 /**
  * An interface representing siamese.
  */
-export interface Siamese {
+export type Siamese = Cat & {
   breed?: string;
-}
+};
 
 /**
  * An interface representing Fish.
  */
 export interface Fish {
-  fishtype: string;
+  /**
+   * Polymorphic discriminator
+   */
+  fishtype:
+    | "salmon"
+    | "smart_salmon"
+    | "shark"
+    | "sawshark"
+    | "goblin"
+    | "cookiecuttershark";
   species?: string;
   length: number;
   siblings?: FishUnion[];
@@ -179,6 +194,10 @@ export interface Fish {
  * An interface representing DotFish.
  */
 export interface DotFish {
+  /**
+   * Polymorphic discriminator
+   */
+  "fish.type": "DotSalmon";
   fishType: string;
   species?: string;
 }
@@ -196,18 +215,18 @@ export interface DotFishMarket {
 /**
  * An interface representing DotSalmon.
  */
-export interface DotSalmon {
+export type DotSalmon = DotFish & {
   location?: string;
   iswild?: boolean;
-}
+};
 
 /**
  * An interface representing salmon.
  */
-export interface Salmon {
+export type Salmon = Fish & {
   location?: string;
   iswild?: boolean;
-}
+};
 
 /**
  * An interface representing readonly-obj.
@@ -221,6 +240,10 @@ export interface ReadonlyObj {
  * An interface representing MyBaseType.
  */
 export interface MyBaseType {
+  /**
+   * Polymorphic discriminator
+   */
+  kind: "Kind1";
   propB1?: string;
   helper?: MyBaseHelperType;
 }
@@ -235,48 +258,51 @@ export interface MyBaseHelperType {
 /**
  * An interface representing smart_salmon.
  */
-export interface SmartSalmon {
+export type SmartSalmon = Salmon & {
+  /**
+   * Describes unknown properties. The value of an unknown property can be of "any" type.
+   */
+  [property: string]: any;
   collegeDegree?: string;
-}
+};
 
 /**
  * An interface representing shark.
  */
-export interface Shark {
+export type Shark = Fish & {
   age?: number;
   birthday: Date;
-}
+};
 
 /**
  * An interface representing sawshark.
  */
-export interface Sawshark {
+export type Sawshark = Shark & {
   picture?: Uint8Array;
-}
+};
 
 /**
  * An interface representing goblinshark.
  */
-export interface Goblinshark {
+export type Goblinshark = Shark & {
   jawsize?: number;
   /**
    * Colors possible
    */
   color?: GoblinSharkColor;
-}
+};
 
 /**
  * An interface representing cookiecuttershark.
  */
-export interface Cookiecuttershark {}
+export type Cookiecuttershark = Shark & {};
 
 /**
  * An interface representing MyDerivedType.
  */
-export interface MyDerivedType {
+export type MyDerivedType = MyBaseType & {
   propD1?: string;
-}
-
+};
 /**
  * Defines values for CMYKColors.
  */
@@ -285,3 +311,663 @@ export type CMYKColors = "cyan" | "Magenta" | "YELLOW" | "blacK";
  * Defines values for GoblinSharkColor.
  */
 export type GoblinSharkColor = "pink" | "gray" | "brown" | "RED" | "red";
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type BasicGetValidResponse = Basic & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Basic;
+  };
+};
+
+/**
+ * Contains response data for the getInvalid operation.
+ */
+export type BasicGetInvalidResponse = Basic & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Basic;
+  };
+};
+
+/**
+ * Contains response data for the getEmpty operation.
+ */
+export type BasicGetEmptyResponse = Basic & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Basic;
+  };
+};
+
+/**
+ * Contains response data for the getNull operation.
+ */
+export type BasicGetNullResponse = Basic & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Basic;
+  };
+};
+
+/**
+ * Contains response data for the getNotProvided operation.
+ */
+export type BasicGetNotProvidedResponse = Basic & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Basic;
+  };
+};
+
+/**
+ * Contains response data for the getInt operation.
+ */
+export type PrimitiveGetIntResponse = IntWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: IntWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getLong operation.
+ */
+export type PrimitiveGetLongResponse = LongWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: LongWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getFloat operation.
+ */
+export type PrimitiveGetFloatResponse = FloatWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: FloatWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getDouble operation.
+ */
+export type PrimitiveGetDoubleResponse = DoubleWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DoubleWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getBool operation.
+ */
+export type PrimitiveGetBoolResponse = BooleanWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: BooleanWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getString operation.
+ */
+export type PrimitiveGetStringResponse = StringWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: StringWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getDate operation.
+ */
+export type PrimitiveGetDateResponse = DateWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DateWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getDateTime operation.
+ */
+export type PrimitiveGetDateTimeResponse = DatetimeWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DatetimeWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getDateTimeRfc1123 operation.
+ */
+export type PrimitiveGetDateTimeRfc1123Response = Datetimerfc1123Wrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Datetimerfc1123Wrapper;
+  };
+};
+
+/**
+ * Contains response data for the getDuration operation.
+ */
+export type PrimitiveGetDurationResponse = DurationWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DurationWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getByte operation.
+ */
+export type PrimitiveGetByteResponse = ByteWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ByteWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type ArrayGetValidResponse = ArrayWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ArrayWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getEmpty operation.
+ */
+export type ArrayGetEmptyResponse = ArrayWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ArrayWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getNotProvided operation.
+ */
+export type ArrayGetNotProvidedResponse = ArrayWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ArrayWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type DictionaryGetValidResponse = DictionaryWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DictionaryWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getEmpty operation.
+ */
+export type DictionaryGetEmptyResponse = DictionaryWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DictionaryWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getNull operation.
+ */
+export type DictionaryGetNullResponse = DictionaryWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DictionaryWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getNotProvided operation.
+ */
+export type DictionaryGetNotProvidedResponse = DictionaryWrapper & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DictionaryWrapper;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type InheritanceGetValidResponse = Siamese & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Siamese;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type PolymorphismGetValidResponse = FishUnion & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: FishUnion;
+  };
+};
+
+/**
+ * Contains response data for the getDotSyntax operation.
+ */
+export type PolymorphismGetDotSyntaxResponse = DotFishUnion & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DotFishUnion;
+  };
+};
+
+/**
+ * Contains response data for the getComposedWithDiscriminator operation.
+ */
+export type PolymorphismGetComposedWithDiscriminatorResponse = DotFishMarket & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DotFishMarket;
+  };
+};
+
+/**
+ * Contains response data for the getComposedWithoutDiscriminator operation.
+ */
+export type PolymorphismGetComposedWithoutDiscriminatorResponse = DotFishMarket & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: DotFishMarket;
+  };
+};
+
+/**
+ * Contains response data for the getComplicated operation.
+ */
+export type PolymorphismGetComplicatedResponse = SalmonUnion & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: SalmonUnion;
+  };
+};
+
+/**
+ * Contains response data for the putMissingDiscriminator operation.
+ */
+export type PolymorphismPutMissingDiscriminatorResponse = SalmonUnion & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: SalmonUnion;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type PolymorphicrecursiveGetValidResponse = FishUnion & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: FishUnion;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type ReadonlypropertyGetValidResponse = ReadonlyObj & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: ReadonlyObj;
+  };
+};
+
+/**
+ * Contains response data for the getValid operation.
+ */
+export type FlattencomplexGetValidResponse = MyBaseTypeUnion & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: MyBaseTypeUnion;
+  };
+};

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -176,7 +176,7 @@ export type Siamese = Cat & {
  */
 export interface Fish {
   /**
-   * Polymorphic discriminator
+   * Polymorphic discriminator, which specifies the different types this object can be
    */
   fishtype:
     | "salmon"
@@ -195,7 +195,7 @@ export interface Fish {
  */
 export interface DotFish {
   /**
-   * Polymorphic discriminator
+   * Polymorphic discriminator, which specifies the different types this object can be
    */
   "fish.type": "DotSalmon";
   fishType: string;
@@ -241,7 +241,7 @@ export interface ReadonlyObj {
  */
 export interface MyBaseType {
   /**
-   * Polymorphic discriminator
+   * Polymorphic discriminator, which specifies the different types this object can be
    */
   kind: "Kind1";
   propB1?: string;

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -32,27 +32,10 @@ export class Array {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.ArrayGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.ArrayGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.ArrayGetValidResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Array {
   putValid(
     complexBody: Models.ArrayWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.ArrayWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.ArrayWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.ArrayWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -101,27 +60,10 @@ export class Array {
    */
   getEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.ArrayGetEmptyResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.ArrayGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getEmptyOperationSpec,
-      callback
+      getEmptyOperationSpec
     ) as Promise<Models.ArrayGetEmptyResponse>;
   }
 
@@ -133,34 +75,10 @@ export class Array {
   putEmpty(
     complexBody: Models.ArrayWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"
-   * @param callback The callback.
-   */
-  putEmpty(
-    complexBody: Models.ArrayWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putEmpty(
-    complexBody: Models.ArrayWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putEmpty(
-    complexBody: Models.ArrayWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putEmptyOperationSpec,
-      callback
+      putEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -170,27 +88,10 @@ export class Array {
    */
   getNotProvided(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.ArrayGetNotProvidedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNotProvided(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNotProvided(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNotProvided(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.ArrayGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNotProvidedOperationSpec,
-      callback
+      getNotProvidedOperationSpec
     ) as Promise<Models.ArrayGetNotProvidedResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -30,7 +30,9 @@ export class Array {
    * Get complex types with array property
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.ArrayGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Array {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.ArrayGetValidResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Array {
   putValid(
     complexBody: Models.ArrayWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"
    * @param callback The callback.
@@ -90,14 +92,16 @@ export class Array {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with array property which is empty
    * @param options The options parameters.
    */
-  getEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.ArrayGetEmptyResponse>;
   /**
    * @param callback The callback.
    */
@@ -118,7 +122,7 @@ export class Array {
       { options },
       getEmptyOperationSpec,
       callback
-    );
+    ) as Promise<Models.ArrayGetEmptyResponse>;
   }
 
   /**
@@ -129,7 +133,7 @@ export class Array {
   putEmpty(
     complexBody: Models.ArrayWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog"
    * @param callback The callback.
@@ -157,14 +161,16 @@ export class Array {
       { complexBody, options },
       putEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with array property while server doesn't provide a response payload
    * @param options The options parameters.
    */
-  getNotProvided(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNotProvided(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.ArrayGetNotProvidedResponse>;
   /**
    * @param callback The callback.
    */
@@ -185,7 +191,7 @@ export class Array {
       { options },
       getNotProvidedOperationSpec,
       callback
-    );
+    ) as Promise<Models.ArrayGetNotProvidedResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -46,7 +46,7 @@ export class Array {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.ArrayGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -85,7 +85,7 @@ export class Array {
     complexBody: Models.ArrayWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,
@@ -113,7 +113,7 @@ export class Array {
   getEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.ArrayGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
       getEmptyOperationSpec,
@@ -152,7 +152,7 @@ export class Array {
     complexBody: Models.ArrayWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putEmptyOperationSpec,
@@ -180,7 +180,7 @@ export class Array {
   getNotProvided(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.ArrayGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNotProvidedOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/basic.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basic.ts
@@ -46,7 +46,7 @@ export class Basic {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.BasicGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -85,7 +85,7 @@ export class Basic {
     complexBody: Models.Basic,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,
@@ -113,7 +113,7 @@ export class Basic {
   getInvalid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.BasicGetInvalidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getInvalidOperationSpec,
@@ -141,7 +141,7 @@ export class Basic {
   getEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.BasicGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
       getEmptyOperationSpec,
@@ -169,7 +169,7 @@ export class Basic {
   getNull(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.BasicGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNullOperationSpec,
@@ -197,7 +197,7 @@ export class Basic {
   getNotProvided(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.BasicGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNotProvidedOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/basic.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basic.ts
@@ -30,7 +30,9 @@ export class Basic {
    * Get complex type {id: 2, name: 'abc', color: 'YELLOW'}
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.BasicGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Basic {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.BasicGetValidResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Basic {
   putValid(
     complexBody: Models.Basic,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
    * @param callback The callback.
@@ -90,14 +92,16 @@ export class Basic {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get a basic complex type that is invalid for the local strong type
    * @param options The options parameters.
    */
-  getInvalid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getInvalid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.BasicGetInvalidResponse>;
   /**
    * @param callback The callback.
    */
@@ -118,14 +122,16 @@ export class Basic {
       { options },
       getInvalidOperationSpec,
       callback
-    );
+    ) as Promise<Models.BasicGetInvalidResponse>;
   }
 
   /**
    * Get a basic complex type that is empty
    * @param options The options parameters.
    */
-  getEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.BasicGetEmptyResponse>;
   /**
    * @param callback The callback.
    */
@@ -146,14 +152,16 @@ export class Basic {
       { options },
       getEmptyOperationSpec,
       callback
-    );
+    ) as Promise<Models.BasicGetEmptyResponse>;
   }
 
   /**
    * Get a basic complex type whose properties are null
    * @param options The options parameters.
    */
-  getNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNull(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.BasicGetNullResponse>;
   /**
    * @param callback The callback.
    */
@@ -174,14 +182,16 @@ export class Basic {
       { options },
       getNullOperationSpec,
       callback
-    );
+    ) as Promise<Models.BasicGetNullResponse>;
   }
 
   /**
    * Get a basic complex type while the server doesn't provide a response payload
    * @param options The options parameters.
    */
-  getNotProvided(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNotProvided(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.BasicGetNotProvidedResponse>;
   /**
    * @param callback The callback.
    */
@@ -202,7 +212,7 @@ export class Basic {
       { options },
       getNotProvidedOperationSpec,
       callback
-    );
+    ) as Promise<Models.BasicGetNotProvidedResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/basic.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basic.ts
@@ -32,27 +32,10 @@ export class Basic {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BasicGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.BasicGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.BasicGetValidResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Basic {
   putValid(
     complexBody: Models.Basic,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.Basic,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put {id: 2, name: 'abc', color: 'Magenta'}
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.Basic,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.Basic,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -101,27 +60,10 @@ export class Basic {
    */
   getInvalid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BasicGetInvalidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getInvalid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getInvalid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getInvalid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.BasicGetInvalidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getInvalidOperationSpec,
-      callback
+      getInvalidOperationSpec
     ) as Promise<Models.BasicGetInvalidResponse>;
   }
 
@@ -131,27 +73,10 @@ export class Basic {
    */
   getEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BasicGetEmptyResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.BasicGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getEmptyOperationSpec,
-      callback
+      getEmptyOperationSpec
     ) as Promise<Models.BasicGetEmptyResponse>;
   }
 
@@ -161,27 +86,10 @@ export class Basic {
    */
   getNull(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BasicGetNullResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNull(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNull(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.BasicGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNullOperationSpec,
-      callback
+      getNullOperationSpec
     ) as Promise<Models.BasicGetNullResponse>;
   }
 
@@ -191,27 +99,10 @@ export class Basic {
    */
   getNotProvided(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.BasicGetNotProvidedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNotProvided(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNotProvided(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNotProvided(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.BasicGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNotProvidedOperationSpec,
-      callback
+      getNotProvidedOperationSpec
     ) as Promise<Models.BasicGetNotProvidedResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -32,27 +32,10 @@ export class Dictionary {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DictionaryGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.DictionaryGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.DictionaryGetValidResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Dictionary {
   putValid(
     complexBody: Models.DictionaryWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.DictionaryWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.DictionaryWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.DictionaryWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -101,27 +60,10 @@ export class Dictionary {
    */
   getEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DictionaryGetEmptyResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.DictionaryGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getEmptyOperationSpec,
-      callback
+      getEmptyOperationSpec
     ) as Promise<Models.DictionaryGetEmptyResponse>;
   }
 
@@ -133,34 +75,10 @@ export class Dictionary {
   putEmpty(
     complexBody: Models.DictionaryWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
-   * @param callback The callback.
-   */
-  putEmpty(
-    complexBody: Models.DictionaryWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putEmpty(
-    complexBody: Models.DictionaryWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putEmpty(
-    complexBody: Models.DictionaryWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putEmptyOperationSpec,
-      callback
+      putEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -170,27 +88,10 @@ export class Dictionary {
    */
   getNull(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DictionaryGetNullResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNull(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNull(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.DictionaryGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNullOperationSpec,
-      callback
+      getNullOperationSpec
     ) as Promise<Models.DictionaryGetNullResponse>;
   }
 
@@ -200,27 +101,10 @@ export class Dictionary {
    */
   getNotProvided(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.DictionaryGetNotProvidedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNotProvided(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNotProvided(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNotProvided(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.DictionaryGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNotProvidedOperationSpec,
-      callback
+      getNotProvidedOperationSpec
     ) as Promise<Models.DictionaryGetNotProvidedResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -30,7 +30,9 @@ export class Dictionary {
    * Get complex types with dictionary property
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.DictionaryGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Dictionary {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.DictionaryGetValidResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Dictionary {
   putValid(
     complexBody: Models.DictionaryWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
    * @param callback The callback.
@@ -90,14 +92,16 @@ export class Dictionary {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with dictionary property which is empty
    * @param options The options parameters.
    */
-  getEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.DictionaryGetEmptyResponse>;
   /**
    * @param callback The callback.
    */
@@ -118,7 +122,7 @@ export class Dictionary {
       { options },
       getEmptyOperationSpec,
       callback
-    );
+    ) as Promise<Models.DictionaryGetEmptyResponse>;
   }
 
   /**
@@ -129,7 +133,7 @@ export class Dictionary {
   putEmpty(
     complexBody: Models.DictionaryWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null
    * @param callback The callback.
@@ -157,14 +161,16 @@ export class Dictionary {
       { complexBody, options },
       putEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with dictionary property which is null
    * @param options The options parameters.
    */
-  getNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNull(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.DictionaryGetNullResponse>;
   /**
    * @param callback The callback.
    */
@@ -185,14 +191,16 @@ export class Dictionary {
       { options },
       getNullOperationSpec,
       callback
-    );
+    ) as Promise<Models.DictionaryGetNullResponse>;
   }
 
   /**
    * Get complex types with dictionary property while server doesn't provide a response payload
    * @param options The options parameters.
    */
-  getNotProvided(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNotProvided(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.DictionaryGetNotProvidedResponse>;
   /**
    * @param callback The callback.
    */
@@ -213,7 +221,7 @@ export class Dictionary {
       { options },
       getNotProvidedOperationSpec,
       callback
-    );
+    ) as Promise<Models.DictionaryGetNotProvidedResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -46,7 +46,7 @@ export class Dictionary {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.DictionaryGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -85,7 +85,7 @@ export class Dictionary {
     complexBody: Models.DictionaryWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,
@@ -113,7 +113,7 @@ export class Dictionary {
   getEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.DictionaryGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
       getEmptyOperationSpec,
@@ -152,7 +152,7 @@ export class Dictionary {
     complexBody: Models.DictionaryWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putEmptyOperationSpec,
@@ -180,7 +180,7 @@ export class Dictionary {
   getNull(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.DictionaryGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNullOperationSpec,
@@ -208,7 +208,7 @@ export class Dictionary {
   getNotProvided(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.DictionaryGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNotProvidedOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
+++ b/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
@@ -32,27 +32,10 @@ export class Flattencomplex {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.FlattencomplexGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.FlattencomplexGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.FlattencomplexGetValidResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
+++ b/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
@@ -30,7 +30,9 @@ export class Flattencomplex {
    * MISSING·OPERATION-DESCRIPTION
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.FlattencomplexGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Flattencomplex {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.FlattencomplexGetValidResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
+++ b/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
@@ -46,7 +46,7 @@ export class Flattencomplex {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.FlattencomplexGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -46,7 +46,7 @@ export class Inheritance {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.InheritanceGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -85,7 +85,7 @@ export class Inheritance {
     complexBody: Models.Siamese,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -30,7 +30,9 @@ export class Inheritance {
    * Get complex types that extend others
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.InheritanceGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Inheritance {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.InheritanceGetValidResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Inheritance {
   putValid(
     complexBody: Models.Siamese,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
    * @param callback The callback.
@@ -90,7 +92,7 @@ export class Inheritance {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -32,27 +32,10 @@ export class Inheritance {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.InheritanceGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.InheritanceGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.InheritanceGetValidResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Inheritance {
   putValid(
     complexBody: Models.Siamese,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.Siamese,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries".
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.Siamese,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.Siamese,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -46,7 +46,7 @@ export class Polymorphicrecursive {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphicrecursiveGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -181,7 +181,7 @@ export class Polymorphicrecursive {
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -30,7 +30,9 @@ export class Polymorphicrecursive {
    * Get complex types that are polymorphic and have recursive references
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PolymorphicrecursiveGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Polymorphicrecursive {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphicrecursiveGetValidResponse>;
   }
 
   /**
@@ -94,7 +96,7 @@ export class Polymorphicrecursive {
   putValid(
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put a salmon that looks like this:
    * {
@@ -186,7 +188,7 @@ export class Polymorphicrecursive {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -32,27 +32,10 @@ export class Polymorphicrecursive {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphicrecursiveGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphicrecursiveGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.PolymorphicrecursiveGetValidResponse>;
   }
 
@@ -96,98 +79,10 @@ export class Polymorphicrecursive {
   putValid(
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put a salmon that looks like this:
-   * {
-   *         'fishtype':'Salmon',
-   *         'location':'alaska',
-   *         'iswild':true,
-   *         'species':'king',
-   *         'length':1.0,
-   *         'siblings':[
-   *           {
-   *             'fishtype':'Shark',
-   *             'age':6,
-   *             'birthday': '2012-01-05T01:00:00Z',
-   *             'length':20.0,
-   *             'species':'predator',
-   *           },
-   *           {
-   *             'fishtype':'Sawshark',
-   *             'age':105,
-   *             'birthday': '1900-01-05T01:00:00Z',
-   *             'length':10.0,
-   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *             'species':'dangerous',
-   *           },
-   *           {
-   *             'fishtype': 'goblin',
-   *             'age': 1,
-   *             'birthday': '2015-08-08T00:00:00Z',
-   *             'length': 30.0,
-   *             'species': 'scary',
-   *             'jawsize': 5
-   *           }
-   *         ]
-   *       };
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.FishUnion,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put a salmon that looks like this:
-   * {
-   *         'fishtype':'Salmon',
-   *         'location':'alaska',
-   *         'iswild':true,
-   *         'species':'king',
-   *         'length':1.0,
-   *         'siblings':[
-   *           {
-   *             'fishtype':'Shark',
-   *             'age':6,
-   *             'birthday': '2012-01-05T01:00:00Z',
-   *             'length':20.0,
-   *             'species':'predator',
-   *           },
-   *           {
-   *             'fishtype':'Sawshark',
-   *             'age':105,
-   *             'birthday': '1900-01-05T01:00:00Z',
-   *             'length':10.0,
-   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *             'species':'dangerous',
-   *           },
-   *           {
-   *             'fishtype': 'goblin',
-   *             'age': 1,
-   *             'birthday': '2015-08-08T00:00:00Z',
-   *             'length': 30.0,
-   *             'species': 'scary',
-   *             'jawsize': 5
-   *           }
-   *         ]
-   *       };
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.FishUnion,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.FishUnion,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -92,7 +92,7 @@ export class Polymorphicrecursive {
    * @param options The options parameters.
    */
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -132,7 +132,7 @@ export class Polymorphicrecursive {
    * @param callback The callback.
    */
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -173,12 +173,12 @@ export class Polymorphicrecursive {
    * @param callback The callback.
    */
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -92,7 +92,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -132,7 +132,7 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -173,12 +173,12 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   putValid(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {
@@ -313,7 +313,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   putComplicated(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -321,7 +321,7 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putComplicated(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -330,12 +330,12 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putComplicated(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   putComplicated(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {
@@ -352,7 +352,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   putMissingDiscriminator(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -360,7 +360,7 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putMissingDiscriminator(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -369,12 +369,12 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putMissingDiscriminator(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   putMissingDiscriminator(
-    complexBody: Models.Salmon,
+    complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {
@@ -423,7 +423,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   putValidMissingRequired(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -463,7 +463,7 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putValidMissingRequired(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -504,12 +504,12 @@ export class Polymorphism {
    * @param callback The callback.
    */
   putValidMissingRequired(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   putValidMissingRequired(
-    complexBody: Models.Fish,
+    complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -30,7 +30,9 @@ export class Polymorphism {
    * Get complex types that are polymorphic
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PolymorphismGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Polymorphism {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphismGetValidResponse>;
   }
 
   /**
@@ -94,7 +96,7 @@ export class Polymorphism {
   putValid(
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put a salmon that looks like this:
    * {
@@ -186,14 +188,16 @@ export class Polymorphism {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types that are polymorphic, JSON key contains a dot
    * @param options The options parameters.
    */
-  getDotSyntax(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getDotSyntax(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PolymorphismGetDotSyntaxResponse>;
   /**
    * @param callback The callback.
    */
@@ -214,7 +218,7 @@ export class Polymorphism {
       { options },
       getDotSyntaxOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphismGetDotSyntaxResponse>;
   }
 
   /**
@@ -223,7 +227,7 @@ export class Polymorphism {
    */
   getComposedWithDiscriminator(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse>;
   /**
    * @param callback The callback.
    */
@@ -244,7 +248,7 @@ export class Polymorphism {
       { options },
       getComposedWithDiscriminatorOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse>;
   }
 
   /**
@@ -253,7 +257,7 @@ export class Polymorphism {
    */
   getComposedWithoutDiscriminator(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse>;
   /**
    * @param callback The callback.
    */
@@ -276,14 +280,16 @@ export class Polymorphism {
       { options },
       getComposedWithoutDiscriminatorOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse>;
   }
 
   /**
    * Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties
    * @param options The options parameters.
    */
-  getComplicated(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getComplicated(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PolymorphismGetComplicatedResponse>;
   /**
    * @param callback The callback.
    */
@@ -304,7 +310,7 @@ export class Polymorphism {
       { options },
       getComplicatedOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphismGetComplicatedResponse>;
   }
 
   /**
@@ -315,7 +321,7 @@ export class Polymorphism {
   putComplicated(
     complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody
    * @param callback The callback.
@@ -343,7 +349,7 @@ export class Polymorphism {
       { complexBody, options },
       putComplicatedOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -354,7 +360,7 @@ export class Polymorphism {
   putMissingDiscriminator(
     complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
   /**
    * @param complexBody
    * @param callback The callback.
@@ -382,7 +388,7 @@ export class Polymorphism {
       { complexBody, options },
       putMissingDiscriminatorOperationSpec,
       callback
-    );
+    ) as Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
   }
 
   /**
@@ -425,7 +431,7 @@ export class Polymorphism {
   putValidMissingRequired(
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put a salmon that looks like this:
    * {
@@ -517,7 +523,7 @@ export class Polymorphism {
       { complexBody, options },
       putValidMissingRequiredOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -32,27 +32,10 @@ export class Polymorphism {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphismGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphismGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.PolymorphismGetValidResponse>;
   }
 
@@ -96,98 +79,10 @@ export class Polymorphism {
   putValid(
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put a salmon that looks like this:
-   * {
-   *         'fishtype':'Salmon',
-   *         'location':'alaska',
-   *         'iswild':true,
-   *         'species':'king',
-   *         'length':1.0,
-   *         'siblings':[
-   *           {
-   *             'fishtype':'Shark',
-   *             'age':6,
-   *             'birthday': '2012-01-05T01:00:00Z',
-   *             'length':20.0,
-   *             'species':'predator',
-   *           },
-   *           {
-   *             'fishtype':'Sawshark',
-   *             'age':105,
-   *             'birthday': '1900-01-05T01:00:00Z',
-   *             'length':10.0,
-   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *             'species':'dangerous',
-   *           },
-   *           {
-   *             'fishtype': 'goblin',
-   *             'age': 1,
-   *             'birthday': '2015-08-08T00:00:00Z',
-   *             'length': 30.0,
-   *             'species': 'scary',
-   *             'jawsize': 5
-   *           }
-   *         ]
-   *       };
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.FishUnion,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put a salmon that looks like this:
-   * {
-   *         'fishtype':'Salmon',
-   *         'location':'alaska',
-   *         'iswild':true,
-   *         'species':'king',
-   *         'length':1.0,
-   *         'siblings':[
-   *           {
-   *             'fishtype':'Shark',
-   *             'age':6,
-   *             'birthday': '2012-01-05T01:00:00Z',
-   *             'length':20.0,
-   *             'species':'predator',
-   *           },
-   *           {
-   *             'fishtype':'Sawshark',
-   *             'age':105,
-   *             'birthday': '1900-01-05T01:00:00Z',
-   *             'length':10.0,
-   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *             'species':'dangerous',
-   *           },
-   *           {
-   *             'fishtype': 'goblin',
-   *             'age': 1,
-   *             'birthday': '2015-08-08T00:00:00Z',
-   *             'length': 30.0,
-   *             'species': 'scary',
-   *             'jawsize': 5
-   *           }
-   *         ]
-   *       };
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.FishUnion,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.FishUnion,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -197,27 +92,10 @@ export class Polymorphism {
    */
   getDotSyntax(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphismGetDotSyntaxResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getDotSyntax(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getDotSyntax(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getDotSyntax(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphismGetDotSyntaxResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getDotSyntaxOperationSpec,
-      callback
+      getDotSyntaxOperationSpec
     ) as Promise<Models.PolymorphismGetDotSyntaxResponse>;
   }
 
@@ -227,27 +105,10 @@ export class Polymorphism {
    */
   getComposedWithDiscriminator(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getComposedWithDiscriminator(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getComposedWithDiscriminator(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getComposedWithDiscriminator(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getComposedWithDiscriminatorOperationSpec,
-      callback
+      getComposedWithDiscriminatorOperationSpec
     ) as Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse>;
   }
 
@@ -257,29 +118,10 @@ export class Polymorphism {
    */
   getComposedWithoutDiscriminator(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getComposedWithoutDiscriminator(
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getComposedWithoutDiscriminator(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getComposedWithoutDiscriminator(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getComposedWithoutDiscriminatorOperationSpec,
-      callback
+      getComposedWithoutDiscriminatorOperationSpec
     ) as Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse>;
   }
 
@@ -289,27 +131,10 @@ export class Polymorphism {
    */
   getComplicated(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphismGetComplicatedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getComplicated(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getComplicated(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getComplicated(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphismGetComplicatedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getComplicatedOperationSpec,
-      callback
+      getComplicatedOperationSpec
     ) as Promise<Models.PolymorphismGetComplicatedResponse>;
   }
 
@@ -321,34 +146,10 @@ export class Polymorphism {
   putComplicated(
     complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody
-   * @param callback The callback.
-   */
-  putComplicated(
-    complexBody: Models.SalmonUnion,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putComplicated(
-    complexBody: Models.SalmonUnion,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putComplicated(
-    complexBody: Models.SalmonUnion,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putComplicatedOperationSpec,
-      callback
+      putComplicatedOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -360,34 +161,10 @@ export class Polymorphism {
   putMissingDiscriminator(
     complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
-  /**
-   * @param complexBody
-   * @param callback The callback.
-   */
-  putMissingDiscriminator(
-    complexBody: Models.SalmonUnion,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putMissingDiscriminator(
-    complexBody: Models.SalmonUnion,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putMissingDiscriminator(
-    complexBody: Models.SalmonUnion,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PolymorphismPutMissingDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putMissingDiscriminatorOperationSpec,
-      callback
+      putMissingDiscriminatorOperationSpec
     ) as Promise<Models.PolymorphismPutMissingDiscriminatorResponse>;
   }
 
@@ -431,98 +208,10 @@ export class Polymorphism {
   putValidMissingRequired(
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put a salmon that looks like this:
-   * {
-   *         'fishtype':'Salmon',
-   *         'location':'alaska',
-   *         'iswild':true,
-   *         'species':'king',
-   *         'length':1.0,
-   *         'siblings':[
-   *           {
-   *             'fishtype':'Shark',
-   *             'age':6,
-   *             'birthday': '2012-01-05T01:00:00Z',
-   *             'length':20.0,
-   *             'species':'predator',
-   *           },
-   *           {
-   *             'fishtype':'Sawshark',
-   *             'age':105,
-   *             'birthday': '1900-01-05T01:00:00Z',
-   *             'length':10.0,
-   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *             'species':'dangerous',
-   *           },
-   *           {
-   *             'fishtype': 'goblin',
-   *             'age': 1,
-   *             'birthday': '2015-08-08T00:00:00Z',
-   *             'length': 30.0,
-   *             'species': 'scary',
-   *             'jawsize': 5
-   *           }
-   *         ]
-   *       };
-   * @param callback The callback.
-   */
-  putValidMissingRequired(
-    complexBody: Models.FishUnion,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put a salmon that looks like this:
-   * {
-   *         'fishtype':'Salmon',
-   *         'location':'alaska',
-   *         'iswild':true,
-   *         'species':'king',
-   *         'length':1.0,
-   *         'siblings':[
-   *           {
-   *             'fishtype':'Shark',
-   *             'age':6,
-   *             'birthday': '2012-01-05T01:00:00Z',
-   *             'length':20.0,
-   *             'species':'predator',
-   *           },
-   *           {
-   *             'fishtype':'Sawshark',
-   *             'age':105,
-   *             'birthday': '1900-01-05T01:00:00Z',
-   *             'length':10.0,
-   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *             'species':'dangerous',
-   *           },
-   *           {
-   *             'fishtype': 'goblin',
-   *             'age': 1,
-   *             'birthday': '2015-08-08T00:00:00Z',
-   *             'length': 30.0,
-   *             'species': 'scary',
-   *             'jawsize': 5
-   *           }
-   *         ]
-   *       };
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValidMissingRequired(
-    complexBody: Models.FishUnion,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValidMissingRequired(
-    complexBody: Models.FishUnion,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidMissingRequiredOperationSpec,
-      callback
+      putValidMissingRequiredOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -46,7 +46,7 @@ export class Polymorphism {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphismGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -181,7 +181,7 @@ export class Polymorphism {
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,
@@ -209,7 +209,7 @@ export class Polymorphism {
   getDotSyntax(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphismGetDotSyntaxResponse> {
     return this.client.sendOperationRequest(
       { options },
       getDotSyntaxOperationSpec,
@@ -239,7 +239,7 @@ export class Polymorphism {
   getComposedWithDiscriminator(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { options },
       getComposedWithDiscriminatorOperationSpec,
@@ -271,7 +271,7 @@ export class Polymorphism {
   getComposedWithoutDiscriminator(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { options },
       getComposedWithoutDiscriminatorOperationSpec,
@@ -299,7 +299,7 @@ export class Polymorphism {
   getComplicated(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphismGetComplicatedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getComplicatedOperationSpec,
@@ -338,7 +338,7 @@ export class Polymorphism {
     complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putComplicatedOperationSpec,
@@ -377,7 +377,7 @@ export class Polymorphism {
     complexBody: Models.SalmonUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PolymorphismPutMissingDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putMissingDiscriminatorOperationSpec,
@@ -512,7 +512,7 @@ export class Polymorphism {
     complexBody: Models.FishUnion,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidMissingRequiredOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/primitive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/primitive.ts
@@ -46,7 +46,7 @@ export class Primitive {
   getInt(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetIntResponse> {
     return this.client.sendOperationRequest(
       { options },
       getIntOperationSpec,
@@ -85,7 +85,7 @@ export class Primitive {
     complexBody: Models.IntWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putIntOperationSpec,
@@ -113,7 +113,7 @@ export class Primitive {
   getLong(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetLongResponse> {
     return this.client.sendOperationRequest(
       { options },
       getLongOperationSpec,
@@ -152,7 +152,7 @@ export class Primitive {
     complexBody: Models.LongWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putLongOperationSpec,
@@ -180,7 +180,7 @@ export class Primitive {
   getFloat(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetFloatResponse> {
     return this.client.sendOperationRequest(
       { options },
       getFloatOperationSpec,
@@ -219,7 +219,7 @@ export class Primitive {
     complexBody: Models.FloatWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putFloatOperationSpec,
@@ -247,7 +247,7 @@ export class Primitive {
   getDouble(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetDoubleResponse> {
     return this.client.sendOperationRequest(
       { options },
       getDoubleOperationSpec,
@@ -286,7 +286,7 @@ export class Primitive {
     complexBody: Models.DoubleWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putDoubleOperationSpec,
@@ -314,7 +314,7 @@ export class Primitive {
   getBool(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetBoolResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBoolOperationSpec,
@@ -353,7 +353,7 @@ export class Primitive {
     complexBody: Models.BooleanWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putBoolOperationSpec,
@@ -381,7 +381,7 @@ export class Primitive {
   getString(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetStringResponse> {
     return this.client.sendOperationRequest(
       { options },
       getStringOperationSpec,
@@ -420,7 +420,7 @@ export class Primitive {
     complexBody: Models.StringWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putStringOperationSpec,
@@ -448,7 +448,7 @@ export class Primitive {
   getDate(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetDateResponse> {
     return this.client.sendOperationRequest(
       { options },
       getDateOperationSpec,
@@ -487,7 +487,7 @@ export class Primitive {
     complexBody: Models.DateWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putDateOperationSpec,
@@ -515,7 +515,7 @@ export class Primitive {
   getDateTime(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetDateTimeResponse> {
     return this.client.sendOperationRequest(
       { options },
       getDateTimeOperationSpec,
@@ -554,7 +554,7 @@ export class Primitive {
     complexBody: Models.DatetimeWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putDateTimeOperationSpec,
@@ -582,7 +582,7 @@ export class Primitive {
   getDateTimeRfc1123(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetDateTimeRfc1123Response> {
     return this.client.sendOperationRequest(
       { options },
       getDateTimeRfc1123OperationSpec,
@@ -621,7 +621,7 @@ export class Primitive {
     complexBody: Models.Datetimerfc1123Wrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putDateTimeRfc1123OperationSpec,
@@ -649,7 +649,7 @@ export class Primitive {
   getDuration(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetDurationResponse> {
     return this.client.sendOperationRequest(
       { options },
       getDurationOperationSpec,
@@ -688,7 +688,7 @@ export class Primitive {
     complexBody: Models.DurationWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putDurationOperationSpec,
@@ -716,7 +716,7 @@ export class Primitive {
   getByte(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.PrimitiveGetByteResponse> {
     return this.client.sendOperationRequest(
       { options },
       getByteOperationSpec,
@@ -755,7 +755,7 @@ export class Primitive {
     complexBody: Models.ByteWrapper,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putByteOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/primitive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/primitive.ts
@@ -32,27 +32,10 @@ export class Primitive {
    */
   getInt(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetIntResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getInt(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getInt(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getInt(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetIntResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getIntOperationSpec,
-      callback
+      getIntOperationSpec
     ) as Promise<Models.PrimitiveGetIntResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Primitive {
   putInt(
     complexBody: Models.IntWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put -1 and 2
-   * @param callback The callback.
-   */
-  putInt(
-    complexBody: Models.IntWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put -1 and 2
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putInt(
-    complexBody: Models.IntWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putInt(
-    complexBody: Models.IntWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putIntOperationSpec,
-      callback
+      putIntOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -101,27 +60,10 @@ export class Primitive {
    */
   getLong(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetLongResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getLong(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getLong(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getLong(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetLongResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getLongOperationSpec,
-      callback
+      getLongOperationSpec
     ) as Promise<Models.PrimitiveGetLongResponse>;
   }
 
@@ -133,34 +75,10 @@ export class Primitive {
   putLong(
     complexBody: Models.LongWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put 1099511627775 and -999511627788
-   * @param callback The callback.
-   */
-  putLong(
-    complexBody: Models.LongWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put 1099511627775 and -999511627788
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putLong(
-    complexBody: Models.LongWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putLong(
-    complexBody: Models.LongWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putLongOperationSpec,
-      callback
+      putLongOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -170,27 +88,10 @@ export class Primitive {
    */
   getFloat(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetFloatResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getFloat(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getFloat(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getFloat(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetFloatResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getFloatOperationSpec,
-      callback
+      getFloatOperationSpec
     ) as Promise<Models.PrimitiveGetFloatResponse>;
   }
 
@@ -202,34 +103,10 @@ export class Primitive {
   putFloat(
     complexBody: Models.FloatWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put 1.05 and -0.003
-   * @param callback The callback.
-   */
-  putFloat(
-    complexBody: Models.FloatWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put 1.05 and -0.003
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putFloat(
-    complexBody: Models.FloatWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putFloat(
-    complexBody: Models.FloatWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putFloatOperationSpec,
-      callback
+      putFloatOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -239,27 +116,10 @@ export class Primitive {
    */
   getDouble(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetDoubleResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getDouble(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getDouble(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getDouble(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetDoubleResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getDoubleOperationSpec,
-      callback
+      getDoubleOperationSpec
     ) as Promise<Models.PrimitiveGetDoubleResponse>;
   }
 
@@ -271,34 +131,10 @@ export class Primitive {
   putDouble(
     complexBody: Models.DoubleWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
-   * @param callback The callback.
-   */
-  putDouble(
-    complexBody: Models.DoubleWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putDouble(
-    complexBody: Models.DoubleWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putDouble(
-    complexBody: Models.DoubleWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putDoubleOperationSpec,
-      callback
+      putDoubleOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -308,27 +144,10 @@ export class Primitive {
    */
   getBool(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetBoolResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBool(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBool(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBool(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetBoolResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBoolOperationSpec,
-      callback
+      getBoolOperationSpec
     ) as Promise<Models.PrimitiveGetBoolResponse>;
   }
 
@@ -340,34 +159,10 @@ export class Primitive {
   putBool(
     complexBody: Models.BooleanWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put true and false
-   * @param callback The callback.
-   */
-  putBool(
-    complexBody: Models.BooleanWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put true and false
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putBool(
-    complexBody: Models.BooleanWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putBool(
-    complexBody: Models.BooleanWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putBoolOperationSpec,
-      callback
+      putBoolOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -377,27 +172,10 @@ export class Primitive {
    */
   getString(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetStringResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getString(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getString(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getString(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetStringResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getStringOperationSpec,
-      callback
+      getStringOperationSpec
     ) as Promise<Models.PrimitiveGetStringResponse>;
   }
 
@@ -409,34 +187,10 @@ export class Primitive {
   putString(
     complexBody: Models.StringWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put 'goodrequest', '', and null
-   * @param callback The callback.
-   */
-  putString(
-    complexBody: Models.StringWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put 'goodrequest', '', and null
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putString(
-    complexBody: Models.StringWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putString(
-    complexBody: Models.StringWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putStringOperationSpec,
-      callback
+      putStringOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -446,27 +200,10 @@ export class Primitive {
    */
   getDate(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetDateResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getDate(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getDate(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getDate(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetDateResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getDateOperationSpec,
-      callback
+      getDateOperationSpec
     ) as Promise<Models.PrimitiveGetDateResponse>;
   }
 
@@ -478,34 +215,10 @@ export class Primitive {
   putDate(
     complexBody: Models.DateWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put '0001-01-01' and '2016-02-29'
-   * @param callback The callback.
-   */
-  putDate(
-    complexBody: Models.DateWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put '0001-01-01' and '2016-02-29'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putDate(
-    complexBody: Models.DateWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putDate(
-    complexBody: Models.DateWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putDateOperationSpec,
-      callback
+      putDateOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -515,27 +228,10 @@ export class Primitive {
    */
   getDateTime(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetDateTimeResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getDateTime(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getDateTime(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getDateTime(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetDateTimeResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getDateTimeOperationSpec,
-      callback
+      getDateTimeOperationSpec
     ) as Promise<Models.PrimitiveGetDateTimeResponse>;
   }
 
@@ -547,34 +243,10 @@ export class Primitive {
   putDateTime(
     complexBody: Models.DatetimeWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
-   * @param callback The callback.
-   */
-  putDateTime(
-    complexBody: Models.DatetimeWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putDateTime(
-    complexBody: Models.DatetimeWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putDateTime(
-    complexBody: Models.DatetimeWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putDateTimeOperationSpec,
-      callback
+      putDateTimeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -584,27 +256,10 @@ export class Primitive {
    */
   getDateTimeRfc1123(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
-  /**
-   * @param callback The callback.
-   */
-  getDateTimeRfc1123(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getDateTimeRfc1123(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getDateTimeRfc1123(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetDateTimeRfc1123Response> {
     return this.client.sendOperationRequest(
       { options },
-      getDateTimeRfc1123OperationSpec,
-      callback
+      getDateTimeRfc1123OperationSpec
     ) as Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
   }
 
@@ -616,34 +271,10 @@ export class Primitive {
   putDateTimeRfc1123(
     complexBody: Models.Datetimerfc1123Wrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
-   * @param callback The callback.
-   */
-  putDateTimeRfc1123(
-    complexBody: Models.Datetimerfc1123Wrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putDateTimeRfc1123(
-    complexBody: Models.Datetimerfc1123Wrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putDateTimeRfc1123(
-    complexBody: Models.Datetimerfc1123Wrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putDateTimeRfc1123OperationSpec,
-      callback
+      putDateTimeRfc1123OperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -653,27 +284,10 @@ export class Primitive {
    */
   getDuration(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetDurationResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getDuration(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getDuration(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getDuration(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetDurationResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getDurationOperationSpec,
-      callback
+      getDurationOperationSpec
     ) as Promise<Models.PrimitiveGetDurationResponse>;
   }
 
@@ -685,34 +299,10 @@ export class Primitive {
   putDuration(
     complexBody: Models.DurationWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put 'P123DT22H14M12.011S'
-   * @param callback The callback.
-   */
-  putDuration(
-    complexBody: Models.DurationWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put 'P123DT22H14M12.011S'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putDuration(
-    complexBody: Models.DurationWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putDuration(
-    complexBody: Models.DurationWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putDurationOperationSpec,
-      callback
+      putDurationOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -722,27 +312,10 @@ export class Primitive {
    */
   getByte(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.PrimitiveGetByteResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getByte(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getByte(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getByte(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.PrimitiveGetByteResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getByteOperationSpec,
-      callback
+      getByteOperationSpec
     ) as Promise<Models.PrimitiveGetByteResponse>;
   }
 
@@ -754,34 +327,10 @@ export class Primitive {
   putByte(
     complexBody: Models.ByteWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
-   * @param callback The callback.
-   */
-  putByte(
-    complexBody: Models.ByteWrapper,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putByte(
-    complexBody: Models.ByteWrapper,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putByte(
-    complexBody: Models.ByteWrapper,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putByteOperationSpec,
-      callback
+      putByteOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/primitive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/primitive.ts
@@ -30,7 +30,9 @@ export class Primitive {
    * Get complex types with integer properties
    * @param options The options parameters.
    */
-  getInt(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getInt(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetIntResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Primitive {
       { options },
       getIntOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetIntResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Primitive {
   putInt(
     complexBody: Models.IntWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put -1 and 2
    * @param callback The callback.
@@ -90,14 +92,16 @@ export class Primitive {
       { complexBody, options },
       putIntOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with long properties
    * @param options The options parameters.
    */
-  getLong(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getLong(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetLongResponse>;
   /**
    * @param callback The callback.
    */
@@ -118,7 +122,7 @@ export class Primitive {
       { options },
       getLongOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetLongResponse>;
   }
 
   /**
@@ -129,7 +133,7 @@ export class Primitive {
   putLong(
     complexBody: Models.LongWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put 1099511627775 and -999511627788
    * @param callback The callback.
@@ -157,14 +161,16 @@ export class Primitive {
       { complexBody, options },
       putLongOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with float properties
    * @param options The options parameters.
    */
-  getFloat(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getFloat(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetFloatResponse>;
   /**
    * @param callback The callback.
    */
@@ -185,7 +191,7 @@ export class Primitive {
       { options },
       getFloatOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetFloatResponse>;
   }
 
   /**
@@ -196,7 +202,7 @@ export class Primitive {
   putFloat(
     complexBody: Models.FloatWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put 1.05 and -0.003
    * @param callback The callback.
@@ -224,14 +230,16 @@ export class Primitive {
       { complexBody, options },
       putFloatOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with double properties
    * @param options The options parameters.
    */
-  getDouble(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getDouble(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetDoubleResponse>;
   /**
    * @param callback The callback.
    */
@@ -252,7 +260,7 @@ export class Primitive {
       { options },
       getDoubleOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetDoubleResponse>;
   }
 
   /**
@@ -263,7 +271,7 @@ export class Primitive {
   putDouble(
     complexBody: Models.DoubleWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005
    * @param callback The callback.
@@ -291,14 +299,16 @@ export class Primitive {
       { complexBody, options },
       putDoubleOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with bool properties
    * @param options The options parameters.
    */
-  getBool(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBool(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetBoolResponse>;
   /**
    * @param callback The callback.
    */
@@ -319,7 +329,7 @@ export class Primitive {
       { options },
       getBoolOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetBoolResponse>;
   }
 
   /**
@@ -330,7 +340,7 @@ export class Primitive {
   putBool(
     complexBody: Models.BooleanWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put true and false
    * @param callback The callback.
@@ -358,14 +368,16 @@ export class Primitive {
       { complexBody, options },
       putBoolOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with string properties
    * @param options The options parameters.
    */
-  getString(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getString(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetStringResponse>;
   /**
    * @param callback The callback.
    */
@@ -386,7 +398,7 @@ export class Primitive {
       { options },
       getStringOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetStringResponse>;
   }
 
   /**
@@ -397,7 +409,7 @@ export class Primitive {
   putString(
     complexBody: Models.StringWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put 'goodrequest', '', and null
    * @param callback The callback.
@@ -425,14 +437,16 @@ export class Primitive {
       { complexBody, options },
       putStringOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with date properties
    * @param options The options parameters.
    */
-  getDate(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getDate(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetDateResponse>;
   /**
    * @param callback The callback.
    */
@@ -453,7 +467,7 @@ export class Primitive {
       { options },
       getDateOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetDateResponse>;
   }
 
   /**
@@ -464,7 +478,7 @@ export class Primitive {
   putDate(
     complexBody: Models.DateWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put '0001-01-01' and '2016-02-29'
    * @param callback The callback.
@@ -492,14 +506,16 @@ export class Primitive {
       { complexBody, options },
       putDateOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with datetime properties
    * @param options The options parameters.
    */
-  getDateTime(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getDateTime(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetDateTimeResponse>;
   /**
    * @param callback The callback.
    */
@@ -520,7 +536,7 @@ export class Primitive {
       { options },
       getDateTimeOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetDateTimeResponse>;
   }
 
   /**
@@ -531,7 +547,7 @@ export class Primitive {
   putDateTime(
     complexBody: Models.DatetimeWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'
    * @param callback The callback.
@@ -559,14 +575,16 @@ export class Primitive {
       { complexBody, options },
       putDateTimeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with datetimeRfc1123 properties
    * @param options The options parameters.
    */
-  getDateTimeRfc1123(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getDateTimeRfc1123(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
   /**
    * @param callback The callback.
    */
@@ -587,7 +605,7 @@ export class Primitive {
       { options },
       getDateTimeRfc1123OperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetDateTimeRfc1123Response>;
   }
 
   /**
@@ -598,7 +616,7 @@ export class Primitive {
   putDateTimeRfc1123(
     complexBody: Models.Datetimerfc1123Wrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'
    * @param callback The callback.
@@ -626,14 +644,16 @@ export class Primitive {
       { complexBody, options },
       putDateTimeRfc1123OperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with duration properties
    * @param options The options parameters.
    */
-  getDuration(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getDuration(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetDurationResponse>;
   /**
    * @param callback The callback.
    */
@@ -654,7 +674,7 @@ export class Primitive {
       { options },
       getDurationOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetDurationResponse>;
   }
 
   /**
@@ -665,7 +685,7 @@ export class Primitive {
   putDuration(
     complexBody: Models.DurationWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put 'P123DT22H14M12.011S'
    * @param callback The callback.
@@ -693,14 +713,16 @@ export class Primitive {
       { complexBody, options },
       putDurationOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get complex types with byte properties
    * @param options The options parameters.
    */
-  getByte(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getByte(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.PrimitiveGetByteResponse>;
   /**
    * @param callback The callback.
    */
@@ -721,7 +743,7 @@ export class Primitive {
       { options },
       getByteOperationSpec,
       callback
-    );
+    ) as Promise<Models.PrimitiveGetByteResponse>;
   }
 
   /**
@@ -732,7 +754,7 @@ export class Primitive {
   putByte(
     complexBody: Models.ByteWrapper,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)
    * @param callback The callback.
@@ -760,7 +782,7 @@ export class Primitive {
       { complexBody, options },
       putByteOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -32,27 +32,10 @@ export class Readonlyproperty {
    */
   getValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.ReadonlypropertyGetValidResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.ReadonlypropertyGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getValidOperationSpec,
-      callback
+      getValidOperationSpec
     ) as Promise<Models.ReadonlypropertyGetValidResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Readonlyproperty {
   putValid(
     complexBody: Models.ReadonlyObj,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param complexBody
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.ReadonlyObj,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param complexBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putValid(
-    complexBody: Models.ReadonlyObj,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putValid(
-    complexBody: Models.ReadonlyObj,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
-      putValidOperationSpec,
-      callback
+      putValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -46,7 +46,7 @@ export class Readonlyproperty {
   getValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.ReadonlypropertyGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
       getValidOperationSpec,
@@ -85,7 +85,7 @@ export class Readonlyproperty {
     complexBody: Models.ReadonlyObj,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
       putValidOperationSpec,

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -30,7 +30,9 @@ export class Readonlyproperty {
    * Get complex types that have readonly properties
    * @param options The options parameters.
    */
-  getValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.ReadonlypropertyGetValidResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Readonlyproperty {
       { options },
       getValidOperationSpec,
       callback
-    );
+    ) as Promise<Models.ReadonlypropertyGetValidResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Readonlyproperty {
   putValid(
     complexBody: Models.ReadonlyObj,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param complexBody
    * @param callback The callback.
@@ -90,7 +92,7 @@ export class Readonlyproperty {
       { complexBody, options },
       putValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/tsconfig.json
+++ b/test/integration/generated/bodyComplex/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
     "importHelpers": true

--- a/test/integration/generated/bodyString/package.json
+++ b/test/integration/generated/bodyString/package.json
@@ -3,11 +3,7 @@
   "author": "Microsoft Corporation",
   "description": "Test Infrastructure for AutoRest Swagger BAT",
   "version": "1.0.0-preview1",
-  "dependencies": {
-    "@azure/core-arm": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
-    "tslib": "^1.9.3"
-  },
+  "dependencies": { "@azure/core-http": "^1.0.0", "tslib": "^1.9.3" },
   "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "./dist/bodyString.js",

--- a/test/integration/generated/bodyString/src/bodyStringClientContext.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClientContext.ts
@@ -13,6 +13,8 @@ const packageName = "bodyString";
 const packageVersion = "1.0.0-preview1";
 
 export class BodyStringClientContext extends coreHttp.ServiceClient {
+  $host: string;
+
   /**
    * Initializes a new instance of the BodyStringClientContext class.
    *
@@ -32,5 +34,6 @@ export class BodyStringClientContext extends coreHttp.ServiceClient {
 
     this.baseUri = options.baseUri || this.baseUri || "http://localhost:3000";
     this.requestContentType = "application/json; charset=utf-8";
+    this.$host = "http://localhost:3000";
   }
 }

--- a/test/integration/generated/bodyString/src/models/index.ts
+++ b/test/integration/generated/bodyString/src/models/index.ts
@@ -30,3 +30,273 @@ export interface RefColorConstant {
  * Defines values for Colors.
  */
 export type Colors = "red color" | "green-color" | "blue_color";
+
+/**
+ * Contains response data for the getNull operation.
+ */
+export type StringGetNullResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: String;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: String;
+  };
+};
+
+/**
+ * Contains response data for the getEmpty operation.
+ */
+export type StringGetEmptyResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: String;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: String;
+  };
+};
+
+/**
+ * Contains response data for the getMbcs operation.
+ */
+export type StringGetMbcsResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: String;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: String;
+  };
+};
+
+/**
+ * Contains response data for the getWhitespace operation.
+ */
+export type StringGetWhitespaceResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: String;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: String;
+  };
+};
+
+/**
+ * Contains response data for the getNotProvided operation.
+ */
+export type StringGetNotProvidedResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: String;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: String;
+  };
+};
+
+/**
+ * Contains response data for the getBase64Encoded operation.
+ */
+export type StringGetBase64EncodedResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: Uint8Array;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Uint8Array;
+  };
+};
+
+/**
+ * Contains response data for the getBase64UrlEncoded operation.
+ */
+export type StringGetBase64UrlEncodedResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: Uint8Array;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Uint8Array;
+  };
+};
+
+/**
+ * Contains response data for the getNullBase64UrlEncoded operation.
+ */
+export type StringGetNullBase64UrlEncodedResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: Uint8Array;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Uint8Array;
+  };
+};
+
+/**
+ * Contains response data for the getNotExpandable operation.
+ */
+export type EnumGetNotExpandableResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: Colors;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Colors;
+  };
+};
+
+/**
+ * Contains response data for the getReferenced operation.
+ */
+export type EnumGetReferencedResponse = {
+  /**
+   * The parsed response body.
+   */
+  body: Colors;
+
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: Colors;
+  };
+};
+
+/**
+ * Contains response data for the getReferencedConstant operation.
+ */
+export type EnumGetReferencedConstantResponse = RefColorConstant & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The response body as text (string format)
+     */
+    bodyAsText: string;
+
+    /**
+     * The response body as parsed JSON or XML
+     */
+    parsedBody: RefColorConstant;
+  };
+};

--- a/test/integration/generated/bodyString/src/operations/enum.ts
+++ b/test/integration/generated/bodyString/src/operations/enum.ts
@@ -30,7 +30,9 @@ export class Enum {
    * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
    * @param options The options parameters.
    */
-  getNotExpandable(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNotExpandable(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.EnumGetNotExpandableResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,7 +53,7 @@ export class Enum {
       { options },
       getNotExpandableOperationSpec,
       callback
-    );
+    ) as Promise<Models.EnumGetNotExpandableResponse>;
   }
 
   /**
@@ -62,7 +64,7 @@ export class Enum {
   putNotExpandable(
     stringBody: Models.Colors,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param stringBody
    * @param callback The callback.
@@ -90,14 +92,16 @@ export class Enum {
       { stringBody, options },
       putNotExpandableOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get enum value 'red color' from enumeration of 'red color', 'green-color', 'blue_color'.
    * @param options The options parameters.
    */
-  getReferenced(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getReferenced(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.EnumGetReferencedResponse>;
   /**
    * @param callback The callback.
    */
@@ -118,7 +122,7 @@ export class Enum {
       { options },
       getReferencedOperationSpec,
       callback
-    );
+    ) as Promise<Models.EnumGetReferencedResponse>;
   }
 
   /**
@@ -129,7 +133,7 @@ export class Enum {
   putReferenced(
     enumStringBody: Models.Colors,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param enumStringBody
    * @param callback The callback.
@@ -157,14 +161,16 @@ export class Enum {
       { enumStringBody, options },
       putReferencedOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get value 'green-color' from the constant.
    * @param options The options parameters.
    */
-  getReferencedConstant(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getReferencedConstant(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.EnumGetReferencedConstantResponse>;
   /**
    * @param callback The callback.
    */
@@ -185,7 +191,7 @@ export class Enum {
       { options },
       getReferencedConstantOperationSpec,
       callback
-    );
+    ) as Promise<Models.EnumGetReferencedConstantResponse>;
   }
 
   /**
@@ -196,7 +202,7 @@ export class Enum {
   putReferencedConstant(
     enumStringBody: Models.RefColorConstant,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param enumStringBody
    * @param callback The callback.
@@ -224,7 +230,7 @@ export class Enum {
       { enumStringBody, options },
       putReferencedConstantOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyString/src/operations/enum.ts
+++ b/test/integration/generated/bodyString/src/operations/enum.ts
@@ -32,27 +32,10 @@ export class Enum {
    */
   getNotExpandable(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.EnumGetNotExpandableResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNotExpandable(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNotExpandable(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNotExpandable(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.EnumGetNotExpandableResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNotExpandableOperationSpec,
-      callback
+      getNotExpandableOperationSpec
     ) as Promise<Models.EnumGetNotExpandableResponse>;
   }
 
@@ -64,34 +47,10 @@ export class Enum {
   putNotExpandable(
     stringBody: Models.Colors,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param stringBody
-   * @param callback The callback.
-   */
-  putNotExpandable(
-    stringBody: Models.Colors,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param stringBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putNotExpandable(
-    stringBody: Models.Colors,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putNotExpandable(
-    stringBody: Models.Colors,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringBody, options },
-      putNotExpandableOperationSpec,
-      callback
+      putNotExpandableOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -101,27 +60,10 @@ export class Enum {
    */
   getReferenced(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.EnumGetReferencedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getReferenced(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getReferenced(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getReferenced(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.EnumGetReferencedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getReferencedOperationSpec,
-      callback
+      getReferencedOperationSpec
     ) as Promise<Models.EnumGetReferencedResponse>;
   }
 
@@ -133,34 +75,10 @@ export class Enum {
   putReferenced(
     enumStringBody: Models.Colors,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param enumStringBody
-   * @param callback The callback.
-   */
-  putReferenced(
-    enumStringBody: Models.Colors,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param enumStringBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putReferenced(
-    enumStringBody: Models.Colors,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putReferenced(
-    enumStringBody: Models.Colors,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumStringBody, options },
-      putReferencedOperationSpec,
-      callback
+      putReferencedOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -170,27 +88,10 @@ export class Enum {
    */
   getReferencedConstant(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.EnumGetReferencedConstantResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getReferencedConstant(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getReferencedConstant(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getReferencedConstant(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.EnumGetReferencedConstantResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getReferencedConstantOperationSpec,
-      callback
+      getReferencedConstantOperationSpec
     ) as Promise<Models.EnumGetReferencedConstantResponse>;
   }
 
@@ -202,34 +103,10 @@ export class Enum {
   putReferencedConstant(
     enumStringBody: Models.RefColorConstant,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param enumStringBody
-   * @param callback The callback.
-   */
-  putReferencedConstant(
-    enumStringBody: Models.RefColorConstant,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param enumStringBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putReferencedConstant(
-    enumStringBody: Models.RefColorConstant,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putReferencedConstant(
-    enumStringBody: Models.RefColorConstant,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumStringBody, options },
-      putReferencedConstantOperationSpec,
-      callback
+      putReferencedConstantOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/bodyString/src/operations/enum.ts
+++ b/test/integration/generated/bodyString/src/operations/enum.ts
@@ -46,7 +46,7 @@ export class Enum {
   getNotExpandable(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.EnumGetNotExpandableResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNotExpandableOperationSpec,
@@ -85,7 +85,7 @@ export class Enum {
     stringBody: Models.Colors,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringBody, options },
       putNotExpandableOperationSpec,
@@ -113,7 +113,7 @@ export class Enum {
   getReferenced(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.EnumGetReferencedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getReferencedOperationSpec,
@@ -152,7 +152,7 @@ export class Enum {
     enumStringBody: Models.Colors,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumStringBody, options },
       putReferencedOperationSpec,
@@ -180,7 +180,7 @@ export class Enum {
   getReferencedConstant(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.EnumGetReferencedConstantResponse> {
     return this.client.sendOperationRequest(
       { options },
       getReferencedConstantOperationSpec,
@@ -219,7 +219,7 @@ export class Enum {
     enumStringBody: Models.RefColorConstant,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumStringBody, options },
       putReferencedConstantOperationSpec,

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -30,7 +30,9 @@ export class String {
    * Get null string value value
    * @param options The options parameters.
    */
-  getNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNull(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetNullResponse>;
   /**
    * @param callback The callback.
    */
@@ -46,19 +48,21 @@ export class String {
   getNull(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.String> {
+  ): Promise<Models.StringGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNullOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetNullResponse>;
   }
 
   /**
    * Set string value null
    * @param options The options parameters.
    */
-  putNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  putNull(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -79,14 +83,16 @@ export class String {
       { options },
       putNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get empty string value value ''
    * @param options The options parameters.
    */
-  getEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetEmptyResponse>;
   /**
    * @param callback The callback.
    */
@@ -102,19 +108,21 @@ export class String {
   getEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.String> {
+  ): Promise<Models.StringGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
       getEmptyOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetEmptyResponse>;
   }
 
   /**
    * Set string value empty ''
    * @param options The options parameters.
    */
-  putEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  putEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -135,14 +143,16 @@ export class String {
       { options },
       putEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get mbcs string value '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    * @param options The options parameters.
    */
-  getMbcs(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getMbcs(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetMbcsResponse>;
   /**
    * @param callback The callback.
    */
@@ -158,19 +168,21 @@ export class String {
   getMbcs(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.String> {
+  ): Promise<Models.StringGetMbcsResponse> {
     return this.client.sendOperationRequest(
       { options },
       getMbcsOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetMbcsResponse>;
   }
 
   /**
    * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    * @param options The options parameters.
    */
-  putMbcs(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  putMbcs(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -191,14 +203,16 @@ export class String {
       { options },
       putMbcsOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get string value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
    * @param options The options parameters.
    */
-  getWhitespace(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getWhitespace(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetWhitespaceResponse>;
   /**
    * @param callback The callback.
    */
@@ -214,19 +228,21 @@ export class String {
   getWhitespace(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.String> {
+  ): Promise<Models.StringGetWhitespaceResponse> {
     return this.client.sendOperationRequest(
       { options },
       getWhitespaceOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetWhitespaceResponse>;
   }
 
   /**
    * Set String value with leading and trailing whitespace '<tab><space><space>Now is the time for all good men to come to the aid of their country<tab><space><space>'
    * @param options The options parameters.
    */
-  putWhitespace(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  putWhitespace(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -247,14 +263,16 @@ export class String {
       { options },
       putWhitespaceOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get String value when no string value is sent in response payload
    * @param options The options parameters.
    */
-  getNotProvided(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNotProvided(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetNotProvidedResponse>;
   /**
    * @param callback The callback.
    */
@@ -270,19 +288,21 @@ export class String {
   getNotProvided(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.String> {
+  ): Promise<Models.StringGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNotProvidedOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetNotProvidedResponse>;
   }
 
   /**
    * Get value that is base64 encoded
    * @param options The options parameters.
    */
-  getBase64Encoded(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBase64Encoded(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetBase64EncodedResponse>;
   /**
    * @param callback The callback.
    */
@@ -298,19 +318,21 @@ export class String {
   getBase64Encoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.Uint8Array> {
+  ): Promise<Models.StringGetBase64EncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBase64EncodedOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetBase64EncodedResponse>;
   }
 
   /**
    * Get value that is base64url encoded
    * @param options The options parameters.
    */
-  getBase64UrlEncoded(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBase64UrlEncoded(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetBase64UrlEncodedResponse>;
   /**
    * @param callback The callback.
    */
@@ -326,12 +348,12 @@ export class String {
   getBase64UrlEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.Uint8Array> {
+  ): Promise<Models.StringGetBase64UrlEncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBase64UrlEncodedOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetBase64UrlEncodedResponse>;
   }
 
   /**
@@ -342,7 +364,7 @@ export class String {
   putBase64UrlEncoded(
     stringBody: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param stringBody
    * @param callback The callback.
@@ -370,14 +392,16 @@ export class String {
       { stringBody, options },
       putBase64UrlEncodedOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null value that is expected to be base64url encoded
    * @param options The options parameters.
    */
-  getNullBase64UrlEncoded(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNullBase64UrlEncoded(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<Models.StringGetNullBase64UrlEncodedResponse>;
   /**
    * @param callback The callback.
    */
@@ -393,12 +417,12 @@ export class String {
   getNullBase64UrlEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<Models.Uint8Array> {
+  ): Promise<Models.StringGetNullBase64UrlEncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNullBase64UrlEncodedOperationSpec,
       callback
-    );
+    ) as Promise<Models.StringGetNullBase64UrlEncodedResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -46,7 +46,7 @@ export class String {
   getNull(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.String> {
     return this.client.sendOperationRequest(
       { options },
       getNullOperationSpec,
@@ -74,7 +74,7 @@ export class String {
   putNull(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       putNullOperationSpec,
@@ -102,7 +102,7 @@ export class String {
   getEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.String> {
     return this.client.sendOperationRequest(
       { options },
       getEmptyOperationSpec,
@@ -130,7 +130,7 @@ export class String {
   putEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       putEmptyOperationSpec,
@@ -158,7 +158,7 @@ export class String {
   getMbcs(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.String> {
     return this.client.sendOperationRequest(
       { options },
       getMbcsOperationSpec,
@@ -186,7 +186,7 @@ export class String {
   putMbcs(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       putMbcsOperationSpec,
@@ -214,7 +214,7 @@ export class String {
   getWhitespace(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.String> {
     return this.client.sendOperationRequest(
       { options },
       getWhitespaceOperationSpec,
@@ -242,7 +242,7 @@ export class String {
   putWhitespace(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       putWhitespaceOperationSpec,
@@ -270,7 +270,7 @@ export class String {
   getNotProvided(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.String> {
     return this.client.sendOperationRequest(
       { options },
       getNotProvidedOperationSpec,
@@ -298,7 +298,7 @@ export class String {
   getBase64Encoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.Uint8Array> {
     return this.client.sendOperationRequest(
       { options },
       getBase64EncodedOperationSpec,
@@ -326,7 +326,7 @@ export class String {
   getBase64UrlEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.Uint8Array> {
     return this.client.sendOperationRequest(
       { options },
       getBase64UrlEncodedOperationSpec,
@@ -365,7 +365,7 @@ export class String {
     stringBody: Uint8Array,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringBody, options },
       putBase64UrlEncodedOperationSpec,
@@ -393,7 +393,7 @@ export class String {
   getNullBase64UrlEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<Models.Uint8Array> {
     return this.client.sendOperationRequest(
       { options },
       getNullBase64UrlEncodedOperationSpec,

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -32,27 +32,10 @@ export class String {
    */
   getNull(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetNullResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNull(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNull(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNullOperationSpec,
-      callback
+      getNullOperationSpec
     ) as Promise<Models.StringGetNullResponse>;
   }
 
@@ -62,27 +45,10 @@ export class String {
    */
   putNull(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  putNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putNull(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putNull(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      putNullOperationSpec,
-      callback
+      putNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -92,27 +58,10 @@ export class String {
    */
   getEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetEmptyResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getEmptyOperationSpec,
-      callback
+      getEmptyOperationSpec
     ) as Promise<Models.StringGetEmptyResponse>;
   }
 
@@ -122,27 +71,10 @@ export class String {
    */
   putEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  putEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      putEmptyOperationSpec,
-      callback
+      putEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -152,27 +84,10 @@ export class String {
    */
   getMbcs(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetMbcsResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getMbcs(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getMbcs(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getMbcs(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetMbcsResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getMbcsOperationSpec,
-      callback
+      getMbcsOperationSpec
     ) as Promise<Models.StringGetMbcsResponse>;
   }
 
@@ -182,27 +97,10 @@ export class String {
    */
   putMbcs(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  putMbcs(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putMbcs(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putMbcs(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      putMbcsOperationSpec,
-      callback
+      putMbcsOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -212,27 +110,10 @@ export class String {
    */
   getWhitespace(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetWhitespaceResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getWhitespace(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getWhitespace(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getWhitespace(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetWhitespaceResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getWhitespaceOperationSpec,
-      callback
+      getWhitespaceOperationSpec
     ) as Promise<Models.StringGetWhitespaceResponse>;
   }
 
@@ -242,27 +123,10 @@ export class String {
    */
   putWhitespace(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  putWhitespace(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putWhitespace(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putWhitespace(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      putWhitespaceOperationSpec,
-      callback
+      putWhitespaceOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -272,27 +136,10 @@ export class String {
    */
   getNotProvided(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetNotProvidedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNotProvided(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNotProvided(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNotProvided(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNotProvidedOperationSpec,
-      callback
+      getNotProvidedOperationSpec
     ) as Promise<Models.StringGetNotProvidedResponse>;
   }
 
@@ -302,27 +149,10 @@ export class String {
    */
   getBase64Encoded(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetBase64EncodedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBase64Encoded(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBase64Encoded(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBase64Encoded(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetBase64EncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBase64EncodedOperationSpec,
-      callback
+      getBase64EncodedOperationSpec
     ) as Promise<Models.StringGetBase64EncodedResponse>;
   }
 
@@ -332,27 +162,10 @@ export class String {
    */
   getBase64UrlEncoded(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetBase64UrlEncodedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBase64UrlEncoded(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBase64UrlEncoded(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBase64UrlEncoded(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetBase64UrlEncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBase64UrlEncodedOperationSpec,
-      callback
+      getBase64UrlEncodedOperationSpec
     ) as Promise<Models.StringGetBase64UrlEncodedResponse>;
   }
 
@@ -364,34 +177,10 @@ export class String {
   putBase64UrlEncoded(
     stringBody: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param stringBody
-   * @param callback The callback.
-   */
-  putBase64UrlEncoded(
-    stringBody: Uint8Array,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param stringBody
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  putBase64UrlEncoded(
-    stringBody: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  putBase64UrlEncoded(
-    stringBody: Uint8Array,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringBody, options },
-      putBase64UrlEncodedOperationSpec,
-      callback
+      putBase64UrlEncodedOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -401,27 +190,10 @@ export class String {
    */
   getNullBase64UrlEncoded(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<Models.StringGetNullBase64UrlEncodedResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNullBase64UrlEncoded(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNullBase64UrlEncoded(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNullBase64UrlEncoded(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<Models.StringGetNullBase64UrlEncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNullBase64UrlEncodedOperationSpec,
-      callback
+      getNullBase64UrlEncodedOperationSpec
     ) as Promise<Models.StringGetNullBase64UrlEncodedResponse>;
   }
 }

--- a/test/integration/generated/bodyString/tsconfig.json
+++ b/test/integration/generated/bodyString/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
     "importHelpers": true

--- a/test/integration/generated/url/package.json
+++ b/test/integration/generated/url/package.json
@@ -3,11 +3,7 @@
   "author": "Microsoft Corporation",
   "description": "Test Infrastructure for AutoRest",
   "version": "1.0.0-preview1",
-  "dependencies": {
-    "@azure/core-arm": "^1.0.0",
-    "@azure/core-http": "^1.0.0",
-    "tslib": "^1.9.3"
-  },
+  "dependencies": { "@azure/core-http": "^1.0.0", "tslib": "^1.9.3" },
   "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "./dist/url.js",

--- a/test/integration/generated/url/src/models/index.ts
+++ b/test/integration/generated/url/src/models/index.ts
@@ -20,3 +20,261 @@ export interface ErrorModel {
  * Defines values for UriColor.
  */
 export type UriColor = "red color" | "green color" | "blue color";
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesGetBooleanNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null boolean value
+   */
+  boolQuery?: boolean;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesGetIntNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null integer value
+   */
+  intQuery?: number;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesGetLongNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null 64 bit integer value
+   */
+  longQuery?: number;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesFloatNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null numeric value
+   */
+  floatQuery?: number;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesDoubleNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null numeric value
+   */
+  doubleQuery?: number;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesStringNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null string value
+   */
+  stringQuery?: string;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesEnumValidOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * 'green color' enum value
+   */
+  enumQuery?: UriColor;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesEnumNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * 'green color' enum value
+   */
+  enumQuery?: UriColor;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesByteMultiByteOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+   */
+  byteQuery?: Uint8Array;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesByteNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+   */
+  byteQuery?: Uint8Array;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesDateNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null as date (no query parameters in uri)
+   */
+  dateQuery?: Date;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesDateTimeNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * null as date-time (no query parameters)
+   */
+  dateTimeQuery?: Date;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesArrayStringCsvValidOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+   */
+  arrayQuery?: string[];
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesArrayStringCsvNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+   */
+  arrayQuery?: string[];
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesArrayStringCsvEmptyOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+   */
+  arrayQuery?: string[];
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesArrayStringSsvValidOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
+   */
+  arrayQuery?: string[];
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesArrayStringTsvValidOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
+   */
+  arrayQuery?: string[];
+}
+
+/**
+ * Optional parameters.
+ */
+export interface QueriesArrayStringPipesValidOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
+   */
+  arrayQuery?: string[];
+}
+
+/**
+ * Optional parameters.
+ */
+export interface PathItemsGetAllWithValuesOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * A string value 'pathItemStringQuery' that appears as a query parameter
+   */
+  pathItemStringQuery?: string;
+  /**
+   * should contain value 'localStringQuery'
+   */
+  localStringQuery?: string;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface PathItemsGetGlobalQueryNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * A string value 'pathItemStringQuery' that appears as a query parameter
+   */
+  pathItemStringQuery?: string;
+  /**
+   * should contain value 'localStringQuery'
+   */
+  localStringQuery?: string;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface PathItemsGetGlobalAndLocalQueryNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * A string value 'pathItemStringQuery' that appears as a query parameter
+   */
+  pathItemStringQuery?: string;
+  /**
+   * should contain value 'localStringQuery'
+   */
+  localStringQuery?: string;
+}
+
+/**
+ * Optional parameters.
+ */
+export interface PathItemsGetLocalPathItemQueryNullOptionalParams
+  extends coreHttp.RequestOptionsBase {
+  /**
+   * A string value 'pathItemStringQuery' that appears as a query parameter
+   */
+  pathItemStringQuery?: string;
+  /**
+   * should contain value 'localStringQuery'
+   */
+  localStringQuery?: string;
+}

--- a/test/integration/generated/url/src/operations/pathItems.ts
+++ b/test/integration/generated/url/src/operations/pathItems.ts
@@ -36,39 +36,10 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetAllWithValuesOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param callback The callback.
-   */
-  getAllWithValues(
-    pathItemStringPath: string,
-    localStringPath: string,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getAllWithValues(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options: Models.PathItemsGetAllWithValuesOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getAllWithValues(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options?: Models.PathItemsGetAllWithValuesOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
-      getAllWithValuesOperationSpec,
-      callback
+      getAllWithValuesOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -82,39 +53,10 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetGlobalQueryNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param callback The callback.
-   */
-  getGlobalQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getGlobalQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options: Models.PathItemsGetGlobalQueryNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getGlobalQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options?: Models.PathItemsGetGlobalQueryNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
-      getGlobalQueryNullOperationSpec,
-      callback
+      getGlobalQueryNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -128,39 +70,10 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param callback The callback.
-   */
-  getGlobalAndLocalQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getGlobalAndLocalQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getGlobalAndLocalQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options?: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
-      getGlobalAndLocalQueryNullOperationSpec,
-      callback
+      getGlobalAndLocalQueryNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -174,39 +87,10 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetLocalPathItemQueryNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param callback The callback.
-   */
-  getLocalPathItemQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
-   * @param localStringPath should contain value 'localStringPath'
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getLocalPathItemQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options: Models.PathItemsGetLocalPathItemQueryNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getLocalPathItemQueryNull(
-    pathItemStringPath: string,
-    localStringPath: string,
-    options?: Models.PathItemsGetLocalPathItemQueryNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
-      getLocalPathItemQueryNullOperationSpec,
-      callback
+      getLocalPathItemQueryNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/url/src/operations/pathItems.ts
+++ b/test/integration/generated/url/src/operations/pathItems.ts
@@ -36,7 +36,7 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetAllWithValuesOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    * @param localStringPath should contain value 'localStringPath'
@@ -69,7 +69,7 @@ export class PathItems {
       { pathItemStringPath, localStringPath, options },
       getAllWithValuesOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -82,7 +82,7 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetGlobalQueryNullOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    * @param localStringPath should contain value 'localStringPath'
@@ -115,7 +115,7 @@ export class PathItems {
       { pathItemStringPath, localStringPath, options },
       getGlobalQueryNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -128,7 +128,7 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    * @param localStringPath should contain value 'localStringPath'
@@ -161,7 +161,7 @@ export class PathItems {
       { pathItemStringPath, localStringPath, options },
       getGlobalAndLocalQueryNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -174,7 +174,7 @@ export class PathItems {
     pathItemStringPath: string,
     localStringPath: string,
     options?: Models.PathItemsGetLocalPathItemQueryNullOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
    * @param localStringPath should contain value 'localStringPath'
@@ -207,7 +207,7 @@ export class PathItems {
       { pathItemStringPath, localStringPath, options },
       getLocalPathItemQueryNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/url/src/operations/pathItems.ts
+++ b/test/integration/generated/url/src/operations/pathItems.ts
@@ -35,7 +35,7 @@ export class PathItems {
   getAllWithValues(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: Models.PathItemsGetAllWithValuesOptionalParams
   ): Promise<any>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
@@ -56,15 +56,15 @@ export class PathItems {
   getAllWithValues(
     pathItemStringPath: string,
     localStringPath: string,
-    options: coreHttp.RequestOptionsBase,
+    options: Models.PathItemsGetAllWithValuesOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getAllWithValues(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.PathItemsGetAllWithValuesOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
       getAllWithValuesOperationSpec,
@@ -81,7 +81,7 @@ export class PathItems {
   getGlobalQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: Models.PathItemsGetGlobalQueryNullOptionalParams
   ): Promise<any>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
@@ -102,15 +102,15 @@ export class PathItems {
   getGlobalQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options: coreHttp.RequestOptionsBase,
+    options: Models.PathItemsGetGlobalQueryNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getGlobalQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.PathItemsGetGlobalQueryNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
       getGlobalQueryNullOperationSpec,
@@ -127,7 +127,7 @@ export class PathItems {
   getGlobalAndLocalQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams
   ): Promise<any>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
@@ -148,15 +148,15 @@ export class PathItems {
   getGlobalAndLocalQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options: coreHttp.RequestOptionsBase,
+    options: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getGlobalAndLocalQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.PathItemsGetGlobalAndLocalQueryNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
       getGlobalAndLocalQueryNullOperationSpec,
@@ -173,7 +173,7 @@ export class PathItems {
   getLocalPathItemQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: Models.PathItemsGetLocalPathItemQueryNullOptionalParams
   ): Promise<any>;
   /**
    * @param pathItemStringPath A string value 'pathItemStringPath' that appears in the path
@@ -194,15 +194,15 @@ export class PathItems {
   getLocalPathItemQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options: coreHttp.RequestOptionsBase,
+    options: Models.PathItemsGetLocalPathItemQueryNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getLocalPathItemQueryNull(
     pathItemStringPath: string,
     localStringPath: string,
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.PathItemsGetLocalPathItemQueryNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { pathItemStringPath, localStringPath, options },
       getLocalPathItemQueryNullOperationSpec,

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -32,27 +32,10 @@ export class Paths {
    */
   getBooleanTrue(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBooleanTrue(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBooleanTrue(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBooleanTrue(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBooleanTrueOperationSpec,
-      callback
+      getBooleanTrueOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -62,27 +45,10 @@ export class Paths {
    */
   getBooleanFalse(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBooleanFalse(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBooleanFalse(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBooleanFalse(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBooleanFalseOperationSpec,
-      callback
+      getBooleanFalseOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -92,27 +58,10 @@ export class Paths {
    */
   getIntOneMillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getIntOneMillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getIntOneMillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getIntOneMillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getIntOneMillionOperationSpec,
-      callback
+      getIntOneMillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -122,27 +71,10 @@ export class Paths {
    */
   getIntNegativeOneMillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getIntNegativeOneMillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getIntNegativeOneMillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getIntNegativeOneMillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getIntNegativeOneMillionOperationSpec,
-      callback
+      getIntNegativeOneMillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -152,27 +84,10 @@ export class Paths {
    */
   getTenBillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getTenBillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getTenBillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getTenBillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getTenBillionOperationSpec,
-      callback
+      getTenBillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -182,27 +97,10 @@ export class Paths {
    */
   getNegativeTenBillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNegativeTenBillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNegativeTenBillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNegativeTenBillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNegativeTenBillionOperationSpec,
-      callback
+      getNegativeTenBillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -212,27 +110,10 @@ export class Paths {
    */
   floatScientificPositive(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  floatScientificPositive(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  floatScientificPositive(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  floatScientificPositive(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      floatScientificPositiveOperationSpec,
-      callback
+      floatScientificPositiveOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -242,27 +123,10 @@ export class Paths {
    */
   floatScientificNegative(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  floatScientificNegative(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  floatScientificNegative(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  floatScientificNegative(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      floatScientificNegativeOperationSpec,
-      callback
+      floatScientificNegativeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -272,27 +136,10 @@ export class Paths {
    */
   doubleDecimalPositive(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  doubleDecimalPositive(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  doubleDecimalPositive(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  doubleDecimalPositive(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      doubleDecimalPositiveOperationSpec,
-      callback
+      doubleDecimalPositiveOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -302,27 +149,10 @@ export class Paths {
    */
   doubleDecimalNegative(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  doubleDecimalNegative(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  doubleDecimalNegative(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  doubleDecimalNegative(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      doubleDecimalNegativeOperationSpec,
-      callback
+      doubleDecimalNegativeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -332,27 +162,10 @@ export class Paths {
    */
   stringUnicode(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringUnicode(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringUnicode(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringUnicode(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringUnicodeOperationSpec,
-      callback
+      stringUnicodeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -362,27 +175,10 @@ export class Paths {
    */
   stringUrlEncoded(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringUrlEncoded(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringUrlEncoded(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringUrlEncoded(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringUrlEncodedOperationSpec,
-      callback
+      stringUrlEncodedOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -392,27 +188,10 @@ export class Paths {
    */
   stringUrlNonEncoded(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringUrlNonEncoded(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringUrlNonEncoded(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringUrlNonEncoded(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringUrlNonEncodedOperationSpec,
-      callback
+      stringUrlNonEncodedOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -422,27 +201,10 @@ export class Paths {
    */
   stringEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringEmptyOperationSpec,
-      callback
+      stringEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -454,31 +216,10 @@ export class Paths {
   stringNull(
     stringPath: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param stringPath null string value
-   * @param callback The callback.
-   */
-  stringNull(stringPath: string, callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param stringPath null string value
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringNull(
-    stringPath: string,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringNull(
-    stringPath: string,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringPath, options },
-      stringNullOperationSpec,
-      callback
+      stringNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -490,34 +231,10 @@ export class Paths {
   enumValid(
     enumPath: Models.UriColor,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param enumPath send the value green
-   * @param callback The callback.
-   */
-  enumValid(
-    enumPath: Models.UriColor,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param enumPath send the value green
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  enumValid(
-    enumPath: Models.UriColor,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  enumValid(
-    enumPath: Models.UriColor,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumPath, options },
-      enumValidOperationSpec,
-      callback
+      enumValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -529,34 +246,10 @@ export class Paths {
   enumNull(
     enumPath: Models.UriColor,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param enumPath send the value green
-   * @param callback The callback.
-   */
-  enumNull(
-    enumPath: Models.UriColor,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param enumPath send the value green
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  enumNull(
-    enumPath: Models.UriColor,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  enumNull(
-    enumPath: Models.UriColor,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumPath, options },
-      enumNullOperationSpec,
-      callback
+      enumNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -568,34 +261,10 @@ export class Paths {
   byteMultiByte(
     bytePath: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-   * @param callback The callback.
-   */
-  byteMultiByte(
-    bytePath: Uint8Array,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  byteMultiByte(
-    bytePath: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  byteMultiByte(
-    bytePath: Uint8Array,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bytePath, options },
-      byteMultiByteOperationSpec,
-      callback
+      byteMultiByteOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -605,27 +274,10 @@ export class Paths {
    */
   byteEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  byteEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  byteEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  byteEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      byteEmptyOperationSpec,
-      callback
+      byteEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -637,31 +289,10 @@ export class Paths {
   byteNull(
     bytePath: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-   * @param callback The callback.
-   */
-  byteNull(bytePath: Uint8Array, callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  byteNull(
-    bytePath: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  byteNull(
-    bytePath: Uint8Array,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bytePath, options },
-      byteNullOperationSpec,
-      callback
+      byteNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -671,27 +302,10 @@ export class Paths {
    */
   dateValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  dateValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      dateValidOperationSpec,
-      callback
+      dateValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -703,31 +317,10 @@ export class Paths {
   dateNull(
     datePath: Date,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param datePath null as date (should throw)
-   * @param callback The callback.
-   */
-  dateNull(datePath: Date, callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param datePath null as date (should throw)
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateNull(
-    datePath: Date,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateNull(
-    datePath: Date,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { datePath, options },
-      dateNullOperationSpec,
-      callback
+      dateNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -737,27 +330,10 @@ export class Paths {
    */
   dateTimeValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  dateTimeValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateTimeValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateTimeValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      dateTimeValidOperationSpec,
-      callback
+      dateTimeValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -769,34 +345,10 @@ export class Paths {
   dateTimeNull(
     dateTimePath: Date,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param dateTimePath null as date-time
-   * @param callback The callback.
-   */
-  dateTimeNull(
-    dateTimePath: Date,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param dateTimePath null as date-time
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateTimeNull(
-    dateTimePath: Date,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateTimeNull(
-    dateTimePath: Date,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { dateTimePath, options },
-      dateTimeNullOperationSpec,
-      callback
+      dateTimeNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -808,34 +360,10 @@ export class Paths {
   base64Url(
     base64UrlPath: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param base64UrlPath base64url encoded value
-   * @param callback The callback.
-   */
-  base64Url(
-    base64UrlPath: Uint8Array,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param base64UrlPath base64url encoded value
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  base64Url(
-    base64UrlPath: Uint8Array,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  base64Url(
-    base64UrlPath: Uint8Array,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { base64UrlPath, options },
-      base64UrlOperationSpec,
-      callback
+      base64UrlOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -847,34 +375,10 @@ export class Paths {
   arrayCsvInPath(
     arrayPath: string[],
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-   * @param callback The callback.
-   */
-  arrayCsvInPath(
-    arrayPath: string[],
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayCsvInPath(
-    arrayPath: string[],
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayCsvInPath(
-    arrayPath: string[],
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { arrayPath, options },
-      arrayCsvInPathOperationSpec,
-      callback
+      arrayCsvInPathOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -886,34 +390,10 @@ export class Paths {
   unixTimeUrl(
     unixTimeUrlPath: Date,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param unixTimeUrlPath Unix time encoded value
-   * @param callback The callback.
-   */
-  unixTimeUrl(
-    unixTimeUrlPath: Date,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  /**
-   * @param unixTimeUrlPath Unix time encoded value
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  unixTimeUrl(
-    unixTimeUrlPath: Date,
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  unixTimeUrl(
-    unixTimeUrlPath: Date,
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { unixTimeUrlPath, options },
-      unixTimeUrlOperationSpec,
-      callback
+      unixTimeUrlOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -30,7 +30,9 @@ export class Paths {
    * Get true Boolean value on path
    * @param options The options parameters.
    */
-  getBooleanTrue(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBooleanTrue(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,14 +53,16 @@ export class Paths {
       { options },
       getBooleanTrueOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get false Boolean value on path
    * @param options The options parameters.
    */
-  getBooleanFalse(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBooleanFalse(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -79,14 +83,16 @@ export class Paths {
       { options },
       getBooleanFalseOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '1000000' integer value
    * @param options The options parameters.
    */
-  getIntOneMillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getIntOneMillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -107,14 +113,16 @@ export class Paths {
       { options },
       getIntOneMillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-1000000' integer value
    * @param options The options parameters.
    */
-  getIntNegativeOneMillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getIntNegativeOneMillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -135,14 +143,16 @@ export class Paths {
       { options },
       getIntNegativeOneMillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '10000000000' 64 bit integer value
    * @param options The options parameters.
    */
-  getTenBillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getTenBillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -163,14 +173,16 @@ export class Paths {
       { options },
       getTenBillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-10000000000' 64 bit integer value
    * @param options The options parameters.
    */
-  getNegativeTenBillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNegativeTenBillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -191,14 +203,16 @@ export class Paths {
       { options },
       getNegativeTenBillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '1.034E+20' numeric value
    * @param options The options parameters.
    */
-  floatScientificPositive(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  floatScientificPositive(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -219,14 +233,16 @@ export class Paths {
       { options },
       floatScientificPositiveOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-1.034E-20' numeric value
    * @param options The options parameters.
    */
-  floatScientificNegative(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  floatScientificNegative(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -247,14 +263,16 @@ export class Paths {
       { options },
       floatScientificNegativeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '9999999.999' numeric value
    * @param options The options parameters.
    */
-  doubleDecimalPositive(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  doubleDecimalPositive(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -275,14 +293,16 @@ export class Paths {
       { options },
       doubleDecimalPositiveOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-9999999.999' numeric value
    * @param options The options parameters.
    */
-  doubleDecimalNegative(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  doubleDecimalNegative(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -303,14 +323,16 @@ export class Paths {
       { options },
       doubleDecimalNegativeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
    * @param options The options parameters.
    */
-  stringUnicode(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringUnicode(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -331,14 +353,16 @@ export class Paths {
       { options },
       stringUnicodeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get 'begin!*'();:@ &=+$,/?#[]end
    * @param options The options parameters.
    */
-  stringUrlEncoded(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringUrlEncoded(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -359,14 +383,16 @@ export class Paths {
       { options },
       stringUrlEncodedOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get 'begin!*'();:@&=+$,end
    * @param options The options parameters.
    */
-  stringUrlNonEncoded(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringUrlNonEncoded(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -387,14 +413,16 @@ export class Paths {
       { options },
       stringUrlNonEncodedOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get ''
    * @param options The options parameters.
    */
-  stringEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -415,7 +443,7 @@ export class Paths {
       { options },
       stringEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -426,7 +454,7 @@ export class Paths {
   stringNull(
     stringPath: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param stringPath null string value
    * @param callback The callback.
@@ -451,7 +479,7 @@ export class Paths {
       { stringPath, options },
       stringNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -462,7 +490,7 @@ export class Paths {
   enumValid(
     enumPath: Models.UriColor,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param enumPath send the value green
    * @param callback The callback.
@@ -490,7 +518,7 @@ export class Paths {
       { enumPath, options },
       enumValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -501,7 +529,7 @@ export class Paths {
   enumNull(
     enumPath: Models.UriColor,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param enumPath send the value green
    * @param callback The callback.
@@ -529,7 +557,7 @@ export class Paths {
       { enumPath, options },
       enumNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -540,7 +568,7 @@ export class Paths {
   byteMultiByte(
     bytePath: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    * @param callback The callback.
@@ -568,14 +596,16 @@ export class Paths {
       { bytePath, options },
       byteMultiByteOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '' as byte array
    * @param options The options parameters.
    */
-  byteEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  byteEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -596,7 +626,7 @@ export class Paths {
       { options },
       byteEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -607,7 +637,7 @@ export class Paths {
   byteNull(
     bytePath: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    * @param callback The callback.
@@ -632,14 +662,16 @@ export class Paths {
       { bytePath, options },
       byteNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '2012-01-01' as date
    * @param options The options parameters.
    */
-  dateValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -660,7 +692,7 @@ export class Paths {
       { options },
       dateValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -668,7 +700,10 @@ export class Paths {
    * @param datePath null as date (should throw)
    * @param options The options parameters.
    */
-  dateNull(datePath: Date, options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateNull(
+    datePath: Date,
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param datePath null as date (should throw)
    * @param callback The callback.
@@ -693,14 +728,16 @@ export class Paths {
       { datePath, options },
       dateNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '2012-01-01T01:01:01Z' as date-time
    * @param options The options parameters.
    */
-  dateTimeValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateTimeValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -721,7 +758,7 @@ export class Paths {
       { options },
       dateTimeValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -732,7 +769,7 @@ export class Paths {
   dateTimeNull(
     dateTimePath: Date,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param dateTimePath null as date-time
    * @param callback The callback.
@@ -760,7 +797,7 @@ export class Paths {
       { dateTimePath, options },
       dateTimeNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -771,7 +808,7 @@ export class Paths {
   base64Url(
     base64UrlPath: Uint8Array,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param base64UrlPath base64url encoded value
    * @param callback The callback.
@@ -799,7 +836,7 @@ export class Paths {
       { base64UrlPath, options },
       base64UrlOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -810,7 +847,7 @@ export class Paths {
   arrayCsvInPath(
     arrayPath: string[],
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    * @param callback The callback.
@@ -838,7 +875,7 @@ export class Paths {
       { arrayPath, options },
       arrayCsvInPathOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -849,7 +886,7 @@ export class Paths {
   unixTimeUrl(
     unixTimeUrlPath: Date,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param unixTimeUrlPath Unix time encoded value
    * @param callback The callback.
@@ -877,7 +914,7 @@ export class Paths {
       { unixTimeUrlPath, options },
       unixTimeUrlOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -668,24 +668,30 @@ export class Paths {
    * @param datePath null as date (should throw)
    * @param options The options parameters.
    */
-  dateNull(datePath: any, options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateNull(
+    datePath: Models.Date,
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<any>;
   /**
    * @param datePath null as date (should throw)
    * @param callback The callback.
    */
-  dateNull(datePath: any, callback: coreHttp.ServiceCallback<any>): void;
+  dateNull(
+    datePath: Models.Date,
+    callback: coreHttp.ServiceCallback<any>
+  ): void;
   /**
    * @param datePath null as date (should throw)
    * @param options The options parameters.
    * @param callback The callback.
    */
   dateNull(
-    datePath: any,
+    datePath: Models.Date,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   dateNull(
-    datePath: any,
+    datePath: Models.Date,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {
@@ -730,7 +736,7 @@ export class Paths {
    * @param options The options parameters.
    */
   dateTimeNull(
-    dateTimePath: any,
+    dateTimePath: Models.Date,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -738,7 +744,7 @@ export class Paths {
    * @param callback The callback.
    */
   dateTimeNull(
-    dateTimePath: any,
+    dateTimePath: Models.Date,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -747,12 +753,12 @@ export class Paths {
    * @param callback The callback.
    */
   dateTimeNull(
-    dateTimePath: any,
+    dateTimePath: Models.Date,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   dateTimeNull(
-    dateTimePath: any,
+    dateTimePath: Models.Date,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {
@@ -808,26 +814,29 @@ export class Paths {
    * @param options The options parameters.
    */
   arrayCsvInPath(
-    arrayPath: any,
+    arrayPath: Models.String[],
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
    * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    * @param callback The callback.
    */
-  arrayCsvInPath(arrayPath: any, callback: coreHttp.ServiceCallback<any>): void;
+  arrayCsvInPath(
+    arrayPath: Models.String[],
+    callback: coreHttp.ServiceCallback<any>
+  ): void;
   /**
    * @param arrayPath an array of string ['ArrayPath1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    * @param options The options parameters.
    * @param callback The callback.
    */
   arrayCsvInPath(
-    arrayPath: any,
+    arrayPath: Models.String[],
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayCsvInPath(
-    arrayPath: any,
+    arrayPath: Models.String[],
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {
@@ -844,7 +853,7 @@ export class Paths {
    * @param options The options parameters.
    */
   unixTimeUrl(
-    unixTimeUrlPath: any,
+    unixTimeUrlPath: Models.Date,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -852,7 +861,7 @@ export class Paths {
    * @param callback The callback.
    */
   unixTimeUrl(
-    unixTimeUrlPath: any,
+    unixTimeUrlPath: Models.Date,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -861,12 +870,12 @@ export class Paths {
    * @param callback The callback.
    */
   unixTimeUrl(
-    unixTimeUrlPath: any,
+    unixTimeUrlPath: Models.Date,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   unixTimeUrl(
-    unixTimeUrlPath: any,
+    unixTimeUrlPath: Models.Date,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
   ): Promise<any> {

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -46,7 +46,7 @@ export class Paths {
   getBooleanTrue(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBooleanTrueOperationSpec,
@@ -74,7 +74,7 @@ export class Paths {
   getBooleanFalse(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBooleanFalseOperationSpec,
@@ -102,7 +102,7 @@ export class Paths {
   getIntOneMillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getIntOneMillionOperationSpec,
@@ -130,7 +130,7 @@ export class Paths {
   getIntNegativeOneMillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getIntNegativeOneMillionOperationSpec,
@@ -158,7 +158,7 @@ export class Paths {
   getTenBillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getTenBillionOperationSpec,
@@ -186,7 +186,7 @@ export class Paths {
   getNegativeTenBillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNegativeTenBillionOperationSpec,
@@ -214,7 +214,7 @@ export class Paths {
   floatScientificPositive(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       floatScientificPositiveOperationSpec,
@@ -242,7 +242,7 @@ export class Paths {
   floatScientificNegative(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       floatScientificNegativeOperationSpec,
@@ -270,7 +270,7 @@ export class Paths {
   doubleDecimalPositive(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       doubleDecimalPositiveOperationSpec,
@@ -298,7 +298,7 @@ export class Paths {
   doubleDecimalNegative(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       doubleDecimalNegativeOperationSpec,
@@ -326,7 +326,7 @@ export class Paths {
   stringUnicode(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringUnicodeOperationSpec,
@@ -354,7 +354,7 @@ export class Paths {
   stringUrlEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringUrlEncodedOperationSpec,
@@ -382,7 +382,7 @@ export class Paths {
   stringUrlNonEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringUrlNonEncodedOperationSpec,
@@ -410,7 +410,7 @@ export class Paths {
   stringEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringEmptyOperationSpec,
@@ -446,7 +446,7 @@ export class Paths {
     stringPath: string,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringPath, options },
       stringNullOperationSpec,
@@ -485,7 +485,7 @@ export class Paths {
     enumPath: Models.UriColor,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumPath, options },
       enumValidOperationSpec,
@@ -524,7 +524,7 @@ export class Paths {
     enumPath: Models.UriColor,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumPath, options },
       enumNullOperationSpec,
@@ -563,7 +563,7 @@ export class Paths {
     bytePath: Uint8Array,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bytePath, options },
       byteMultiByteOperationSpec,
@@ -591,7 +591,7 @@ export class Paths {
   byteEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       byteEmptyOperationSpec,
@@ -627,7 +627,7 @@ export class Paths {
     bytePath: Uint8Array,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bytePath, options },
       byteNullOperationSpec,
@@ -655,7 +655,7 @@ export class Paths {
   dateValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       dateValidOperationSpec,
@@ -668,33 +668,27 @@ export class Paths {
    * @param datePath null as date (should throw)
    * @param options The options parameters.
    */
-  dateNull(
-    datePath: Models.Date,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<any>;
+  dateNull(datePath: Date, options?: coreHttp.RequestOptionsBase): Promise<any>;
   /**
    * @param datePath null as date (should throw)
    * @param callback The callback.
    */
-  dateNull(
-    datePath: Models.Date,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
+  dateNull(datePath: Date, callback: coreHttp.ServiceCallback<any>): void;
   /**
    * @param datePath null as date (should throw)
    * @param options The options parameters.
    * @param callback The callback.
    */
   dateNull(
-    datePath: Models.Date,
+    datePath: Date,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   dateNull(
-    datePath: Models.Date,
+    datePath: Date,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { datePath, options },
       dateNullOperationSpec,
@@ -722,7 +716,7 @@ export class Paths {
   dateTimeValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       dateTimeValidOperationSpec,
@@ -736,7 +730,7 @@ export class Paths {
    * @param options The options parameters.
    */
   dateTimeNull(
-    dateTimePath: Models.Date,
+    dateTimePath: Date,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -744,7 +738,7 @@ export class Paths {
    * @param callback The callback.
    */
   dateTimeNull(
-    dateTimePath: Models.Date,
+    dateTimePath: Date,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -753,15 +747,15 @@ export class Paths {
    * @param callback The callback.
    */
   dateTimeNull(
-    dateTimePath: Models.Date,
+    dateTimePath: Date,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   dateTimeNull(
-    dateTimePath: Models.Date,
+    dateTimePath: Date,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { dateTimePath, options },
       dateTimeNullOperationSpec,
@@ -800,7 +794,7 @@ export class Paths {
     base64UrlPath: Uint8Array,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { base64UrlPath, options },
       base64UrlOperationSpec,
@@ -814,7 +808,7 @@ export class Paths {
    * @param options The options parameters.
    */
   arrayCsvInPath(
-    arrayPath: Models.String[],
+    arrayPath: string[],
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -822,7 +816,7 @@ export class Paths {
    * @param callback The callback.
    */
   arrayCsvInPath(
-    arrayPath: Models.String[],
+    arrayPath: string[],
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -831,15 +825,15 @@ export class Paths {
    * @param callback The callback.
    */
   arrayCsvInPath(
-    arrayPath: Models.String[],
+    arrayPath: string[],
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayCsvInPath(
-    arrayPath: Models.String[],
+    arrayPath: string[],
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { arrayPath, options },
       arrayCsvInPathOperationSpec,
@@ -853,7 +847,7 @@ export class Paths {
    * @param options The options parameters.
    */
   unixTimeUrl(
-    unixTimeUrlPath: Models.Date,
+    unixTimeUrlPath: Date,
     options?: coreHttp.RequestOptionsBase
   ): Promise<any>;
   /**
@@ -861,7 +855,7 @@ export class Paths {
    * @param callback The callback.
    */
   unixTimeUrl(
-    unixTimeUrlPath: Models.Date,
+    unixTimeUrlPath: Date,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   /**
@@ -870,15 +864,15 @@ export class Paths {
    * @param callback The callback.
    */
   unixTimeUrl(
-    unixTimeUrlPath: Models.Date,
+    unixTimeUrlPath: Date,
     options: coreHttp.RequestOptionsBase,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   unixTimeUrl(
-    unixTimeUrlPath: Models.Date,
+    unixTimeUrlPath: Date,
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { unixTimeUrlPath, options },
       unixTimeUrlOperationSpec,

--- a/test/integration/generated/url/src/operations/queries.ts
+++ b/test/integration/generated/url/src/operations/queries.ts
@@ -46,7 +46,7 @@ export class Queries {
   getBooleanTrue(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBooleanTrueOperationSpec,
@@ -74,7 +74,7 @@ export class Queries {
   getBooleanFalse(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBooleanFalseOperationSpec,
@@ -86,7 +86,9 @@ export class Queries {
    * Get null Boolean value on query (query string should be absent)
    * @param options The options parameters.
    */
-  getBooleanNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBooleanNull(
+    options?: Models.QueriesGetBooleanNullOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -96,13 +98,13 @@ export class Queries {
    * @param callback The callback.
    */
   getBooleanNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesGetBooleanNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getBooleanNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesGetBooleanNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getBooleanNullOperationSpec,
@@ -130,7 +132,7 @@ export class Queries {
   getIntOneMillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getIntOneMillionOperationSpec,
@@ -158,7 +160,7 @@ export class Queries {
   getIntNegativeOneMillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getIntNegativeOneMillionOperationSpec,
@@ -170,7 +172,7 @@ export class Queries {
    * Get null integer value (no query parameter)
    * @param options The options parameters.
    */
-  getIntNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getIntNull(options?: Models.QueriesGetIntNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -180,13 +182,13 @@ export class Queries {
    * @param callback The callback.
    */
   getIntNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesGetIntNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getIntNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesGetIntNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getIntNullOperationSpec,
@@ -214,7 +216,7 @@ export class Queries {
   getTenBillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getTenBillionOperationSpec,
@@ -242,7 +244,7 @@ export class Queries {
   getNegativeTenBillion(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getNegativeTenBillionOperationSpec,
@@ -254,7 +256,7 @@ export class Queries {
    * Get 'null 64 bit integer value (no query param in uri)
    * @param options The options parameters.
    */
-  getLongNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getLongNull(options?: Models.QueriesGetLongNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -264,13 +266,13 @@ export class Queries {
    * @param callback The callback.
    */
   getLongNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesGetLongNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   getLongNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesGetLongNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       getLongNullOperationSpec,
@@ -298,7 +300,7 @@ export class Queries {
   floatScientificPositive(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       floatScientificPositiveOperationSpec,
@@ -326,7 +328,7 @@ export class Queries {
   floatScientificNegative(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       floatScientificNegativeOperationSpec,
@@ -338,7 +340,7 @@ export class Queries {
    * Get null numeric value (no query parameter)
    * @param options The options parameters.
    */
-  floatNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  floatNull(options?: Models.QueriesFloatNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -348,13 +350,13 @@ export class Queries {
    * @param callback The callback.
    */
   floatNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesFloatNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   floatNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesFloatNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       floatNullOperationSpec,
@@ -382,7 +384,7 @@ export class Queries {
   doubleDecimalPositive(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       doubleDecimalPositiveOperationSpec,
@@ -410,7 +412,7 @@ export class Queries {
   doubleDecimalNegative(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       doubleDecimalNegativeOperationSpec,
@@ -422,7 +424,7 @@ export class Queries {
    * Get null numeric value (no query parameter)
    * @param options The options parameters.
    */
-  doubleNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  doubleNull(options?: Models.QueriesDoubleNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -432,13 +434,13 @@ export class Queries {
    * @param callback The callback.
    */
   doubleNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesDoubleNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   doubleNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesDoubleNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       doubleNullOperationSpec,
@@ -466,7 +468,7 @@ export class Queries {
   stringUnicode(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringUnicodeOperationSpec,
@@ -494,7 +496,7 @@ export class Queries {
   stringUrlEncoded(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringUrlEncodedOperationSpec,
@@ -522,7 +524,7 @@ export class Queries {
   stringEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringEmptyOperationSpec,
@@ -534,7 +536,7 @@ export class Queries {
    * Get null (no query parameter in url)
    * @param options The options parameters.
    */
-  stringNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringNull(options?: Models.QueriesStringNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -544,13 +546,13 @@ export class Queries {
    * @param callback The callback.
    */
   stringNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesStringNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   stringNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesStringNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       stringNullOperationSpec,
@@ -562,7 +564,7 @@ export class Queries {
    * Get using uri with query parameter 'green color'
    * @param options The options parameters.
    */
-  enumValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  enumValid(options?: Models.QueriesEnumValidOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -572,13 +574,13 @@ export class Queries {
    * @param callback The callback.
    */
   enumValid(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesEnumValidOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   enumValid(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesEnumValidOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       enumValidOperationSpec,
@@ -590,7 +592,7 @@ export class Queries {
    * Get null (no query parameter in url)
    * @param options The options parameters.
    */
-  enumNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  enumNull(options?: Models.QueriesEnumNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -600,13 +602,13 @@ export class Queries {
    * @param callback The callback.
    */
   enumNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesEnumNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   enumNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesEnumNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       enumNullOperationSpec,
@@ -618,7 +620,9 @@ export class Queries {
    * Get '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    * @param options The options parameters.
    */
-  byteMultiByte(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  byteMultiByte(
+    options?: Models.QueriesByteMultiByteOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -628,13 +632,13 @@ export class Queries {
    * @param callback The callback.
    */
   byteMultiByte(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesByteMultiByteOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   byteMultiByte(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesByteMultiByteOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       byteMultiByteOperationSpec,
@@ -662,7 +666,7 @@ export class Queries {
   byteEmpty(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       byteEmptyOperationSpec,
@@ -674,7 +678,7 @@ export class Queries {
    * Get null as byte array (no query parameters in uri)
    * @param options The options parameters.
    */
-  byteNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  byteNull(options?: Models.QueriesByteNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -684,13 +688,13 @@ export class Queries {
    * @param callback The callback.
    */
   byteNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesByteNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   byteNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesByteNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       byteNullOperationSpec,
@@ -718,7 +722,7 @@ export class Queries {
   dateValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       dateValidOperationSpec,
@@ -730,7 +734,7 @@ export class Queries {
    * Get null as date - this should result in no query parameters in uri
    * @param options The options parameters.
    */
-  dateNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateNull(options?: Models.QueriesDateNullOptionalParams): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -740,13 +744,13 @@ export class Queries {
    * @param callback The callback.
    */
   dateNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesDateNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   dateNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesDateNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       dateNullOperationSpec,
@@ -774,7 +778,7 @@ export class Queries {
   dateTimeValid(
     options?: coreHttp.RequestOptionsBase,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       dateTimeValidOperationSpec,
@@ -786,7 +790,9 @@ export class Queries {
    * Get null as date-time, should result in no query parameters in uri
    * @param options The options parameters.
    */
-  dateTimeNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateTimeNull(
+    options?: Models.QueriesDateTimeNullOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -796,13 +802,13 @@ export class Queries {
    * @param callback The callback.
    */
   dateTimeNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesDateTimeNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   dateTimeNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesDateTimeNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       dateTimeNullOperationSpec,
@@ -814,7 +820,9 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    * @param options The options parameters.
    */
-  arrayStringCsvValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  arrayStringCsvValid(
+    options?: Models.QueriesArrayStringCsvValidOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -824,13 +832,13 @@ export class Queries {
    * @param callback The callback.
    */
   arrayStringCsvValid(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesArrayStringCsvValidOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayStringCsvValid(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesArrayStringCsvValidOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       arrayStringCsvValidOperationSpec,
@@ -842,7 +850,9 @@ export class Queries {
    * Get a null array of string using the csv-array format
    * @param options The options parameters.
    */
-  arrayStringCsvNull(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  arrayStringCsvNull(
+    options?: Models.QueriesArrayStringCsvNullOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -852,13 +862,13 @@ export class Queries {
    * @param callback The callback.
    */
   arrayStringCsvNull(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesArrayStringCsvNullOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayStringCsvNull(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesArrayStringCsvNullOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       arrayStringCsvNullOperationSpec,
@@ -870,7 +880,9 @@ export class Queries {
    * Get an empty array [] of string using the csv-array format
    * @param options The options parameters.
    */
-  arrayStringCsvEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  arrayStringCsvEmpty(
+    options?: Models.QueriesArrayStringCsvEmptyOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -880,13 +892,13 @@ export class Queries {
    * @param callback The callback.
    */
   arrayStringCsvEmpty(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesArrayStringCsvEmptyOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayStringCsvEmpty(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesArrayStringCsvEmptyOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       arrayStringCsvEmptyOperationSpec,
@@ -898,7 +910,9 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
    * @param options The options parameters.
    */
-  arrayStringSsvValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  arrayStringSsvValid(
+    options?: Models.QueriesArrayStringSsvValidOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -908,13 +922,13 @@ export class Queries {
    * @param callback The callback.
    */
   arrayStringSsvValid(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesArrayStringSsvValidOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayStringSsvValid(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesArrayStringSsvValidOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       arrayStringSsvValidOperationSpec,
@@ -926,7 +940,9 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
    * @param options The options parameters.
    */
-  arrayStringTsvValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  arrayStringTsvValid(
+    options?: Models.QueriesArrayStringTsvValidOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -936,13 +952,13 @@ export class Queries {
    * @param callback The callback.
    */
   arrayStringTsvValid(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesArrayStringTsvValidOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayStringTsvValid(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesArrayStringTsvValidOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       arrayStringTsvValidOperationSpec,
@@ -954,7 +970,9 @@ export class Queries {
    * Get an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
    * @param options The options parameters.
    */
-  arrayStringPipesValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  arrayStringPipesValid(
+    options?: Models.QueriesArrayStringPipesValidOptionalParams
+  ): Promise<any>;
   /**
    * @param callback The callback.
    */
@@ -964,13 +982,13 @@ export class Queries {
    * @param callback The callback.
    */
   arrayStringPipesValid(
-    options: coreHttp.RequestOptionsBase,
+    options: Models.QueriesArrayStringPipesValidOptionalParams,
     callback: coreHttp.ServiceCallback<any>
   ): void;
   arrayStringPipesValid(
-    options?: coreHttp.RequestOptionsBase,
+    options?: Models.QueriesArrayStringPipesValidOptionalParams,
     callback?: coreHttp.ServiceCallback<any>
-  ): Promise<any> {
+  ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       arrayStringPipesValidOperationSpec,

--- a/test/integration/generated/url/src/operations/queries.ts
+++ b/test/integration/generated/url/src/operations/queries.ts
@@ -30,7 +30,9 @@ export class Queries {
    * Get true Boolean value on path
    * @param options The options parameters.
    */
-  getBooleanTrue(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBooleanTrue(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -51,14 +53,16 @@ export class Queries {
       { options },
       getBooleanTrueOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get false Boolean value on path
    * @param options The options parameters.
    */
-  getBooleanFalse(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getBooleanFalse(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -79,7 +83,7 @@ export class Queries {
       { options },
       getBooleanFalseOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -88,7 +92,7 @@ export class Queries {
    */
   getBooleanNull(
     options?: Models.QueriesGetBooleanNullOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -109,14 +113,16 @@ export class Queries {
       { options },
       getBooleanNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '1000000' integer value
    * @param options The options parameters.
    */
-  getIntOneMillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getIntOneMillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -137,14 +143,16 @@ export class Queries {
       { options },
       getIntOneMillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-1000000' integer value
    * @param options The options parameters.
    */
-  getIntNegativeOneMillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getIntNegativeOneMillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -165,14 +173,16 @@ export class Queries {
       { options },
       getIntNegativeOneMillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null integer value (no query parameter)
    * @param options The options parameters.
    */
-  getIntNull(options?: Models.QueriesGetIntNullOptionalParams): Promise<any>;
+  getIntNull(
+    options?: Models.QueriesGetIntNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -193,14 +203,16 @@ export class Queries {
       { options },
       getIntNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '10000000000' 64 bit integer value
    * @param options The options parameters.
    */
-  getTenBillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getTenBillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -221,14 +233,16 @@ export class Queries {
       { options },
       getTenBillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-10000000000' 64 bit integer value
    * @param options The options parameters.
    */
-  getNegativeTenBillion(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  getNegativeTenBillion(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -249,14 +263,16 @@ export class Queries {
       { options },
       getNegativeTenBillionOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get 'null 64 bit integer value (no query param in uri)
    * @param options The options parameters.
    */
-  getLongNull(options?: Models.QueriesGetLongNullOptionalParams): Promise<any>;
+  getLongNull(
+    options?: Models.QueriesGetLongNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -277,14 +293,16 @@ export class Queries {
       { options },
       getLongNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '1.034E+20' numeric value
    * @param options The options parameters.
    */
-  floatScientificPositive(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  floatScientificPositive(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -305,14 +323,16 @@ export class Queries {
       { options },
       floatScientificPositiveOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-1.034E-20' numeric value
    * @param options The options parameters.
    */
-  floatScientificNegative(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  floatScientificNegative(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -333,14 +353,16 @@ export class Queries {
       { options },
       floatScientificNegativeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null numeric value (no query parameter)
    * @param options The options parameters.
    */
-  floatNull(options?: Models.QueriesFloatNullOptionalParams): Promise<any>;
+  floatNull(
+    options?: Models.QueriesFloatNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -361,14 +383,16 @@ export class Queries {
       { options },
       floatNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '9999999.999' numeric value
    * @param options The options parameters.
    */
-  doubleDecimalPositive(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  doubleDecimalPositive(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -389,14 +413,16 @@ export class Queries {
       { options },
       doubleDecimalPositiveOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '-9999999.999' numeric value
    * @param options The options parameters.
    */
-  doubleDecimalNegative(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  doubleDecimalNegative(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -417,14 +443,16 @@ export class Queries {
       { options },
       doubleDecimalNegativeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null numeric value (no query parameter)
    * @param options The options parameters.
    */
-  doubleNull(options?: Models.QueriesDoubleNullOptionalParams): Promise<any>;
+  doubleNull(
+    options?: Models.QueriesDoubleNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -445,14 +473,16 @@ export class Queries {
       { options },
       doubleNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '啊齄丂狛狜隣郎隣兀﨩' multi-byte string value
    * @param options The options parameters.
    */
-  stringUnicode(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringUnicode(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -473,14 +503,16 @@ export class Queries {
       { options },
       stringUnicodeOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get 'begin!*'();:@ &=+$,/?#[]end
    * @param options The options parameters.
    */
-  stringUrlEncoded(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringUrlEncoded(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -501,14 +533,16 @@ export class Queries {
       { options },
       stringUrlEncodedOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get ''
    * @param options The options parameters.
    */
-  stringEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  stringEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -529,14 +563,16 @@ export class Queries {
       { options },
       stringEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null (no query parameter in url)
    * @param options The options parameters.
    */
-  stringNull(options?: Models.QueriesStringNullOptionalParams): Promise<any>;
+  stringNull(
+    options?: Models.QueriesStringNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -557,14 +593,16 @@ export class Queries {
       { options },
       stringNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get using uri with query parameter 'green color'
    * @param options The options parameters.
    */
-  enumValid(options?: Models.QueriesEnumValidOptionalParams): Promise<any>;
+  enumValid(
+    options?: Models.QueriesEnumValidOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -585,14 +623,16 @@ export class Queries {
       { options },
       enumValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null (no query parameter in url)
    * @param options The options parameters.
    */
-  enumNull(options?: Models.QueriesEnumNullOptionalParams): Promise<any>;
+  enumNull(
+    options?: Models.QueriesEnumNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -613,7 +653,7 @@ export class Queries {
       { options },
       enumNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -622,7 +662,7 @@ export class Queries {
    */
   byteMultiByte(
     options?: Models.QueriesByteMultiByteOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -643,14 +683,16 @@ export class Queries {
       { options },
       byteMultiByteOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '' as byte array
    * @param options The options parameters.
    */
-  byteEmpty(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  byteEmpty(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -671,14 +713,16 @@ export class Queries {
       { options },
       byteEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null as byte array (no query parameters in uri)
    * @param options The options parameters.
    */
-  byteNull(options?: Models.QueriesByteNullOptionalParams): Promise<any>;
+  byteNull(
+    options?: Models.QueriesByteNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -699,14 +743,16 @@ export class Queries {
       { options },
       byteNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '2012-01-01' as date
    * @param options The options parameters.
    */
-  dateValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -727,14 +773,16 @@ export class Queries {
       { options },
       dateValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get null as date - this should result in no query parameters in uri
    * @param options The options parameters.
    */
-  dateNull(options?: Models.QueriesDateNullOptionalParams): Promise<any>;
+  dateNull(
+    options?: Models.QueriesDateNullOptionalParams
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -755,14 +803,16 @@ export class Queries {
       { options },
       dateNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
    * Get '2012-01-01T01:01:01Z' as date-time
    * @param options The options parameters.
    */
-  dateTimeValid(options?: coreHttp.RequestOptionsBase): Promise<any>;
+  dateTimeValid(
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -783,7 +833,7 @@ export class Queries {
       { options },
       dateTimeValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -792,7 +842,7 @@ export class Queries {
    */
   dateTimeNull(
     options?: Models.QueriesDateTimeNullOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -813,7 +863,7 @@ export class Queries {
       { options },
       dateTimeNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -822,7 +872,7 @@ export class Queries {
    */
   arrayStringCsvValid(
     options?: Models.QueriesArrayStringCsvValidOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -843,7 +893,7 @@ export class Queries {
       { options },
       arrayStringCsvValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -852,7 +902,7 @@ export class Queries {
    */
   arrayStringCsvNull(
     options?: Models.QueriesArrayStringCsvNullOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -873,7 +923,7 @@ export class Queries {
       { options },
       arrayStringCsvNullOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -882,7 +932,7 @@ export class Queries {
    */
   arrayStringCsvEmpty(
     options?: Models.QueriesArrayStringCsvEmptyOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -903,7 +953,7 @@ export class Queries {
       { options },
       arrayStringCsvEmptyOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -912,7 +962,7 @@ export class Queries {
    */
   arrayStringSsvValid(
     options?: Models.QueriesArrayStringSsvValidOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -933,7 +983,7 @@ export class Queries {
       { options },
       arrayStringSsvValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -942,7 +992,7 @@ export class Queries {
    */
   arrayStringTsvValid(
     options?: Models.QueriesArrayStringTsvValidOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -963,7 +1013,7 @@ export class Queries {
       { options },
       arrayStringTsvValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 
   /**
@@ -972,7 +1022,7 @@ export class Queries {
    */
   arrayStringPipesValid(
     options?: Models.QueriesArrayStringPipesValidOptionalParams
-  ): Promise<any>;
+  ): Promise<coreHttp.RestResponse>;
   /**
    * @param callback The callback.
    */
@@ -993,7 +1043,7 @@ export class Queries {
       { options },
       arrayStringPipesValidOperationSpec,
       callback
-    );
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/url/src/operations/queries.ts
+++ b/test/integration/generated/url/src/operations/queries.ts
@@ -32,27 +32,10 @@ export class Queries {
    */
   getBooleanTrue(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBooleanTrue(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBooleanTrue(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBooleanTrue(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBooleanTrueOperationSpec,
-      callback
+      getBooleanTrueOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -62,27 +45,10 @@ export class Queries {
    */
   getBooleanFalse(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBooleanFalse(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBooleanFalse(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBooleanFalse(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBooleanFalseOperationSpec,
-      callback
+      getBooleanFalseOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -92,27 +58,10 @@ export class Queries {
    */
   getBooleanNull(
     options?: Models.QueriesGetBooleanNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getBooleanNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getBooleanNull(
-    options: Models.QueriesGetBooleanNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getBooleanNull(
-    options?: Models.QueriesGetBooleanNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getBooleanNullOperationSpec,
-      callback
+      getBooleanNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -122,27 +71,10 @@ export class Queries {
    */
   getIntOneMillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getIntOneMillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getIntOneMillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getIntOneMillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getIntOneMillionOperationSpec,
-      callback
+      getIntOneMillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -152,27 +84,10 @@ export class Queries {
    */
   getIntNegativeOneMillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getIntNegativeOneMillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getIntNegativeOneMillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getIntNegativeOneMillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getIntNegativeOneMillionOperationSpec,
-      callback
+      getIntNegativeOneMillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -182,27 +97,10 @@ export class Queries {
    */
   getIntNull(
     options?: Models.QueriesGetIntNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getIntNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getIntNull(
-    options: Models.QueriesGetIntNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getIntNull(
-    options?: Models.QueriesGetIntNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getIntNullOperationSpec,
-      callback
+      getIntNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -212,27 +110,10 @@ export class Queries {
    */
   getTenBillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getTenBillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getTenBillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getTenBillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getTenBillionOperationSpec,
-      callback
+      getTenBillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -242,27 +123,10 @@ export class Queries {
    */
   getNegativeTenBillion(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getNegativeTenBillion(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getNegativeTenBillion(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getNegativeTenBillion(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getNegativeTenBillionOperationSpec,
-      callback
+      getNegativeTenBillionOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -272,27 +136,10 @@ export class Queries {
    */
   getLongNull(
     options?: Models.QueriesGetLongNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  getLongNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  getLongNull(
-    options: Models.QueriesGetLongNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  getLongNull(
-    options?: Models.QueriesGetLongNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      getLongNullOperationSpec,
-      callback
+      getLongNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -302,27 +149,10 @@ export class Queries {
    */
   floatScientificPositive(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  floatScientificPositive(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  floatScientificPositive(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  floatScientificPositive(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      floatScientificPositiveOperationSpec,
-      callback
+      floatScientificPositiveOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -332,27 +162,10 @@ export class Queries {
    */
   floatScientificNegative(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  floatScientificNegative(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  floatScientificNegative(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  floatScientificNegative(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      floatScientificNegativeOperationSpec,
-      callback
+      floatScientificNegativeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -362,27 +175,10 @@ export class Queries {
    */
   floatNull(
     options?: Models.QueriesFloatNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  floatNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  floatNull(
-    options: Models.QueriesFloatNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  floatNull(
-    options?: Models.QueriesFloatNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      floatNullOperationSpec,
-      callback
+      floatNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -392,27 +188,10 @@ export class Queries {
    */
   doubleDecimalPositive(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  doubleDecimalPositive(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  doubleDecimalPositive(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  doubleDecimalPositive(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      doubleDecimalPositiveOperationSpec,
-      callback
+      doubleDecimalPositiveOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -422,27 +201,10 @@ export class Queries {
    */
   doubleDecimalNegative(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  doubleDecimalNegative(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  doubleDecimalNegative(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  doubleDecimalNegative(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      doubleDecimalNegativeOperationSpec,
-      callback
+      doubleDecimalNegativeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -452,27 +214,10 @@ export class Queries {
    */
   doubleNull(
     options?: Models.QueriesDoubleNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  doubleNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  doubleNull(
-    options: Models.QueriesDoubleNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  doubleNull(
-    options?: Models.QueriesDoubleNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      doubleNullOperationSpec,
-      callback
+      doubleNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -482,27 +227,10 @@ export class Queries {
    */
   stringUnicode(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringUnicode(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringUnicode(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringUnicode(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringUnicodeOperationSpec,
-      callback
+      stringUnicodeOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -512,27 +240,10 @@ export class Queries {
    */
   stringUrlEncoded(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringUrlEncoded(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringUrlEncoded(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringUrlEncoded(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringUrlEncodedOperationSpec,
-      callback
+      stringUrlEncodedOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -542,27 +253,10 @@ export class Queries {
    */
   stringEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringEmptyOperationSpec,
-      callback
+      stringEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -572,27 +266,10 @@ export class Queries {
    */
   stringNull(
     options?: Models.QueriesStringNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  stringNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  stringNull(
-    options: Models.QueriesStringNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  stringNull(
-    options?: Models.QueriesStringNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      stringNullOperationSpec,
-      callback
+      stringNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -602,27 +279,10 @@ export class Queries {
    */
   enumValid(
     options?: Models.QueriesEnumValidOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  enumValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  enumValid(
-    options: Models.QueriesEnumValidOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  enumValid(
-    options?: Models.QueriesEnumValidOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      enumValidOperationSpec,
-      callback
+      enumValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -632,27 +292,10 @@ export class Queries {
    */
   enumNull(
     options?: Models.QueriesEnumNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  enumNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  enumNull(
-    options: Models.QueriesEnumNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  enumNull(
-    options?: Models.QueriesEnumNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      enumNullOperationSpec,
-      callback
+      enumNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -662,27 +305,10 @@ export class Queries {
    */
   byteMultiByte(
     options?: Models.QueriesByteMultiByteOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  byteMultiByte(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  byteMultiByte(
-    options: Models.QueriesByteMultiByteOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  byteMultiByte(
-    options?: Models.QueriesByteMultiByteOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      byteMultiByteOperationSpec,
-      callback
+      byteMultiByteOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -692,27 +318,10 @@ export class Queries {
    */
   byteEmpty(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  byteEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  byteEmpty(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  byteEmpty(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      byteEmptyOperationSpec,
-      callback
+      byteEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -722,27 +331,10 @@ export class Queries {
    */
   byteNull(
     options?: Models.QueriesByteNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  byteNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  byteNull(
-    options: Models.QueriesByteNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  byteNull(
-    options?: Models.QueriesByteNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      byteNullOperationSpec,
-      callback
+      byteNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -752,27 +344,10 @@ export class Queries {
    */
   dateValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  dateValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      dateValidOperationSpec,
-      callback
+      dateValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -782,27 +357,10 @@ export class Queries {
    */
   dateNull(
     options?: Models.QueriesDateNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  dateNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateNull(
-    options: Models.QueriesDateNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateNull(
-    options?: Models.QueriesDateNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      dateNullOperationSpec,
-      callback
+      dateNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -812,27 +370,10 @@ export class Queries {
    */
   dateTimeValid(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  dateTimeValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateTimeValid(
-    options: coreHttp.RequestOptionsBase,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateTimeValid(
-    options?: coreHttp.RequestOptionsBase,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      dateTimeValidOperationSpec,
-      callback
+      dateTimeValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -842,27 +383,10 @@ export class Queries {
    */
   dateTimeNull(
     options?: Models.QueriesDateTimeNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  dateTimeNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  dateTimeNull(
-    options: Models.QueriesDateTimeNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  dateTimeNull(
-    options?: Models.QueriesDateTimeNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      dateTimeNullOperationSpec,
-      callback
+      dateTimeNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -872,27 +396,10 @@ export class Queries {
    */
   arrayStringCsvValid(
     options?: Models.QueriesArrayStringCsvValidOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  arrayStringCsvValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayStringCsvValid(
-    options: Models.QueriesArrayStringCsvValidOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayStringCsvValid(
-    options?: Models.QueriesArrayStringCsvValidOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      arrayStringCsvValidOperationSpec,
-      callback
+      arrayStringCsvValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -902,27 +409,10 @@ export class Queries {
    */
   arrayStringCsvNull(
     options?: Models.QueriesArrayStringCsvNullOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  arrayStringCsvNull(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayStringCsvNull(
-    options: Models.QueriesArrayStringCsvNullOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayStringCsvNull(
-    options?: Models.QueriesArrayStringCsvNullOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      arrayStringCsvNullOperationSpec,
-      callback
+      arrayStringCsvNullOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -932,27 +422,10 @@ export class Queries {
    */
   arrayStringCsvEmpty(
     options?: Models.QueriesArrayStringCsvEmptyOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  arrayStringCsvEmpty(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayStringCsvEmpty(
-    options: Models.QueriesArrayStringCsvEmptyOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayStringCsvEmpty(
-    options?: Models.QueriesArrayStringCsvEmptyOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      arrayStringCsvEmptyOperationSpec,
-      callback
+      arrayStringCsvEmptyOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -962,27 +435,10 @@ export class Queries {
    */
   arrayStringSsvValid(
     options?: Models.QueriesArrayStringSsvValidOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  arrayStringSsvValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayStringSsvValid(
-    options: Models.QueriesArrayStringSsvValidOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayStringSsvValid(
-    options?: Models.QueriesArrayStringSsvValidOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      arrayStringSsvValidOperationSpec,
-      callback
+      arrayStringSsvValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -992,27 +448,10 @@ export class Queries {
    */
   arrayStringTsvValid(
     options?: Models.QueriesArrayStringTsvValidOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  arrayStringTsvValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayStringTsvValid(
-    options: Models.QueriesArrayStringTsvValidOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayStringTsvValid(
-    options?: Models.QueriesArrayStringTsvValidOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      arrayStringTsvValidOperationSpec,
-      callback
+      arrayStringTsvValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 
@@ -1022,27 +461,10 @@ export class Queries {
    */
   arrayStringPipesValid(
     options?: Models.QueriesArrayStringPipesValidOptionalParams
-  ): Promise<coreHttp.RestResponse>;
-  /**
-   * @param callback The callback.
-   */
-  arrayStringPipesValid(callback: coreHttp.ServiceCallback<any>): void;
-  /**
-   * @param options The options parameters.
-   * @param callback The callback.
-   */
-  arrayStringPipesValid(
-    options: Models.QueriesArrayStringPipesValidOptionalParams,
-    callback: coreHttp.ServiceCallback<any>
-  ): void;
-  arrayStringPipesValid(
-    options?: Models.QueriesArrayStringPipesValidOptionalParams,
-    callback?: coreHttp.ServiceCallback<any>
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
-      arrayStringPipesValidOperationSpec,
-      callback
+      arrayStringPipesValidOperationSpec
     ) as Promise<coreHttp.RestResponse>;
   }
 }

--- a/test/integration/generated/url/src/urlClient.ts
+++ b/test/integration/generated/url/src/urlClient.ts
@@ -20,7 +20,7 @@ class UrlClient extends UrlClientContext {
    * Initializes a new instance of the UrlClient class.
    * @param options The parameter options
    */
-  constructor(globalStringPath: any, options?: any) {
+  constructor(globalStringPath: string, options?: any) {
     super(globalStringPath, options);
     this.paths = new operations.Paths(this);
     this.queries = new operations.Queries(this);

--- a/test/integration/generated/url/src/urlClientContext.ts
+++ b/test/integration/generated/url/src/urlClientContext.ts
@@ -13,15 +13,16 @@ const packageName = "url";
 const packageVersion = "1.0.0-preview1";
 
 export class UrlClientContext extends coreHttp.ServiceClient {
-  globalStringPath: any;
-  globalStringQuery?: any;
+  $host: string;
+  globalStringPath: string;
+  globalStringQuery?: string;
 
   /**
    * Initializes a new instance of the UrlClientContext class.
    *
    * @param options The parameter options
    */
-  constructor(globalStringPath: any, options?: any) {
+  constructor(globalStringPath: string, options?: any) {
     if (globalStringPath === undefined) {
       throw new Error("'globalStringPath' cannot be null");
     }
@@ -46,5 +47,7 @@ export class UrlClientContext extends coreHttp.ServiceClient {
     ) {
       this.globalStringQuery = options.globalStringQuery;
     }
+
+    this.$host = "http://localhost:3000";
   }
 }

--- a/test/integration/generated/url/tsconfig.json
+++ b/test/integration/generated/url/tsconfig.json
@@ -9,7 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "lib": ["es6"],
+    "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
     "importHelpers": true

--- a/test/integration/url.spec.ts
+++ b/test/integration/url.spec.ts
@@ -128,7 +128,7 @@ describe("Integration tests for Url", () => {
     });
 
     it("getGlobalAndLocalQueryNull should work when use null values in different portion of url", async function() {
-      client.globalStringQuery = null;
+      client.globalStringQuery = null as any;
       const optionalParams = {
         localStringQuery: null as any,
         pathItemStringQuery: "pathItemStringQuery"
@@ -143,8 +143,7 @@ describe("Integration tests for Url", () => {
     });
 
     it("getGlobalQueryNull should work when use null values in different portion of url", async function() {
-      // INVESTIGATE
-      client.globalStringQuery = null;
+      client.globalStringQuery = null as any;
       const optionalParams = {
         localStringQuery: "localStringQuery",
         pathItemStringQuery: "pathItemStringQuery"

--- a/test/integration/url.spec.ts
+++ b/test/integration/url.spec.ts
@@ -130,7 +130,7 @@ describe("Integration tests for Url", () => {
     it("getGlobalAndLocalQueryNull should work when use null values in different portion of url", async function() {
       client.globalStringQuery = null;
       const optionalParams = {
-        localStringQuery: null,
+        localStringQuery: null as any,
         pathItemStringQuery: "pathItemStringQuery"
       };
 
@@ -161,8 +161,8 @@ describe("Integration tests for Url", () => {
     it("getLocalPathItemQueryNull should work when use null values in different portion of url", async function() {
       client.globalStringQuery = "globalStringQuery";
       const optionalParams = {
-        localStringQuery: null,
-        pathItemStringQuery: null
+        localStringQuery: null as any,
+        pathItemStringQuery: null as any
       };
 
       await client.pathItems.getLocalPathItemQueryNull(
@@ -220,7 +220,7 @@ describe("Integration tests for Url", () => {
       await shouldThrow(() =>
         client.queries.enumValid({ enumQuery: <UrlModels.UriColor>"" })
       );
-      await client.queries.enumNull({ enumQuery: null });
+      await client.queries.enumNull({ enumQuery: null as any });
       await client.queries.enumValid({ enumQuery: "green color" });
       assert.ok("Call succeeded");
     });
@@ -229,9 +229,9 @@ describe("Integration tests for Url", () => {
       const testArray = [
         "ArrayQuery1",
         "begin!*'();:@ &=+$,/?#[]end",
-        null,
+        null as any,
         ""
-      ];
+      ] as string[];
       await client.queries.arrayStringCsvEmpty({ arrayQuery: [] });
       await client.queries.arrayStringCsvValid({ arrayQuery: testArray });
       await client.queries.arrayStringPipesValid({ arrayQuery: testArray });
@@ -244,23 +244,23 @@ describe("Integration tests for Url", () => {
       await client.paths.arrayCsvInPath([
         "ArrayPath1",
         "begin!*'();:@ &=+$,/?#[]end",
-        null,
+        null as any,
         ""
-      ]);
+      ] as string[]);
       assert.ok("Call succeeded");
     });
 
     it("should work when use null values in url query", async function() {
-      await client.queries.byteNull({ byteQuery: null });
-      await client.queries.dateNull({ dateQuery: null });
-      await client.queries.dateTimeNull({ dateTimeQuery: null });
-      await client.queries.doubleNull({ doubleQuery: null });
-      await client.queries.floatNull({ floatQuery: null });
-      await client.queries.getBooleanNull({ boolQuery: null });
-      await client.queries.getIntNull({ intQuery: null });
-      await client.queries.getLongNull({ longQuery: null });
-      await client.queries.stringNull({ stringQuery: null });
-      await client.queries.arrayStringCsvNull({ arrayQuery: null });
+      await client.queries.byteNull({ byteQuery: null as any });
+      await client.queries.dateNull({ dateQuery: null as any });
+      await client.queries.dateTimeNull({ dateTimeQuery: null as any });
+      await client.queries.doubleNull({ doubleQuery: null as any });
+      await client.queries.floatNull({ floatQuery: null as any });
+      await client.queries.getBooleanNull({ boolQuery: null as any });
+      await client.queries.getIntNull({ intQuery: null as any });
+      await client.queries.getLongNull({ longQuery: null as any });
+      await client.queries.stringNull({ stringQuery: null as any });
+      await client.queries.arrayStringCsvNull({ arrayQuery: null as any });
       assert.ok("Calls succeeded");
     });
   });

--- a/test/unit/generators/utils/parameterUtils.spec.ts
+++ b/test/unit/generators/utils/parameterUtils.spec.ts
@@ -9,6 +9,7 @@ import {
   SchemaType,
   ImplementationLocation
 } from "@azure-tools/codemodel";
+import { PropertyKind } from "../../../../src/models/modelDetails";
 
 describe("parameterUtils", () => {
   describe("filterParameters", () => {
@@ -157,7 +158,7 @@ const getParameter = ({
   parameterPath,
   mapper,
   collectionFormat,
-  modelType,
+  typeDetails,
   schemaType,
   sufix = "",
   isGlobal = false,
@@ -177,7 +178,10 @@ const getParameter = ({
   location: location || ParameterLocation.Body,
   parameterPath: parameterPath || `MockParameter${sufix}`,
   mapper: mapper || "MockMapper",
-  modelType: modelType || "MockModel",
+  typeDetails: typeDetails || {
+    typeName: "MockModel",
+    kind: PropertyKind.Composite
+  },
   schemaType: schemaType || SchemaType.String,
   parameter,
   isGlobal,

--- a/test/unit/generators/utils/parameterUtils.spec.ts
+++ b/test/unit/generators/utils/parameterUtils.spec.ts
@@ -1,0 +1,188 @@
+import { filterOperationParameters } from "../../../../src/generators/utils/parameterUtils";
+import { ParameterDetails } from "../../../../src/models/parameterDetails";
+import { OperationDetails } from "../../../../src/models/operationDetails";
+import * as assert from "assert";
+import {
+  ParameterLocation,
+  Parameter,
+  StringSchema,
+  SchemaType,
+  ImplementationLocation
+} from "@azure-tools/codemodel";
+
+describe("parameterUtils", () => {
+  describe("filterParameters", () => {
+    let operation: OperationDetails;
+    beforeEach(() => {
+      operation = {
+        name: "mockOperation",
+        fullName: "mockgroup_mockoperation",
+        description: "some mock operation",
+        apiVersions: ["1.0.0"]
+      } as OperationDetails;
+    });
+
+    it("should include optional parameters", () => {
+      const operationsIn = [operation.fullName];
+      const parameters = [
+        getParameter({ name: "requiredParam", operationsIn, required: true }),
+        getParameter({
+          name: "optionalParameter",
+          operationsIn,
+          required: false
+        })
+      ];
+
+      const result = filterOperationParameters(parameters, operation, {
+        includeOptional: true
+      });
+
+      assert.equal(result.length, 2);
+    });
+
+    it("should not include optional parameters", () => {
+      const operationsIn = [operation.fullName];
+      const parameters = [
+        getParameter({ name: "requiredParam", operationsIn, required: true }),
+        getParameter({
+          name: "optionalParameter",
+          operationsIn,
+          required: false
+        })
+      ];
+
+      const result = filterOperationParameters(parameters, operation, {
+        includeOptional: false
+      });
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0], parameters[0]);
+    });
+
+    it("should honor includeConstant option", () => {
+      const operationsIn = [operation.fullName];
+      const parameters = [
+        getParameter({
+          name: "constantParameter",
+          operationsIn,
+          schemaType: SchemaType.Constant
+        })
+      ];
+
+      let result = filterOperationParameters(parameters, operation, {
+        includeConstantParameters: true
+      });
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0], parameters[0]);
+
+      result = filterOperationParameters(parameters, operation, {
+        includeConstantParameters: false
+      });
+
+      assert.equal(result.length, 0);
+    });
+    it("should include honor incluideClientParmeter options", () => {
+      const operationsIn = [operation.fullName];
+      const parameters = [
+        getParameter({
+          name: "clientParameter",
+          operationsIn,
+          implementationLocation: ImplementationLocation.Client
+        })
+      ];
+
+      let result = filterOperationParameters(parameters, operation, {
+        includeClientParams: true
+      });
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0], parameters[0]);
+
+      result = filterOperationParameters(parameters, operation, {
+        includeClientParams: false
+      });
+
+      assert.equal(result.length, 0);
+    });
+
+    it("should honor includeGlobalParameters", () => {
+      const operationsIn = [operation.fullName];
+      const parameters = [
+        getParameter({
+          name: "globalParameter",
+          operationsIn,
+          isGlobal: true
+        })
+      ];
+
+      let result = filterOperationParameters(parameters, operation, {
+        includeGlobalParameters: true
+      });
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0], parameters[0]);
+
+      result = filterOperationParameters(parameters, operation, {
+        includeGlobalParameters: false
+      });
+
+      assert.equal(result.length, 0);
+    });
+    it("should include only parameters used by the operation", () => {
+      const parameters = [
+        getParameter({
+          name: "foreignParameter",
+          operationsIn: ["some_other_operation"]
+        }),
+        getParameter({
+          name: "goodParameter",
+          operationsIn: [operation.fullName]
+        })
+      ];
+
+      let result = filterOperationParameters(parameters, operation);
+
+      assert.equal(result.length, 1);
+      assert.equal(result[0], parameters[1]);
+    });
+  });
+});
+
+const getParameter = ({
+  name,
+  description,
+  nameRef,
+  location,
+  parameterPath,
+  mapper,
+  collectionFormat,
+  modelType,
+  schemaType,
+  sufix = "",
+  isGlobal = false,
+  required = true,
+  parameter = new Parameter(
+    "mockParameter",
+    "",
+    new StringSchema("mock_string", "")
+  ),
+  operationsIn = [],
+  implementationLocation = ImplementationLocation.Method
+}: Partial<ParameterDetails & { sufix: string }>): ParameterDetails => ({
+  nameRef: nameRef || `MockParameter${sufix}`,
+  description: description || `mock parameter description${sufix}`,
+  name: name || `mockParameter${sufix}`,
+  serializedName: `mock_parameter${sufix}`,
+  location: location || ParameterLocation.Body,
+  parameterPath: parameterPath || `MockParameter${sufix}`,
+  mapper: mapper || "MockMapper",
+  modelType: modelType || "MockModel",
+  schemaType: schemaType || SchemaType.String,
+  parameter,
+  isGlobal,
+  required,
+  operationsIn,
+  collectionFormat,
+  implementationLocation
+});

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -16,7 +16,8 @@ import {
   ConstantSchema,
   ConstantValue,
   Parameter,
-  StringSchema
+  StringSchema,
+  ImplementationLocation
 } from "@azure-tools/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper } from "@azure/core-http";
@@ -210,7 +211,9 @@ describe("OperationTransforms", () => {
             parameter,
             modelType: "string",
             name: "MockOperation",
-            description: ""
+            description: "",
+            schemaType: SchemaType.String,
+            implementationLocation: ImplementationLocation.Method
           }
         ]);
         checkHttpMethodAndPath(operationSpec);

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -176,7 +176,7 @@ describe("OperationTransforms", () => {
         checkHttpMethodAndPath(operationSpec);
       });
 
-      it.skip("should create an operation spec with correct responses from a basic response", () => {
+      it("should create an operation spec with correct responses from a basic response", () => {
         const mockOperation = getOperation();
         const operationDetails = transformOperation(
           mockOperation,
@@ -184,7 +184,7 @@ describe("OperationTransforms", () => {
         );
         const operationSpec = transformOperationSpec(operationDetails, []);
         checkHttpMethodAndPath(operationSpec);
-        assert.deepEqual(operationSpec.responses[200], {});
+        assert.notEqual(operationSpec.responses[200], undefined);
       });
 
       it("should create an operation spec with correct parameters", () => {

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -22,6 +22,7 @@ import {
 import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper } from "@azure/core-http";
 import { OperationSpecDetails } from "../../../src/models/operationDetails";
+import { PropertyKind } from "../../../src/models/modelDetails";
 
 const choice = new ChoiceSchema("mockChoice", "", {
   choices: [
@@ -135,7 +136,10 @@ describe("OperationTransforms", () => {
             }
           },
           responses: [
-            responseSchema || { protocol: { http: { statusCodes: ["200"] } } }
+            responseSchema ||
+              new SchemaResponse(new StringSchema("string", ""), {
+                protocol: { http: { statusCodes: ["200"] } }
+              })
           ],
           exceptions: [getErrorResponseSchema()],
           language: {
@@ -172,7 +176,7 @@ describe("OperationTransforms", () => {
         checkHttpMethodAndPath(operationSpec);
       });
 
-      it("should create an operation spec with correct responses from a basic response", () => {
+      it.skip("should create an operation spec with correct responses from a basic response", () => {
         const mockOperation = getOperation();
         const operationDetails = transformOperation(
           mockOperation,
@@ -209,7 +213,7 @@ describe("OperationTransforms", () => {
             location: ParameterLocation.Body,
             serializedName: "",
             parameter,
-            modelType: "string",
+            typeDetails: { typeName: "string", kind: PropertyKind.Primitive },
             name: "MockOperation",
             description: "",
             schemaType: SchemaType.String,

--- a/test/unit/transforms/transforms.spec.ts
+++ b/test/unit/transforms/transforms.spec.ts
@@ -1,10 +1,6 @@
 import * as assert from "assert";
 
-import {
-  transformObject,
-  transformProperty,
-  transformChoice
-} from "../../../src/transforms/transforms";
+import { transformChoice } from "../../../src/transforms/transforms";
 
 import {
   CodeModel,
@@ -19,6 +15,10 @@ import {
   ChoiceValue,
   BooleanSchema
 } from "@azure-tools/codemodel";
+import {
+  transformProperty,
+  transformObject
+} from "../../../src/transforms/objectTransforms";
 
 const appleSchema = new ObjectSchema("Apple", "An apple.", {
   properties: [
@@ -76,7 +76,7 @@ describe("Transforms", () => {
 
   describe("ObjectSchema to ModelDetails", () => {
     it("retains basic details and contains properties", () => {
-      const model = transformObject(appleSchema);
+      const model = transformObject(appleSchema, []);
       assert.strictEqual(model.name, "Apple");
       assert.strictEqual(model.properties.length, 3);
       assert.strictEqual(model.properties[0].name, "color");


### PR DESCRIPTION
Picking up @daviwil PR (Azure/autorest.typescript.v3/pull/15) which generates the necessary model types for operation requests and responses and hooks them up to the `operationsGenerator` so that they get used in the method signatures that get generated.

Also including support for representing Polymorphic parameters and inheritance and some refactoring for better code reuse

P.S. sorry for the big PR :flushed: