### PR TITLE
[v6] Improve model generation for multi-response operations

### DIFF
--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -41,7 +41,7 @@ export interface OperationResponseTypes {
  * Details of an operation response, transformed from Response or SchemaResponse.
  */
 export interface OperationResponseDetails {
-  statusCodes: string[]; // Can be a status code number or "default"
+  statusCode: string; // Can be a status code number or "default"
   mediaType?: KnownMediaType;
   mappers: OperationResponseMappers;
   types: OperationResponseTypes;

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -159,13 +159,12 @@ export function extractSchemaResponses(responses: OperationResponseDetails[]) {
   return responses.reduce(
     (
       result: OperationSpecResponses,
-      { statusCodes, mappers }: OperationResponseDetails
+      { statusCode, mappers }: OperationResponseDetails
     ) => {
-      if (!statusCodes || !statusCodes.length) {
+      if (!statusCode) {
         return result;
       }
 
-      const statusCode = statusCodes[0];
       result[statusCode] = mappers;
       return result;
     },
@@ -225,8 +224,14 @@ export function transformOperationResponse(
 
   const isDefault = httpInfo.statusCodes.indexOf("default") > -1;
 
+  if (!httpInfo.statusCodes.length) {
+    throw new Error(
+      `Unexpected empty statusCodes in operation ${operationFullName}`
+    );
+  }
+
   return {
-    statusCodes: httpInfo.statusCodes,
+    statusCode: httpInfo.statusCodes[0],
     mediaType: httpInfo.knownMediaType,
     mappers,
     types,


### PR DESCRIPTION
While prototyping LRO, I found that Models for operations that define multiple responses would get an invalid file with duplicate Response models. This is because operations may define multiple responses ([example](https://github.com/Azure/autorest.testserver/blob/804ffe742eb02fbe30ed928f286b0b593e8c8d90/swagger/lro.json#L44))

In this PR I'm handling this and assigning the operations a union type with all the possible response types when needed.