### PR TITLE
Update to v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/typescript",
-    "version": "0.1.0",
+    "version": "6.0.0",
     "private": true,
     "scripts": {
         "build": "tsc -p .",


### PR DESCRIPTION
As discussed with @chradek , autorest dashboard will report version based on the version in package.json. This would need to be the actual version of the future autorest.typescript based on m4 in order to be readable in dashboard.