### PR TITLE
[v6] Multiple fixes

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -373,7 +373,7 @@ function writeOptionalParameters(
     name: `${operationGroupName}${operationName}OptionalParams`,
     docs: ["Optional parameters."],
     isExported: true,
-    extends: [baseClass || "coreHttp.RequestOptionsBase"],
+    extends: [baseClass || "coreHttp.OperationOptions"],
     properties: optionalParams.map<PropertySignatureStructure>(p => ({
       name: p.name,
       hasQuestionToken: true,

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -54,14 +54,16 @@ const writeClientModels = (
 ) => {
   let clientOptionalParams = clientDetails.parameters.filter(
     p =>
-      !p.required && p.implementationLocation === ImplementationLocation.Client
+      (!p.required || p.defaultValue) &&
+      p.implementationLocation === ImplementationLocation.Client
   );
 
   writeOptionalParameters(
     clientDetails.name,
     "",
     clientOptionalParams,
-    modelsIndexFile
+    modelsIndexFile,
+    "coreHttp.ServiceClientOptions"
   );
 };
 
@@ -360,7 +362,8 @@ function writeOptionalParameters(
   operationGroupName: string,
   operationName: string,
   optionalParams: ParameterDetails[],
-  modelsIndexFile: SourceFile
+  modelsIndexFile: SourceFile,
+  baseClass?: string
 ) {
   if (!optionalParams || !optionalParams.length) {
     return;
@@ -370,10 +373,10 @@ function writeOptionalParameters(
     name: `${operationGroupName}${operationName}OptionalParams`,
     docs: ["Optional parameters."],
     isExported: true,
-    extends: ["coreHttp.RequestOptionsBase"],
+    extends: [baseClass || "coreHttp.RequestOptionsBase"],
     properties: optionalParams.map<PropertySignatureStructure>(p => ({
       name: p.name,
-      hasQuestionToken: !p.required,
+      hasQuestionToken: true,
       type: p.typeDetails.typeName,
       docs: p.description ? [p.description] : undefined,
       kind: StructureKind.PropertySignature

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -27,6 +27,7 @@ import {
   OperationResponseDetails
 } from "../models/operationDetails";
 import { ParameterDetails } from "../models/parameterDetails";
+import { ImplementationLocation } from "@azure-tools/codemodel";
 
 export function generateModels(clientDetails: ClientDetails, project: Project) {
   const modelsIndexFile = project.createSourceFile(
@@ -44,7 +45,25 @@ export function generateModels(clientDetails: ClientDetails, project: Project) {
   writeObjects(clientDetails, modelsIndexFile);
   writeChoices(clientDetails, modelsIndexFile);
   writeOperationModels(clientDetails, modelsIndexFile);
+  writeClientModels(clientDetails, modelsIndexFile);
 }
+
+const writeClientModels = (
+  clientDetails: ClientDetails,
+  modelsIndexFile: SourceFile
+) => {
+  let clientOptionalParams = clientDetails.parameters.filter(
+    p =>
+      !p.required && p.implementationLocation === ImplementationLocation.Client
+  );
+
+  writeOptionalParameters(
+    clientDetails.name,
+    "",
+    clientOptionalParams,
+    modelsIndexFile
+  );
+};
 
 const writeOperationModels = (
   clientDetails: ClientDetails,

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -312,7 +312,7 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
   if (parents) {
     modelsIndexFile.addTypeAlias({
       name: model.name,
-      docs: [model.description],
+      docs: model.description ? [model.description] : [],
       isExported: true,
       type: Writers.intersectionType(
         parents,
@@ -323,7 +323,7 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
   } else {
     modelsIndexFile.addInterface({
       name: model.name,
-      docs: [model.description],
+      docs: model.description ? [model.description] : [],
       isExported: true,
       properties,
       leadingTrivia: writer => writer.blankLine()

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -14,7 +14,6 @@ import {
 import { normalizeName, NameType } from "../utils/nameUtils";
 import { ClientDetails } from "../models/clientDetails";
 import { transformOperationSpec } from "../transforms/operationTransforms";
-import { MapperType } from "@azure/core-http";
 import {
   OperationGroupDetails,
   OperationSpecDetails,
@@ -199,7 +198,7 @@ function getOptionsParameter(
     includeOptional: true
   }).some(p => !p.required)
     ? `Models.${operation.typeDetails.typeName}OptionalParams`
-    : "coreHttp.RequestOptionsBase";
+    : "coreHttp.OperationOptions";
 
   return {
     name: "options",

--- a/src/models/clientDetails.ts
+++ b/src/models/clientDetails.ts
@@ -6,7 +6,7 @@ import { OperationGroupDetails } from "./operationDetails";
 import { Mapper } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";
 import { ObjectDetails } from "./modelDetails";
-import { BaseUrlDetails } from "../transforms/urlTransforms";
+import { EndpointDetails } from "../transforms/urlTransforms";
 import { KnownMediaType } from "@azure-tools/codegen";
 
 export interface ClientOptions {
@@ -26,6 +26,6 @@ export interface ClientDetails {
   operationGroups: OperationGroupDetails[];
   parameters: ParameterDetails[];
   options: ClientOptions;
-  baseUrl: BaseUrlDetails;
+  endpoint: EndpointDetails;
   srcPath?: string;
 }

--- a/src/models/modelDetails.ts
+++ b/src/models/modelDetails.ts
@@ -19,7 +19,7 @@ export enum ObjectKind {
  */
 export interface BasicObjectDetails {
   name: string;
-  description: string;
+  description?: string;
   serializedName: string;
   properties: PropertyDetails[];
   kind: ObjectKind;

--- a/src/transforms/constants.ts
+++ b/src/transforms/constants.ts
@@ -1,1 +1,0 @@
-export const TOPLEVEL_OPERATIONGROUP = "topleveloperationgroup";

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -73,6 +73,8 @@ export async function transformMappers(
   codeModel: CodeModel,
   { mediaTypes }: ClientOptions
 ): Promise<Mapper[]> {
+  const clientName = getLanguageMetadata(codeModel.language).name;
+
   if (!codeModel.schemas.objects) {
     return [];
   }
@@ -80,7 +82,7 @@ export async function transformMappers(
   const hasXmlMetadata = mediaTypes?.has(KnownMediaType.Xml);
   return [
     ...codeModel.schemas.objects,
-    ...extractHeaders(codeModel.operationGroups)
+    ...extractHeaders(codeModel.operationGroups, clientName)
   ].map(objectSchema =>
     transformMapper({ schema: objectSchema, options: { hasXmlMetadata } })
   );

--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -24,8 +24,9 @@ export function transformObjects(
   codeModel: CodeModel,
   uberParents: ObjectDetails[]
 ): ObjectDetails[] {
+  const clientName = getLanguageMetadata(codeModel.language).name;
   const objectSchemas = codeModel.schemas.objects || [];
-  const headersSchemas = extractHeaders(codeModel.operationGroups);
+  const headersSchemas = extractHeaders(codeModel.operationGroups, clientName);
   const objectDetails = [...objectSchemas, ...headersSchemas].map(object =>
     transformObject(object, uberParents)
   );

--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -49,8 +49,7 @@ export function transformObject(
     kind,
     name,
     serializedName: metadata.serializedName,
-    description:
-      metadata.description || `An interface representing ${metadata.name}.`,
+    description: metadata.description || undefined,
     schema,
     properties: schema.properties
       ? schema.properties.map(prop => transformProperty(prop))

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -54,6 +54,26 @@ const buildCredentialsParameter = (): ParameterDetails => ({
   schemaType: SchemaType.Object
 });
 
+const buildBaseUriParameter = (): ParameterDetails => ({
+  nameRef: "baseUri",
+  description: "Overrides request baseUri.",
+  name: "baseUri",
+  serializedName: "baseUri",
+  location: ParameterLocation.None,
+  required: false,
+  parameterPath: "baseUri",
+  mapper: "any",
+  isGlobal: true,
+  parameter: {} as Parameter,
+  implementationLocation: ImplementationLocation.Client,
+  typeDetails: {
+    typeName: "string",
+    kind: PropertyKind.Primitive
+  },
+  isSynthetic: true,
+  schemaType: SchemaType.String
+});
+
 export function transformParameters(
   codeModel: CodeModel,
   options: ClientOptions
@@ -75,6 +95,8 @@ export function transformParameters(
     const creds = buildCredentialsParameter();
     parameters.unshift(creds);
   }
+
+  parameters.push(buildBaseUriParameter());
 
   return parameters;
 }

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -23,7 +23,6 @@ import {
 import { isEqual, isNil } from "lodash";
 import { getTypeForSchema } from "../utils/schemaHelpers";
 import { getStringForValue } from "../utils/valueHelpers";
-import { TOPLEVEL_OPERATIONGROUP } from "./constants";
 import { ClientOptions } from "../models/clientDetails";
 import { PropertyKind } from "../models/modelDetails";
 import { KnownMediaType } from "@azure-tools/codegen";
@@ -54,14 +53,14 @@ const buildCredentialsParameter = (): ParameterDetails => ({
   schemaType: SchemaType.Object
 });
 
-const buildBaseUriParameter = (): ParameterDetails => ({
-  nameRef: "baseUri",
-  description: "Overrides request baseUri.",
-  name: "baseUri",
-  serializedName: "baseUri",
+const buildEndpointParameter = (): ParameterDetails => ({
+  nameRef: "endpoint",
+  description: "Overrides client endpoint.",
+  name: "endpoint",
+  serializedName: "endpoint",
   location: ParameterLocation.None,
   required: false,
-  parameterPath: "baseUri",
+  parameterPath: "endpoint",
   mapper: "any",
   isGlobal: true,
   parameter: {} as Parameter,
@@ -96,15 +95,15 @@ export function transformParameters(
     parameters.unshift(creds);
   }
 
-  parameters.push(buildBaseUriParameter());
+  parameters.push(buildEndpointParameter());
 
   return parameters;
 }
 
 const extractOperationParameters = (codeModel: CodeModel) =>
   codeModel.operationGroups.reduce<OperationParameterDetails[]>((acc, og) => {
-    const groupName =
-      getLanguageMetadata(og.language).name || TOPLEVEL_OPERATIONGROUP;
+    const clientName = getLanguageMetadata(codeModel.language).name;
+    const groupName = getLanguageMetadata(og.language).name || clientName;
     return [
       ...acc,
       ...og.operations.reduce<OperationParameterDetails[]>(

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -85,7 +85,7 @@ export async function transformCodeModel(
     operationGroups,
     parameters,
     options,
-    baseUrl
+    endpoint: baseUrl
   };
 }
 

--- a/src/transforms/urlTransforms.ts
+++ b/src/transforms/urlTransforms.ts
@@ -1,15 +1,15 @@
 import { CodeModel } from "@azure-tools/codemodel";
 import { getLanguageMetadata } from "../utils/languageHelpers";
 
-export interface BaseUrlDetails {
+export interface EndpointDetails {
   isCustom: boolean;
-  baseUrl?: string;
+  endpoint?: string;
 }
 
 export async function transformBaseUrl(
   codeModel: CodeModel
-): Promise<BaseUrlDetails> {
-  let baseUrl: string | undefined = "";
+): Promise<EndpointDetails> {
+  let endpoint: string | undefined = "";
   let isCustom = false;
 
   const $host = (codeModel.globalParameters || []).find(p => {
@@ -21,13 +21,13 @@ export async function transformBaseUrl(
     // No support yet for multi-baseUrl yet Issue #553
     const { request } = codeModel.operationGroups[0].operations[0];
     isCustom = true;
-    baseUrl = request.protocol.http!.uri;
+    endpoint = request.protocol.http!.uri;
   } else {
-    baseUrl = $host.clientDefaultValue;
+    endpoint = $host.clientDefaultValue;
   }
 
   return {
-    baseUrl,
+    endpoint: endpoint,
     isCustom
   };
 }

--- a/src/utils/extractHeaders.ts
+++ b/src/utils/extractHeaders.ts
@@ -2,13 +2,20 @@ import { OperationGroup, ObjectSchema } from "@azure-tools/codemodel";
 import { getOperationFullName } from "./nameUtils";
 import { headersToSchema } from "./headersToSchema";
 
-export function extractHeaders(operationGroups: OperationGroup[]) {
+export function extractHeaders(
+  operationGroups: OperationGroup[],
+  clientName: string
+) {
   let responseHeaders: ObjectSchema[] = [];
 
   operationGroups.forEach(operationGroup =>
     operationGroup.operations.forEach(operation =>
       operation.responses?.forEach(response => {
-        const operationName = getOperationFullName(operationGroup, operation);
+        const operationName = getOperationFullName(
+          operationGroup,
+          operation,
+          clientName
+        );
         const headers = response.protocol.http?.headers;
         if (headers) {
           const headerSchema = headersToSchema(headers, operationName);

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { Operation, OperationGroup } from "@azure-tools/codemodel";
 import { getLanguageMetadata } from "./languageHelpers";
-import { TOPLEVEL_OPERATIONGROUP } from "../transforms/constants";
 
 const ReservedModelNames = ["Error"];
 
@@ -83,11 +82,11 @@ function getNameParts(name: string) {
 
 export function getOperationFullName(
   operationGroup: OperationGroup,
-  operation: Operation
+  operation: Operation,
+  clientName: string
 ) {
   const groupName = normalizeName(
-    getLanguageMetadata(operationGroup.language).name ||
-      TOPLEVEL_OPERATIONGROUP,
+    getLanguageMetadata(operationGroup.language).name || clientName,
     NameType.Property
   );
   const operationName = normalizeName(

--- a/test/integration/bodyComplex.spec.ts
+++ b/test/integration/bodyComplex.spec.ts
@@ -16,7 +16,7 @@ import {
 import { RestError } from "@azure/core-http";
 
 const clientOptions = {
-  baseUri: "http://localhost:3000"
+  endpoint: "http://localhost:3000"
 };
 
 describe("typescript", function() {

--- a/test/integration/custom-url.spec.ts
+++ b/test/integration/custom-url.spec.ts
@@ -1,7 +1,7 @@
 import { CustomUrlClient } from "./generated/customUrl/src/customUrlClient";
 import * as assert from "assert";
 
-describe("Custom BaseUri", () => {
+describe("Custom Endpoint", () => {
   let client: CustomUrlClient;
   let clientOptions: any;
   beforeEach(() => {

--- a/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
@@ -16,7 +16,7 @@ class BodyComplexClient extends BodyComplexClientContext {
    * Initializes a new instance of the BodyComplexClient class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.BodyComplexClientOptionalParams) {
     super(options);
     this.basic = new operations.Basic(this);
     this.primitive = new operations.Primitive(this);

--- a/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
@@ -15,7 +15,6 @@ const packageVersion = "1.0.0-preview1";
 export class BodyComplexClientContext extends coreHttp.ServiceClient {
   $host: string;
   apiVersion: string;
-  baseUri?: string;
 
   /**
    * Initializes a new instance of the BodyComplexClientContext class.
@@ -36,7 +35,7 @@ export class BodyComplexClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.baseUri || "{$host}";
+    this.baseUri = options.endpoint || "{$host}";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
@@ -7,6 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
+import * as Models from "./models";
 
 const packageName = "bodyString";
 const packageVersion = "1.0.0-preview1";
@@ -14,12 +15,13 @@ const packageVersion = "1.0.0-preview1";
 export class BodyComplexClientContext extends coreHttp.ServiceClient {
   $host: string;
   apiVersion: string;
+  baseUri?: string;
 
   /**
    * Initializes a new instance of the BodyComplexClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.BodyComplexClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -971,3 +971,22 @@ export type FlattencomplexGetValidResponse = MyBaseTypeUnion & {
     parsedBody: MyBaseTypeUnion;
   };
 };
+
+/**
+ * Optional parameters.
+ */
+export interface BodyComplexClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /**
+   * server parameter
+   */
+  $host?: string;
+  /**
+   * Api Version
+   */
+  apiVersion?: string;
+  /**
+   * Overrides request baseUri.
+   */
+  baseUri?: string;
+}

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -14,9 +14,6 @@ export type SalmonUnion = Salmon | SmartSalmon;
 export type MyBaseTypeUnion = MyBaseType | MyDerivedType;
 export type SharkUnion = Shark | Sawshark | Goblinshark | Cookiecuttershark;
 
-/**
- * An interface representing Basic.
- */
 export interface Basic {
   /**
    * Basic Id
@@ -29,111 +26,69 @@ export interface Basic {
   color?: CMYKColors;
 }
 
-/**
- * An interface representing Error.
- */
 export interface ErrorModel {
   status?: number;
   message?: string;
 }
 
-/**
- * An interface representing IntWrapper.
- */
 export interface IntWrapper {
   field1?: number;
   field2?: number;
 }
 
-/**
- * An interface representing LongWrapper.
- */
 export interface LongWrapper {
   field1?: number;
   field2?: number;
 }
 
-/**
- * An interface representing FloatWrapper.
- */
 export interface FloatWrapper {
   field1?: number;
   field2?: number;
 }
 
-/**
- * An interface representing DoubleWrapper.
- */
 export interface DoubleWrapper {
   field1?: number;
   field56ZerosAfterTheDotAndNegativeZeroBeforeDotAndThisIsALongFieldNameOnPurpose?: number;
 }
 
-/**
- * An interface representing BooleanWrapper.
- */
 export interface BooleanWrapper {
   fieldTrue?: boolean;
   fieldFalse?: boolean;
 }
 
-/**
- * An interface representing StringWrapper.
- */
 export interface StringWrapper {
   field?: string;
   empty?: string;
   null?: string;
 }
 
-/**
- * An interface representing DateWrapper.
- */
 export interface DateWrapper {
   field?: Date;
   leap?: Date;
 }
 
-/**
- * An interface representing DatetimeWrapper.
- */
 export interface DatetimeWrapper {
   field?: Date;
   now?: Date;
 }
 
-/**
- * An interface representing Datetimerfc1123Wrapper.
- */
 export interface Datetimerfc1123Wrapper {
   field?: Date;
   now?: Date;
 }
 
-/**
- * An interface representing DurationWrapper.
- */
 export interface DurationWrapper {
   field?: string;
 }
 
-/**
- * An interface representing ByteWrapper.
- */
 export interface ByteWrapper {
   field?: Uint8Array;
 }
 
-/**
- * An interface representing ArrayWrapper.
- */
 export interface ArrayWrapper {
   array?: string[];
 }
 
-/**
- * An interface representing DictionaryWrapper.
- */
 export interface DictionaryWrapper {
   /**
    * Dictionary of <string>
@@ -141,39 +96,24 @@ export interface DictionaryWrapper {
   defaultProgram?: { [propertyName: string]: string };
 }
 
-/**
- * An interface representing Pet.
- */
 export interface Pet {
   id?: number;
   name?: string;
 }
 
-/**
- * An interface representing Cat.
- */
 export type Cat = Pet & {
   color?: string;
   hates?: Dog[];
 };
 
-/**
- * An interface representing Dog.
- */
 export type Dog = Pet & {
   food?: string;
 };
 
-/**
- * An interface representing Siamese.
- */
 export type Siamese = Cat & {
   breed?: string;
 };
 
-/**
- * An interface representing Fish.
- */
 export interface Fish {
   /**
    * Polymorphic discriminator, which specifies the different types this object can be
@@ -190,9 +130,6 @@ export interface Fish {
   siblings?: FishUnion[];
 }
 
-/**
- * An interface representing DotFish.
- */
 export interface DotFish {
   /**
    * Polymorphic discriminator, which specifies the different types this object can be
@@ -202,9 +139,6 @@ export interface DotFish {
   species?: string;
 }
 
-/**
- * An interface representing DotFishMarket.
- */
 export interface DotFishMarket {
   sampleSalmon?: DotSalmon;
   salmons?: DotSalmon[];
@@ -212,33 +146,21 @@ export interface DotFishMarket {
   fishes?: DotFishUnion[];
 }
 
-/**
- * An interface representing DotSalmon.
- */
 export type DotSalmon = DotFish & {
   location?: string;
   iswild?: boolean;
 };
 
-/**
- * An interface representing Salmon.
- */
 export type Salmon = Fish & {
   location?: string;
   iswild?: boolean;
 };
 
-/**
- * An interface representing ReadonlyObj.
- */
 export interface ReadonlyObj {
   readonly id?: string;
   size?: number;
 }
 
-/**
- * An interface representing MyBaseType.
- */
 export interface MyBaseType {
   /**
    * Polymorphic discriminator, which specifies the different types this object can be
@@ -248,16 +170,10 @@ export interface MyBaseType {
   helper?: MyBaseHelperType;
 }
 
-/**
- * An interface representing MyBaseHelperType.
- */
 export interface MyBaseHelperType {
   propBH1?: string;
 }
 
-/**
- * An interface representing SmartSalmon.
- */
 export type SmartSalmon = Salmon & {
   /**
    * Describes unknown properties. The value of an unknown property can be of "any" type.
@@ -266,24 +182,15 @@ export type SmartSalmon = Salmon & {
   collegeDegree?: string;
 };
 
-/**
- * An interface representing Shark.
- */
 export type Shark = Fish & {
   age?: number;
   birthday: Date;
 };
 
-/**
- * An interface representing Sawshark.
- */
 export type Sawshark = Shark & {
   picture?: Uint8Array;
 };
 
-/**
- * An interface representing Goblinshark.
- */
 export type Goblinshark = Shark & {
   jawsize?: number;
   /**
@@ -292,14 +199,8 @@ export type Goblinshark = Shark & {
   color?: GoblinSharkColor;
 };
 
-/**
- * An interface representing Cookiecuttershark.
- */
 export type Cookiecuttershark = Shark & {};
 
-/**
- * An interface representing MyDerivedType.
- */
 export type MyDerivedType = MyBaseType & {
   propD1?: string;
 };

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -986,7 +986,7 @@ export interface BodyComplexClientOptionalParams
    */
   apiVersion?: string;
   /**
-   * Overrides request baseUri.
+   * Overrides client endpoint.
    */
-  baseUri?: string;
+  endpoint?: string;
 }

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -31,7 +31,7 @@ export class Array {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.ArrayGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -47,7 +47,7 @@ export class Array {
    */
   putValid(
     complexBody: Models.ArrayWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -60,7 +60,7 @@ export class Array {
    * @param options The options parameters.
    */
   getEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.ArrayGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -76,7 +76,7 @@ export class Array {
    */
   putEmpty(
     complexBody: Models.ArrayWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -89,7 +89,7 @@ export class Array {
    * @param options The options parameters.
    */
   getNotProvided(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.ArrayGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/bodyComplex/src/operations/basic.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basic.ts
@@ -31,7 +31,7 @@ export class Basic {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.BasicGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -46,7 +46,7 @@ export class Basic {
    */
   putValid(
     complexBody: Models.Basic,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -59,7 +59,7 @@ export class Basic {
    * @param options The options parameters.
    */
   getInvalid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.BasicGetInvalidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -72,7 +72,7 @@ export class Basic {
    * @param options The options parameters.
    */
   getEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.BasicGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -85,7 +85,7 @@ export class Basic {
    * @param options The options parameters.
    */
   getNull(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.BasicGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -98,7 +98,7 @@ export class Basic {
    * @param options The options parameters.
    */
   getNotProvided(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.BasicGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -31,7 +31,7 @@ export class Dictionary {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.DictionaryGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -47,7 +47,7 @@ export class Dictionary {
    */
   putValid(
     complexBody: Models.DictionaryWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -60,7 +60,7 @@ export class Dictionary {
    * @param options The options parameters.
    */
   getEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.DictionaryGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -76,7 +76,7 @@ export class Dictionary {
    */
   putEmpty(
     complexBody: Models.DictionaryWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -89,7 +89,7 @@ export class Dictionary {
    * @param options The options parameters.
    */
   getNull(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.DictionaryGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -102,7 +102,7 @@ export class Dictionary {
    * @param options The options parameters.
    */
   getNotProvided(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.DictionaryGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
+++ b/test/integration/generated/bodyComplex/src/operations/flattencomplex.ts
@@ -30,7 +30,7 @@ export class Flattencomplex {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.FlattencomplexGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -31,7 +31,7 @@ export class Inheritance {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.InheritanceGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -48,7 +48,7 @@ export class Inheritance {
    */
   putValid(
     complexBody: Models.Siamese,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -31,7 +31,7 @@ export class Polymorphicrecursive {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphicrecursiveGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -78,7 +78,7 @@ export class Polymorphicrecursive {
    */
   putValid(
     complexBody: Models.FishUnion,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -31,7 +31,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphismGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -78,7 +78,7 @@ export class Polymorphism {
    */
   putValid(
     complexBody: Models.FishUnion,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -91,7 +91,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   getDotSyntax(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphismGetDotSyntaxResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -106,7 +106,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   getComposedWithDiscriminator(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphismGetComposedWithDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -121,7 +121,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   getComposedWithoutDiscriminator(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphismGetComposedWithoutDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -135,7 +135,7 @@ export class Polymorphism {
    * @param options The options parameters.
    */
   getComplicated(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphismGetComplicatedResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -151,7 +151,7 @@ export class Polymorphism {
    */
   putComplicated(
     complexBody: Models.SalmonUnion,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -166,7 +166,7 @@ export class Polymorphism {
    */
   putMissingDiscriminator(
     complexBody: Models.SalmonUnion,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PolymorphismPutMissingDiscriminatorResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -214,7 +214,7 @@ export class Polymorphism {
    */
   putValidMissingRequired(
     complexBody: Models.FishUnion,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },

--- a/test/integration/generated/bodyComplex/src/operations/primitive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/primitive.ts
@@ -31,7 +31,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getInt(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetIntResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -46,7 +46,7 @@ export class Primitive {
    */
   putInt(
     complexBody: Models.IntWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -59,7 +59,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getLong(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetLongResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -74,7 +74,7 @@ export class Primitive {
    */
   putLong(
     complexBody: Models.LongWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -87,7 +87,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getFloat(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetFloatResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -102,7 +102,7 @@ export class Primitive {
    */
   putFloat(
     complexBody: Models.FloatWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -115,7 +115,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getDouble(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetDoubleResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -131,7 +131,7 @@ export class Primitive {
    */
   putDouble(
     complexBody: Models.DoubleWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -144,7 +144,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getBool(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetBoolResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -159,7 +159,7 @@ export class Primitive {
    */
   putBool(
     complexBody: Models.BooleanWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -172,7 +172,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getString(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetStringResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -187,7 +187,7 @@ export class Primitive {
    */
   putString(
     complexBody: Models.StringWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -200,7 +200,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getDate(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetDateResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -215,7 +215,7 @@ export class Primitive {
    */
   putDate(
     complexBody: Models.DateWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -228,7 +228,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getDateTime(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetDateTimeResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -243,7 +243,7 @@ export class Primitive {
    */
   putDateTime(
     complexBody: Models.DatetimeWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -256,7 +256,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getDateTimeRfc1123(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetDateTimeRfc1123Response> {
     return this.client.sendOperationRequest(
       { options },
@@ -271,7 +271,7 @@ export class Primitive {
    */
   putDateTimeRfc1123(
     complexBody: Models.Datetimerfc1123Wrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -284,7 +284,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getDuration(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetDurationResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -299,7 +299,7 @@ export class Primitive {
    */
   putDuration(
     complexBody: Models.DurationWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },
@@ -312,7 +312,7 @@ export class Primitive {
    * @param options The options parameters.
    */
   getByte(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.PrimitiveGetByteResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -327,7 +327,7 @@ export class Primitive {
    */
   putByte(
     complexBody: Models.ByteWrapper,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -31,7 +31,7 @@ export class Readonlyproperty {
    * @param options The options parameters.
    */
   getValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.ReadonlypropertyGetValidResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -46,7 +46,7 @@ export class Readonlyproperty {
    */
   putValid(
     complexBody: Models.ReadonlyObj,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { complexBody, options },

--- a/test/integration/generated/bodyString/src/bodyStringClient.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClient.ts
@@ -16,7 +16,7 @@ class BodyStringClient extends BodyStringClientContext {
    * Initializes a new instance of the BodyStringClient class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.BodyStringClientOptionalParams) {
     super(options);
     this.string = new operations.String(this);
     this.enum = new operations.Enum(this);

--- a/test/integration/generated/bodyString/src/bodyStringClientContext.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClientContext.ts
@@ -14,7 +14,6 @@ const packageVersion = "1.0.0-preview1";
 
 export class BodyStringClientContext extends coreHttp.ServiceClient {
   $host: string;
-  baseUri?: string;
 
   /**
    * Initializes a new instance of the BodyStringClientContext class.
@@ -35,7 +34,7 @@ export class BodyStringClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.baseUri || "{$host}";
+    this.baseUri = options.endpoint || "{$host}";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyString/src/bodyStringClientContext.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClientContext.ts
@@ -7,18 +7,20 @@
  */
 
 import * as coreHttp from "@azure/core-http";
+import * as Models from "./models";
 
 const packageName = "bodyString";
 const packageVersion = "1.0.0-preview1";
 
 export class BodyStringClientContext extends coreHttp.ServiceClient {
   $host: string;
+  baseUri?: string;
 
   /**
    * Initializes a new instance of the BodyStringClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.BodyStringClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyString/src/models/index.ts
+++ b/test/integration/generated/bodyString/src/models/index.ts
@@ -311,7 +311,7 @@ export interface BodyStringClientOptionalParams
    */
   $host?: string;
   /**
-   * Overrides request baseUri.
+   * Overrides client endpoint.
    */
-  baseUri?: string;
+  endpoint?: string;
 }

--- a/test/integration/generated/bodyString/src/models/index.ts
+++ b/test/integration/generated/bodyString/src/models/index.ts
@@ -300,3 +300,18 @@ export type EnumGetReferencedConstantResponse = RefColorConstant & {
     parsedBody: RefColorConstant;
   };
 };
+
+/**
+ * Optional parameters.
+ */
+export interface BodyStringClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /**
+   * server parameter
+   */
+  $host?: string;
+  /**
+   * Overrides request baseUri.
+   */
+  baseUri?: string;
+}

--- a/test/integration/generated/bodyString/src/models/index.ts
+++ b/test/integration/generated/bodyString/src/models/index.ts
@@ -8,17 +8,11 @@
 
 import * as coreHttp from "@azure/core-http";
 
-/**
- * An interface representing Error.
- */
 export interface ErrorModel {
   status?: number;
   message?: string;
 }
 
-/**
- * An interface representing RefColorConstant.
- */
 export interface RefColorConstant {
   /**
    * Sample string.

--- a/test/integration/generated/bodyString/src/operations/enum.ts
+++ b/test/integration/generated/bodyString/src/operations/enum.ts
@@ -31,7 +31,7 @@ export class Enum {
    * @param options The options parameters.
    */
   getNotExpandable(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.EnumGetNotExpandableResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -46,7 +46,7 @@ export class Enum {
    */
   putNotExpandable(
     stringBody: Models.Colors,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringBody, options },
@@ -59,7 +59,7 @@ export class Enum {
    * @param options The options parameters.
    */
   getReferenced(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.EnumGetReferencedResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -74,7 +74,7 @@ export class Enum {
    */
   putReferenced(
     enumStringBody: Models.Colors,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumStringBody, options },
@@ -87,7 +87,7 @@ export class Enum {
    * @param options The options parameters.
    */
   getReferencedConstant(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.EnumGetReferencedConstantResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -102,7 +102,7 @@ export class Enum {
    */
   putReferencedConstant(
     enumStringBody: Models.RefColorConstant,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumStringBody, options },

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -31,7 +31,7 @@ export class String {
    * @param options The options parameters.
    */
   getNull(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetNullResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -43,9 +43,7 @@ export class String {
    * Set string value null
    * @param options The options parameters.
    */
-  putNull(
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  putNull(options?: coreHttp.OperationOptions): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       putNullOperationSpec
@@ -57,7 +55,7 @@ export class String {
    * @param options The options parameters.
    */
   getEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetEmptyResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -70,7 +68,7 @@ export class String {
    * @param options The options parameters.
    */
   putEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -83,7 +81,7 @@ export class String {
    * @param options The options parameters.
    */
   getMbcs(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetMbcsResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -95,9 +93,7 @@ export class String {
    * Set string value mbcs '啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€'
    * @param options The options parameters.
    */
-  putMbcs(
-    options?: coreHttp.RequestOptionsBase
-  ): Promise<coreHttp.RestResponse> {
+  putMbcs(options?: coreHttp.OperationOptions): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
       putMbcsOperationSpec
@@ -110,7 +106,7 @@ export class String {
    * @param options The options parameters.
    */
   getWhitespace(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetWhitespaceResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -124,7 +120,7 @@ export class String {
    * @param options The options parameters.
    */
   putWhitespace(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -137,7 +133,7 @@ export class String {
    * @param options The options parameters.
    */
   getNotProvided(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetNotProvidedResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -150,7 +146,7 @@ export class String {
    * @param options The options parameters.
    */
   getBase64Encoded(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetBase64EncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -163,7 +159,7 @@ export class String {
    * @param options The options parameters.
    */
   getBase64UrlEncoded(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetBase64UrlEncodedResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -178,7 +174,7 @@ export class String {
    */
   putBase64UrlEncoded(
     stringBody: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringBody, options },
@@ -191,7 +187,7 @@ export class String {
    * @param options The options parameters.
    */
   getNullBase64UrlEncoded(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.StringGetNullBase64UrlEncodedResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/customUrl/src/customUrlClient.ts
+++ b/test/integration/generated/customUrl/src/customUrlClient.ts
@@ -16,7 +16,7 @@ class CustomUrlClient extends CustomUrlClientContext {
    * Initializes a new instance of the CustomUrlClient class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.CustomUrlClientOptionalParams) {
     super(options);
     this.paths = new operations.Paths(this);
   }

--- a/test/integration/generated/customUrl/src/customUrlClientContext.ts
+++ b/test/integration/generated/customUrl/src/customUrlClientContext.ts
@@ -7,18 +7,20 @@
  */
 
 import * as coreHttp from "@azure/core-http";
+import * as Models from "./models";
 
 const packageName = "custom-url";
 const packageVersion = "1.0.0-preview1";
 
 export class CustomUrlClientContext extends coreHttp.ServiceClient {
   host: string;
+  baseUri?: string;
 
   /**
    * Initializes a new instance of the CustomUrlClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.CustomUrlClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/customUrl/src/customUrlClientContext.ts
+++ b/test/integration/generated/customUrl/src/customUrlClientContext.ts
@@ -14,7 +14,6 @@ const packageVersion = "1.0.0-preview1";
 
 export class CustomUrlClientContext extends coreHttp.ServiceClient {
   host: string;
-  baseUri?: string;
 
   /**
    * Initializes a new instance of the CustomUrlClientContext class.
@@ -35,7 +34,7 @@ export class CustomUrlClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.baseUri || "http://{accountName}{host}";
+    this.baseUri = options.endpoint || "http://{accountName}{host}";
 
     // Assigning values to Constant parameters
     this.host = options.host || "host";

--- a/test/integration/generated/customUrl/src/models/index.ts
+++ b/test/integration/generated/customUrl/src/models/index.ts
@@ -15,3 +15,18 @@ export interface ErrorModel {
   status?: number;
   message?: string;
 }
+
+/**
+ * Optional parameters.
+ */
+export interface CustomUrlClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /**
+   * A string value that is used as a global part of the parameterized host
+   */
+  host?: string;
+  /**
+   * Overrides request baseUri.
+   */
+  baseUri?: string;
+}

--- a/test/integration/generated/customUrl/src/models/index.ts
+++ b/test/integration/generated/customUrl/src/models/index.ts
@@ -26,7 +26,7 @@ export interface CustomUrlClientOptionalParams
    */
   host?: string;
   /**
-   * Overrides request baseUri.
+   * Overrides client endpoint.
    */
-  baseUri?: string;
+  endpoint?: string;
 }

--- a/test/integration/generated/customUrl/src/models/index.ts
+++ b/test/integration/generated/customUrl/src/models/index.ts
@@ -8,9 +8,6 @@
 
 import * as coreHttp from "@azure/core-http";
 
-/**
- * An interface representing Error.
- */
 export interface ErrorModel {
   status?: number;
   message?: string;

--- a/test/integration/generated/customUrl/src/operations/paths.ts
+++ b/test/integration/generated/customUrl/src/operations/paths.ts
@@ -33,7 +33,7 @@ export class Paths {
    */
   getEmpty(
     accountName: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { accountName, options },

--- a/test/integration/generated/header/src/headerClient.ts
+++ b/test/integration/generated/header/src/headerClient.ts
@@ -16,7 +16,7 @@ class HeaderClient extends HeaderClientContext {
    * Initializes a new instance of the HeaderClient class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.HeaderClientOptionalParams) {
     super(options);
     this.header = new operations.Header(this);
   }

--- a/test/integration/generated/header/src/headerClientContext.ts
+++ b/test/integration/generated/header/src/headerClientContext.ts
@@ -7,18 +7,20 @@
  */
 
 import * as coreHttp from "@azure/core-http";
+import * as Models from "./models";
 
 const packageName = "header";
 const packageVersion = "1.0.0-preview1";
 
 export class HeaderClientContext extends coreHttp.ServiceClient {
   $host: string;
+  baseUri?: string;
 
   /**
    * Initializes a new instance of the HeaderClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.HeaderClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/header/src/headerClientContext.ts
+++ b/test/integration/generated/header/src/headerClientContext.ts
@@ -14,7 +14,6 @@ const packageVersion = "1.0.0-preview1";
 
 export class HeaderClientContext extends coreHttp.ServiceClient {
   $host: string;
-  baseUri?: string;
 
   /**
    * Initializes a new instance of the HeaderClientContext class.
@@ -35,7 +34,7 @@ export class HeaderClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.baseUri || "{$host}";
+    this.baseUri = options.endpoint || "{$host}";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/header/src/models/index.ts
+++ b/test/integration/generated/header/src/models/index.ts
@@ -228,7 +228,7 @@ export type HeaderResponseBoolResponse = HeaderResponseBoolHeaders & {
  * Optional parameters.
  */
 export interface HeaderParamStringOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * Send a post request with header values "The quick brown fox jumps over the lazy dog" or null or ""
    */
@@ -284,7 +284,7 @@ export type HeaderResponseDatetimeResponse = HeaderResponseDatetimeHeaders & {
  * Optional parameters.
  */
 export interface HeaderParamDatetimeRfc1123OptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * Send a post request with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
    */
@@ -340,7 +340,7 @@ export type HeaderResponseByteResponse = HeaderResponseByteHeaders & {
  * Optional parameters.
  */
 export interface HeaderParamEnumOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * Send a post request with header values 'GREY'
    */
@@ -372,7 +372,7 @@ export interface HeaderClientOptionalParams
    */
   $host?: string;
   /**
-   * Overrides request baseUri.
+   * Overrides client endpoint.
    */
-  baseUri?: string;
+  endpoint?: string;
 }

--- a/test/integration/generated/header/src/models/index.ts
+++ b/test/integration/generated/header/src/models/index.ts
@@ -361,3 +361,18 @@ export type HeaderResponseEnumResponse = HeaderResponseEnumHeaders & {
     parsedHeaders: HeaderResponseEnumHeaders;
   };
 };
+
+/**
+ * Optional parameters.
+ */
+export interface HeaderClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /**
+   * server parameter
+   */
+  $host?: string;
+  /**
+   * Overrides request baseUri.
+   */
+  baseUri?: string;
+}

--- a/test/integration/generated/header/src/models/index.ts
+++ b/test/integration/generated/header/src/models/index.ts
@@ -8,9 +8,6 @@
 
 import * as coreHttp from "@azure/core-http";
 
-/**
- * An interface representing Error.
- */
 export interface ErrorModel {
   status?: number;
   message?: string;

--- a/test/integration/generated/header/src/operations/header.ts
+++ b/test/integration/generated/header/src/operations/header.ts
@@ -33,7 +33,7 @@ export class Header {
    */
   paramExistingKey(
     userAgent: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { userAgent, options },
@@ -46,7 +46,7 @@ export class Header {
    * @param options The options parameters.
    */
   responseExistingKey(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseExistingKeyResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -61,7 +61,7 @@ export class Header {
    */
   paramProtectedKey(
     contentType: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { contentType, options },
@@ -74,7 +74,7 @@ export class Header {
    * @param options The options parameters.
    */
   responseProtectedKey(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseProtectedKeyResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -92,7 +92,7 @@ export class Header {
   paramInteger(
     scenario: string,
     value: number,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -107,7 +107,7 @@ export class Header {
    */
   responseInteger(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseIntegerResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -125,7 +125,7 @@ export class Header {
   paramLong(
     scenario: string,
     value: number,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -140,7 +140,7 @@ export class Header {
    */
   responseLong(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseLongResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -158,7 +158,7 @@ export class Header {
   paramFloat(
     scenario: string,
     value: number,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -173,7 +173,7 @@ export class Header {
    */
   responseFloat(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseFloatResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -191,7 +191,7 @@ export class Header {
   paramDouble(
     scenario: string,
     value: number,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -206,7 +206,7 @@ export class Header {
    */
   responseDouble(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseDoubleResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -224,7 +224,7 @@ export class Header {
   paramBool(
     scenario: string,
     value: boolean,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -239,7 +239,7 @@ export class Header {
    */
   responseBool(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseBoolResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -270,7 +270,7 @@ export class Header {
    */
   responseString(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseStringResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -288,7 +288,7 @@ export class Header {
   paramDate(
     scenario: string,
     value: Date,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -303,7 +303,7 @@ export class Header {
    */
   responseDate(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseDateResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -321,7 +321,7 @@ export class Header {
   paramDatetime(
     scenario: string,
     value: Date,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -336,7 +336,7 @@ export class Header {
    */
   responseDatetime(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseDatetimeResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -367,7 +367,7 @@ export class Header {
    */
   responseDatetimeRfc1123(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseDatetimeRfc1123Response> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -384,7 +384,7 @@ export class Header {
   paramDuration(
     scenario: string,
     value: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -399,7 +399,7 @@ export class Header {
    */
   responseDuration(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseDurationResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -416,7 +416,7 @@ export class Header {
   paramByte(
     scenario: string,
     value: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { scenario, value, options },
@@ -431,7 +431,7 @@ export class Header {
    */
   responseByte(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseByteResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -462,7 +462,7 @@ export class Header {
    */
   responseEnum(
     scenario: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.HeaderResponseEnumResponse> {
     return this.client.sendOperationRequest(
       { scenario, options },
@@ -475,7 +475,7 @@ export class Header {
    * @param options The options parameters.
    */
   customRequestId(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/url/src/models/index.ts
+++ b/test/integration/generated/url/src/models/index.ts
@@ -278,3 +278,21 @@ export interface PathItemsGetLocalPathItemQueryNullOptionalParams
    */
   localStringQuery?: string;
 }
+
+/**
+ * Optional parameters.
+ */
+export interface UrlClientOptionalParams extends coreHttp.ServiceClientOptions {
+  /**
+   * server parameter
+   */
+  $host?: string;
+  /**
+   * should contain value null
+   */
+  globalStringQuery?: string;
+  /**
+   * Overrides request baseUri.
+   */
+  baseUri?: string;
+}

--- a/test/integration/generated/url/src/models/index.ts
+++ b/test/integration/generated/url/src/models/index.ts
@@ -25,7 +25,7 @@ export type UriColor = "red color" | "green color" | "blue color";
  * Optional parameters.
  */
 export interface QueriesGetBooleanNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null boolean value
    */
@@ -36,7 +36,7 @@ export interface QueriesGetBooleanNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesGetIntNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null integer value
    */
@@ -47,7 +47,7 @@ export interface QueriesGetIntNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesGetLongNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null 64 bit integer value
    */
@@ -58,7 +58,7 @@ export interface QueriesGetLongNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesFloatNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null numeric value
    */
@@ -69,7 +69,7 @@ export interface QueriesFloatNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesDoubleNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null numeric value
    */
@@ -80,7 +80,7 @@ export interface QueriesDoubleNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesStringNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null string value
    */
@@ -91,7 +91,7 @@ export interface QueriesStringNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesEnumValidOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * 'green color' enum value
    */
@@ -102,7 +102,7 @@ export interface QueriesEnumValidOptionalParams
  * Optional parameters.
  */
 export interface QueriesEnumNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * 'green color' enum value
    */
@@ -113,7 +113,7 @@ export interface QueriesEnumNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesByteMultiByteOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    */
@@ -124,7 +124,7 @@ export interface QueriesByteMultiByteOptionalParams
  * Optional parameters.
  */
 export interface QueriesByteNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
    */
@@ -135,7 +135,7 @@ export interface QueriesByteNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesDateNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null as date (no query parameters in uri)
    */
@@ -146,7 +146,7 @@ export interface QueriesDateNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesDateTimeNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * null as date-time (no query parameters)
    */
@@ -157,7 +157,7 @@ export interface QueriesDateTimeNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesArrayStringCsvValidOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    */
@@ -168,7 +168,7 @@ export interface QueriesArrayStringCsvValidOptionalParams
  * Optional parameters.
  */
 export interface QueriesArrayStringCsvNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    */
@@ -179,7 +179,7 @@ export interface QueriesArrayStringCsvNullOptionalParams
  * Optional parameters.
  */
 export interface QueriesArrayStringCsvEmptyOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
    */
@@ -190,7 +190,7 @@ export interface QueriesArrayStringCsvEmptyOptionalParams
  * Optional parameters.
  */
 export interface QueriesArrayStringSsvValidOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the ssv-array format
    */
@@ -201,7 +201,7 @@ export interface QueriesArrayStringSsvValidOptionalParams
  * Optional parameters.
  */
 export interface QueriesArrayStringTsvValidOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the tsv-array format
    */
@@ -212,7 +212,7 @@ export interface QueriesArrayStringTsvValidOptionalParams
  * Optional parameters.
  */
 export interface QueriesArrayStringPipesValidOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the pipes-array format
    */
@@ -223,7 +223,7 @@ export interface QueriesArrayStringPipesValidOptionalParams
  * Optional parameters.
  */
 export interface PathItemsGetAllWithValuesOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * A string value 'pathItemStringQuery' that appears as a query parameter
    */
@@ -238,7 +238,7 @@ export interface PathItemsGetAllWithValuesOptionalParams
  * Optional parameters.
  */
 export interface PathItemsGetGlobalQueryNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * A string value 'pathItemStringQuery' that appears as a query parameter
    */
@@ -253,7 +253,7 @@ export interface PathItemsGetGlobalQueryNullOptionalParams
  * Optional parameters.
  */
 export interface PathItemsGetGlobalAndLocalQueryNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * A string value 'pathItemStringQuery' that appears as a query parameter
    */
@@ -268,7 +268,7 @@ export interface PathItemsGetGlobalAndLocalQueryNullOptionalParams
  * Optional parameters.
  */
 export interface PathItemsGetLocalPathItemQueryNullOptionalParams
-  extends coreHttp.RequestOptionsBase {
+  extends coreHttp.OperationOptions {
   /**
    * A string value 'pathItemStringQuery' that appears as a query parameter
    */
@@ -292,7 +292,7 @@ export interface UrlClientOptionalParams extends coreHttp.ServiceClientOptions {
    */
   globalStringQuery?: string;
   /**
-   * Overrides request baseUri.
+   * Overrides client endpoint.
    */
-  baseUri?: string;
+  endpoint?: string;
 }

--- a/test/integration/generated/url/src/models/index.ts
+++ b/test/integration/generated/url/src/models/index.ts
@@ -8,9 +8,6 @@
 
 import * as coreHttp from "@azure/core-http";
 
-/**
- * An interface representing Error.
- */
 export interface ErrorModel {
   status?: number;
   message?: string;

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -31,7 +31,7 @@ export class Paths {
    * @param options The options parameters.
    */
   getBooleanTrue(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -44,7 +44,7 @@ export class Paths {
    * @param options The options parameters.
    */
   getBooleanFalse(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -57,7 +57,7 @@ export class Paths {
    * @param options The options parameters.
    */
   getIntOneMillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -70,7 +70,7 @@ export class Paths {
    * @param options The options parameters.
    */
   getIntNegativeOneMillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -83,7 +83,7 @@ export class Paths {
    * @param options The options parameters.
    */
   getTenBillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -96,7 +96,7 @@ export class Paths {
    * @param options The options parameters.
    */
   getNegativeTenBillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -109,7 +109,7 @@ export class Paths {
    * @param options The options parameters.
    */
   floatScientificPositive(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -122,7 +122,7 @@ export class Paths {
    * @param options The options parameters.
    */
   floatScientificNegative(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -135,7 +135,7 @@ export class Paths {
    * @param options The options parameters.
    */
   doubleDecimalPositive(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -148,7 +148,7 @@ export class Paths {
    * @param options The options parameters.
    */
   doubleDecimalNegative(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -161,7 +161,7 @@ export class Paths {
    * @param options The options parameters.
    */
   stringUnicode(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -174,7 +174,7 @@ export class Paths {
    * @param options The options parameters.
    */
   stringUrlEncoded(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -187,7 +187,7 @@ export class Paths {
    * @param options The options parameters.
    */
   stringUrlNonEncoded(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -200,7 +200,7 @@ export class Paths {
    * @param options The options parameters.
    */
   stringEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -215,7 +215,7 @@ export class Paths {
    */
   stringNull(
     stringPath: string,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { stringPath, options },
@@ -230,7 +230,7 @@ export class Paths {
    */
   enumValid(
     enumPath: Models.UriColor,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumPath, options },
@@ -245,7 +245,7 @@ export class Paths {
    */
   enumNull(
     enumPath: Models.UriColor,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { enumPath, options },
@@ -260,7 +260,7 @@ export class Paths {
    */
   byteMultiByte(
     bytePath: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bytePath, options },
@@ -273,7 +273,7 @@ export class Paths {
    * @param options The options parameters.
    */
   byteEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -288,7 +288,7 @@ export class Paths {
    */
   byteNull(
     bytePath: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bytePath, options },
@@ -301,7 +301,7 @@ export class Paths {
    * @param options The options parameters.
    */
   dateValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -317,7 +317,7 @@ export class Paths {
    */
   dateNull(
     datePath: Date,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { datePath, options },
@@ -330,7 +330,7 @@ export class Paths {
    * @param options The options parameters.
    */
   dateTimeValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -345,7 +345,7 @@ export class Paths {
    */
   dateTimeNull(
     dateTimePath: Date,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { dateTimePath, options },
@@ -360,7 +360,7 @@ export class Paths {
    */
   base64Url(
     base64UrlPath: Uint8Array,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { base64UrlPath, options },
@@ -377,7 +377,7 @@ export class Paths {
    */
   arrayCsvInPath(
     arrayPath: string[],
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { arrayPath, options },
@@ -392,7 +392,7 @@ export class Paths {
    */
   unixTimeUrl(
     unixTimeUrlPath: Date,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { unixTimeUrlPath, options },

--- a/test/integration/generated/url/src/operations/queries.ts
+++ b/test/integration/generated/url/src/operations/queries.ts
@@ -31,7 +31,7 @@ export class Queries {
    * @param options The options parameters.
    */
   getBooleanTrue(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -44,7 +44,7 @@ export class Queries {
    * @param options The options parameters.
    */
   getBooleanFalse(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -70,7 +70,7 @@ export class Queries {
    * @param options The options parameters.
    */
   getIntOneMillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -83,7 +83,7 @@ export class Queries {
    * @param options The options parameters.
    */
   getIntNegativeOneMillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -109,7 +109,7 @@ export class Queries {
    * @param options The options parameters.
    */
   getTenBillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -122,7 +122,7 @@ export class Queries {
    * @param options The options parameters.
    */
   getNegativeTenBillion(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -148,7 +148,7 @@ export class Queries {
    * @param options The options parameters.
    */
   floatScientificPositive(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -161,7 +161,7 @@ export class Queries {
    * @param options The options parameters.
    */
   floatScientificNegative(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -187,7 +187,7 @@ export class Queries {
    * @param options The options parameters.
    */
   doubleDecimalPositive(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -200,7 +200,7 @@ export class Queries {
    * @param options The options parameters.
    */
   doubleDecimalNegative(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -226,7 +226,7 @@ export class Queries {
    * @param options The options parameters.
    */
   stringUnicode(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -239,7 +239,7 @@ export class Queries {
    * @param options The options parameters.
    */
   stringUrlEncoded(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -252,7 +252,7 @@ export class Queries {
    * @param options The options parameters.
    */
   stringEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -317,7 +317,7 @@ export class Queries {
    * @param options The options parameters.
    */
   byteEmpty(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -343,7 +343,7 @@ export class Queries {
    * @param options The options parameters.
    */
   dateValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -369,7 +369,7 @@ export class Queries {
    * @param options The options parameters.
    */
   dateTimeValid(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/url/src/urlClient.ts
+++ b/test/integration/generated/url/src/urlClient.ts
@@ -17,7 +17,10 @@ class UrlClient extends UrlClientContext {
    * @param globalStringPath A string value 'globalItemStringPath' that appears in the path
    * @param options The parameter options
    */
-  constructor(globalStringPath: string, options?: any) {
+  constructor(
+    globalStringPath: string,
+    options?: Models.UrlClientOptionalParams
+  ) {
     super(globalStringPath, options);
     this.paths = new operations.Paths(this);
     this.queries = new operations.Queries(this);

--- a/test/integration/generated/url/src/urlClientContext.ts
+++ b/test/integration/generated/url/src/urlClientContext.ts
@@ -16,7 +16,6 @@ export class UrlClientContext extends coreHttp.ServiceClient {
   $host: string;
   globalStringPath: string;
   globalStringQuery?: string;
-  baseUri?: string;
 
   /**
    * Initializes a new instance of the UrlClientContext class.
@@ -45,7 +44,7 @@ export class UrlClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.baseUri || "{$host}";
+    this.baseUri = options.endpoint || "{$host}";
 
     // Parameter assignments
     this.globalStringPath = globalStringPath;

--- a/test/integration/generated/url/src/urlClientContext.ts
+++ b/test/integration/generated/url/src/urlClientContext.ts
@@ -7,6 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
+import * as Models from "./models";
 
 const packageName = "url";
 const packageVersion = "1.0.0-preview1";
@@ -15,13 +16,17 @@ export class UrlClientContext extends coreHttp.ServiceClient {
   $host: string;
   globalStringPath: string;
   globalStringQuery?: string;
+  baseUri?: string;
 
   /**
    * Initializes a new instance of the UrlClientContext class.
    * @param globalStringPath A string value 'globalItemStringPath' that appears in the path
    * @param options The parameter options
    */
-  constructor(globalStringPath: string, options?: any) {
+  constructor(
+    globalStringPath: string,
+    options?: Models.UrlClientOptionalParams
+  ) {
     if (globalStringPath === undefined) {
       throw new Error("'globalStringPath' cannot be null");
     }

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -75,9 +75,6 @@ export interface Slide {
   items?: string[];
 }
 
-/**
- * An interface representing Error.
- */
 export interface ErrorModel {
   status?: number;
   message?: string;
@@ -206,9 +203,6 @@ export interface RetentionPolicy {
   days?: number;
 }
 
-/**
- * An interface representing Metrics.
- */
 export interface Metrics {
   /**
    * The version of Storage Analytics to configure.
@@ -300,17 +294,11 @@ export interface ListBlobsResponse {
   nextMarker: string;
 }
 
-/**
- * An interface representing Blobs.
- */
 export interface Blobs {
   blobPrefix?: BlobPrefix[];
   blob?: Blob[];
 }
 
-/**
- * An interface representing BlobPrefix.
- */
 export interface BlobPrefix {
   name: string;
 }
@@ -369,16 +357,10 @@ export interface BlobProperties {
   archiveStatus?: ArchiveStatus;
 }
 
-/**
- * An interface representing JsonInput.
- */
 export interface JsonInput {
   id?: number;
 }
 
-/**
- * An interface representing JsonOutput.
- */
 export interface JsonOutput {
   id?: number;
 }

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -754,3 +754,18 @@ export type XmlJsonOutputResponse = JsonOutput & {
     parsedBody: JsonOutput;
   };
 };
+
+/**
+ * Optional parameters.
+ */
+export interface XmlServiceClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /**
+   * server parameter
+   */
+  $host?: string;
+  /**
+   * Overrides request baseUri.
+   */
+  baseUri?: string;
+}

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -765,7 +765,7 @@ export interface XmlServiceClientOptionalParams
    */
   $host?: string;
   /**
-   * Overrides request baseUri.
+   * Overrides client endpoint.
    */
-  baseUri?: string;
+  endpoint?: string;
 }

--- a/test/integration/generated/xmlservice/src/operations/xml.ts
+++ b/test/integration/generated/xmlservice/src/operations/xml.ts
@@ -31,7 +31,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getComplexTypeRefNoMeta(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetComplexTypeRefNoMetaResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -46,7 +46,7 @@ export class Xml {
    */
   putComplexTypeRefNoMeta(
     model: Models.RootWithRefAndNoMeta,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { model, options },
@@ -59,7 +59,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getComplexTypeRefWithMeta(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetComplexTypeRefWithMetaResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -74,7 +74,7 @@ export class Xml {
    */
   putComplexTypeRefWithMeta(
     model: Models.RootWithRefAndMeta,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { model, options },
@@ -87,7 +87,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getSimple(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetSimpleResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -102,7 +102,7 @@ export class Xml {
    */
   putSimple(
     slideshow: Models.Slideshow,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { slideshow, options },
@@ -115,7 +115,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getWrappedLists(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetWrappedListsResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -130,7 +130,7 @@ export class Xml {
    */
   putWrappedLists(
     wrappedLists: Models.AppleBarrel,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { wrappedLists, options },
@@ -143,7 +143,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getHeaders(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetHeadersResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -156,7 +156,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getEmptyList(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetEmptyListResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -171,7 +171,7 @@ export class Xml {
    */
   putEmptyList(
     slideshow: Models.Slideshow,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { slideshow, options },
@@ -184,7 +184,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getEmptyWrappedLists(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetEmptyWrappedListsResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -199,7 +199,7 @@ export class Xml {
    */
   putEmptyWrappedLists(
     appleBarrel: Models.AppleBarrel,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { appleBarrel, options },
@@ -212,7 +212,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getRootList(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetRootListResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -227,7 +227,7 @@ export class Xml {
    */
   putRootList(
     bananas: Models.Banana[],
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bananas, options },
@@ -240,7 +240,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getRootListSingleItem(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetRootListSingleItemResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -255,7 +255,7 @@ export class Xml {
    */
   putRootListSingleItem(
     bananas: Models.Banana[],
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bananas, options },
@@ -268,7 +268,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getEmptyRootList(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetEmptyRootListResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -283,7 +283,7 @@ export class Xml {
    */
   putEmptyRootList(
     bananas: Models.Banana[],
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { bananas, options },
@@ -296,7 +296,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getEmptyChildElement(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetEmptyChildElementResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -311,7 +311,7 @@ export class Xml {
    */
   putEmptyChildElement(
     banana: Models.Banana,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { banana, options },
@@ -324,7 +324,7 @@ export class Xml {
    * @param options The options parameters.
    */
   listContainers(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlListContainersResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -337,7 +337,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getServiceProperties(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetServicePropertiesResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -352,7 +352,7 @@ export class Xml {
    */
   putServiceProperties(
     properties: Models.StorageServiceProperties,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { properties, options },
@@ -365,7 +365,7 @@ export class Xml {
    * @param options The options parameters.
    */
   getAcls(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlGetAclsResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -380,7 +380,7 @@ export class Xml {
    */
   putAcls(
     properties: Models.SignedIdentifier[],
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { properties, options },
@@ -393,7 +393,7 @@ export class Xml {
    * @param options The options parameters.
    */
   listBlobs(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlListBlobsResponse> {
     return this.client.sendOperationRequest(
       { options },
@@ -409,7 +409,7 @@ export class Xml {
    */
   jsonInput(
     properties: Models.JsonInput,
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(
       { properties, options },
@@ -422,7 +422,7 @@ export class Xml {
    * @param options The options parameters.
    */
   jsonOutput(
-    options?: coreHttp.RequestOptionsBase
+    options?: coreHttp.OperationOptions
   ): Promise<Models.XmlJsonOutputResponse> {
     return this.client.sendOperationRequest(
       { options },

--- a/test/integration/generated/xmlservice/src/xmlServiceClient.ts
+++ b/test/integration/generated/xmlservice/src/xmlServiceClient.ts
@@ -16,7 +16,7 @@ class XmlServiceClient extends XmlServiceClientContext {
    * Initializes a new instance of the XmlServiceClient class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.XmlServiceClientOptionalParams) {
     super(options);
     this.xml = new operations.Xml(this);
   }

--- a/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
+++ b/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
@@ -7,18 +7,20 @@
  */
 
 import * as coreHttp from "@azure/core-http";
+import * as Models from "./models";
 
 const packageName = "xmlservice";
 const packageVersion = "1.0.0-preview1";
 
 export class XmlServiceClientContext extends coreHttp.ServiceClient {
   $host: string;
+  baseUri?: string;
 
   /**
    * Initializes a new instance of the XmlServiceClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: any) {
+  constructor(options?: Models.XmlServiceClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
+++ b/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
@@ -14,7 +14,6 @@ const packageVersion = "1.0.0-preview1";
 
 export class XmlServiceClientContext extends coreHttp.ServiceClient {
   $host: string;
-  baseUri?: string;
 
   /**
    * Initializes a new instance of the XmlServiceClientContext class.
@@ -35,7 +34,7 @@ export class XmlServiceClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.baseUri || "{$host}";
+    this.baseUri = options.endpoint || "{$host}";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/url.spec.ts
+++ b/test/integration/url.spec.ts
@@ -7,7 +7,7 @@ describe("Integration tests for Url", () => {
   beforeEach(() => {
     const clientOptions = {
       noRetryPolicy: true,
-      baseUri: "http://localhost:3000"
+      endpoint: "http://localhost:3000"
     };
     client = new UrlClient("globalStringPath", clientOptions);
   });

--- a/test/integration/xmlService.spec.ts
+++ b/test/integration/xmlService.spec.ts
@@ -9,7 +9,7 @@ import {
 } from "./generated/xmlservice/src/xmlServiceClient";
 should();
 const testClient = new XmlServiceClient({
-  baseUri: "http://localhost:3000"
+  endpoint: "http://localhost:3000"
 });
 
 function getAbortController() {

--- a/test/unit/transforms/parameterTransforms.spec.ts
+++ b/test/unit/transforms/parameterTransforms.spec.ts
@@ -88,7 +88,7 @@ describe("parameterTransforms", () => {
       const codeModel = new CodeModel("testCodeModel");
       const parameters = transformParameters(codeModel, clientOptions);
 
-      assert.deepEqual(parameters[0].name, "baseUri");
+      assert.deepEqual(parameters[0].name, "endpoint");
     });
 
     it("should extract all operation parameters, 2 different parameters same name", () => {
@@ -162,7 +162,7 @@ describe("parameterTransforms", () => {
       assert.equal(parameters.length, 3);
       assert.deepEqual(
         parameters.map(p => p.nameRef),
-        ["mockParam", "mockParam1", "baseUri"]
+        ["mockParam", "mockParam1", "endpoint"]
       );
 
       const p1: ParameterDetails = parameters.find(
@@ -234,7 +234,7 @@ describe("parameterTransforms", () => {
       assert.equal(parameters.length, 2);
       assert.deepEqual(
         parameters.map(p => p.nameRef),
-        ["mockParam1", "baseUri"]
+        ["mockParam1", "endpoint"]
       );
 
       const p1: ParameterDetails = parameters.find(
@@ -304,7 +304,7 @@ describe("parameterTransforms", () => {
       assert.equal(parameters.length, 3);
       assert.deepEqual(
         parameters.map(p => p.nameRef),
-        ["mockParam1", "mockParam2", "baseUri"]
+        ["mockParam1", "mockParam2", "endpoint"]
       );
 
       const p1: ParameterDetails = parameters.find(

--- a/test/unit/transforms/parameterTransforms.spec.ts
+++ b/test/unit/transforms/parameterTransforms.spec.ts
@@ -88,7 +88,7 @@ describe("parameterTransforms", () => {
       const codeModel = new CodeModel("testCodeModel");
       const parameters = transformParameters(codeModel, clientOptions);
 
-      assert.deepEqual(parameters, []);
+      assert.deepEqual(parameters[0].name, "baseUri");
     });
 
     it("should extract all operation parameters, 2 different parameters same name", () => {
@@ -159,10 +159,10 @@ describe("parameterTransforms", () => {
       codeModel.operationGroups = [op1, op2];
       const parameters = transformParameters(codeModel, clientOptions);
 
-      assert.equal(parameters.length, 2);
+      assert.equal(parameters.length, 3);
       assert.deepEqual(
         parameters.map(p => p.nameRef),
-        ["mockParam", "mockParam1"]
+        ["mockParam", "mockParam1", "baseUri"]
       );
 
       const p1: ParameterDetails = parameters.find(
@@ -231,10 +231,10 @@ describe("parameterTransforms", () => {
       codeModel.operationGroups = [op1, op2];
       const parameters = transformParameters(codeModel, clientOptions);
 
-      assert.equal(parameters.length, 1);
+      assert.equal(parameters.length, 2);
       assert.deepEqual(
         parameters.map(p => p.nameRef),
-        ["mockParam1"]
+        ["mockParam1", "baseUri"]
       );
 
       const p1: ParameterDetails = parameters.find(
@@ -301,10 +301,10 @@ describe("parameterTransforms", () => {
       ];
       const parameters = transformParameters(codeModel, clientOptions);
 
-      assert.equal(parameters.length, 2);
+      assert.equal(parameters.length, 3);
       assert.deepEqual(
         parameters.map(p => p.nameRef),
-        ["mockParam1", "mockParam2"]
+        ["mockParam1", "mockParam2", "baseUri"]
       );
 
       const p1: ParameterDetails = parameters.find(


### PR DESCRIPTION
This PR contains a few fixes from discussions during our review:

* Switch options type from OperationRequestBase with OperationBase
   * Add a synthetic `endpoint` client parameter. This was required since we can no longer cheat using OperationRequestBase indexer
* Add missing options types in Client and ClientContext
* Remove clientContext properties that are not needed in serialization
* Remove useless docstring for interfaces, if SWAGGER doesn't include a description drop it
* Name client level operations after the Client rather than with the "topLevelOperation" constant 