### PR TITLE
Client Operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist
 package-lock.json
 node_modules
 test.json
+test/**/dist
+test/**/esm
+test/**/node_modules

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ More information about these can be found [here](https://github.com/Azure/autore
 ```yaml
 version: 3.0.6192
 use-extension:
-  "@autorest/modelerfour": "4.3.142"
+  "@autorest/modelerfour": "4.4.158"
 
 pipeline:
   typescript: # <- name of plugin

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -37,7 +37,7 @@ export function generateClientContext(
   );
 
   const sourceFile = project.createSourceFile(
-    `src/${clientContextFileName}.ts`,
+    `${clientDetails.srcPath}/${clientContextFileName}.ts`,
     undefined,
     {
       overwrite: true
@@ -75,11 +75,6 @@ function writeImports(sourceFile: SourceFile) {
   sourceFile.addImportDeclaration({
     namespaceImport: "coreHttp",
     moduleSpecifier: "@azure/core-http"
-  });
-
-  sourceFile.addImportDeclaration({
-    namespaceImport: "Models",
-    moduleSpecifier: "./models"
   });
 }
 

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -124,10 +124,12 @@ function writeConstructorBody(
     writeStatement(writeDefaultOptions(hasCredentials)),
     requiredParameters.length ? "// Parameter assignments" : "",
     writeStatements(getRequiredParamAssignments(requiredPaams), addBlankLine),
-    constantParameters ? "// Assigning values to Constant parameters" : "",
+    constantParameters.length
+      ? "// Assigning values to Constant parameters"
+      : "",
     writeStatements(constantParameters, addBlankLine),
     writeStatement(getBaseUriStatement(clientDetails.baseUrl), addBlankLine),
-    optionalParameters
+    optionalParameters.length
       ? "// Replacing parameter defaults with user-provided parameters."
       : "",
     writeStatements(optionalParameters)

--- a/src/generators/clientFileGenerator.ts
+++ b/src/generators/clientFileGenerator.ts
@@ -27,7 +27,7 @@ export function generateClient(clientDetails: ClientDetails, project: Project) {
   const mappersName = getMappersName(clientDetails.className);
   const clientContextClassName = `${clientDetails.className}Context`;
 
-  // A client has inline operations when there is only one operation group
+  // A client has inline operations when it has a toplevel operation group
   const hasInlineOperations = clientDetails.operationGroups.some(
     og => og.isTopLevel
   );

--- a/src/generators/mappersGenerator.ts
+++ b/src/generators/mappersGenerator.ts
@@ -18,7 +18,7 @@ export function generateMappers(
   project: Project
 ) {
   const mappersFile = project.createSourceFile(
-    "src/models/mappers.ts",
+    `${clientDetails.srcPath}/models/mappers.ts`,
     undefined,
     { overwrite: true }
   );

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -27,7 +27,7 @@ import { ParameterDetails } from "../models/parameterDetails";
 
 export function generateModels(clientDetails: ClientDetails, project: Project) {
   const modelsIndexFile = project.createSourceFile(
-    "src/models/index.ts",
+    `${clientDetails.srcPath}/models/index.ts`,
     undefined,
     { overwrite: true }
   );

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -38,17 +38,15 @@ export function generateOperations(
   clientDetails: ClientDetails,
   project: Project
 ): void {
-  if (clientDetails.operationGroups.length === 1) {
-    // When there is only one operationGroup, we want to add the operations to the Client Class.
-    // Skip and let Client generator handle operations
-    return;
-  }
-
   let fileNames: string[] = [];
-  clientDetails.operationGroups.forEach(operationDetails => {
-    fileNames.push(normalizeName(operationDetails.name, NameType.File));
-    generateOperation(operationDetails, clientDetails, project);
-  });
+
+  clientDetails.operationGroups
+    // Toplevel operations are inlined in the client
+    .filter(og => !og.isTopLevel)
+    .forEach(operationDetails => {
+      fileNames.push(normalizeName(operationDetails.name, NameType.File));
+      generateOperation(operationDetails, clientDetails, project);
+    });
 
   const operationIndexFile = project.createSourceFile(
     `${clientDetails.srcPath}/operations/index.ts`,

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -40,27 +40,31 @@ export function generateOperations(
 ): void {
   let fileNames: string[] = [];
 
-  clientDetails.operationGroups
-    // Toplevel operations are inlined in the client
-    .filter(og => !og.isTopLevel)
-    .forEach(operationDetails => {
-      fileNames.push(normalizeName(operationDetails.name, NameType.File));
-      generateOperation(operationDetails, clientDetails, project);
-    });
-
-  const operationIndexFile = project.createSourceFile(
-    `${clientDetails.srcPath}/operations/index.ts`,
-    undefined,
-    { overwrite: true }
+  // Toplevel operations are inlined in the client
+  const operationGroups = clientDetails.operationGroups.filter(
+    og => !og.isTopLevel
   );
 
-  operationIndexFile.addExportDeclarations(
-    fileNames.map(fileName => {
-      return {
-        moduleSpecifier: `./${fileName}`
-      } as ExportDeclarationStructure;
-    })
-  );
+  operationGroups.forEach(operationDetails => {
+    fileNames.push(normalizeName(operationDetails.name, NameType.File));
+    generateOperation(operationDetails, clientDetails, project);
+  });
+
+  if (operationGroups.length) {
+    const operationIndexFile = project.createSourceFile(
+      `${clientDetails.srcPath}/operations/index.ts`,
+      undefined,
+      { overwrite: true }
+    );
+
+    operationIndexFile.addExportDeclarations(
+      fileNames.map(fileName => {
+        return {
+          moduleSpecifier: `./${fileName}`
+        } as ExportDeclarationStructure;
+      })
+    );
+  }
 }
 
 /**

--- a/src/generators/parametersGenerator.ts
+++ b/src/generators/parametersGenerator.ts
@@ -14,7 +14,7 @@ export function generateParameters(
   project: Project
 ): void {
   const parametersFile = project.createSourceFile(
-    "src/models/parameters.ts",
+    `${clientDetails.srcPath}/models/parameters.ts`,
     undefined,
     { overwrite: true }
   );

--- a/src/generators/static/packageFileGenerator.ts
+++ b/src/generators/static/packageFileGenerator.ts
@@ -51,7 +51,7 @@ export function generatePackageJson(
       "esm/**/*.js.map",
       "esm/**/*.d.ts",
       "esm/**/*.d.ts.map",
-      "src/**/*.ts",
+      `${clientDetails.srcPath}/**/*.ts`,
       "README.md",
       "rollup.config.js",
       "tsconfig.json"

--- a/src/models/clientDetails.ts
+++ b/src/models/clientDetails.ts
@@ -25,4 +25,5 @@ export interface ClientDetails {
   parameters: ParameterDetails[];
   options: ClientOptions;
   baseUrl: BaseUrlDetails;
+  srcPath?: string;
 }

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -59,6 +59,7 @@ export interface OperationGroupDetails {
   key: string;
   name: string;
   operations: OperationDetails[];
+  isTopLevel: boolean;
 }
 
 export interface OperationSpecResponse {

--- a/src/transforms/constants.ts
+++ b/src/transforms/constants.ts
@@ -1,0 +1,1 @@
+export const TOPLEVEL_OPERATIONGROUP = "topleveloperationgroup";

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -29,7 +29,6 @@ import { getTypeForSchema } from "../utils/schemaHelpers";
 import { getMapperTypeFromSchema } from "./mapperTransforms";
 import { ParameterDetails } from "../models/parameterDetails";
 import { PropertyKind, TypeDetails } from "../models/modelDetails";
-import { isNil } from "lodash";
 import { TOPLEVEL_OPERATIONGROUP } from "./constants";
 
 export function transformOperationSpec(
@@ -258,7 +257,7 @@ export function transformOperationGroup(
   operationGroup: OperationGroup
 ): OperationGroupDetails {
   const metadata = getLanguageMetadata(operationGroup.language);
-  const isTopLevel = isNil(metadata.name);
+  const isTopLevel = !metadata.name;
   const name = normalizeName(
     metadata.name || TOPLEVEL_OPERATIONGROUP,
     NameType.Property

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -29,6 +29,8 @@ import { getTypeForSchema } from "../utils/schemaHelpers";
 import { getMapperTypeFromSchema } from "./mapperTransforms";
 import { ParameterDetails } from "../models/parameterDetails";
 import { PropertyKind, TypeDetails } from "../models/modelDetails";
+import { isNil } from "lodash";
+import { TOPLEVEL_OPERATIONGROUP } from "./constants";
 
 export function transformOperationSpec(
   operationDetails: OperationDetails,
@@ -256,14 +258,18 @@ export function transformOperationGroup(
   operationGroup: OperationGroup
 ): OperationGroupDetails {
   const metadata = getLanguageMetadata(operationGroup.language);
-  // TODO: Probably want to inline operations in client when there is only one operation group (#551)
-  const name = normalizeName(metadata.name || "operations", NameType.Property);
+  const isTopLevel = isNil(metadata.name);
+  const name = normalizeName(
+    metadata.name || TOPLEVEL_OPERATIONGROUP,
+    NameType.Property
+  );
   return {
     name,
     key: operationGroup.$key,
     operations: operationGroup.operations.map(operation =>
       transformOperation(operation, name)
-    )
+    ),
+    isTopLevel
   };
 }
 

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -23,6 +23,7 @@ import {
 import { isEqual, isNil } from "lodash";
 import { getTypeForSchema } from "../utils/schemaHelpers";
 import { getStringForValue } from "../utils/valueHelpers";
+import { TOPLEVEL_OPERATIONGROUP } from "./constants";
 
 interface OperationParameterDetails {
   parameter: Parameter;
@@ -41,7 +42,8 @@ export function transformParameters(codeModel: CodeModel): ParameterDetails[] {
 const extractOperationParameters = (codeModel: CodeModel) =>
   codeModel.operationGroups.reduce<OperationParameterDetails[]>((acc, og) => {
     // TODO: Probably want to inline operations in client when there is only one operation group (#551)
-    const groupName = getLanguageMetadata(og.language).name || "operations";
+    const groupName =
+      getLanguageMetadata(og.language).name || TOPLEVEL_OPERATIONGROUP;
     return [
       ...acc,
       ...og.operations.reduce<OperationParameterDetails[]>(

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -41,7 +41,6 @@ export function transformParameters(codeModel: CodeModel): ParameterDetails[] {
 
 const extractOperationParameters = (codeModel: CodeModel) =>
   codeModel.operationGroups.reduce<OperationParameterDetails[]>((acc, og) => {
-    // TODO: Probably want to inline operations in client when there is only one operation group (#551)
     const groupName =
       getLanguageMetadata(og.language).name || TOPLEVEL_OPERATIONGROUP;
     return [

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -49,7 +49,12 @@ export async function generateTypeScriptLibrary(
     }
   });
 
+  const srcPath =
+    ((await host.GetValue("source-code-folder-path")) as string) || "src";
+
   const clientDetails = await transformCodeModel(codeModel, host);
+  clientDetails.srcPath = srcPath;
+
   const packageName = await host.GetValue("package-name");
   const packageNameParts = packageName.match(/(^@(.*)\/)?(.*)/);
   const packageDetails: PackageDetails = {

--- a/test/integration/custom-url.spec.ts
+++ b/test/integration/custom-url.spec.ts
@@ -10,7 +10,7 @@ describe("Custom BaseUri", () => {
   });
 
   it("should return 200", async () => {
-    const response = await client.paths.getEmpty("local");
+    const response = await client.getEmpty("local");
     assert.equal(response._response.status, 200);
   });
 });

--- a/test/integration/custom-url.spec.ts
+++ b/test/integration/custom-url.spec.ts
@@ -10,7 +10,7 @@ describe("Custom BaseUri", () => {
   });
 
   it("should return 200", async () => {
-    const response = await client.getEmpty("local");
+    const response = await client.paths.getEmpty("local");
     assert.equal(response._response.status, 200);
   });
 });

--- a/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
@@ -12,16 +12,6 @@ import * as Mappers from "./models/mappers";
 import { BodyComplexClientContext } from "./bodyComplexClientContext";
 
 class BodyComplexClient extends BodyComplexClientContext {
-  basic: operations.Basic;
-  primitive: operations.Primitive;
-  array: operations.Array;
-  dictionary: operations.Dictionary;
-  inheritance: operations.Inheritance;
-  polymorphism: operations.Polymorphism;
-  polymorphicrecursive: operations.Polymorphicrecursive;
-  readonlyproperty: operations.Readonlyproperty;
-  flattencomplex: operations.Flattencomplex;
-
   /**
    * Initializes a new instance of the BodyComplexClient class.
    * @param options The parameter options
@@ -38,6 +28,16 @@ class BodyComplexClient extends BodyComplexClientContext {
     this.readonlyproperty = new operations.Readonlyproperty(this);
     this.flattencomplex = new operations.Flattencomplex(this);
   }
+
+  basic: operations.Basic;
+  primitive: operations.Primitive;
+  array: operations.Array;
+  dictionary: operations.Dictionary;
+  inheritance: operations.Inheritance;
+  polymorphism: operations.Polymorphism;
+  polymorphicrecursive: operations.Polymorphicrecursive;
+  readonlyproperty: operations.Readonlyproperty;
+  flattencomplex: operations.Flattencomplex;
 }
 
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
@@ -6,9 +6,9 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
-import * as operations from "./operations";
 import { BodyComplexClientContext } from "./bodyComplexClientContext";
 
 class BodyComplexClient extends BodyComplexClientContext {

--- a/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
@@ -7,7 +7,6 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
 
 const packageName = "bodyString";
 const packageVersion = "1.0.0-preview1";

--- a/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
+++ b/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
@@ -27,7 +27,6 @@ export class Flattencomplex {
   }
 
   /**
-   * MISSING·OPERATION-DESCRIPTION
    * @param options The options parameters.
    */
   getValid(

--- a/test/integration/generated/bodyString/src/bodyStringClient.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClient.ts
@@ -6,9 +6,9 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
-import * as operations from "./operations";
 import { BodyStringClientContext } from "./bodyStringClientContext";
 
 class BodyStringClient extends BodyStringClientContext {

--- a/test/integration/generated/bodyString/src/bodyStringClient.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClient.ts
@@ -12,9 +12,6 @@ import * as Mappers from "./models/mappers";
 import { BodyStringClientContext } from "./bodyStringClientContext";
 
 class BodyStringClient extends BodyStringClientContext {
-  string: operations.String;
-  enum: operations.Enum;
-
   /**
    * Initializes a new instance of the BodyStringClient class.
    * @param options The parameter options
@@ -24,6 +21,9 @@ class BodyStringClient extends BodyStringClientContext {
     this.string = new operations.String(this);
     this.enum = new operations.Enum(this);
   }
+
+  string: operations.String;
+  enum: operations.Enum;
 }
 
 // Operation Specifications

--- a/test/integration/generated/bodyString/src/bodyStringClientContext.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClientContext.ts
@@ -7,7 +7,6 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
 
 const packageName = "bodyString";
 const packageVersion = "1.0.0-preview1";

--- a/test/integration/generated/customUrl/src/customUrlClient.ts
+++ b/test/integration/generated/customUrl/src/customUrlClient.ts
@@ -6,51 +6,23 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import * as coreHttp from "@azure/core-http";
-import * as Parameters from "./models/parameters";
+import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { CustomUrlClientContext } from "./customUrlClientContext";
 
 class CustomUrlClient extends CustomUrlClientContext {
   /**
-   * Get a 200 to test a valid base uri
-   * @param accountName Account Name
-   * @param options The options parameters.
-   */
-  getEmpty(
-    accountName: string,
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
-    return this.sendOperationRequest(
-      { accountName, options },
-      getEmptyOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
-  }
-
-  /**
    * Initializes a new instance of the CustomUrlClient class.
    * @param options The parameter options
    */
   constructor(options?: any) {
     super(options);
+    this.paths = new operations.Paths(this);
   }
+
+  paths: operations.Paths;
 }
-// Operation Specifications
-
-const serializer = new coreHttp.Serializer(Mappers);
-
-const getEmptyOperationSpec: coreHttp.OperationSpec = {
-  path: "/customuri",
-  httpMethod: "GET",
-  responses: {
-    default: {
-      bodyMapper: Mappers.ErrorModel
-    }
-  },
-  urlParameters: [Parameters.accountName, Parameters.host],
-  serializer
-};
 
 // Operation Specifications
 
@@ -60,3 +32,4 @@ export {
   Models as CustomUrlModels,
   Mappers as CustomUrlMappers
 };
+export * from "./operations";

--- a/test/integration/generated/customUrl/src/customUrlClient.ts
+++ b/test/integration/generated/customUrl/src/customUrlClient.ts
@@ -6,13 +6,27 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+import * as coreHttp from "@azure/core-http";
+import * as Parameters from "./models/parameters";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
-import * as operations from "./operations";
 import { CustomUrlClientContext } from "./customUrlClientContext";
 
 class CustomUrlClient extends CustomUrlClientContext {
-  paths: operations.Paths;
+  /**
+   * Get a 200 to test a valid base uri
+   * @param accountName Account Name
+   * @param options The options parameters.
+   */
+  getEmpty(
+    accountName: string,
+    options?: coreHttp.RequestOptionsBase
+  ): Promise<coreHttp.RestResponse> {
+    return this.sendOperationRequest(
+      { accountName, options },
+      getEmptyOperationSpec
+    ) as Promise<coreHttp.RestResponse>;
+  }
 
   /**
    * Initializes a new instance of the CustomUrlClient class.
@@ -20,9 +34,23 @@ class CustomUrlClient extends CustomUrlClientContext {
    */
   constructor(options?: any) {
     super(options);
-    this.paths = new operations.Paths(this);
   }
 }
+// Operation Specifications
+
+const serializer = new coreHttp.Serializer(Mappers);
+
+const getEmptyOperationSpec: coreHttp.OperationSpec = {
+  path: "/customuri",
+  httpMethod: "GET",
+  responses: {
+    default: {
+      bodyMapper: Mappers.ErrorModel
+    }
+  },
+  urlParameters: [Parameters.accountName, Parameters.host],
+  serializer
+};
 
 // Operation Specifications
 
@@ -32,4 +60,3 @@ export {
   Models as CustomUrlModels,
   Mappers as CustomUrlMappers
 };
-export * from "./operations";

--- a/test/integration/generated/customUrl/src/customUrlClientContext.ts
+++ b/test/integration/generated/customUrl/src/customUrlClientContext.ts
@@ -7,7 +7,6 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
 
 const packageName = "custom-url";
 const packageVersion = "1.0.0-preview1";

--- a/test/integration/generated/url/src/urlClient.ts
+++ b/test/integration/generated/url/src/urlClient.ts
@@ -12,10 +12,6 @@ import * as Mappers from "./models/mappers";
 import { UrlClientContext } from "./urlClientContext";
 
 class UrlClient extends UrlClientContext {
-  paths: operations.Paths;
-  queries: operations.Queries;
-  pathItems: operations.PathItems;
-
   /**
    * Initializes a new instance of the UrlClient class.
    * @param options The parameter options
@@ -26,6 +22,10 @@ class UrlClient extends UrlClientContext {
     this.queries = new operations.Queries(this);
     this.pathItems = new operations.PathItems(this);
   }
+
+  paths: operations.Paths;
+  queries: operations.Queries;
+  pathItems: operations.PathItems;
 }
 
 // Operation Specifications

--- a/test/integration/generated/url/src/urlClient.ts
+++ b/test/integration/generated/url/src/urlClient.ts
@@ -6,9 +6,9 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
-import * as operations from "./operations";
 import { UrlClientContext } from "./urlClientContext";
 
 class UrlClient extends UrlClientContext {

--- a/test/integration/generated/url/src/urlClientContext.ts
+++ b/test/integration/generated/url/src/urlClientContext.ts
@@ -7,7 +7,6 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
 
 const packageName = "url";
 const packageVersion = "1.0.0-preview1";


### PR DESCRIPTION
This PR contains the following work:

- Add operations as client properties when there is only one OperationGroup. Otherwise, keep the current behavior of adding a class for each operation group.

- Support `source-code-folder-path` flag to specify a custom source folder path