### PR TITLE
[v6] Complete Response Type Generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@autorest/autorest": {
-      "version": "3.0.6146",
-      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6146.tgz",
-      "integrity": "sha512-K+2u+CyT6EKb9loGqHE5forJTqVH9042ivJQcLzKaH9CrJWkF5jF2LYBHu8ffszyHv6vLQuHSUNgM6Km2kdkbQ=="
+      "version": "3.0.6168",
+      "resolved": "https://registry.npmjs.org/@autorest/autorest/-/autorest-3.0.6168.tgz",
+      "integrity": "sha512-UbplqbwloDRQmENabfRmY6/GRdgsUIWqGrIKaI7UjcnPJ0fasoAxd8QaTtP2lVyoyhftARl7w3Uc54Qyrvs5vQ=="
     },
     "@autorest/test-server": {
       "version": "3.0.27",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "unit-test": "mocha -r ts-node/register './test/unit/**/*spec.ts'",
         "integration-test": "start-server-and-test start-test-server:v1 http://localhost:3000 generate-and-test",
         "integration-test:new": "npm-run-all start-test-server generate-and-test integration-test:alone stop-test-server",
-        "generate-and-test": "npm-run-all -s build -p generate-bodystring generate-bodycomplex generate-url generate-customurl generate-xmlservice -s integration-test:alone",
+        "generate-and-test": "npm-run-all -s build -p generate-bodystring generate-bodycomplex generate-url generate-customurl generate-xmlservice generate-header -s integration-test:alone",
         "integration-test:alone": "mocha -r ts-node/register './test/integration/**/*spec.ts'",
         "start-test-server": "ts-node test/utils/start-server.ts",
         "start-test-server:v1": "ts-node test/integration/testserver-v1/index.ts",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "LICENSE"
     ],
     "dependencies": {
-        "@autorest/autorest": "^3.0.6146",
+        "@autorest/autorest": "^3.0.6168",
         "@azure-tools/async-io": "3.0.203",
         "@azure-tools/autorest-extension-base": "3.1.206",
         "@azure-tools/codegen": "2.1.218",

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -195,7 +195,7 @@ type IntersectionTypeParameters = [
 ];
 
 /**
- * This function vuilds the type to represent an Operation response, taking the response headers and body
+ * This function builds the type to represent an Operation response, taking the response headers and body
  * to create a type that contains all the properties that a response may include
  */
 function buildResponseType(

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -27,7 +27,6 @@ import {
   OperationResponseDetails
 } from "../models/operationDetails";
 import { ParameterDetails } from "../models/parameterDetails";
-import { type } from "os";
 
 export function generateModels(clientDetails: ClientDetails, project: Project) {
   const modelsIndexFile = project.createSourceFile(

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -89,7 +89,7 @@ function writeResponseTypes(
     // Filter responses that are not marked as errors and that have either body or headers
     .filter(
       ({ isError, mappers }) =>
-        !isError && (!!mappers.bodyMapper || !!mappers.headersMapper)
+        !isError && (mappers.bodyMapper || mappers.headersMapper)
     )
     .forEach(operation => {
       // Define possible values for response

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -163,6 +163,7 @@ function buildResponses({ responses }: OperationSpecDetails): string[] {
   const responseCodes = Object.keys(responses);
   let parsedResponses: string[] = [];
   responseCodes.forEach(code => {
+    // TODO: Need to handle headers there too!
     // Check whether we have an actual mapper or a string reference
     const bodyMapper = responses[code].bodyMapper;
     const isCompositeMapper =
@@ -307,7 +308,8 @@ export function writeOperations(
 
 function getResponseType(operation: OperationDetails) {
   const hasSuccessResponse = operation.responses.some(
-    r => !r.isError && !!r.bodyMapper
+    ({ isError, mappers }) =>
+      !isError && (!!mappers.bodyMapper || !!mappers.headersMapper)
   );
 
   const responseName = hasSuccessResponse ? operation.typeDetails.typeName : "";

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -18,7 +18,8 @@ import { MapperType } from "@azure/core-http";
 import {
   OperationGroupDetails,
   OperationSpecDetails,
-  OperationDetails
+  OperationDetails,
+  OperationResponseMapper
 } from "../models/operationDetails";
 import { isString } from "util";
 import { ParameterDetails } from "../models/parameterDetails";
@@ -163,29 +164,30 @@ function buildResponses({ responses }: OperationSpecDetails): string[] {
   const responseCodes = Object.keys(responses);
   let parsedResponses: string[] = [];
   responseCodes.forEach(code => {
-    // TODO: Need to handle headers there too!
     // Check whether we have an actual mapper or a string reference
-    const bodyMapper = responses[code].bodyMapper;
-    const isCompositeMapper =
-      bodyMapper &&
-      !isString(bodyMapper) &&
-      bodyMapper.type.name === MapperType.Composite;
-
-    if (isCompositeMapper) {
-      parsedResponses.push(`${code}: ${JSON.stringify(responses[code])}`);
-    } else if (bodyMapper) {
-      // Mapper is a reference to an existing mapper in the Mappers file
-      const bodyMapperString = `bodyMapper: ${
-        isString(bodyMapper) ? bodyMapper : JSON.stringify(bodyMapper)
-      }`;
-
-      parsedResponses.push(`${code}: {
-        ${bodyMapperString}
+    const { bodyMapper, headersMapper } = responses[code];
+    const bodyMapperString = buildMapper(bodyMapper, "bodyMapper");
+    const headersMapperString = buildMapper(headersMapper, "headersMapper");
+    parsedResponses.push(`${code}: {
+        ${bodyMapperString}${headersMapperString}
       }`);
-    }
   });
 
   return parsedResponses;
+}
+
+function buildMapper(
+  mapper: OperationResponseMapper | undefined,
+  mapperName: string
+) {
+  if (!mapper) {
+    return "";
+  }
+
+  // When mapper is a reference (string) we don't need to stringify the object
+  let mapperString = isString(mapper) ? mapper : JSON.stringify(mapper);
+
+  return `${mapperName}: ${mapperString},`;
 }
 
 function getOptionsParameter(

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -16,14 +16,34 @@ export interface OperationRequestDetails {
   mediaType?: KnownMediaType;
 }
 
+export type OperationResponseMapper = Mapper | string;
+
+/**
+ * Contains all the mappers related to an operation response
+ */
+export interface OperationResponseMappers {
+  bodyMapper?: OperationResponseMapper;
+  headersMapper?: OperationResponseMapper;
+}
+
+/**
+ * Contains the type information about each part of the response
+ * these types will be used to generate the ResponseType by
+ * combining these types as needed.
+ */
+export interface OperationResponseTypes {
+  bodyType?: TypeDetails;
+  headersType?: TypeDetails;
+}
+
 /**
  * Details of an operation response, transformed from Response or SchemaResponse.
  */
 export interface OperationResponseDetails {
   statusCodes: string[]; // Can be a status code number or "default"
   mediaType?: KnownMediaType;
-  bodyMapper?: Mapper | string;
-  typeDetails: TypeDetails;
+  mappers: OperationResponseMappers;
+  types: OperationResponseTypes;
   isError?: boolean;
 }
 
@@ -70,5 +90,5 @@ export interface OperationSpecResponse {
 }
 
 export type OperationSpecResponses = {
-  [responseCode: string]: OperationSpecResponse;
+  [responseCode: string]: OperationResponseMappers;
 };

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -484,7 +484,8 @@ function transformConstantMapper(pipelineValue: PipelineValue): PipelineValue {
   }
   const serializedName =
     (options && options.serializedName) ||
-    getLanguageMetadata(schema.language).name;
+    getLanguageMetadata(schema.language).serializedName;
+
   const constantSchema = schema as ConstantSchema;
 
   const mapper: Mapper = {

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -484,7 +484,8 @@ function transformConstantMapper(pipelineValue: PipelineValue): PipelineValue {
   }
   const serializedName =
     (options && options.serializedName) ||
-    getLanguageMetadata(schema.language).serializedName;
+    getLanguageMetadata(schema.language).serializedName ||
+    getLanguageMetadata(schema.language).name;
 
   const constantSchema = schema as ConstantSchema;
 

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -22,7 +22,9 @@ import {
   OperationResponseDetails,
   OperationRequestDetails,
   OperationSpecDetails,
-  OperationSpecResponses
+  OperationSpecResponses,
+  OperationResponseMappers,
+  OperationResponseTypes
 } from "../models/operationDetails";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 import { getTypeForSchema, isSchemaResponse } from "../utils/schemaHelpers";
@@ -31,6 +33,7 @@ import { ParameterDetails } from "../models/parameterDetails";
 import { PropertyKind, TypeDetails } from "../models/modelDetails";
 import { TOPLEVEL_OPERATIONGROUP } from "./constants";
 import { KnownMediaType } from "@azure-tools/codegen";
+import { headersToSchema } from "../utils/headersToSchema";
 
 export function transformOperationSpec(
   operationDetails: OperationDetails,
@@ -73,8 +76,7 @@ export function extractSpecResponses({
     throw new Error(`The operation ${name} contains no responses`);
   }
 
-  const schemaResponses = extractSchemaResponses(responses);
-  return schemaResponses;
+  return extractSchemaResponses(responses);
 }
 
 export interface SpecType {
@@ -140,20 +142,16 @@ export function getSpecType(responseSchema: Schema, expand = false): SpecType {
 
 export function extractSchemaResponses(responses: OperationResponseDetails[]) {
   return responses.reduce(
-    (result: OperationSpecResponses, response: OperationResponseDetails) => {
-      const statusCodes = response.statusCodes;
-
+    (
+      result: OperationSpecResponses,
+      { statusCodes, mappers }: OperationResponseDetails
+    ) => {
       if (!statusCodes || !statusCodes.length) {
         return result;
       }
 
       const statusCode = statusCodes[0];
-      result[statusCode] = {};
-      if (response.bodyMapper) {
-        result[statusCode] = {
-          bodyMapper: response.bodyMapper
-        };
-      }
+      result[statusCode] = mappers;
       return result;
     },
     {}
@@ -174,50 +172,42 @@ export function transformOperationRequest(
 }
 
 export function transformOperationResponse(
-  response: SchemaResponse | Response
+  response: SchemaResponse | Response,
+  operationFullName: string
 ): OperationResponseDetails {
-  let isError =
+  const httpInfo = response.protocol.http;
+  const isError =
     !!response.extensions && !!response.extensions["x-ms-error-response"];
 
-  if (!isSchemaResponse(response)) {
-    const schemalessResponse = response as Response;
-    return {
-      statusCodes: schemalessResponse.protocol.http!.statusCodes,
-      typeDetails: {
-        typeName: "",
-        isConstant: false,
-        kind: PropertyKind.Primitive,
-        isError
-      }
-    } as OperationResponseDetails;
-  }
-
-  const schemaResponse = response as SchemaResponse;
-  const typeDetails = getTypeForSchema(schemaResponse.schema);
-  if (!typeDetails) {
-    throw new Error(
-      `Unable to extract responseType for ${schemaResponse.schema.type}`
-    );
-  }
-
-  const httpInfo = response.protocol.http;
-  if (httpInfo) {
-    const isDefault = httpInfo.statusCodes.indexOf("default") > -1;
-    const mediaType: KnownMediaType = httpInfo.knownMediaType;
-    const bodyMapper = getBodyMapperFromSchema(
-      schemaResponse.schema,
-      mediaType
-    );
-    return {
-      statusCodes: httpInfo.statusCodes,
-      mediaType,
-      bodyMapper,
-      typeDetails,
-      isError: isDefault || isError
-    };
-  } else {
+  if (!httpInfo) {
     throw new Error("Operation does not specify HTTP response details.");
   }
+
+  const headersSchema = headersToSchema(httpInfo.headers, operationFullName);
+  const mediaType = httpInfo.knownMediaType;
+  const mappers: OperationResponseMappers = {
+    bodyMapper: isSchemaResponse(response)
+      ? getMapperForSchema(response.schema, mediaType)
+      : undefined,
+    headersMapper: headersSchema
+      ? getMapperForSchema(headersSchema, mediaType)
+      : undefined
+  };
+
+  const types: OperationResponseTypes = {
+    bodyType: isSchemaResponse(response)
+      ? getTypeForSchema(response.schema)
+      : undefined,
+    headersType: headersSchema ? getTypeForSchema(headersSchema) : undefined
+  };
+  const isDefault = httpInfo.statusCodes.indexOf("default") > -1;
+  return {
+    statusCodes: httpInfo.statusCodes,
+    mediaType: httpInfo.knownMediaType,
+    mappers,
+    types,
+    isError: isDefault || isError
+  };
 }
 
 export async function transformOperation(
@@ -226,6 +216,7 @@ export async function transformOperation(
 ): Promise<OperationDetails> {
   const metadata = getLanguageMetadata(operation.language);
   const name = normalizeName(metadata.name, NameType.Property);
+  const operationFullName = `${operationGroupName}_${name}`;
   const responsesAndErrors = [
     ...(operation.responses || []),
     ...(operation.exceptions || [])
@@ -240,14 +231,14 @@ export async function transformOperation(
 
   const request = transformOperationRequest(operation.request);
   const responses = responsesAndErrors.map(response =>
-    transformOperationResponse(response as SchemaResponse)
+    transformOperationResponse(response, operationFullName)
   );
-
   const mediaTypes = await getOperationMediaTypes(request, responses);
+
   return {
     name,
     typeDetails,
-    fullName: `${operationGroupName}_${name}`.toLowerCase(),
+    fullName: operationFullName.toLowerCase(),
     apiVersions: operation.apiVersions
       ? operation.apiVersions.map(v => v.version)
       : [],
@@ -336,7 +327,7 @@ function getGroupedParameters(
   };
 }
 
-function getBodyMapperFromSchema(
+function getMapperForSchema(
   responseSchema: Schema,
   mediaType?: KnownMediaType,
   expand = false

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -171,6 +171,10 @@ export function transformOperationRequest(
   };
 }
 
+/**
+ * Build OperationResponseDetails by extracting body and header information
+ * from the response
+ */
 export function transformOperationResponse(
   response: SchemaResponse | Response,
   operationFullName: string
@@ -183,8 +187,10 @@ export function transformOperationResponse(
     throw new Error("Operation does not specify HTTP response details.");
   }
 
+  // Transform Headers to am ObjectSchema to represent headers as an object
   const headersSchema = headersToSchema(httpInfo.headers, operationFullName);
   const mediaType = httpInfo.knownMediaType;
+
   const mappers: OperationResponseMappers = {
     bodyMapper: isSchemaResponse(response)
       ? getMapperForSchema(response.schema, mediaType)
@@ -200,7 +206,9 @@ export function transformOperationResponse(
       : undefined,
     headersType: headersSchema ? getTypeForSchema(headersSchema) : undefined
   };
+
   const isDefault = httpInfo.statusCodes.indexOf("default") > -1;
+
   return {
     statusCodes: httpInfo.statusCodes,
     mediaType: httpInfo.knownMediaType,

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -204,7 +204,7 @@ function getIsGlobal(parameter: Parameter) {
 
 function getParameterPath(parameter: Parameter) {
   const metadata = getLanguageMetadata(parameter.language);
-  // Parameter path needs to match the name of the parameter for correct serialization
+  // ParameterPath has to include the name we used for the parameter, not the serializedName
   const name = normalizeName(metadata.name, NameType.Property);
   return isClientImplementation(parameter) || parameter.required
     ? name

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -204,11 +204,11 @@ function getIsGlobal(parameter: Parameter) {
 
 function getParameterPath(parameter: Parameter) {
   const metadata = getLanguageMetadata(parameter.language);
-  const serializedName =
-    metadata.serializedName || normalizeName(metadata.name, NameType.Property);
+  // Parameter path needs to match the name of the parameter for correct serialization
+  const name = normalizeName(metadata.name, NameType.Property);
   return isClientImplementation(parameter) || parameter.required
-    ? serializedName
-    : ["options", serializedName];
+    ? name
+    : ["options", name];
 }
 
 const isClientImplementation = (parameter: Parameter) =>

--- a/src/utils/headersToSchema.ts
+++ b/src/utils/headersToSchema.ts
@@ -20,8 +20,12 @@ export function headersToSchema(
     }
 
     const { description } = getLanguageMetadata(schema.language);
-
-    headersSchema.properties.push(new Property(header, description, schema));
+    headersSchema.properties.push(
+      new Property(header, description, schema, {
+        // core-http serializer requires Header serialized names to be lowercase
+        serializedName: header.toLocaleLowerCase()
+      })
+    );
   });
 
   return headersSchema;

--- a/src/utils/schemaHelpers.ts
+++ b/src/utils/schemaHelpers.ts
@@ -77,7 +77,10 @@ export function getTypeForSchema(schema: Schema): TypeDetails {
 
     case SchemaType.Object:
       const objSchema = schema as ObjectSchema;
-      const { name } = getLanguageMetadata(schema.language);
+      const name = normalizeName(
+        getLanguageMetadata(schema.language).name,
+        NameType.Interface
+      );
 
       // Polymorphic objects with children will get a union type as type
       // since they can take different shapes

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -136,7 +136,7 @@ export interface ArrayWrapper {
  */
 export interface DictionaryWrapper {
   /**
-   * Dictionary of <components·schemas·dictionary_wrapper·properties·defaultprogram·additionalproperties>
+   * Dictionary of <string>
    */
   defaultProgram?: { [propertyName: string]: string };
 }

--- a/test/integration/generated/bodyComplex/src/models/parameters.ts
+++ b/test/integration/generated/bodyComplex/src/models/parameters.ts
@@ -22,7 +22,7 @@ export const $host: coreHttp.OperationURLParameter = {
 };
 
 export const apiVersion: coreHttp.OperationQueryParameter = {
-  parameterPath: "api-version",
+  parameterPath: "apiVersion",
   mapper: {
     defaultValue: "2016-02-29",
     serializedName: "api-version",

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -119,6 +119,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/array/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -145,6 +146,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/array/empty",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/basic.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basic.ts
@@ -128,6 +128,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/basic/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -132,6 +132,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/dictionary/typed/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -158,6 +159,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/dictionary/typed/empty",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -78,6 +78,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/inheritance/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -108,6 +108,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/polymorphicrecursive/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -244,6 +244,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/polymorphism/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -312,6 +313,7 @@ const putComplicatedOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/polymorphism/complicated",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -339,6 +341,7 @@ const putValidMissingRequiredOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/polymorphism/missingrequired/invalid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/primitive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/primitive.ts
@@ -357,6 +357,7 @@ const putIntOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/integer",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -383,6 +384,7 @@ const putLongOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/long",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -409,6 +411,7 @@ const putFloatOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/float",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -435,6 +438,7 @@ const putDoubleOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/double",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -461,6 +465,7 @@ const putBoolOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/bool",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -487,6 +492,7 @@ const putStringOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/string",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -513,6 +519,7 @@ const putDateOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/date",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -539,6 +546,7 @@ const putDateTimeOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/datetime",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -565,6 +573,7 @@ const putDateTimeRfc1123OperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/datetimerfc1123",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -591,6 +600,7 @@ const putDurationOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/duration",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -617,6 +627,7 @@ const putByteOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/primitive/byte",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -76,6 +76,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   path: "/complex/readonlyproperty/valid",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyString/src/models/index.ts
+++ b/test/integration/generated/bodyString/src/models/index.ts
@@ -38,7 +38,7 @@ export type StringGetNullResponse = {
   /**
    * The parsed response body.
    */
-  body: String;
+  body: string;
 
   /**
    * The underlying HTTP response.
@@ -52,7 +52,7 @@ export type StringGetNullResponse = {
     /**
      * The response body as parsed JSON or XML
      */
-    parsedBody: String;
+    parsedBody: string;
   };
 };
 
@@ -63,7 +63,7 @@ export type StringGetEmptyResponse = {
   /**
    * The parsed response body.
    */
-  body: String;
+  body: string;
 
   /**
    * The underlying HTTP response.
@@ -77,7 +77,7 @@ export type StringGetEmptyResponse = {
     /**
      * The response body as parsed JSON or XML
      */
-    parsedBody: String;
+    parsedBody: string;
   };
 };
 
@@ -88,7 +88,7 @@ export type StringGetMbcsResponse = {
   /**
    * The parsed response body.
    */
-  body: String;
+  body: string;
 
   /**
    * The underlying HTTP response.
@@ -102,7 +102,7 @@ export type StringGetMbcsResponse = {
     /**
      * The response body as parsed JSON or XML
      */
-    parsedBody: String;
+    parsedBody: string;
   };
 };
 
@@ -113,7 +113,7 @@ export type StringGetWhitespaceResponse = {
   /**
    * The parsed response body.
    */
-  body: String;
+  body: string;
 
   /**
    * The underlying HTTP response.
@@ -127,7 +127,7 @@ export type StringGetWhitespaceResponse = {
     /**
      * The response body as parsed JSON or XML
      */
-    parsedBody: String;
+    parsedBody: string;
   };
 };
 
@@ -138,7 +138,7 @@ export type StringGetNotProvidedResponse = {
   /**
    * The parsed response body.
    */
-  body: String;
+  body: string;
 
   /**
    * The underlying HTTP response.
@@ -152,7 +152,7 @@ export type StringGetNotProvidedResponse = {
     /**
      * The response body as parsed JSON or XML
      */
-    parsedBody: String;
+    parsedBody: string;
   };
 };
 

--- a/test/integration/generated/bodyString/src/operations/enum.ts
+++ b/test/integration/generated/bodyString/src/operations/enum.ts
@@ -138,6 +138,7 @@ const putNotExpandableOperationSpec: coreHttp.OperationSpec = {
   path: "/string/enum/notExpandable",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -170,6 +171,7 @@ const putReferencedOperationSpec: coreHttp.OperationSpec = {
   path: "/string/enum/Referenced",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -196,6 +198,7 @@ const putReferencedConstantOperationSpec: coreHttp.OperationSpec = {
   path: "/string/enum/ReferencedConstant",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -221,6 +221,7 @@ const putNullOperationSpec: coreHttp.OperationSpec = {
   path: "/string/null",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -247,6 +248,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/string/empty",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -273,6 +275,7 @@ const putMbcsOperationSpec: coreHttp.OperationSpec = {
   path: "/string/mbcs",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -299,6 +302,7 @@ const putWhitespaceOperationSpec: coreHttp.OperationSpec = {
   path: "/string/whitespace",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -353,6 +357,7 @@ const putBase64UrlEncodedOperationSpec: coreHttp.OperationSpec = {
   path: "/string/base64UrlEncoding",
   httpMethod: "PUT",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/customUrl/src/operations/paths.ts
+++ b/test/integration/generated/customUrl/src/operations/paths.ts
@@ -49,6 +49,7 @@ const getEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/customuri",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/header/src/models/index.ts
+++ b/test/integration/generated/header/src/models/index.ts
@@ -120,6 +120,111 @@ export interface HeaderResponseEnumHeaders {
 export type GreyscaleColors = "White" | "black" | "GREY";
 
 /**
+ * Contains response data for the responseExistingKey operation.
+ */
+export type HeaderResponseExistingKeyResponse = HeaderResponseExistingKeyHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseExistingKeyHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseProtectedKey operation.
+ */
+export type HeaderResponseProtectedKeyResponse = HeaderResponseProtectedKeyHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseProtectedKeyHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseInteger operation.
+ */
+export type HeaderResponseIntegerResponse = HeaderResponseIntegerHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseIntegerHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseLong operation.
+ */
+export type HeaderResponseLongResponse = HeaderResponseLongHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseLongHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseFloat operation.
+ */
+export type HeaderResponseFloatResponse = HeaderResponseFloatHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseFloatHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseDouble operation.
+ */
+export type HeaderResponseDoubleResponse = HeaderResponseDoubleHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseDoubleHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseBool operation.
+ */
+export type HeaderResponseBoolResponse = HeaderResponseBoolHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseBoolHeaders;
+  };
+};
+
+/**
  * Optional parameters.
  */
 export interface HeaderParamStringOptionalParams
@@ -129,6 +234,51 @@ export interface HeaderParamStringOptionalParams
    */
   value?: string;
 }
+
+/**
+ * Contains response data for the responseString operation.
+ */
+export type HeaderResponseStringResponse = HeaderResponseStringHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseStringHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseDate operation.
+ */
+export type HeaderResponseDateResponse = HeaderResponseDateHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseDateHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseDatetime operation.
+ */
+export type HeaderResponseDatetimeResponse = HeaderResponseDatetimeHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseDatetimeHeaders;
+  };
+};
 
 /**
  * Optional parameters.
@@ -142,6 +292,51 @@ export interface HeaderParamDatetimeRfc1123OptionalParams
 }
 
 /**
+ * Contains response data for the responseDatetimeRfc1123 operation.
+ */
+export type HeaderResponseDatetimeRfc1123Response = HeaderResponseDatetimeRfc1123Headers & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseDatetimeRfc1123Headers;
+  };
+};
+
+/**
+ * Contains response data for the responseDuration operation.
+ */
+export type HeaderResponseDurationResponse = HeaderResponseDurationHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseDurationHeaders;
+  };
+};
+
+/**
+ * Contains response data for the responseByte operation.
+ */
+export type HeaderResponseByteResponse = HeaderResponseByteHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseByteHeaders;
+  };
+};
+
+/**
  * Optional parameters.
  */
 export interface HeaderParamEnumOptionalParams
@@ -151,3 +346,18 @@ export interface HeaderParamEnumOptionalParams
    */
   value?: GreyscaleColors;
 }
+
+/**
+ * Contains response data for the responseEnum operation.
+ */
+export type HeaderResponseEnumResponse = HeaderResponseEnumHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: HeaderResponseEnumHeaders;
+  };
+};

--- a/test/integration/generated/header/src/models/mappers.ts
+++ b/test/integration/generated/header/src/models/mappers.ts
@@ -26,7 +26,7 @@ export const HeaderResponseExistingKeyHeaders: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "HeaderResponseExistingKeyHeaders",
     modelProperties: {
-      userAgent: { type: { name: "String" }, serializedName: "User-Agent" }
+      userAgent: { type: { name: "String" }, serializedName: "user-agent" }
     }
   }
 };
@@ -37,7 +37,7 @@ export const HeaderResponseProtectedKeyHeaders: coreHttp.CompositeMapper = {
     name: "Composite",
     className: "HeaderResponseProtectedKeyHeaders",
     modelProperties: {
-      contentType: { type: { name: "String" }, serializedName: "Content-Type" }
+      contentType: { type: { name: "String" }, serializedName: "content-type" }
     }
   }
 };

--- a/test/integration/generated/header/src/models/parameters.ts
+++ b/test/integration/generated/header/src/models/parameters.ts
@@ -22,7 +22,7 @@ export const $host: coreHttp.OperationURLParameter = {
 };
 
 export const userAgent: coreHttp.OperationParameter = {
-  parameterPath: "User-Agent",
+  parameterPath: "userAgent",
   mapper: {
     serializedName: "User-Agent",
     required: true,
@@ -33,7 +33,7 @@ export const userAgent: coreHttp.OperationParameter = {
 };
 
 export const contentType: coreHttp.OperationParameter = {
-  parameterPath: "Content-Type",
+  parameterPath: "contentType",
   mapper: {
     serializedName: "Content-Type",
     required: true,

--- a/test/integration/generated/header/src/models/parameters.ts
+++ b/test/integration/generated/header/src/models/parameters.ts
@@ -12,9 +12,11 @@ import * as Mappers from "../models/mappers";
 export const $host: coreHttp.OperationURLParameter = {
   parameterPath: "$host",
   mapper: {
-    type: { name: "String" },
     serializedName: "$host",
-    required: true
+    required: true,
+    type: {
+      name: "String"
+    }
   },
   skipEncoding: true
 };
@@ -22,131 +24,162 @@ export const $host: coreHttp.OperationURLParameter = {
 export const userAgent: coreHttp.OperationParameter = {
   parameterPath: "User-Agent",
   mapper: {
-    type: { name: "String" },
     serializedName: "User-Agent",
-    required: true
+    required: true,
+    type: {
+      name: "String"
+    }
   }
 };
 
 export const contentType: coreHttp.OperationParameter = {
   parameterPath: "Content-Type",
   mapper: {
-    type: { name: "String" },
     serializedName: "Content-Type",
-    required: true
+    required: true,
+    type: {
+      name: "String"
+    }
   }
 };
 
 export const scenario: coreHttp.OperationParameter = {
   parameterPath: "scenario",
   mapper: {
-    type: { name: "String" },
     serializedName: "scenario",
-    required: true
+    required: true,
+    type: {
+      name: "String"
+    }
   }
 };
 
 export const value: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "Number" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "Number"
+    }
   }
 };
 
 export const value1: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "Number" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "Number"
+    }
   }
 };
 
 export const value2: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "Number" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "Number"
+    }
   }
 };
 
 export const value3: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "Number" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "Number"
+    }
   }
 };
 
 export const value4: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "Boolean" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "Boolean"
+    }
   }
 };
 
 export const value5: coreHttp.OperationParameter = {
   parameterPath: ["options", "value"],
   mapper: {
-    type: { name: "String" },
-    serializedName: "value"
+    serializedName: "value",
+    type: {
+      name: "String"
+    }
   }
 };
 
 export const value6: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "Date" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "Date"
+    }
   }
 };
 
 export const value7: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "DateTime" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "DateTime"
+    }
   }
 };
 
 export const value8: coreHttp.OperationParameter = {
   parameterPath: ["options", "value"],
   mapper: {
-    type: { name: "DateTimeRfc1123" },
-    serializedName: "value"
+    serializedName: "value",
+    type: {
+      name: "DateTimeRfc1123"
+    }
   }
 };
 
 export const value9: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "TimeSpan" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "TimeSpan"
+    }
   }
 };
 
 export const value10: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
-    type: { name: "ByteArray" },
     serializedName: "value",
-    required: true
+    required: true,
+    type: {
+      name: "ByteArray"
+    }
   }
 };
 
 export const value11: coreHttp.OperationParameter = {
   parameterPath: ["options", "value"],
   mapper: {
-    type: { name: "Enum", allowedValues: ["White", "black", "GREY"] },
-    serializedName: "value"
+    serializedName: "value",
+    type: {
+      name: "Enum",
+      allowedValues: ["White", "black", "GREY"]
+    }
   }
 };

--- a/test/integration/generated/header/src/operations/header.ts
+++ b/test/integration/generated/header/src/operations/header.ts
@@ -47,11 +47,11 @@ export class Header {
    */
   responseExistingKey(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseExistingKeyResponse> {
     return this.client.sendOperationRequest(
       { options },
       responseExistingKeyOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseExistingKeyResponse>;
   }
 
   /**
@@ -75,11 +75,11 @@ export class Header {
    */
   responseProtectedKey(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseProtectedKeyResponse> {
     return this.client.sendOperationRequest(
       { options },
       responseProtectedKeyOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseProtectedKeyResponse>;
   }
 
   /**
@@ -108,11 +108,11 @@ export class Header {
   responseInteger(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseIntegerResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseIntegerOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseIntegerResponse>;
   }
 
   /**
@@ -141,11 +141,11 @@ export class Header {
   responseLong(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseLongResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseLongOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseLongResponse>;
   }
 
   /**
@@ -174,11 +174,11 @@ export class Header {
   responseFloat(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseFloatResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseFloatOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseFloatResponse>;
   }
 
   /**
@@ -207,11 +207,11 @@ export class Header {
   responseDouble(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseDoubleResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseDoubleOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseDoubleResponse>;
   }
 
   /**
@@ -240,11 +240,11 @@ export class Header {
   responseBool(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseBoolResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseBoolOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseBoolResponse>;
   }
 
   /**
@@ -271,11 +271,11 @@ export class Header {
   responseString(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseStringResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseStringOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseStringResponse>;
   }
 
   /**
@@ -304,11 +304,11 @@ export class Header {
   responseDate(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseDateResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseDateOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseDateResponse>;
   }
 
   /**
@@ -337,11 +337,11 @@ export class Header {
   responseDatetime(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseDatetimeResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseDatetimeOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseDatetimeResponse>;
   }
 
   /**
@@ -368,11 +368,11 @@ export class Header {
   responseDatetimeRfc1123(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseDatetimeRfc1123Response> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseDatetimeRfc1123OperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseDatetimeRfc1123Response>;
   }
 
   /**
@@ -400,11 +400,11 @@ export class Header {
   responseDuration(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseDurationResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseDurationOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseDurationResponse>;
   }
 
   /**
@@ -432,11 +432,11 @@ export class Header {
   responseByte(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseByteResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseByteOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseByteResponse>;
   }
 
   /**
@@ -463,11 +463,11 @@ export class Header {
   responseEnum(
     scenario: string,
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.HeaderResponseEnumResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
       responseEnumOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.HeaderResponseEnumResponse>;
   }
 
   /**
@@ -485,7 +485,7 @@ export class Header {
 }
 // Operation Specifications
 
-const serializer = new coreHttp.Serializer(Mappers);
+const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
 
 const paramExistingKeyOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/existingkey",

--- a/test/integration/generated/header/src/operations/header.ts
+++ b/test/integration/generated/header/src/operations/header.ts
@@ -491,6 +491,7 @@ const paramExistingKeyOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/existingkey",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -503,6 +504,9 @@ const responseExistingKeyOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/existingkey",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseExistingKeyHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -514,6 +518,7 @@ const paramProtectedKeyOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/protectedkey",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -526,6 +531,9 @@ const responseProtectedKeyOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/protectedkey",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseProtectedKeyHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -537,6 +545,7 @@ const paramIntegerOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/integer",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -549,6 +558,9 @@ const responseIntegerOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/integer",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseIntegerHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -561,6 +573,7 @@ const paramLongOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/long",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -573,6 +586,9 @@ const responseLongOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/long",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseLongHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -585,6 +601,7 @@ const paramFloatOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/float",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -597,6 +614,9 @@ const responseFloatOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/float",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseFloatHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -609,6 +629,7 @@ const paramDoubleOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/double",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -621,6 +642,9 @@ const responseDoubleOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/double",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseDoubleHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -633,6 +657,7 @@ const paramBoolOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/bool",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -645,6 +670,9 @@ const responseBoolOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/bool",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseBoolHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -657,6 +685,7 @@ const paramStringOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/string",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -669,6 +698,9 @@ const responseStringOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/string",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseStringHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -681,6 +713,7 @@ const paramDateOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/date",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -693,6 +726,9 @@ const responseDateOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/date",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseDateHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -705,6 +741,7 @@ const paramDatetimeOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/datetime",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -717,6 +754,9 @@ const responseDatetimeOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/datetime",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseDatetimeHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -729,6 +769,7 @@ const paramDatetimeRfc1123OperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/datetimerfc1123",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -741,6 +782,9 @@ const responseDatetimeRfc1123OperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/datetimerfc1123",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseDatetimeRfc1123Headers
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -753,6 +797,7 @@ const paramDurationOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/duration",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -765,6 +810,9 @@ const responseDurationOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/duration",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseDurationHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -777,6 +825,7 @@ const paramByteOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/byte",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -789,6 +838,9 @@ const responseByteOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/byte",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseByteHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -801,6 +853,7 @@ const paramEnumOperationSpec: coreHttp.OperationSpec = {
   path: "/header/param/prim/enum",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -813,6 +866,9 @@ const responseEnumOperationSpec: coreHttp.OperationSpec = {
   path: "/header/response/prim/enum",
   httpMethod: "POST",
   responses: {
+    200: {
+      headersMapper: Mappers.HeaderResponseEnumHeaders
+    },
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -826,6 +882,7 @@ const customRequestIdOperationSpec: coreHttp.OperationSpec = {
     "/header/custom/x-ms-client-request-id/9C4D50EE-2D56-4CD3-8152-34347DC9F2B0",
   httpMethod: "POST",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/url/src/operations/pathItems.ts
+++ b/test/integration/generated/url/src/operations/pathItems.ts
@@ -111,6 +111,7 @@ const getAllWithValuesOperationSpec: coreHttp.OperationSpec = {
     "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/pathItemStringQuery/localStringQuery",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -133,6 +134,7 @@ const getGlobalQueryNullOperationSpec: coreHttp.OperationSpec = {
     "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/localStringQuery",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -155,6 +157,7 @@ const getGlobalAndLocalQueryNullOperationSpec: coreHttp.OperationSpec = {
     "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/null/pathItemStringQuery/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -177,6 +180,7 @@ const getLocalPathItemQueryNullOperationSpec: coreHttp.OperationSpec = {
     "/pathitem/nullable/globalStringPath/{globalStringPath}/pathItemStringPath/{pathItemStringPath}/localStringPath/{localStringPath}/globalStringQuery/null/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -408,6 +408,7 @@ const getBooleanTrueOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/bool/true/{boolPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -419,6 +420,7 @@ const getBooleanFalseOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/bool/false/{boolPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -430,6 +432,7 @@ const getIntOneMillionOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/int/1000000/{intPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -441,6 +444,7 @@ const getIntNegativeOneMillionOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/int/-1000000/{intPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -452,6 +456,7 @@ const getTenBillionOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/long/10000000000/{longPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -463,6 +468,7 @@ const getNegativeTenBillionOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/long/-10000000000/{longPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -474,6 +480,7 @@ const floatScientificPositiveOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/float/1.034E+20/{floatPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -485,6 +492,7 @@ const floatScientificNegativeOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/float/-1.034E-20/{floatPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -496,6 +504,7 @@ const doubleDecimalPositiveOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/double/9999999.999/{doublePath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -507,6 +516,7 @@ const doubleDecimalNegativeOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/double/-9999999.999/{doublePath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -518,6 +528,7 @@ const stringUnicodeOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/string/unicode/{stringPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -530,6 +541,7 @@ const stringUrlEncodedOperationSpec: coreHttp.OperationSpec = {
     "/paths/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend/{stringPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -541,6 +553,7 @@ const stringUrlNonEncodedOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/string/begin!*'();:@&=+$,end/{stringPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -552,6 +565,7 @@ const stringEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/string/empty/{stringPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -563,6 +577,7 @@ const stringNullOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/string/null/{stringPath}",
   httpMethod: "GET",
   responses: {
+    400: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -574,6 +589,7 @@ const enumValidOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/enum/green%20color/{enumPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -585,6 +601,7 @@ const enumNullOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/string/null/{enumPath}",
   httpMethod: "GET",
   responses: {
+    400: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -596,6 +613,7 @@ const byteMultiByteOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/byte/multibyte/{bytePath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -607,6 +625,7 @@ const byteEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/byte/empty/{bytePath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -618,6 +637,7 @@ const byteNullOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/byte/null/{bytePath}",
   httpMethod: "GET",
   responses: {
+    400: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -629,6 +649,7 @@ const dateValidOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/date/2012-01-01/{datePath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -640,6 +661,7 @@ const dateNullOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/date/null/{datePath}",
   httpMethod: "GET",
   responses: {
+    400: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -651,6 +673,7 @@ const dateTimeValidOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/datetime/2012-01-01T01%3A01%3A01Z/{dateTimePath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -662,6 +685,7 @@ const dateTimeNullOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/datetime/null/{dateTimePath}",
   httpMethod: "GET",
   responses: {
+    400: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -673,6 +697,7 @@ const base64UrlOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/string/bG9yZW0/{base64UrlPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -685,6 +710,7 @@ const arrayCsvInPathOperationSpec: coreHttp.OperationSpec = {
     "/paths/array/ArrayPath1%2cbegin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend%2c%2c/{arrayPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -696,6 +722,7 @@ const unixTimeUrlOperationSpec: coreHttp.OperationSpec = {
   path: "/paths/int/1460505600/{unixTimeUrlPath}",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/url/src/operations/queries.ts
+++ b/test/integration/generated/url/src/operations/queries.ts
@@ -480,6 +480,7 @@ const getBooleanTrueOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/bool/true",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -492,6 +493,7 @@ const getBooleanFalseOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/bool/false",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -504,6 +506,7 @@ const getBooleanNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/bool/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -516,6 +519,7 @@ const getIntOneMillionOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/int/1000000",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -528,6 +532,7 @@ const getIntNegativeOneMillionOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/int/-1000000",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -540,6 +545,7 @@ const getIntNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/int/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -552,6 +558,7 @@ const getTenBillionOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/long/10000000000",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -564,6 +571,7 @@ const getNegativeTenBillionOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/long/-10000000000",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -576,6 +584,7 @@ const getLongNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/long/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -588,6 +597,7 @@ const floatScientificPositiveOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/float/1.034E+20",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -600,6 +610,7 @@ const floatScientificNegativeOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/float/-1.034E-20",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -612,6 +623,7 @@ const floatNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/float/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -624,6 +636,7 @@ const doubleDecimalPositiveOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/double/9999999.999",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -636,6 +649,7 @@ const doubleDecimalNegativeOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/double/-9999999.999",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -648,6 +662,7 @@ const doubleNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/double/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -660,6 +675,7 @@ const stringUnicodeOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/string/unicode/",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -673,6 +689,7 @@ const stringUrlEncodedOperationSpec: coreHttp.OperationSpec = {
     "/queries/string/begin%21%2A%27%28%29%3B%3A%40%20%26%3D%2B%24%2C%2F%3F%23%5B%5Dend",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -685,6 +702,7 @@ const stringEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/string/empty",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -697,6 +715,7 @@ const stringNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/string/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -709,6 +728,7 @@ const enumValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/enum/green%20color",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -721,6 +741,7 @@ const enumNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/enum/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -733,6 +754,7 @@ const byteMultiByteOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/byte/multibyte",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -745,6 +767,7 @@ const byteEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/byte/empty",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -757,6 +780,7 @@ const byteNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/byte/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -769,6 +793,7 @@ const dateValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/date/2012-01-01",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -781,6 +806,7 @@ const dateNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/date/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -793,6 +819,7 @@ const dateTimeValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/datetime/2012-01-01T01%3A01%3A01Z",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -805,6 +832,7 @@ const dateTimeNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/datetime/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -817,6 +845,7 @@ const arrayStringCsvValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/array/csv/string/valid",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -829,6 +858,7 @@ const arrayStringCsvNullOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/array/csv/string/null",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -841,6 +871,7 @@ const arrayStringCsvEmptyOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/array/csv/string/empty",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -853,6 +884,7 @@ const arrayStringSsvValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/array/ssv/string/valid",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -865,6 +897,7 @@ const arrayStringTsvValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/array/tsv/string/valid",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -877,6 +910,7 @@ const arrayStringPipesValidOperationSpec: coreHttp.OperationSpec = {
   path: "/queries/array/pipes/string/valid",
   httpMethod: "GET",
   responses: {
+    200: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -521,6 +521,21 @@ export type XmlGetWrappedListsResponse = AppleBarrel & {
 };
 
 /**
+ * Contains response data for the getHeaders operation.
+ */
+export type XmlGetHeadersResponse = XmlGetHeadersHeaders & {
+  /**
+   * The underlying HTTP response.
+   */
+  _response: coreHttp.HttpResponse & {
+    /**
+     * The parsed HTTP response headers.
+     */
+    parsedHeaders: XmlGetHeadersHeaders;
+  };
+};
+
+/**
  * Contains response data for the getEmptyList operation.
  */
 export type XmlGetEmptyListResponse = Slideshow & {

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -125,7 +125,7 @@ export interface Container {
    */
   properties: ContainerProperties;
   /**
-   * Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
+   * Dictionary of <string>
    */
   metadata?: { [propertyName: string]: string };
 }
@@ -327,7 +327,7 @@ export interface Blob {
    */
   properties: BlobProperties;
   /**
-   * Dictionary of <paths·xml-headers·get·responses·200·headers·custom_header·schema>
+   * Dictionary of <string>
    */
   metadata?: { [propertyName: string]: string };
 }

--- a/test/integration/generated/xmlservice/src/models/mappers.ts
+++ b/test/integration/generated/xmlservice/src/models/mappers.ts
@@ -928,8 +928,8 @@ export const XmlGetHeadersHeaders: coreHttp.CompositeMapper = {
     modelProperties: {
       customHeader: {
         type: { name: "String" },
-        serializedName: "Custom-Header",
-        xmlName: "Custom-Header"
+        serializedName: "custom-header",
+        xmlName: "custom-header"
       }
     }
   }

--- a/test/integration/generated/xmlservice/src/operations/xml.ts
+++ b/test/integration/generated/xmlservice/src/operations/xml.ts
@@ -449,7 +449,7 @@ const getComplexTypeRefNoMetaOperationSpec: coreHttp.OperationSpec = {
 const putComplexTypeRefNoMetaOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/complex-type-ref-no-meta",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.model,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -471,7 +471,7 @@ const getComplexTypeRefWithMetaOperationSpec: coreHttp.OperationSpec = {
 const putComplexTypeRefWithMetaOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/complex-type-ref-with-meta",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.model1,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -497,6 +497,7 @@ const putSimpleOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/simple",
   httpMethod: "PUT",
   responses: {
+    201: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -523,6 +524,7 @@ const putWrappedListsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/wrapped-lists",
   httpMethod: "PUT",
   responses: {
+    201: {},
     default: {
       bodyMapper: Mappers.ErrorModel
     }
@@ -536,9 +538,12 @@ const putWrappedListsOperationSpec: coreHttp.OperationSpec = {
 const getHeadersOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/headers",
   httpMethod: "GET",
-  responses: {},
+  responses: {
+    200: {
+      headersMapper: Mappers.XmlGetHeadersHeaders
+    }
+  },
   urlParameters: [Parameters.$host],
-  isXML: true,
   serializer
 };
 const getEmptyListOperationSpec: coreHttp.OperationSpec = {
@@ -556,7 +561,7 @@ const getEmptyListOperationSpec: coreHttp.OperationSpec = {
 const putEmptyListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-list",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.slideshow,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -578,7 +583,7 @@ const getEmptyWrappedListsOperationSpec: coreHttp.OperationSpec = {
 const putEmptyWrappedListsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-wrapped-lists",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.appleBarrel,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -608,7 +613,7 @@ const getRootListOperationSpec: coreHttp.OperationSpec = {
 const putRootListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/root-list",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.bananas,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -638,7 +643,7 @@ const getRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
 const putRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/root-list-single-item",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.bananas,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -668,7 +673,7 @@ const getEmptyRootListOperationSpec: coreHttp.OperationSpec = {
 const putEmptyRootListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-root-list",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.bananas,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -690,7 +695,7 @@ const getEmptyChildElementOperationSpec: coreHttp.OperationSpec = {
 const putEmptyChildElementOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-child-element",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.banana,
   urlParameters: [Parameters.$host],
   isXML: true,
@@ -726,7 +731,7 @@ const getServicePropertiesOperationSpec: coreHttp.OperationSpec = {
 const putServicePropertiesOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.properties,
   queryParameters: [Parameters.comp1, Parameters.restype],
   urlParameters: [Parameters.$host],
@@ -761,7 +766,7 @@ const getAclsOperationSpec: coreHttp.OperationSpec = {
 const putAclsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/mycontainer",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 201: {} },
   requestBody: Parameters.properties1,
   queryParameters: [Parameters.comp2, Parameters.restype1],
   urlParameters: [Parameters.$host],
@@ -785,7 +790,7 @@ const listBlobsOperationSpec: coreHttp.OperationSpec = {
 const jsonInputOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/jsoninput",
   httpMethod: "PUT",
-  responses: {},
+  responses: { 200: {} },
   requestBody: Parameters.properties2,
   urlParameters: [Parameters.$host],
   serializer

--- a/test/integration/generated/xmlservice/src/operations/xml.ts
+++ b/test/integration/generated/xmlservice/src/operations/xml.ts
@@ -144,11 +144,11 @@ export class Xml {
    */
   getHeaders(
     options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  ): Promise<Models.XmlGetHeadersResponse> {
     return this.client.sendOperationRequest(
       { options },
       getHeadersOperationSpec
-    ) as Promise<coreHttp.RestResponse>;
+    ) as Promise<Models.XmlGetHeadersResponse>;
   }
 
   /**
@@ -538,6 +538,7 @@ const getHeadersOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {},
   urlParameters: [Parameters.$host],
+  isXML: true,
   serializer
 };
 const getEmptyListOperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/header.spec.ts
+++ b/test/integration/header.spec.ts
@@ -1,0 +1,206 @@
+import * as coreHttp from "@azure/core-http";
+import { should } from "chai";
+import { isEqual } from "lodash";
+import { HeaderClient } from "./generated/header/src/headerClient";
+
+should();
+
+describe("typescript", function() {
+  describe("Swagger Header BAT", function() {
+    describe("Basic Header Operations", function() {
+      let testClient: HeaderClient;
+      beforeEach(() => {
+        testClient = new HeaderClient();
+      });
+
+      it("should override existing headers (nodejs only)", async function() {
+        if (!coreHttp.isNode) {
+          this.skip();
+        }
+
+        await testClient.header.paramExistingKey("overwrite");
+        const response = await testClient.header.responseExistingKey();
+        response.userAgent!.should.be.deep.equal("overwrite");
+      });
+
+      it("should throw on changing protected headers", async function() {
+        await testClient.header.paramProtectedKey("text/html");
+        const response = await testClient.header.responseProtectedKey();
+        response.contentType!.should.be.deep.equal("text/html; charset=utf-8");
+      });
+
+      it("should send and receive integer type headers", async function() {
+        await testClient.header.paramInteger("positive", 1);
+        await testClient.header.paramInteger("negative", -2);
+
+        const response1 = await testClient.header.responseInteger("positive");
+        response1.value!.should.be.deep.equal(1);
+
+        const response2 = await testClient.header.responseInteger("negative");
+        response2.value!.should.be.deep.equal(-2);
+      });
+
+      it("should send and receive long type headers", async function() {
+        await testClient.header.paramLong("positive", 105);
+        await testClient.header.paramLong("negative", -2);
+
+        const response1 = await testClient.header.responseLong("positive");
+        response1.value!.should.be.deep.equal(105);
+
+        const response2 = await testClient.header.responseLong("negative");
+        response2.value!.should.be.deep.equal(-2);
+      });
+
+      it("should send and receive float type headers", async function() {
+        await testClient.header.paramFloat("positive", 0.07);
+        await testClient.header.paramFloat("negative", -3.0);
+
+        const response1 = await testClient.header.responseFloat("positive");
+        response1.value!.should.be.deep.equal(0.07);
+
+        const response2 = await testClient.header.responseFloat("negative");
+        response2.value!.should.be.deep.equal(-3.0);
+      });
+
+      it("should send and receive double type headers", async function() {
+        await testClient.header.paramDouble("positive", 7e120);
+        await testClient.header.paramDouble("negative", -3.0);
+
+        const response1 = await testClient.header.responseDouble("positive");
+        response1.value!.should.be.deep.equal(7e120);
+
+        const response2 = await testClient.header.responseDouble("negative");
+        response2.value!.should.be.deep.equal(-3.0);
+      });
+
+      it("should send and receive boolean type headers", async function() {
+        await testClient.header.paramBool("true", true);
+        await testClient.header.paramBool("false", false);
+
+        const response1 = await testClient.header.responseBool("true");
+        response1.value!.should.be.deep.equal(true);
+
+        const response2 = await testClient.header.responseBool("false");
+        response2.value!.should.be.deep.equal(false);
+      });
+
+      it("should send and receive string type headers", async function() {
+        await testClient.header.paramString("valid", {
+          value: "The quick brown fox jumps over the lazy dog"
+        });
+        await testClient.header.paramString("null", { value: null as any });
+        await testClient.header.paramString("empty", { value: "" });
+
+        const response1 = await testClient.header.responseString("valid");
+        response1.value!.should.be.deep.equal(
+          "The quick brown fox jumps over the lazy dog"
+        );
+
+        // Note: converting the header value "null" to a null literal is not supported.
+        // const response2 = await testClient.header.responseString('null');
+        // response2.value!.should.not.exist;
+
+        const response3 = await testClient.header.responseString("empty");
+        response3.value!.should.be.deep.equal("");
+      });
+
+      it("should send and receive enum type headers", async function() {
+        await testClient.header.paramEnum("valid", { value: "GREY" });
+        await testClient.header.paramEnum("null", { value: null as any });
+
+        const response1 = await testClient.header.responseEnum("valid");
+        response1.value!.should.be.deep.equal("GREY");
+
+        const response2 = await testClient.header.responseEnum("null");
+        response2.value!.should.be.deep.equal("");
+      });
+
+      it("should send and receive date type headers", async function() {
+        await testClient.header.paramDate("valid", new Date("2010-01-01"));
+        await testClient.header.paramDate("min", new Date("0001-01-01"));
+
+        const response1 = await testClient.header.responseDate("valid");
+        isEqual(
+          new Date(response1.value!),
+          new Date("2010-01-01")
+        ).should.be.deep.equal(true);
+
+        const response2 = await testClient.header.responseDate("min");
+        isEqual(response2.value!, new Date("0001-01-01")).should.be.deep.equal(
+          true
+        );
+      });
+
+      it("should send and receive datetime type headers", async function() {
+        await testClient.header.paramDatetime(
+          "valid",
+          new Date("2010-01-01T12:34:56Z")
+        );
+        await testClient.header.paramDatetime(
+          "min",
+          new Date("0001-01-01T00:00:00Z")
+        );
+
+        const response1 = await testClient.header.responseDatetime("valid");
+        isEqual(
+          response1.value!,
+          new Date("2010-01-01T12:34:56Z")
+        ).should.be.deep.equal(true);
+
+        const response2 = await testClient.header.responseDatetime("min");
+        isEqual(
+          response2.value!,
+          new Date("0001-01-01T00:00:00Z")
+        ).should.be.deep.equal(true);
+      });
+
+      it("should send and receive datetimerfc1123 type headers", async function() {
+        await testClient.header.paramDatetimeRfc1123("valid", {
+          value: new Date("2010-01-01T12:34:56Z")
+        });
+        await testClient.header.paramDatetimeRfc1123("min", {
+          value: new Date("0001-01-01T00:00:00Z")
+        });
+
+        const response1 = await testClient.header.responseDatetimeRfc1123(
+          "valid"
+        );
+        isEqual(
+          response1.value,
+          new Date("Fri, 01 Jan 2010 12:34:56 GMT")
+        ).should.be.deep.equal(true);
+
+        const response2 = await testClient.header.responseDatetimeRfc1123(
+          "min"
+        );
+        isEqual(
+          response2.value,
+          new Date("Mon, 01 Jan 0001 00:00:00 GMT")
+        ).should.be.deep.equal(true);
+      });
+
+      it("should send and receive duration type headers", async function() {
+        const duration = "P123DT22H14M12.011S";
+        await testClient.header.paramDuration("valid", duration);
+
+        const response = await testClient.header.responseDuration("valid");
+        isEqual(response.value!, "P123DT22H14M12.011S").should.be.deep.equal(
+          true
+        );
+      });
+
+      it("should send and receive byte array type headers", async function() {
+        const value = "啊齄丂狛狜隣郎隣兀﨩";
+        const bytes = Buffer.from(value, "utf8");
+        await testClient.header.paramByte("valid", bytes);
+
+        const response = await testClient.header.responseByte("valid");
+
+        response.value!.length.should.equal(bytes.length);
+        for (let i = 0; i < bytes.length; i++) {
+          response.value![i].should.equal(bytes[i]);
+        }
+      });
+    });
+  });
+});

--- a/test/integration/xmlService.spec.ts
+++ b/test/integration/xmlService.spec.ts
@@ -433,7 +433,7 @@ describe("typescript", function() {
     // TODO: Need to support response headers. Issue #512
     it.skip("should deserialize custom headers in an XML client", async function() {
       const headersResponse = await testClient.xml.getHeaders();
-      headersResponse.customHeader.should.equal("custom-value");
+      headersResponse.customHeader!.should.equal("custom-value");
     });
   });
 });

--- a/test/integration/xmlService.spec.ts
+++ b/test/integration/xmlService.spec.ts
@@ -431,7 +431,7 @@ describe("typescript", function() {
     });
 
     // TODO: Need to support response headers. Issue #512
-    it.skip("should deserialize custom headers in an XML client", async function() {
+    it("should deserialize custom headers in an XML client", async function() {
       const headersResponse = await testClient.xml.getHeaders();
       headersResponse.customHeader!.should.equal("custom-value");
     });


### PR DESCRIPTION
This PR completes the work to generate correctly Response Types for operation, previously we were only using Body for generating the types, with this PR we also take Headers information to get the right Response type

- Update operationTransforms to also extract response Headers information
- Update modelsGenerator to generate responses as intersection types when there are Headers
- Update operationsGenerator to include headersMappers in the OperationSpec