### PR TITLE
[v6] Implement LRO outline and BodyPolling strategy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -168,6 +168,18 @@
                 }
             }
         },
+        "@azure/core-lro": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.1.tgz",
+            "integrity": "sha512-RIrM6CTRoYoJEXpCuAr8vanXxlFBCCaHpa/PCSUfcYe6B9pAdSi1DTUZZ+2w2ysNIMHB9MyOLEAkzZ/4NCJIdQ==",
+            "requires": {
+                "@azure/abort-controller": "^1.0.0",
+                "@azure/core-http": "^1.0.0",
+                "@opentelemetry/types": "^0.2.0",
+                "events": "^3.0.0",
+                "tslib": "^1.10.0"
+            }
+        },
         "@azure/core-paging": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.0.0.tgz",
@@ -1910,6 +1922,11 @@
                 "stream-combiner": "~0.0.4",
                 "through": "~2.3.1"
             }
+        },
+        "events": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.1.0.tgz",
+            "integrity": "sha512-Rv+u8MLHNOdMjTAFeT3nCjHn2aGlx435FP/sDHNaRhDEMwyI/aB22Kj2qIN8R0cw3z28psEQLYwxVKLsKrMgWg=="
         },
         "execa": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
         "LICENSE"
     ],
     "dependencies": {
-        "autorest": "^3.0.6187",
         "@azure-tools/async-io": "3.0.203",
         "@azure-tools/autorest-extension-base": "3.1.237",
         "@azure-tools/codegen": "2.4.259",
@@ -31,9 +30,11 @@
         "@azure-tools/linq": "3.1.206",
         "@azure-tools/openapi": "3.0.209",
         "@azure/core-http": "^1.0.4",
+        "@azure/core-lro": "^1.0.1",
         "@azure/core-paging": "^1.0.0",
         "@azure/logger": "^1.0.0",
         "@types/lodash": "^4.14.149",
+        "autorest": "^3.0.6187",
         "lodash": "^4.17.15",
         "prettier": "^1.19.1",
         "source-map-support": "^0.5.16",

--- a/src/lro/bodyPollingStrategy.ts
+++ b/src/lro/bodyPollingStrategy.ts
@@ -1,0 +1,47 @@
+import { LROStrategy, BaseResult, LROOperationState } from "./models";
+import { OperationSpec } from "@azure/core-http";
+
+const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+
+/**
+ * Creates a polling strategy based on BodyPolling which uses the provisioning state
+ * from the result to determine the current operation state
+ */
+export function createBodyPollingStrategy<TResult extends BaseResult>({
+  lastOperation: operation,
+  sendOperation
+}: LROOperationState<TResult>): LROStrategy<TResult> {
+  let lastOperation = { ...operation };
+  return {
+    isTerminal: () => {
+      // If provisioning state is missing, default to Success
+      const provisioningState = (
+        lastOperation.result.provisioningState ||
+        lastOperation.result.properties?.provisioningState ||
+        "succeeded"
+      ).toLowerCase();
+
+      return terminalStates.includes(provisioningState);
+    },
+    sendFinalRequest: () => {
+      // BodyPolling doesn't require a final get so return the lastOperation
+      return Promise.resolve(lastOperation);
+    },
+    poll: async () => {
+      // When doing BodyPolling, we need to poll to the original url with a
+      // GET http method
+      const pollingSpec: OperationSpec = {
+        ...lastOperation.spec,
+        httpMethod: "GET"
+      };
+
+      // Execute the polling operation
+      const result = await sendOperation(lastOperation.args, pollingSpec);
+
+      // Update lastOperation
+      lastOperation.spec = pollingSpec;
+      lastOperation.result = result;
+      return lastOperation;
+    }
+  };
+}

--- a/src/lro/bodyPollingStrategy.ts
+++ b/src/lro/bodyPollingStrategy.ts
@@ -38,8 +38,7 @@ export function createBodyPollingStrategy<TResult extends BaseResult>({
       // Execute the polling operation
       const result = await sendOperation(lastOperation.args, pollingSpec);
 
-      // Update lastOperation
-      lastOperation.spec = pollingSpec;
+      // Update lastOperation result
       lastOperation.result = result;
       return lastOperation;
     }

--- a/src/lro/lroPoller.ts
+++ b/src/lro/lroPoller.ts
@@ -1,0 +1,67 @@
+import { Poller } from "@azure/core-lro";
+import { OperationSpec, OperationArguments, delay } from "@azure/core-http";
+import { BaseResult, LROOperationState } from "./models";
+import { makeOperation } from "./operation";
+
+export interface LROPollerOptions<TResult extends BaseResult> {
+  /**
+   * Defines how much time the poller is going to wait before making a new request to the service.
+   */
+  intervalInMs?: number;
+  /**
+   * Arguments used to send the initial operation
+   */
+  initialOperationArguments: OperationArguments;
+  /**
+   * Operation spec provided for the initial operation
+   */
+  initialOperationSpec: OperationSpec;
+  /**
+   * Result from the initial operation
+   */
+  initialOperationResult: TResult;
+  /**
+   * Function to execute an operation based on an operation spec and arguments
+   */
+  sendOperation: (
+    args: OperationArguments,
+    spec: OperationSpec
+  ) => Promise<TResult>;
+}
+
+export class LROPoller<TResult extends BaseResult> extends Poller<
+  LROOperationState<TResult>,
+  TResult
+> {
+  private intervalInMs: number;
+
+  constructor({
+    initialOperationArguments,
+    initialOperationResult,
+    initialOperationSpec,
+    sendOperation,
+    intervalInMs = 2000
+  }: LROPollerOptions<TResult>) {
+    const state: LROOperationState<TResult> = {
+      // Initial operation will become the last operation
+      lastOperation: {
+        args: initialOperationArguments,
+        spec: initialOperationSpec,
+        result: initialOperationResult
+      },
+      sendOperation
+    };
+
+    const operation = makeOperation(state);
+    super(operation);
+
+    this.intervalInMs = intervalInMs;
+  }
+
+  /**
+   * The method used by the poller to wait before attempting to update its operation.
+   */
+  async delay(): Promise<void> {
+    delay(this.intervalInMs);
+  }
+}

--- a/src/lro/lroPoller.ts
+++ b/src/lro/lroPoller.ts
@@ -61,7 +61,7 @@ export class LROPoller<TResult extends BaseResult> extends Poller<
   /**
    * The method used by the poller to wait before attempting to update its operation.
    */
-  async delay(): Promise<void> {
-    delay(this.intervalInMs);
+  delay(): Promise<void> {
+    return delay(this.intervalInMs);
   }
 }

--- a/src/lro/models.ts
+++ b/src/lro/models.ts
@@ -1,0 +1,38 @@
+import { OperationArguments, OperationSpec } from "@azure/core-http";
+import { PollOperationState, PollOperation } from "@azure/core-lro";
+
+export interface BaseResult {
+  location?: string;
+  operationLocation?: string;
+  azureAsyncOperation?: string;
+  provisioningState?: string;
+  properties?: {
+    provisioningState?: string;
+  };
+}
+
+export interface LastOperation<TResult extends BaseResult> {
+  args: OperationArguments;
+  spec: OperationSpec;
+  result: TResult;
+}
+
+export interface LROOperationState<TResult extends BaseResult>
+  extends PollOperationState<TResult> {
+  lastOperation: LastOperation<TResult>;
+  sendOperation: (
+    args: OperationArguments,
+    spec: OperationSpec
+  ) => Promise<TResult>;
+}
+
+export interface LROStrategy<TResult extends BaseResult> {
+  isTerminal: () => boolean;
+  sendFinalRequest: () => Promise<LastOperation<TResult>>;
+  poll: () => Promise<LastOperation<TResult>>;
+}
+
+export type LROOperation<TResult extends BaseResult> = PollOperation<
+  LROOperationState<TResult>,
+  TResult
+>;

--- a/src/lro/models.ts
+++ b/src/lro/models.ts
@@ -1,7 +1,11 @@
-import { OperationArguments, OperationSpec } from "@azure/core-http";
+import {
+  OperationArguments,
+  OperationSpec,
+  RestResponse
+} from "@azure/core-http";
 import { PollOperationState, PollOperation } from "@azure/core-lro";
 
-export interface BaseResult {
+export interface BaseResult extends RestResponse {
   location?: string;
   operationLocation?: string;
   azureAsyncOperation?: string;

--- a/src/lro/operation.ts
+++ b/src/lro/operation.ts
@@ -1,0 +1,108 @@
+import {
+  BaseResult,
+  LROOperationState,
+  LROOperation,
+  LROStrategy
+} from "./models";
+import { createBodyPollingStrategy } from "./bodyPollingStrategy";
+
+/**
+ * Creates a copy of the operation from a given State
+ */
+export function makeOperation<TResult extends BaseResult>(
+  state: LROOperationState<TResult>
+): LROOperation<TResult> {
+  return {
+    state: { ...state },
+    update,
+    cancel,
+    toString: function(this: LROOperation<TResult>) {
+      return JSON.stringify(this.state);
+    }
+  };
+}
+
+/**
+ * General update function for LROPoller, the general process is as follows
+ * 1. Check initial operation result to determine the strategy to use
+ *  - Strategies: Location, Azure-AsyncOperation, Original Uri
+ * 2. Check if the operation result has a terminal state
+ *  - Terminal state will be determined by each strategy
+ *  2.1 If it is terminal state Check if a final GET request is required, if so
+ *      send final GET request and return result from operation. If no final GET
+ *      is required, just return the result from operation.
+ *      - Determining what to call for final request is responsibility of each strategy
+ *  2.2 If it is not terminal state, call the polling operation call it and go to step 1
+ *      - Determining what to call for polling is responsibility of each strategy
+ *      - Strategies will always use the latest URI for polling if provided otherwise
+ *        the last known one
+ */
+async function update<TResult extends BaseResult>(
+  this: LROOperation<TResult>
+): Promise<LROOperation<TResult>> {
+  const state = { ...this.state };
+
+  // Get strategy from last operation
+  const lroStrategy: LROStrategy<TResult> = getStrategyFromResult(state);
+
+  // Check if last result is terminal
+  if (lroStrategy.isTerminal()) {
+    const result = await lroStrategy.sendFinalRequest();
+    state.lastOperation = result;
+    state.result = state.lastOperation.result;
+    state.isCompleted = true;
+  } else {
+    const result = await lroStrategy.poll();
+    state.lastOperation = result;
+  }
+
+  // Return operation
+  return makeOperation(state);
+}
+
+/**
+ * Swagger doesn't support defining a cancel operation, we'll just mark
+ * the operation state as cancelled
+ */
+async function cancel<TResult extends BaseResult>(
+  this: LROOperation<TResult>
+): Promise<LROOperation<TResult>> {
+  return makeOperation({ ...this.state, isCancelled: true });
+}
+
+/**
+ * This function determines which strategy to use based on the response from
+ * the last operation executed, this last operation can be an initial operation
+ * or a polling operation. The 3 possible strategies are described below:
+ *
+ * A) Azure-AsyncOperation or Operation-Location
+ * B) Location
+ * C) BodyPolling (provisioningState)
+ *  - This strategy is used when:
+ *    - Response doesn't contain any of the following headers Location, Azure-AsyncOperation or Operation-Location
+ *    - Last operation method is PUT
+ */
+function getStrategyFromResult<TResult extends BaseResult>(
+  state: LROOperationState<TResult>
+): LROStrategy<TResult> {
+  const {
+    lastOperation: { spec, result }
+  } = state;
+
+  if (result.azureAsyncOperation) {
+    throw new Error("Azure-AsyncOperation strategy is not yet implemented");
+  }
+
+  if (result.location) {
+    throw new Error("Location strategy is not yet implemented");
+  }
+
+  // TODO: Should we include here other methods like Patch?
+  if (spec.httpMethod === "PUT") {
+    // We should use BodyPolling strategy
+    // Return BodyPolling Strategy
+    return createBodyPollingStrategy(state);
+  }
+
+  throw new Error("Unknown Long Running Operation strategy");
+}

--- a/src/lro/operation.ts
+++ b/src/lro/operation.ts
@@ -54,6 +54,7 @@ async function update<TResult extends BaseResult>(
   } else {
     const result = await lroStrategy.poll();
     state.lastOperation = result;
+    state.result = state.lastOperation.result;
   }
 
   // Return operation
@@ -97,10 +98,7 @@ function getStrategyFromResult<TResult extends BaseResult>(
     throw new Error("Location strategy is not yet implemented");
   }
 
-  // TODO: Should we include here other methods like Patch?
-  if (spec.httpMethod === "PUT") {
-    // We should use BodyPolling strategy
-    // Return BodyPolling Strategy
+  if (["PUT", "PATCH"].includes(spec.httpMethod)) {
     return createBodyPollingStrategy(state);
   }
 

--- a/test/unit/lro/bodyPollingStrategy.spec.ts
+++ b/test/unit/lro/bodyPollingStrategy.spec.ts
@@ -1,0 +1,102 @@
+import { assert } from "chai";
+import { createBodyPollingStrategy } from "../../../src/lro/bodyPollingStrategy";
+import { LastOperation } from "../../../src/lro/models";
+describe("BodyPollingStrategy", () => {
+  const mockSendOperation: any = () => Promise.resolve({});
+  let lastOperation: LastOperation<{}>;
+  beforeEach(() => {
+    lastOperation = {
+      args: {},
+      spec: { httpMethod: "PUT" } as any,
+      result: {}
+    };
+  });
+
+  describe("isTerminal", () => {
+    it("should default to Succeeded and be terminal when no provisioning state was returned", () => {
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      assert.isTrue(pollingStrategy.isTerminal());
+    });
+
+    it("should be terminal state when provisioningState is succeeded", () => {
+      lastOperation.result = { provisioningState: "Succeeded" };
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      assert.isTrue(pollingStrategy.isTerminal());
+    });
+
+    it("should be terminal state when properties.provisioningState is succeeded", () => {
+      lastOperation.result = { properties: { provisioningState: "Succeeded" } };
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      assert.isTrue(pollingStrategy.isTerminal());
+    });
+
+    it("should be terminal state when provisioningState is Failed", () => {
+      lastOperation.result = { provisioningState: "Failed" };
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      assert.isTrue(pollingStrategy.isTerminal());
+    });
+
+    it("should be terminal state when provisioningState is Canceled", () => {
+      lastOperation.result = { provisioningState: "Canceled" };
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      assert.isTrue(pollingStrategy.isTerminal());
+    });
+
+    it("should be not terminal state when provisioningState is not a terminal one", () => {
+      lastOperation.result = { provisioningState: "InProgress" };
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      assert.isFalse(pollingStrategy.isTerminal());
+    });
+  });
+
+  describe("sendFinalRequest", () => {
+    it("should return last operation", async () => {
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      const result = await pollingStrategy.sendFinalRequest();
+      assert.deepEqual(result, lastOperation);
+    });
+  });
+
+  describe("poll", () => {
+    it("should return polling operation with GET http method", async () => {
+      const pollingStrategy = createBodyPollingStrategy({
+        lastOperation,
+        sendOperation: mockSendOperation
+      });
+
+      const result = await pollingStrategy.poll();
+      assert.deepEqual(result.spec, {
+        ...lastOperation.spec,
+        httpMethod: "GET"
+      });
+    });
+  });
+});


### PR DESCRIPTION
Initial implementation of LRO support. This PR includes the outlines for the whole LRO implementation plus the BodyPolling strategy. 

After implementing the rest of the strategies, the plan is to integrate LRO to code generation by including the lro folder in the generated output, and referencing when x-ms-long-running-operation extension is used

Coming up in follow up PRs:
* Azure-AsyncOperation strategy
* Location strategy
* Integrate with Code Generation