### PR TITLE
[v6] respects x-ms-client-name in mappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ More information about these can be found [here](https://github.com/Azure/autore
 ```yaml
 version: 3.0.6246
 use-extension:
-  "@autorest/modelerfour": "4.10.240"
+  "@autorest/modelerfour": "4.10.258"
 
 modelerfour:
   prenamer: true

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -246,8 +246,8 @@ function getRequiredParamChecks(requiredParameters: ParameterDetails[]) {
 }
 
 function getRequiredParamAssignments(requiredParameters: ParameterDetails[]) {
-  const blacklistClientParameters = ["credentials"];
+  const disallowedClientParameters = ["credentials"];
   return requiredParameters
-    .filter(({ name }) => !blacklistClientParameters.includes(name))
+    .filter(({ name }) => !disallowedClientParameters.includes(name))
     .map(({ name }) => `this.${name} = ${name};`);
 }

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -246,5 +246,8 @@ function getRequiredParamChecks(requiredParameters: ParameterDetails[]) {
 }
 
 function getRequiredParamAssignments(requiredParameters: ParameterDetails[]) {
-  return requiredParameters.map(({ name }) => `this.${name} = ${name};`);
+  const blacklistClientParameters = ["credentials"];
+  return requiredParameters
+    .filter(({ name }) => !blacklistClientParameters.includes(name))
+    .map(({ name }) => `this.${name} = ${name};`);
 }

--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -570,7 +570,8 @@ function processProperties(
 ) {
   let modelProperties: ModelProperties = {};
   properties.forEach(prop => {
-    const name = normalizeName(prop.serializedName, NameType.Property);
+    const propName = getLanguageMetadata(prop.language).name;
+    const name = normalizeName(propName, NameType.Property);
     modelProperties[name] = getMapperOrRef(prop.schema, prop.serializedName, {
       ...options,
       required: prop.required,

--- a/test/integration/generated/bodyArray/src/models/index.ts
+++ b/test/integration/generated/bodyArray/src/models/index.ts
@@ -23,6 +23,10 @@ export interface Product {
  */
 export type Enum0 = "foo1" | "foo2" | "foo3";
 /**
+ * Defines values for Enum1.
+ */
+export type Enum1 = "foo1" | "foo2" | "foo3";
+/**
  * Defines values for FooEnum.
  */
 export type FooEnum = "foo1" | "foo2" | "foo3";

--- a/test/integration/generated/bodyArray/src/models/parameters.ts
+++ b/test/integration/generated/bodyArray/src/models/parameters.ts
@@ -130,7 +130,7 @@ export const arrayBody8: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "String" }, serializedName: "Enum0" }
+      element: { type: { name: "String" }, serializedName: "Enum1" }
     }
   }
 };

--- a/test/integration/generated/bodyArray/src/operations/array.ts
+++ b/test/integration/generated/bodyArray/src/operations/array.ts
@@ -425,7 +425,7 @@ export class Array {
    * @param options The options parameters.
    */
   putStringEnumValid(
-    arrayBody: Models.Enum0[],
+    arrayBody: Models.Enum1[],
     options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     return this.client.sendOperationRequest(

--- a/test/integration/generated/bodyComplex/src/models/parameters.ts
+++ b/test/integration/generated/bodyComplex/src/models/parameters.ts
@@ -100,25 +100,45 @@ export const complexBody12: coreHttp.OperationParameter = {
 
 export const complexBody13: coreHttp.OperationParameter = {
   parameterPath: "complexBody",
-  mapper: Mappers.DictionaryWrapper
+  mapper: Mappers.ArrayWrapper
 };
 
 export const complexBody14: coreHttp.OperationParameter = {
   parameterPath: "complexBody",
-  mapper: Mappers.Siamese
+  mapper: Mappers.DictionaryWrapper
 };
 
 export const complexBody15: coreHttp.OperationParameter = {
   parameterPath: "complexBody",
-  mapper: Mappers.Fish
+  mapper: Mappers.DictionaryWrapper
 };
 
 export const complexBody16: coreHttp.OperationParameter = {
   parameterPath: "complexBody",
-  mapper: Mappers.Salmon
+  mapper: Mappers.Siamese
 };
 
 export const complexBody17: coreHttp.OperationParameter = {
+  parameterPath: "complexBody",
+  mapper: Mappers.Fish
+};
+
+export const complexBody18: coreHttp.OperationParameter = {
+  parameterPath: "complexBody",
+  mapper: Mappers.Salmon
+};
+
+export const complexBody19: coreHttp.OperationParameter = {
+  parameterPath: "complexBody",
+  mapper: Mappers.Fish
+};
+
+export const complexBody20: coreHttp.OperationParameter = {
+  parameterPath: "complexBody",
+  mapper: Mappers.Fish
+};
+
+export const complexBody21: coreHttp.OperationParameter = {
   parameterPath: "complexBody",
   mapper: Mappers.ReadonlyObj
 };

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -70,8 +70,7 @@ export class Array {
 
   /**
    * Put complex types with array property which is empty
-   * @param complexBody Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick
-   *                    brown fox jumps over the lazy dog"
+   * @param complexBody Please put an empty array
    * @param options The options parameters.
    */
   putEmpty(
@@ -151,7 +150,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody12,
+  requestBody: Parameters.complexBody13,
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -70,8 +70,7 @@ export class Dictionary {
 
   /**
    * Put complex types with dictionary property which is empty
-   * @param complexBody Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint",
-   *                    "xls":"excel", "exe":"", "":null
+   * @param complexBody Please put an empty dictionary
    * @param options The options parameters.
    */
   putEmpty(
@@ -137,7 +136,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody13,
+  requestBody: Parameters.complexBody14,
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -164,7 +163,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody13,
+  requestBody: Parameters.complexBody15,
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -83,7 +83,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody14,
+  requestBody: Parameters.complexBody16,
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -43,37 +43,57 @@ export class Polymorphicrecursive {
    * Put complex types that are polymorphic and have recursive references
    * @param complexBody Please put a salmon that looks like this:
    *                    {
-   *                            'fishtype':'Salmon',
-   *                            'location':'alaska',
-   *                            'iswild':true,
-   *                            'species':'king',
-   *                            'length':1.0,
-   *                            'siblings':[
-   *                              {
-   *                                'fishtype':'Shark',
-   *                                'age':6,
-   *                                'birthday': '2012-01-05T01:00:00Z',
-   *                                'length':20.0,
-   *                                'species':'predator',
-   *                              },
-   *                              {
-   *                                'fishtype':'Sawshark',
-   *                                'age':105,
-   *                                'birthday': '1900-01-05T01:00:00Z',
-   *                                'length':10.0,
-   *                                'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *                                'species':'dangerous',
-   *                              },
-   *                              {
-   *                                'fishtype': 'goblin',
-   *                                'age': 1,
-   *                                'birthday': '2015-08-08T00:00:00Z',
-   *                                'length': 30.0,
-   *                                'species': 'scary',
-   *                                'jawsize': 5
-   *                              }
-   *                            ]
-   *                          };
+   *                        "fishtype": "salmon",
+   *                        "species": "king",
+   *                        "length": 1,
+   *                        "age": 1,
+   *                        "location": "alaska",
+   *                        "iswild": true,
+   *                        "siblings": [
+   *                            {
+   *                                "fishtype": "shark",
+   *                                "species": "predator",
+   *                                "length": 20,
+   *                                "age": 6,
+   *                                "siblings": [
+   *                                    {
+   *                                        "fishtype": "salmon",
+   *                                        "species": "coho",
+   *                                        "length": 2,
+   *                                        "age": 2,
+   *                                        "location": "atlantic",
+   *                                        "iswild": true,
+   *                                        "siblings": [
+   *                                            {
+   *                                                "fishtype": "shark",
+   *                                                "species": "predator",
+   *                                                "length": 20,
+   *                                                "age": 6
+   *                                            },
+   *                                            {
+   *                                                "fishtype": "sawshark",
+   *                                                "species": "dangerous",
+   *                                                "length": 10,
+   *                                                "age": 105
+   *                                            }
+   *                                        ]
+   *                                    },
+   *                                    {
+   *                                        "fishtype": "sawshark",
+   *                                        "species": "dangerous",
+   *                                        "length": 10,
+   *                                        "age": 105
+   *                                    }
+   *                                ]
+   *                            },
+   *                            {
+   *                                "fishtype": "sawshark",
+   *                                "species": "dangerous",
+   *                                "length": 10,
+   *                                "age": 105
+   *                            }
+   *                        ]
+   *                    }
    * @param options The options parameters.
    */
   putValid(
@@ -113,7 +133,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody15,
+  requestBody: Parameters.complexBody20,
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -177,39 +177,33 @@ export class Polymorphism {
   /**
    * Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request
    * should not be allowed from the client
-   * @param complexBody Please put a salmon that looks like this:
+   * @param complexBody Please attempt put a sawshark that looks like this, the client should not allow
+   *                    this data to be sent:
    *                    {
-   *                            'fishtype':'Salmon',
-   *                            'location':'alaska',
-   *                            'iswild':true,
-   *                            'species':'king',
-   *                            'length':1.0,
-   *                            'siblings':[
-   *                              {
-   *                                'fishtype':'Shark',
-   *                                'age':6,
-   *                                'birthday': '2012-01-05T01:00:00Z',
-   *                                'length':20.0,
-   *                                'species':'predator',
-   *                              },
-   *                              {
-   *                                'fishtype':'Sawshark',
-   *                                'age':105,
-   *                                'birthday': '1900-01-05T01:00:00Z',
-   *                                'length':10.0,
-   *                                'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
-   *                                'species':'dangerous',
-   *                              },
-   *                              {
-   *                                'fishtype': 'goblin',
-   *                                'age': 1,
-   *                                'birthday': '2015-08-08T00:00:00Z',
-   *                                'length': 30.0,
-   *                                'species': 'scary',
-   *                                'jawsize': 5
-   *                              }
-   *                            ]
-   *                          };
+   *                        "fishtype": "sawshark",
+   *                        "species": "snaggle toothed",
+   *                        "length": 18.5,
+   *                        "age": 2,
+   *                        "birthday": "2013-06-01T01:00:00Z",
+   *                        "location": "alaska",
+   *                        "picture": base64(FF FF FF FF FE),
+   *                        "siblings": [
+   *                            {
+   *                                "fishtype": "shark",
+   *                                "species": "predator",
+   *                                "birthday": "2012-01-05T01:00:00Z",
+   *                                "length": 20,
+   *                                "age": 6
+   *                            },
+   *                            {
+   *                                "fishtype": "sawshark",
+   *                                "species": "dangerous",
+   *                                "picture": base64(FF FF FF FF FE),
+   *                                "length": 10,
+   *                                "age": 105
+   *                            }
+   *                        ]
+   *                    }
    * @param options The options parameters.
    */
   putValidMissingRequired(
@@ -249,7 +243,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody15,
+  requestBody: Parameters.complexBody17,
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -318,7 +312,7 @@ const putComplicatedOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody16,
+  requestBody: Parameters.complexBody18,
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -333,7 +327,7 @@ const putMissingDiscriminatorOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody16,
+  requestBody: Parameters.complexBody18,
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -346,7 +340,7 @@ const putValidMissingRequiredOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody15,
+  requestBody: Parameters.complexBody19,
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -81,7 +81,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.complexBody17,
+  requestBody: Parameters.complexBody21,
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/bodyString/src/models/parameters.ts
+++ b/test/integration/generated/bodyString/src/models/parameters.ts
@@ -24,7 +24,7 @@ export const $host: coreHttp.OperationURLParameter = {
 export const stringBody: coreHttp.OperationParameter = {
   parameterPath: ["options", "stringBody"],
   mapper: {
-    serializedName: "StringBody",
+    serializedName: "stringBody",
     isConstant: true,
     type: {
       name: "String"
@@ -36,7 +36,7 @@ export const stringBody1: coreHttp.OperationParameter = {
   parameterPath: "stringBody",
   mapper: {
     defaultValue: "",
-    serializedName: "StringBody",
+    serializedName: "stringBody",
     isConstant: true,
     type: {
       name: "String"
@@ -49,7 +49,7 @@ export const stringBody2: coreHttp.OperationParameter = {
   mapper: {
     defaultValue:
       "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€",
-    serializedName: "StringBody",
+    serializedName: "stringBody",
     isConstant: true,
     type: {
       name: "String"
@@ -62,7 +62,7 @@ export const stringBody3: coreHttp.OperationParameter = {
   mapper: {
     defaultValue:
       "    Now is the time for all good men to come to the aid of their country    ",
-    serializedName: "StringBody",
+    serializedName: "stringBody",
     isConstant: true,
     type: {
       name: "String"

--- a/test/integration/generated/header/src/models/parameters.ts
+++ b/test/integration/generated/header/src/models/parameters.ts
@@ -98,6 +98,17 @@ export const value3: coreHttp.OperationParameter = {
   }
 };
 
+export const scenario1: coreHttp.OperationParameter = {
+  parameterPath: "scenario",
+  mapper: {
+    serializedName: "scenario",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
 export const value4: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
@@ -109,10 +120,32 @@ export const value4: coreHttp.OperationParameter = {
   }
 };
 
+export const scenario2: coreHttp.OperationParameter = {
+  parameterPath: "scenario",
+  mapper: {
+    serializedName: "scenario",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
 export const value5: coreHttp.OperationParameter = {
   parameterPath: ["options", "value"],
   mapper: {
     serializedName: "value",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const scenario3: coreHttp.OperationParameter = {
+  parameterPath: "scenario",
+  mapper: {
+    serializedName: "scenario",
+    required: true,
     type: {
       name: "String"
     }
@@ -151,6 +184,17 @@ export const value8: coreHttp.OperationParameter = {
   }
 };
 
+export const scenario4: coreHttp.OperationParameter = {
+  parameterPath: "scenario",
+  mapper: {
+    serializedName: "scenario",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
 export const value9: coreHttp.OperationParameter = {
   parameterPath: "value",
   mapper: {
@@ -169,6 +213,17 @@ export const value10: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "ByteArray"
+    }
+  }
+};
+
+export const scenario5: coreHttp.OperationParameter = {
+  parameterPath: "scenario",
+  mapper: {
+    serializedName: "scenario",
+    required: true,
+    type: {
+      name: "String"
     }
   }
 };

--- a/test/integration/generated/header/src/operations/header.ts
+++ b/test/integration/generated/header/src/operations/header.ts
@@ -217,7 +217,7 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "true", "value": true or "scenario": "false",
    * "value": false
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "true" or "false"
    * @param value Send a post request with header values true or false
    * @param options The options parameters.
    */
@@ -234,7 +234,7 @@ export class Header {
 
   /**
    * Get a response with header value "value": true or false
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "true" or "false"
    * @param options The options parameters.
    */
   responseBool(
@@ -250,7 +250,7 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "The quick brown fox jumps over
    * the lazy dog" or "scenario": "null", "value": null or "scenario": "empty", "value": ""
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    * @param options The options parameters.
    */
   paramString(
@@ -265,7 +265,7 @@ export class Header {
 
   /**
    * Get a response with header values "The quick brown fox jumps over the lazy dog" or null or ""
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    * @param options The options parameters.
    */
   responseString(
@@ -281,7 +281,7 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "2010-01-01" or "scenario":
    * "min", "value": "0001-01-01"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    * @param value Send a post request with header values "2010-01-01" or "0001-01-01"
    * @param options The options parameters.
    */
@@ -298,7 +298,7 @@ export class Header {
 
   /**
    * Get a response with header values "2010-01-01" or "0001-01-01"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    * @param options The options parameters.
    */
   responseDate(
@@ -314,7 +314,7 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "2010-01-01T12:34:56Z" or
    * "scenario": "min", "value": "0001-01-01T00:00:00Z"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    * @param value Send a post request with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
    * @param options The options parameters.
    */
@@ -331,7 +331,7 @@ export class Header {
 
   /**
    * Get a response with header values "2010-01-01T12:34:56Z" or "0001-01-01T00:00:00Z"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    * @param options The options parameters.
    */
   responseDatetime(
@@ -347,7 +347,7 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "Wed, 01 Jan 2010 12:34:56 GMT"
    * or "scenario": "min", "value": "Mon, 01 Jan 0001 00:00:00 GMT"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    * @param options The options parameters.
    */
   paramDatetimeRfc1123(
@@ -362,7 +362,7 @@ export class Header {
 
   /**
    * Get a response with header values "Wed, 01 Jan 2010 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "min"
    * @param options The options parameters.
    */
   responseDatetimeRfc1123(
@@ -377,7 +377,7 @@ export class Header {
 
   /**
    * Send a post request with header values "scenario": "valid", "value": "P123DT22H14M12.011S"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid"
    * @param value Send a post request with header values "P123DT22H14M12.011S"
    * @param options The options parameters.
    */
@@ -394,7 +394,7 @@ export class Header {
 
   /**
    * Get a response with header values "P123DT22H14M12.011S"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid"
    * @param options The options parameters.
    */
   responseDuration(
@@ -409,7 +409,7 @@ export class Header {
 
   /**
    * Send a post request with header values "scenario": "valid", "value": "啊齄丂狛狜隣郎隣兀﨩"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid"
    * @param value Send a post request with header values "啊齄丂狛狜隣郎隣兀﨩"
    * @param options The options parameters.
    */
@@ -426,7 +426,7 @@ export class Header {
 
   /**
    * Get a response with header values "啊齄丂狛狜隣郎隣兀﨩"
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid"
    * @param options The options parameters.
    */
   responseByte(
@@ -442,7 +442,7 @@ export class Header {
   /**
    * Send a post request with header values "scenario": "valid", "value": "GREY" or "scenario": "null",
    * "value": null
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    * @param options The options parameters.
    */
   paramEnum(
@@ -457,7 +457,7 @@ export class Header {
 
   /**
    * Get a response with header values "GREY" or null
-   * @param scenario Send a post request with header values "scenario": "positive" or "negative"
+   * @param scenario Send a post request with header values "scenario": "valid" or "null" or "empty"
    * @param options The options parameters.
    */
   responseEnum(
@@ -663,7 +663,7 @@ const paramBoolOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value4],
+  headerParameters: [Parameters.scenario1, Parameters.value4],
   serializer
 };
 const responseBoolOperationSpec: coreHttp.OperationSpec = {
@@ -678,7 +678,7 @@ const responseBoolOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario1],
   serializer
 };
 const paramStringOperationSpec: coreHttp.OperationSpec = {
@@ -691,7 +691,7 @@ const paramStringOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value5],
+  headerParameters: [Parameters.scenario2, Parameters.value5],
   serializer
 };
 const responseStringOperationSpec: coreHttp.OperationSpec = {
@@ -706,7 +706,7 @@ const responseStringOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario2],
   serializer
 };
 const paramDateOperationSpec: coreHttp.OperationSpec = {
@@ -719,7 +719,7 @@ const paramDateOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value6],
+  headerParameters: [Parameters.scenario3, Parameters.value6],
   serializer
 };
 const responseDateOperationSpec: coreHttp.OperationSpec = {
@@ -734,7 +734,7 @@ const responseDateOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario3],
   serializer
 };
 const paramDatetimeOperationSpec: coreHttp.OperationSpec = {
@@ -747,7 +747,7 @@ const paramDatetimeOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value7],
+  headerParameters: [Parameters.scenario3, Parameters.value7],
   serializer
 };
 const responseDatetimeOperationSpec: coreHttp.OperationSpec = {
@@ -762,7 +762,7 @@ const responseDatetimeOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario3],
   serializer
 };
 const paramDatetimeRfc1123OperationSpec: coreHttp.OperationSpec = {
@@ -775,7 +775,7 @@ const paramDatetimeRfc1123OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value8],
+  headerParameters: [Parameters.scenario3, Parameters.value8],
   serializer
 };
 const responseDatetimeRfc1123OperationSpec: coreHttp.OperationSpec = {
@@ -790,7 +790,7 @@ const responseDatetimeRfc1123OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario3],
   serializer
 };
 const paramDurationOperationSpec: coreHttp.OperationSpec = {
@@ -803,7 +803,7 @@ const paramDurationOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value9],
+  headerParameters: [Parameters.scenario4, Parameters.value9],
   serializer
 };
 const responseDurationOperationSpec: coreHttp.OperationSpec = {
@@ -818,7 +818,7 @@ const responseDurationOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario4],
   serializer
 };
 const paramByteOperationSpec: coreHttp.OperationSpec = {
@@ -831,7 +831,7 @@ const paramByteOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value10],
+  headerParameters: [Parameters.scenario4, Parameters.value10],
   serializer
 };
 const responseByteOperationSpec: coreHttp.OperationSpec = {
@@ -846,7 +846,7 @@ const responseByteOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario4],
   serializer
 };
 const paramEnumOperationSpec: coreHttp.OperationSpec = {
@@ -859,7 +859,7 @@ const paramEnumOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario, Parameters.value11],
+  headerParameters: [Parameters.scenario5, Parameters.value11],
   serializer
 };
 const responseEnumOperationSpec: coreHttp.OperationSpec = {
@@ -874,7 +874,7 @@ const responseEnumOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario],
+  headerParameters: [Parameters.scenario5],
   serializer
 };
 const customRequestIdOperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/generated/url/src/models/index.ts
+++ b/test/integration/generated/url/src/models/index.ts
@@ -101,7 +101,7 @@ export interface QueriesEnumValidOptionalParams
 export interface QueriesEnumNullOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * 'green color' enum value
+   * null string value
    */
   enumQuery?: UriColor;
 }
@@ -123,7 +123,7 @@ export interface QueriesByteMultiByteOptionalParams
 export interface QueriesByteNullOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+   * null as byte array (no query parameters in uri)
    */
   byteQuery?: Uint8Array;
 }
@@ -167,7 +167,7 @@ export interface QueriesArrayStringCsvValidOptionalParams
 export interface QueriesArrayStringCsvNullOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+   * a null array of string using the csv-array format
    */
   arrayQuery?: string[];
 }
@@ -178,7 +178,7 @@ export interface QueriesArrayStringCsvNullOptionalParams
 export interface QueriesArrayStringCsvEmptyOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * an array of string ['ArrayQuery1', 'begin!*'();:@ &=+$,/?#[]end' , null, ''] using the csv-array format
+   * an empty array [] of string using the csv-array format
    */
   arrayQuery?: string[];
 }
@@ -256,7 +256,7 @@ export interface PathItemsGetGlobalAndLocalQueryNullOptionalParams
    */
   pathItemStringQuery?: string;
   /**
-   * should contain value 'localStringQuery'
+   * should contain null value
    */
   localStringQuery?: string;
 }
@@ -267,11 +267,11 @@ export interface PathItemsGetGlobalAndLocalQueryNullOptionalParams
 export interface PathItemsGetLocalPathItemQueryNullOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * A string value 'pathItemStringQuery' that appears as a query parameter
+   * should contain value null
    */
   pathItemStringQuery?: string;
   /**
-   * should contain value 'localStringQuery'
+   * should contain value null
    */
   localStringQuery?: string;
 }

--- a/test/integration/generated/url/src/models/parameters.ts
+++ b/test/integration/generated/url/src/models/parameters.ts
@@ -213,6 +213,18 @@ export const enumPath: coreHttp.OperationURLParameter = {
   }
 };
 
+export const enumPath1: coreHttp.OperationURLParameter = {
+  parameterPath: "enumPath",
+  mapper: {
+    serializedName: "enumPath",
+    required: true,
+    type: {
+      name: "Enum",
+      allowedValues: ["red color", "green color", "blue color"]
+    }
+  }
+};
+
 export const bytePath: coreHttp.OperationURLParameter = {
   parameterPath: "bytePath",
   mapper: {
@@ -230,6 +242,17 @@ export const bytePath1: coreHttp.OperationURLParameter = {
     defaultValue: new Uint8Array(0),
     serializedName: "bytePath",
     isConstant: true,
+    type: {
+      name: "ByteArray"
+    }
+  }
+};
+
+export const bytePath2: coreHttp.OperationURLParameter = {
+  parameterPath: "bytePath",
+  mapper: {
+    serializedName: "bytePath",
+    required: true,
     type: {
       name: "ByteArray"
     }
@@ -543,6 +566,17 @@ export const enumQuery: coreHttp.OperationQueryParameter = {
   }
 };
 
+export const enumQuery1: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "enumQuery"],
+  mapper: {
+    serializedName: "enumQuery",
+    type: {
+      name: "Enum",
+      allowedValues: ["red color", "green color", "blue color"]
+    }
+  }
+};
+
 export const byteQuery: coreHttp.OperationQueryParameter = {
   parameterPath: ["options", "byteQuery"],
   mapper: {
@@ -559,6 +593,16 @@ export const byteQuery1: coreHttp.OperationQueryParameter = {
     defaultValue: new Uint8Array(0),
     serializedName: "byteQuery",
     isConstant: true,
+    type: {
+      name: "ByteArray"
+    }
+  }
+};
+
+export const byteQuery2: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "byteQuery"],
+  mapper: {
+    serializedName: "byteQuery",
     type: {
       name: "ByteArray"
     }
@@ -630,7 +674,7 @@ export const arrayQuery1: coreHttp.OperationQueryParameter = {
       element: { type: { name: "String" }, serializedName: "String" }
     }
   },
-  collectionFormat: coreHttp.QueryCollectionFormat.Ssv
+  collectionFormat: coreHttp.QueryCollectionFormat.Csv
 };
 
 export const arrayQuery2: coreHttp.OperationQueryParameter = {
@@ -642,10 +686,34 @@ export const arrayQuery2: coreHttp.OperationQueryParameter = {
       element: { type: { name: "String" }, serializedName: "String" }
     }
   },
-  collectionFormat: coreHttp.QueryCollectionFormat.Tsv
+  collectionFormat: coreHttp.QueryCollectionFormat.Csv
 };
 
 export const arrayQuery3: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "arrayQuery"],
+  mapper: {
+    serializedName: "arrayQuery",
+    type: {
+      name: "Sequence",
+      element: { type: { name: "String" }, serializedName: "String" }
+    }
+  },
+  collectionFormat: coreHttp.QueryCollectionFormat.Ssv
+};
+
+export const arrayQuery4: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "arrayQuery"],
+  mapper: {
+    serializedName: "arrayQuery",
+    type: {
+      name: "Sequence",
+      element: { type: { name: "String" }, serializedName: "String" }
+    }
+  },
+  collectionFormat: coreHttp.QueryCollectionFormat.Tsv
+};
+
+export const arrayQuery5: coreHttp.OperationQueryParameter = {
   parameterPath: ["options", "arrayQuery"],
   mapper: {
     serializedName: "arrayQuery",
@@ -711,6 +779,36 @@ export const localStringPath: coreHttp.OperationURLParameter = {
 };
 
 export const localStringQuery: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "localStringQuery"],
+  mapper: {
+    serializedName: "localStringQuery",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const localStringQuery1: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "localStringQuery"],
+  mapper: {
+    serializedName: "localStringQuery",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const pathItemStringQuery1: coreHttp.OperationQueryParameter = {
+  parameterPath: ["options", "pathItemStringQuery"],
+  mapper: {
+    serializedName: "pathItemStringQuery",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const localStringQuery2: coreHttp.OperationQueryParameter = {
   parameterPath: ["options", "localStringQuery"],
   mapper: {
     serializedName: "localStringQuery",

--- a/test/integration/generated/url/src/operations/pathItems.ts
+++ b/test/integration/generated/url/src/operations/pathItems.ts
@@ -165,7 +165,7 @@ const getGlobalAndLocalQueryNullOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [
     Parameters.pathItemStringQuery,
     Parameters.globalStringQuery,
-    Parameters.localStringQuery
+    Parameters.localStringQuery1
   ],
   urlParameters: [
     Parameters.$host,
@@ -186,9 +186,9 @@ const getLocalPathItemQueryNullOperationSpec: coreHttp.OperationSpec = {
     }
   },
   queryParameters: [
-    Parameters.pathItemStringQuery,
     Parameters.globalStringQuery,
-    Parameters.localStringQuery
+    Parameters.pathItemStringQuery1,
+    Parameters.localStringQuery2
   ],
   urlParameters: [
     Parameters.$host,

--- a/test/integration/generated/url/src/operations/paths.ts
+++ b/test/integration/generated/url/src/operations/paths.ts
@@ -240,7 +240,7 @@ export class Paths {
 
   /**
    * Get null (should throw on the client before the request is sent on wire)
-   * @param enumPath send the value green
+   * @param enumPath send null should throw
    * @param options The options parameters.
    */
   enumNull(
@@ -283,7 +283,7 @@ export class Paths {
 
   /**
    * Get null as byte array (should throw)
-   * @param bytePath '啊齄丂狛狜隣郎隣兀﨩' multibyte value as utf-8 encoded byte array
+   * @param bytePath null as byte array (should throw)
    * @param options The options parameters.
    */
   byteNull(
@@ -606,7 +606,7 @@ const enumNullOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  urlParameters: [Parameters.$host, Parameters.enumPath],
+  urlParameters: [Parameters.$host, Parameters.enumPath1],
   serializer
 };
 const byteMultiByteOperationSpec: coreHttp.OperationSpec = {
@@ -642,7 +642,7 @@ const byteNullOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  urlParameters: [Parameters.$host, Parameters.bytePath],
+  urlParameters: [Parameters.$host, Parameters.bytePath2],
   serializer
 };
 const dateValidOperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/generated/url/src/operations/queries.ts
+++ b/test/integration/generated/url/src/operations/queries.ts
@@ -746,7 +746,7 @@ const enumNullOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.enumQuery],
+  queryParameters: [Parameters.enumQuery1],
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -785,7 +785,7 @@ const byteNullOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.byteQuery],
+  queryParameters: [Parameters.byteQuery2],
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -863,7 +863,7 @@ const arrayStringCsvNullOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.arrayQuery],
+  queryParameters: [Parameters.arrayQuery1],
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -876,7 +876,7 @@ const arrayStringCsvEmptyOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.arrayQuery],
+  queryParameters: [Parameters.arrayQuery2],
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -889,7 +889,7 @@ const arrayStringSsvValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.arrayQuery1],
+  queryParameters: [Parameters.arrayQuery3],
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -902,7 +902,7 @@ const arrayStringTsvValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.arrayQuery2],
+  queryParameters: [Parameters.arrayQuery4],
   urlParameters: [Parameters.$host],
   serializer
 };
@@ -915,7 +915,7 @@ const arrayStringPipesValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  queryParameters: [Parameters.arrayQuery3],
+  queryParameters: [Parameters.arrayQuery5],
   urlParameters: [Parameters.$host],
   serializer
 };

--- a/test/integration/generated/xmlservice/src/models/mappers.ts
+++ b/test/integration/generated/xmlservice/src/models/mappers.ts
@@ -769,7 +769,7 @@ export const BlobProperties: coreHttp.CompositeMapper = {
         serializedName: "Content-Language",
         xmlName: "Content-Language"
       },
-      contentMd5: {
+      contentMD5: {
         type: { name: "String" },
         serializedName: "Content-MD5",
         xmlName: "Content-MD5"
@@ -784,7 +784,7 @@ export const BlobProperties: coreHttp.CompositeMapper = {
         serializedName: "Cache-Control",
         xmlName: "Cache-Control"
       },
-      xMsBlobSequenceNumber: {
+      blobSequenceNumber: {
         type: { name: "Number" },
         serializedName: "x-ms-blob-sequence-number",
         xmlName: "x-ms-blob-sequence-number"


### PR DESCRIPTION
Also updates modelerfour and fixes a bug where ClientContext classes were storing `credentials` in a public member that didn't exist. For now I just created a blacklist to hold parameters that shouldn't be exposed, but I think longer-term we could add a field to `ParameterDetails` to determine which parameters should be exposed on the context.

The credentials fix is needed or else TypeScript won't compile the generated code.