### PR TITLE
[v6] Fix polymorphic mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ More information about these can be found [here](https://github.com/Azure/autore
 ```yaml
 version: 3.0.6192
 use-extension:
-  "@autorest/modelerfour": "4.4.158"
+  "@autorest/modelerfour": "4.6.197"
+
+modelerfour:
+  prenamer: true
 
 pipeline:
   typescript: # <- name of plugin

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@azure-tools/linq": "3.1.206",
         "@azure-tools/openapi": "3.0.209",
         "@azure/core-http": "^1.0.0",
+        "@azure/logger": "^1.0.0",
         "@types/lodash": "^4.14.149",
         "lodash": "^4.17.15",
         "prettier": "^1.19.1",

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -396,18 +396,19 @@ function withDiscriminator(
   model: ObjectDetails,
   properties: PropertySignatureStructure[]
 ): PropertySignatureStructure[] {
-  const discriminator = (model as PolymorphicObjectDetails).discriminator;
-  if (!discriminator) {
+  const discriminatorValues = (model as PolymorphicObjectDetails)
+    .discriminatorValues;
+  if (!discriminatorValues) {
     return properties;
   }
 
-  const discProps = keys(discriminator).map<PropertySignatureStructure>(
+  const discProps = keys(discriminatorValues).map<PropertySignatureStructure>(
     key => ({
       docs: [
         `Polymorphic discriminator, which specifies the different types this object can be`
       ],
       name: key,
-      type: discriminator[key].map(disc => `"${disc}"`).join(" | "),
+      type: discriminatorValues[key].map(disc => `"${disc}"`).join(" | "),
       kind: StructureKind.PropertySignature
     })
   );

--- a/src/models/modelDetails.ts
+++ b/src/models/modelDetails.ts
@@ -46,7 +46,12 @@ export type PolymorphicObjectDetails = BasicObjectDetails & {
   /**
    * Polymorphic discriminator
    */
-  discriminator: { [key: string]: string[] };
+  discriminatorValues: { [key: string]: string[] };
+  /**
+   * This is the discriminator path to be used during serialization
+   * which is composed of <ParentName>.<DiscriminatorValue>
+   */
+  discriminatorPath: string;
   /**
    * Name of the union type which represents
    * the polymorphic options

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -144,11 +144,8 @@ function buildMapper(
   const readOnly = !!options.readOnly;
   // Handle x-ms-discriminator-value Extension. More info:
   // https://github.com/Azure/autorest/tree/master/docs/extensions/swagger-extensions-examples/x-ms-discriminator-value
-  const msDiscriminatorValue =
-    schema.extensions && schema.extensions["x-ms-discriminator-value"];
-
   const serializedName =
-    msDiscriminatorValue ||
+    getDiscriminatorValue(schema) ||
     options.serializedName ||
     getLanguageMetadata(schema.language).name;
 
@@ -539,6 +536,17 @@ function processProperties(
   });
 
   return modelProperties;
+}
+
+/**
+ * Gets the discriminator value
+ * The extension x-ms-discriminator-value can be used to override
+ */
+function getDiscriminatorValue(schema: ObjectSchema | Schema) {
+  return (
+    (schema.extensions && schema.extensions["x-ms-discriminator-value"]) ||
+    (schema as ObjectSchema).discriminatorValue
+  );
 }
 
 export function getMapperOrRef(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,2 @@
+import { createClientLogger, setLogLevel } from "@azure/logger";
+export const logger = createClientLogger("Autorest.Typescript");

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -15,7 +15,7 @@ export type MyBaseTypeUnion = MyBaseType | MyDerivedType;
 export type SharkUnion = Shark | Sawshark | Goblinshark | Cookiecuttershark;
 
 /**
- * An interface representing basic.
+ * An interface representing Basic.
  */
 export interface Basic {
   /**
@@ -38,7 +38,7 @@ export interface ErrorModel {
 }
 
 /**
- * An interface representing int-wrapper.
+ * An interface representing IntWrapper.
  */
 export interface IntWrapper {
   field1?: number;
@@ -46,7 +46,7 @@ export interface IntWrapper {
 }
 
 /**
- * An interface representing long-wrapper.
+ * An interface representing LongWrapper.
  */
 export interface LongWrapper {
   field1?: number;
@@ -54,7 +54,7 @@ export interface LongWrapper {
 }
 
 /**
- * An interface representing float-wrapper.
+ * An interface representing FloatWrapper.
  */
 export interface FloatWrapper {
   field1?: number;
@@ -62,7 +62,7 @@ export interface FloatWrapper {
 }
 
 /**
- * An interface representing double-wrapper.
+ * An interface representing DoubleWrapper.
  */
 export interface DoubleWrapper {
   field1?: number;
@@ -70,7 +70,7 @@ export interface DoubleWrapper {
 }
 
 /**
- * An interface representing boolean-wrapper.
+ * An interface representing BooleanWrapper.
  */
 export interface BooleanWrapper {
   fieldTrue?: boolean;
@@ -78,7 +78,7 @@ export interface BooleanWrapper {
 }
 
 /**
- * An interface representing string-wrapper.
+ * An interface representing StringWrapper.
  */
 export interface StringWrapper {
   field?: string;
@@ -87,7 +87,7 @@ export interface StringWrapper {
 }
 
 /**
- * An interface representing date-wrapper.
+ * An interface representing DateWrapper.
  */
 export interface DateWrapper {
   field?: Date;
@@ -95,7 +95,7 @@ export interface DateWrapper {
 }
 
 /**
- * An interface representing datetime-wrapper.
+ * An interface representing DatetimeWrapper.
  */
 export interface DatetimeWrapper {
   field?: Date;
@@ -103,7 +103,7 @@ export interface DatetimeWrapper {
 }
 
 /**
- * An interface representing datetimerfc1123-wrapper.
+ * An interface representing Datetimerfc1123Wrapper.
  */
 export interface Datetimerfc1123Wrapper {
   field?: Date;
@@ -111,28 +111,28 @@ export interface Datetimerfc1123Wrapper {
 }
 
 /**
- * An interface representing duration-wrapper.
+ * An interface representing DurationWrapper.
  */
 export interface DurationWrapper {
   field?: string;
 }
 
 /**
- * An interface representing byte-wrapper.
+ * An interface representing ByteWrapper.
  */
 export interface ByteWrapper {
   field?: Uint8Array;
 }
 
 /**
- * An interface representing array-wrapper.
+ * An interface representing ArrayWrapper.
  */
 export interface ArrayWrapper {
   array?: string[];
 }
 
 /**
- * An interface representing dictionary-wrapper.
+ * An interface representing DictionaryWrapper.
  */
 export interface DictionaryWrapper {
   /**
@@ -142,7 +142,7 @@ export interface DictionaryWrapper {
 }
 
 /**
- * An interface representing pet.
+ * An interface representing Pet.
  */
 export interface Pet {
   id?: number;
@@ -150,7 +150,7 @@ export interface Pet {
 }
 
 /**
- * An interface representing cat.
+ * An interface representing Cat.
  */
 export type Cat = Pet & {
   color?: string;
@@ -158,14 +158,14 @@ export type Cat = Pet & {
 };
 
 /**
- * An interface representing dog.
+ * An interface representing Dog.
  */
 export type Dog = Pet & {
   food?: string;
 };
 
 /**
- * An interface representing siamese.
+ * An interface representing Siamese.
  */
 export type Siamese = Cat & {
   breed?: string;
@@ -221,7 +221,7 @@ export type DotSalmon = DotFish & {
 };
 
 /**
- * An interface representing salmon.
+ * An interface representing Salmon.
  */
 export type Salmon = Fish & {
   location?: string;
@@ -229,7 +229,7 @@ export type Salmon = Fish & {
 };
 
 /**
- * An interface representing readonly-obj.
+ * An interface representing ReadonlyObj.
  */
 export interface ReadonlyObj {
   readonly id?: string;
@@ -256,7 +256,7 @@ export interface MyBaseHelperType {
 }
 
 /**
- * An interface representing smart_salmon.
+ * An interface representing SmartSalmon.
  */
 export type SmartSalmon = Salmon & {
   /**
@@ -267,7 +267,7 @@ export type SmartSalmon = Salmon & {
 };
 
 /**
- * An interface representing shark.
+ * An interface representing Shark.
  */
 export type Shark = Fish & {
   age?: number;
@@ -275,14 +275,14 @@ export type Shark = Fish & {
 };
 
 /**
- * An interface representing sawshark.
+ * An interface representing Sawshark.
  */
 export type Sawshark = Shark & {
   picture?: Uint8Array;
 };
 
 /**
- * An interface representing goblinshark.
+ * An interface representing Goblinshark.
  */
 export type Goblinshark = Shark & {
   jawsize?: number;
@@ -293,7 +293,7 @@ export type Goblinshark = Shark & {
 };
 
 /**
- * An interface representing cookiecuttershark.
+ * An interface representing Cookiecuttershark.
  */
 export type Cookiecuttershark = Shark & {};
 

--- a/test/integration/generated/bodyComplex/src/models/mappers.ts
+++ b/test/integration/generated/bodyComplex/src/models/mappers.ts
@@ -9,7 +9,7 @@
 import * as coreHttp from "@azure/core-http";
 
 export const Basic: coreHttp.CompositeMapper = {
-  serializedName: "basic",
+  serializedName: "Basic",
   type: {
     name: "Composite",
     className: "Basic",
@@ -34,7 +34,7 @@ export const ErrorModel: coreHttp.CompositeMapper = {
 };
 
 export const IntWrapper: coreHttp.CompositeMapper = {
-  serializedName: "int-wrapper",
+  serializedName: "IntWrapper",
   type: {
     name: "Composite",
     className: "IntWrapper",
@@ -46,7 +46,7 @@ export const IntWrapper: coreHttp.CompositeMapper = {
 };
 
 export const LongWrapper: coreHttp.CompositeMapper = {
-  serializedName: "long-wrapper",
+  serializedName: "LongWrapper",
   type: {
     name: "Composite",
     className: "LongWrapper",
@@ -58,7 +58,7 @@ export const LongWrapper: coreHttp.CompositeMapper = {
 };
 
 export const FloatWrapper: coreHttp.CompositeMapper = {
-  serializedName: "float-wrapper",
+  serializedName: "FloatWrapper",
   type: {
     name: "Composite",
     className: "FloatWrapper",
@@ -70,7 +70,7 @@ export const FloatWrapper: coreHttp.CompositeMapper = {
 };
 
 export const DoubleWrapper: coreHttp.CompositeMapper = {
-  serializedName: "double-wrapper",
+  serializedName: "DoubleWrapper",
   type: {
     name: "Composite",
     className: "DoubleWrapper",
@@ -86,7 +86,7 @@ export const DoubleWrapper: coreHttp.CompositeMapper = {
 };
 
 export const BooleanWrapper: coreHttp.CompositeMapper = {
-  serializedName: "boolean-wrapper",
+  serializedName: "BooleanWrapper",
   type: {
     name: "Composite",
     className: "BooleanWrapper",
@@ -98,7 +98,7 @@ export const BooleanWrapper: coreHttp.CompositeMapper = {
 };
 
 export const StringWrapper: coreHttp.CompositeMapper = {
-  serializedName: "string-wrapper",
+  serializedName: "StringWrapper",
   type: {
     name: "Composite",
     className: "StringWrapper",
@@ -111,7 +111,7 @@ export const StringWrapper: coreHttp.CompositeMapper = {
 };
 
 export const DateWrapper: coreHttp.CompositeMapper = {
-  serializedName: "date-wrapper",
+  serializedName: "DateWrapper",
   type: {
     name: "Composite",
     className: "DateWrapper",
@@ -123,7 +123,7 @@ export const DateWrapper: coreHttp.CompositeMapper = {
 };
 
 export const DatetimeWrapper: coreHttp.CompositeMapper = {
-  serializedName: "datetime-wrapper",
+  serializedName: "DatetimeWrapper",
   type: {
     name: "Composite",
     className: "DatetimeWrapper",
@@ -135,7 +135,7 @@ export const DatetimeWrapper: coreHttp.CompositeMapper = {
 };
 
 export const Datetimerfc1123Wrapper: coreHttp.CompositeMapper = {
-  serializedName: "datetimerfc1123-wrapper",
+  serializedName: "Datetimerfc1123Wrapper",
   type: {
     name: "Composite",
     className: "Datetimerfc1123Wrapper",
@@ -147,7 +147,7 @@ export const Datetimerfc1123Wrapper: coreHttp.CompositeMapper = {
 };
 
 export const DurationWrapper: coreHttp.CompositeMapper = {
-  serializedName: "duration-wrapper",
+  serializedName: "DurationWrapper",
   type: {
     name: "Composite",
     className: "DurationWrapper",
@@ -158,7 +158,7 @@ export const DurationWrapper: coreHttp.CompositeMapper = {
 };
 
 export const ByteWrapper: coreHttp.CompositeMapper = {
-  serializedName: "byte-wrapper",
+  serializedName: "ByteWrapper",
   type: {
     name: "Composite",
     className: "ByteWrapper",
@@ -169,7 +169,7 @@ export const ByteWrapper: coreHttp.CompositeMapper = {
 };
 
 export const ArrayWrapper: coreHttp.CompositeMapper = {
-  serializedName: "array-wrapper",
+  serializedName: "ArrayWrapper",
   type: {
     name: "Composite",
     className: "ArrayWrapper",
@@ -179,7 +179,7 @@ export const ArrayWrapper: coreHttp.CompositeMapper = {
           name: "Sequence",
           element: {
             type: { name: "String" },
-            serializedName: "array-wrapper-arrayItem"
+            serializedName: "ArrayWrapperArrayItem"
           }
         },
         serializedName: "array"
@@ -189,7 +189,7 @@ export const ArrayWrapper: coreHttp.CompositeMapper = {
 };
 
 export const DictionaryWrapper: coreHttp.CompositeMapper = {
-  serializedName: "dictionary-wrapper",
+  serializedName: "DictionaryWrapper",
   type: {
     name: "Composite",
     className: "DictionaryWrapper",
@@ -197,7 +197,7 @@ export const DictionaryWrapper: coreHttp.CompositeMapper = {
       defaultProgram: {
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, serializedName: "string" }
+          value: { type: { name: "String" }, serializedName: "String" }
         },
         serializedName: "defaultProgram"
       }
@@ -206,7 +206,7 @@ export const DictionaryWrapper: coreHttp.CompositeMapper = {
 };
 
 export const Pet: coreHttp.CompositeMapper = {
-  serializedName: "pet",
+  serializedName: "Pet",
   type: {
     name: "Composite",
     className: "Pet",
@@ -218,7 +218,7 @@ export const Pet: coreHttp.CompositeMapper = {
 };
 
 export const Cat: coreHttp.CompositeMapper = {
-  serializedName: "cat",
+  serializedName: "Cat",
   type: {
     name: "Composite",
     className: "Cat",
@@ -237,7 +237,7 @@ export const Cat: coreHttp.CompositeMapper = {
 };
 
 export const Dog: coreHttp.CompositeMapper = {
-  serializedName: "dog",
+  serializedName: "Dog",
   type: {
     name: "Composite",
     className: "Dog",
@@ -249,7 +249,7 @@ export const Dog: coreHttp.CompositeMapper = {
 };
 
 export const Siamese: coreHttp.CompositeMapper = {
-  serializedName: "siamese",
+  serializedName: "Siamese",
   type: {
     name: "Composite",
     className: "Siamese",
@@ -380,7 +380,7 @@ export const Salmon: coreHttp.CompositeMapper = {
 };
 
 export const ReadonlyObj: coreHttp.CompositeMapper = {
-  serializedName: "readonly-obj",
+  serializedName: "ReadonlyObj",
   type: {
     name: "Composite",
     className: "ReadonlyObj",
@@ -527,6 +527,7 @@ export const MyDerivedType: coreHttp.CompositeMapper = {
     }
   }
 };
+
 export let discriminators = {
   Fish: Fish,
   DotFish: DotFish,

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -208,7 +208,7 @@ const getNullOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "String" }, serializedName: "string" }
+      bodyMapper: { type: { name: "String" }, serializedName: "String" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -235,7 +235,7 @@ const getEmptyOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "String" }, serializedName: "string" }
+      bodyMapper: { type: { name: "String" }, serializedName: "String" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -262,7 +262,7 @@ const getMbcsOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "String" }, serializedName: "string" }
+      bodyMapper: { type: { name: "String" }, serializedName: "String" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -289,7 +289,7 @@ const getWhitespaceOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "String" }, serializedName: "string" }
+      bodyMapper: { type: { name: "String" }, serializedName: "String" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -316,7 +316,7 @@ const getNotProvidedOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "String" }, serializedName: "string" }
+      bodyMapper: { type: { name: "String" }, serializedName: "String" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -330,7 +330,7 @@ const getBase64EncodedOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "Base64Url" }, serializedName: "byte-array" }
+      bodyMapper: { type: { name: "Base64Url" }, serializedName: "ByteArray" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -344,7 +344,7 @@ const getBase64UrlEncodedOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "Base64Url" }, serializedName: "byte-array" }
+      bodyMapper: { type: { name: "Base64Url" }, serializedName: "ByteArray" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel
@@ -371,7 +371,7 @@ const getNullBase64UrlEncodedOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: { type: { name: "Base64Url" }, serializedName: "byte-array" }
+      bodyMapper: { type: { name: "Base64Url" }, serializedName: "ByteArray" }
     },
     default: {
       bodyMapper: Mappers.ErrorModel

--- a/test/integration/generated/url/src/models/parameters.ts
+++ b/test/integration/generated/url/src/models/parameters.ts
@@ -300,7 +300,7 @@ export const arrayPath: coreHttp.OperationURLParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "String" }, serializedName: "get-0-itemsItem" }
+      element: { type: { name: "String" }, serializedName: "Get0ItemsItem" }
     }
   }
 };
@@ -615,7 +615,7 @@ export const arrayQuery: coreHttp.OperationQueryParameter = {
     serializedName: "arrayQuery",
     type: {
       name: "Sequence",
-      element: { type: { name: "String" }, serializedName: "string" }
+      element: { type: { name: "String" }, serializedName: "String" }
     }
   },
   collectionFormat: coreHttp.QueryCollectionFormat.Csv
@@ -627,7 +627,7 @@ export const arrayQuery1: coreHttp.OperationQueryParameter = {
     serializedName: "arrayQuery",
     type: {
       name: "Sequence",
-      element: { type: { name: "String" }, serializedName: "string" }
+      element: { type: { name: "String" }, serializedName: "String" }
     }
   },
   collectionFormat: coreHttp.QueryCollectionFormat.Ssv
@@ -639,7 +639,7 @@ export const arrayQuery2: coreHttp.OperationQueryParameter = {
     serializedName: "arrayQuery",
     type: {
       name: "Sequence",
-      element: { type: { name: "String" }, serializedName: "string" }
+      element: { type: { name: "String" }, serializedName: "String" }
     }
   },
   collectionFormat: coreHttp.QueryCollectionFormat.Tsv
@@ -651,7 +651,7 @@ export const arrayQuery3: coreHttp.OperationQueryParameter = {
     serializedName: "arrayQuery",
     type: {
       name: "Sequence",
-      element: { type: { name: "String" }, serializedName: "string" }
+      element: { type: { name: "String" }, serializedName: "String" }
     }
   },
   collectionFormat: coreHttp.QueryCollectionFormat.Pipes

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -345,7 +345,7 @@ export interface BlobProperties {
   contentType?: string;
   contentEncoding?: string;
   contentLanguage?: string;
-  contentMd5?: string;
+  contentMD5?: string;
   contentDisposition?: string;
   cacheControl?: string;
   blobSequenceNumber?: number;
@@ -370,16 +370,16 @@ export interface BlobProperties {
 }
 
 /**
- * An interface representing JSONInput.
+ * An interface representing JsonInput.
  */
-export interface JSONInput {
+export interface JsonInput {
   id?: number;
 }
 
 /**
- * An interface representing JSONOutput.
+ * An interface representing JsonOutput.
  */
-export interface JSONOutput {
+export interface JsonOutput {
   id?: number;
 }
 
@@ -738,7 +738,7 @@ export type XmlListBlobsResponse = ListBlobsResponse & {
 /**
  * Contains response data for the jsonOutput operation.
  */
-export type XmlJsonOutputResponse = JSONOutput & {
+export type XmlJsonOutputResponse = JsonOutput & {
   /**
    * The underlying HTTP response.
    */
@@ -751,6 +751,6 @@ export type XmlJsonOutputResponse = JSONOutput & {
     /**
      * The response body as parsed JSON or XML
      */
-    parsedBody: JSONOutput;
+    parsedBody: JsonOutput;
   };
 };

--- a/test/integration/generated/xmlservice/src/models/mappers.ts
+++ b/test/integration/generated/xmlservice/src/models/mappers.ts
@@ -132,7 +132,7 @@ export const Slide: coreHttp.CompositeMapper = {
           name: "Sequence",
           element: {
             type: { name: "String" },
-            serializedName: "Slide-itemsItem"
+            serializedName: "SlideItemsItem"
           }
         },
         serializedName: "items",
@@ -174,7 +174,7 @@ export const AppleBarrel: coreHttp.CompositeMapper = {
           name: "Sequence",
           element: {
             type: { name: "String" },
-            serializedName: "AppleBarrel-GoodApplesItem"
+            serializedName: "AppleBarrelGoodApplesItem"
           }
         },
         serializedName: "GoodApples",
@@ -187,7 +187,7 @@ export const AppleBarrel: coreHttp.CompositeMapper = {
           name: "Sequence",
           element: {
             type: { name: "String" },
-            serializedName: "AppleBarrel-BadApplesItem"
+            serializedName: "AppleBarrelBadApplesItem"
           }
         },
         serializedName: "BadApples",
@@ -296,7 +296,7 @@ export const Container: coreHttp.CompositeMapper = {
       metadata: {
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, serializedName: "string" }
+          value: { type: { name: "String" }, serializedName: "String" }
         },
         serializedName: "Metadata",
         xmlName: "Metadata"
@@ -722,7 +722,7 @@ export const Blob: coreHttp.CompositeMapper = {
       metadata: {
         type: {
           name: "Dictionary",
-          value: { type: { name: "String" }, serializedName: "string" }
+          value: { type: { name: "String" }, serializedName: "String" }
         },
         serializedName: "Metadata",
         xmlName: "Metadata"
@@ -898,22 +898,22 @@ export const BlobProperties: coreHttp.CompositeMapper = {
   }
 };
 
-export const JSONInput: coreHttp.CompositeMapper = {
-  serializedName: "JSONInput",
+export const JsonInput: coreHttp.CompositeMapper = {
+  serializedName: "JsonInput",
   type: {
     name: "Composite",
-    className: "JSONInput",
+    className: "JsonInput",
     modelProperties: {
       id: { type: { name: "Number" }, serializedName: "id", xmlName: "id" }
     }
   }
 };
 
-export const JSONOutput: coreHttp.CompositeMapper = {
-  serializedName: "JSONOutput",
+export const JsonOutput: coreHttp.CompositeMapper = {
+  serializedName: "JsonOutput",
   type: {
     name: "Composite",
-    className: "JSONOutput",
+    className: "JsonOutput",
     modelProperties: {
       id: { type: { name: "Number" }, serializedName: "id", xmlName: "id" }
     }

--- a/test/integration/generated/xmlservice/src/models/parameters.ts
+++ b/test/integration/generated/xmlservice/src/models/parameters.ts
@@ -149,5 +149,5 @@ export const properties1: coreHttp.OperationParameter = {
 
 export const properties2: coreHttp.OperationParameter = {
   parameterPath: "properties",
-  mapper: Mappers.JSONInput
+  mapper: Mappers.JsonInput
 };

--- a/test/integration/generated/xmlservice/src/operations/xml.ts
+++ b/test/integration/generated/xmlservice/src/operations/xml.ts
@@ -408,7 +408,7 @@ export class Xml {
    * @param options The options parameters.
    */
   jsonInput(
-    properties: Models.JSONInput,
+    properties: Models.JsonInput,
     options?: coreHttp.RequestOptionsBase
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
@@ -600,7 +600,7 @@ const getRootListOperationSpec: coreHttp.OperationSpec = {
           name: "Sequence",
           element: { type: { name: "Composite", className: "Banana" } }
         },
-        serializedName: "Array of Banana",
+        serializedName: "ArrayOfBanana",
         xmlName: "bananas",
         xmlElementName: "banana"
       }
@@ -630,7 +630,7 @@ const getRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
           name: "Sequence",
           element: { type: { name: "Composite", className: "Banana" } }
         },
-        serializedName: "Array of Banana",
+        serializedName: "ArrayOfBanana",
         xmlName: "bananas",
         xmlElementName: "banana"
       }
@@ -660,7 +660,7 @@ const getEmptyRootListOperationSpec: coreHttp.OperationSpec = {
           name: "Sequence",
           element: { type: { name: "Composite", className: "Banana" } }
         },
-        serializedName: "Array of Banana",
+        serializedName: "ArrayOfBanana",
         xmlName: "bananas",
         xmlElementName: "banana"
       }
@@ -800,7 +800,7 @@ const jsonOutputOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "GET",
   responses: {
     200: {
-      bodyMapper: Mappers.JSONOutput
+      bodyMapper: Mappers.JsonOutput
     }
   },
   urlParameters: [Parameters.$host],


### PR DESCRIPTION
# Problem
The way we handled PolymorphicDiscriminators broke when consuming latest version of `modelerfour` that now runs `prenamer`.

# Fix
The fix is to make sure we use the discriminatorValue when building the discriminatorPath/discriminatorIndex.

# Cause
We were using serializedName to build the discriminatorPath, this serializedName fallsback to the schema name if there is no a serializedName available. We were lucky before since our test scenarios had the same names as discriminatorValue and modelerfour did not format the names, but now `prenamer` does, and we break. The correct way to do this is by using the discriminatorValue

 Issue #563 is tracking the work to cleanup other places where we fallback to `languages.default.name`

# Context on Discriminators:
In order for `@azure/core-http`  to serialize Polymorphic objects, we need to provide a mapping which correlates the object type with a mapper ([code](https://github.com/Azure/azure-sdk-for-js/blob/44dc6b5cc71d3d96151d7106ea5991a9231faa7a/sdk/core/core-http/lib/serializer.ts#L841)).

This mapping is in the following format

```json
{
"<DiscriminatorPath>": "<Mapper>"
}
```

So for example where we have the following structure
```json
"Fish": {
      "type":  "object",
      "discriminator": "fishtype",
      "required": [ "fishtype", "length" ],
      "properties": {
        "fishtype": {
          "type": "string"
        },
        "species": {
          "type": "string"
        },
        "length": {
          "type": "number",
          "format": "float"
        },
        "siblings": {
          "type": "array",
          "items": {
            "$ref": "#/definitions/Fish"
          }
        }
      }
    },
 "salmon": {
      "allOf": [
        {
          "$ref": "#/definitions/Fish"
        }
      ],
      "type":  "object",
      "properties": {
        "location": {
          "type": "string"
        },
        "iswild": {
          "type": "boolean"
        }
      }
    },
 "shark": {
      "allOf": [
        {
          "$ref": "#/definitions/Fish"
        }
      ],
      "type":  "object",
      "required": [ "birthday" ],
      "properties": {
        "age": {
          "type": "integer",
          "format": "int32"
        },
        "birthday": {
          "type": "string",
          "format": "date-time"
        }
      }
    },
```
It means that whenever we get a Fish, it could be either a `shark`, or a `salmon`.  And the property `fishType` is going to help us know how to serialize it, and our mapping would be like this

```typescript

export const discriminators = {
   "Fish": Mappers.Fish,
   "Fish.shark": Mappers.Shark,
   "Fish.salmon": Mappers.Salmon
}

```