### PR TITLE
[v6] Fix parameter equality check

### DIFF
--- a/test/integration/generated/bodyArray/src/models/parameters.ts
+++ b/test/integration/generated/bodyArray/src/models/parameters.ts
@@ -88,7 +88,7 @@ export const arrayBody4: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "Number" } }
+      element: { type: { name: "String" } }
     }
   }
 };
@@ -100,7 +100,9 @@ export const arrayBody5: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "Number" } }
+      element: {
+        type: { name: "Enum", allowedValues: ["foo1", "foo2", "foo3"] }
+      }
     }
   }
 };
@@ -124,9 +126,7 @@ export const arrayBody7: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: {
-        type: { name: "Enum", allowedValues: ["foo1", "foo2", "foo3"] }
-      }
+      element: { type: { name: "Uuid" } }
     }
   }
 };
@@ -138,7 +138,7 @@ export const arrayBody8: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "String" } }
+      element: { type: { name: "Date" } }
     }
   }
 };
@@ -150,7 +150,7 @@ export const arrayBody9: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "Uuid" } }
+      element: { type: { name: "DateTime" } }
     }
   }
 };
@@ -162,7 +162,7 @@ export const arrayBody10: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "Date" } }
+      element: { type: { name: "DateTimeRfc1123" } }
     }
   }
 };
@@ -174,7 +174,7 @@ export const arrayBody11: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "DateTime" } }
+      element: { type: { name: "TimeSpan" } }
     }
   }
 };
@@ -186,7 +186,7 @@ export const arrayBody12: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "DateTimeRfc1123" } }
+      element: { type: { name: "ByteArray" } }
     }
   }
 };
@@ -198,36 +198,12 @@ export const arrayBody13: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Sequence",
-      element: { type: { name: "TimeSpan" } }
-    }
-  }
-};
-
-export const arrayBody14: coreHttp.OperationParameter = {
-  parameterPath: "arrayBody",
-  mapper: {
-    serializedName: "arrayBody",
-    required: true,
-    type: {
-      name: "Sequence",
-      element: { type: { name: "ByteArray" } }
-    }
-  }
-};
-
-export const arrayBody15: coreHttp.OperationParameter = {
-  parameterPath: "arrayBody",
-  mapper: {
-    serializedName: "arrayBody",
-    required: true,
-    type: {
-      name: "Sequence",
       element: { type: { name: "Composite", className: "Product" } }
     }
   }
 };
 
-export const arrayBody16: coreHttp.OperationParameter = {
+export const arrayBody14: coreHttp.OperationParameter = {
   parameterPath: "arrayBody",
   mapper: {
     serializedName: "arrayBody",
@@ -241,7 +217,7 @@ export const arrayBody16: coreHttp.OperationParameter = {
   }
 };
 
-export const arrayBody17: coreHttp.OperationParameter = {
+export const arrayBody15: coreHttp.OperationParameter = {
   parameterPath: "arrayBody",
   mapper: {
     serializedName: "arrayBody",

--- a/test/integration/generated/bodyArray/src/operations/array.ts
+++ b/test/integration/generated/bodyArray/src/operations/array.ts
@@ -1457,7 +1457,7 @@ const putLongValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody3,
+  requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1519,7 +1519,7 @@ const putFloatValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody4,
+  requestBody: Parameters.arrayBody3,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1581,7 +1581,7 @@ const putDoubleValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody5,
+  requestBody: Parameters.arrayBody3,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1643,7 +1643,7 @@ const putStringValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody6,
+  requestBody: Parameters.arrayBody4,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1678,7 +1678,7 @@ const putEnumValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody7,
+  requestBody: Parameters.arrayBody5,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1708,7 +1708,7 @@ const putStringEnumValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody8,
+  requestBody: Parameters.arrayBody6,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1770,7 +1770,7 @@ const putUuidValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody9,
+  requestBody: Parameters.arrayBody7,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1816,7 +1816,7 @@ const putDateValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody10,
+  requestBody: Parameters.arrayBody8,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1878,7 +1878,7 @@ const putDateTimeValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody11,
+  requestBody: Parameters.arrayBody9,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1943,7 +1943,7 @@ const putDateTimeRfc1123ValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody12,
+  requestBody: Parameters.arrayBody10,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1973,7 +1973,7 @@ const putDurationValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody13,
+  requestBody: Parameters.arrayBody11,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2003,7 +2003,7 @@ const putByteValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody14,
+  requestBody: Parameters.arrayBody12,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2144,7 +2144,7 @@ const putComplexValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody15,
+  requestBody: Parameters.arrayBody13,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2263,7 +2263,7 @@ const putArrayValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody16,
+  requestBody: Parameters.arrayBody14,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2382,7 +2382,7 @@ const putDictionaryValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody17,
+  requestBody: Parameters.arrayBody15,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer

--- a/test/integration/generated/bodyDictionary/src/models/parameters.ts
+++ b/test/integration/generated/bodyDictionary/src/models/parameters.ts
@@ -88,7 +88,7 @@ export const arrayBody4: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "Number" } }
+      value: { type: { name: "String" } }
     }
   }
 };
@@ -100,7 +100,7 @@ export const arrayBody5: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "Number" } }
+      value: { type: { name: "Date" } }
     }
   }
 };
@@ -112,7 +112,7 @@ export const arrayBody6: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "String" } }
+      value: { type: { name: "DateTime" } }
     }
   }
 };
@@ -124,7 +124,7 @@ export const arrayBody7: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "Date" } }
+      value: { type: { name: "DateTimeRfc1123" } }
     }
   }
 };
@@ -136,7 +136,7 @@ export const arrayBody8: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "DateTime" } }
+      value: { type: { name: "TimeSpan" } }
     }
   }
 };
@@ -148,7 +148,7 @@ export const arrayBody9: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "DateTimeRfc1123" } }
+      value: { type: { name: "ByteArray" } }
     }
   }
 };
@@ -160,36 +160,12 @@ export const arrayBody10: coreHttp.OperationParameter = {
     required: true,
     type: {
       name: "Dictionary",
-      value: { type: { name: "TimeSpan" } }
-    }
-  }
-};
-
-export const arrayBody11: coreHttp.OperationParameter = {
-  parameterPath: "arrayBody",
-  mapper: {
-    serializedName: "arrayBody",
-    required: true,
-    type: {
-      name: "Dictionary",
-      value: { type: { name: "ByteArray" } }
-    }
-  }
-};
-
-export const arrayBody12: coreHttp.OperationParameter = {
-  parameterPath: "arrayBody",
-  mapper: {
-    serializedName: "arrayBody",
-    required: true,
-    type: {
-      name: "Dictionary",
       value: { type: { name: "Composite", className: "Widget" } }
     }
   }
 };
 
-export const arrayBody13: coreHttp.OperationParameter = {
+export const arrayBody11: coreHttp.OperationParameter = {
   parameterPath: "arrayBody",
   mapper: {
     serializedName: "arrayBody",
@@ -203,7 +179,7 @@ export const arrayBody13: coreHttp.OperationParameter = {
   }
 };
 
-export const arrayBody14: coreHttp.OperationParameter = {
+export const arrayBody12: coreHttp.OperationParameter = {
   parameterPath: "arrayBody",
   mapper: {
     serializedName: "arrayBody",

--- a/test/integration/generated/bodyDictionary/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyDictionary/src/operations/dictionary.ts
@@ -1435,7 +1435,7 @@ const putLongValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody3,
+  requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1497,7 +1497,7 @@ const putFloatValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody4,
+  requestBody: Parameters.arrayBody3,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1559,7 +1559,7 @@ const putDoubleValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody5,
+  requestBody: Parameters.arrayBody3,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1621,7 +1621,7 @@ const putStringValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody6,
+  requestBody: Parameters.arrayBody4,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1683,7 +1683,7 @@ const putDateValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody7,
+  requestBody: Parameters.arrayBody5,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1745,7 +1745,7 @@ const putDateTimeValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody8,
+  requestBody: Parameters.arrayBody6,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1810,7 +1810,7 @@ const putDateTimeRfc1123ValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody9,
+  requestBody: Parameters.arrayBody7,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1840,7 +1840,7 @@ const putDurationValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody10,
+  requestBody: Parameters.arrayBody8,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -1870,7 +1870,7 @@ const putByteValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody11,
+  requestBody: Parameters.arrayBody9,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2011,7 +2011,7 @@ const putComplexValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody12,
+  requestBody: Parameters.arrayBody10,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2130,7 +2130,7 @@ const putArrayValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody13,
+  requestBody: Parameters.arrayBody11,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -2224,7 +2224,7 @@ const putDictionaryValidOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.arrayBody14,
+  requestBody: Parameters.arrayBody12,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer

--- a/test/integration/generated/bodyInteger/src/models/parameters.ts
+++ b/test/integration/generated/bodyInteger/src/models/parameters.ts
@@ -50,17 +50,6 @@ export const intBody1: coreHttp.OperationParameter = {
     serializedName: "intBody",
     required: true,
     type: {
-      name: "Number"
-    }
-  }
-};
-
-export const intBody2: coreHttp.OperationParameter = {
-  parameterPath: "intBody",
-  mapper: {
-    serializedName: "intBody",
-    required: true,
-    type: {
       name: "UnixTime"
     }
   }

--- a/test/integration/generated/bodyInteger/src/operations/int.ts
+++ b/test/integration/generated/bodyInteger/src/operations/int.ts
@@ -379,7 +379,7 @@ const putMax64OperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.intBody1,
+  requestBody: Parameters.intBody,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -407,7 +407,7 @@ const putMin64OperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.intBody1,
+  requestBody: Parameters.intBody,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -435,7 +435,7 @@ const putUnixTimeDateOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.intBody2,
+  requestBody: Parameters.intBody1,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer

--- a/test/integration/generated/bodyNumber/src/models/parameters.ts
+++ b/test/integration/generated/bodyNumber/src/models/parameters.ts
@@ -47,8 +47,9 @@ export const numberBody: coreHttp.OperationParameter = {
 export const numberBody1: coreHttp.OperationParameter = {
   parameterPath: "numberBody",
   mapper: {
+    defaultValue: 99999999.99,
+    isConstant: true,
     serializedName: "numberBody",
-    required: true,
     type: {
       name: "Number"
     }
@@ -56,53 +57,6 @@ export const numberBody1: coreHttp.OperationParameter = {
 };
 
 export const numberBody2: coreHttp.OperationParameter = {
-  parameterPath: "numberBody",
-  mapper: {
-    defaultValue: 99999999.99,
-    isConstant: true,
-    serializedName: "numberBody",
-    type: {
-      name: "Number"
-    }
-  }
-};
-
-export const numberBody3: coreHttp.OperationParameter = {
-  parameterPath: "numberBody",
-  mapper: {
-    defaultValue: -99999999.99,
-    isConstant: true,
-    serializedName: "numberBody",
-    type: {
-      name: "Number"
-    }
-  }
-};
-
-export const numberBody4: coreHttp.OperationParameter = {
-  parameterPath: "numberBody",
-  mapper: {
-    serializedName: "numberBody",
-    required: true,
-    type: {
-      name: "Number"
-    }
-  }
-};
-
-export const numberBody5: coreHttp.OperationParameter = {
-  parameterPath: "numberBody",
-  mapper: {
-    defaultValue: 99999999.99,
-    isConstant: true,
-    serializedName: "numberBody",
-    type: {
-      name: "Number"
-    }
-  }
-};
-
-export const numberBody6: coreHttp.OperationParameter = {
   parameterPath: "numberBody",
   mapper: {
     defaultValue: -99999999.99,

--- a/test/integration/generated/bodyNumber/src/operations/number.ts
+++ b/test/integration/generated/bodyNumber/src/operations/number.ts
@@ -532,7 +532,7 @@ const putBigDoubleOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody1,
+  requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -560,7 +560,7 @@ const putBigDoublePositiveDecimalOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody2,
+  requestBody: Parameters.numberBody1,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -588,7 +588,7 @@ const putBigDoubleNegativeDecimalOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody3,
+  requestBody: Parameters.numberBody2,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -616,7 +616,7 @@ const putBigDecimalOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody4,
+  requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -644,7 +644,7 @@ const putBigDecimalPositiveDecimalOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody5,
+  requestBody: Parameters.numberBody1,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -672,7 +672,7 @@ const putBigDecimalNegativeDecimalOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody6,
+  requestBody: Parameters.numberBody2,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -728,7 +728,7 @@ const putSmallDoubleOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody1,
+  requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer
@@ -756,7 +756,7 @@ const putSmallDecimalOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.numberBody4,
+  requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType],
   serializer

--- a/test/integration/generated/header/src/models/parameters.ts
+++ b/test/integration/generated/header/src/models/parameters.ts
@@ -217,17 +217,6 @@ export const value10: coreHttp.OperationParameter = {
   }
 };
 
-export const scenario5: coreHttp.OperationParameter = {
-  parameterPath: "scenario",
-  mapper: {
-    serializedName: "scenario",
-    required: true,
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const value11: coreHttp.OperationParameter = {
   parameterPath: ["options", "value"],
   mapper: {

--- a/test/integration/generated/header/src/operations/header.ts
+++ b/test/integration/generated/header/src/operations/header.ts
@@ -964,7 +964,7 @@ const paramEnumOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario5, Parameters.value11],
+  headerParameters: [Parameters.scenario2, Parameters.value11],
   serializer
 };
 const responseEnumOperationSpec: coreHttp.OperationSpec = {
@@ -979,7 +979,7 @@ const responseEnumOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.scenario5],
+  headerParameters: [Parameters.scenario2],
   serializer
 };
 const customRequestIdOperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/generated/mediaTypesV3/src/models/parameters.ts
+++ b/test/integration/generated/mediaTypesV3/src/models/parameters.ts
@@ -87,14 +87,3 @@ export const thing: coreHttp.OperationURLParameter = {
     }
   }
 };
-
-export const excluded1: coreHttp.OperationQueryParameter = {
-  parameterPath: ["options", "excluded"],
-  mapper: {
-    serializedName: "excluded",
-    type: {
-      name: "Sequence",
-      element: { type: { name: "String" } }
-    }
-  }
-};

--- a/test/integration/generated/mediaTypesV3/src/operations/fooApi.ts
+++ b/test/integration/generated/mediaTypesV3/src/operations/fooApi.ts
@@ -190,7 +190,7 @@ const postSend$binaryOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   responses: { 202: {}, 400: {} },
   requestBody: Parameters.data,
-  queryParameters: [Parameters.excluded1],
+  queryParameters: [Parameters.excluded],
   urlParameters: [Parameters.$host, Parameters.thing],
   headerParameters: [Parameters.contentType],
   serializer
@@ -200,7 +200,7 @@ const postSend$textOperationSpec: coreHttp.OperationSpec = {
   httpMethod: "POST",
   responses: { 202: {}, 400: {} },
   requestBody: Parameters.data1,
-  queryParameters: [Parameters.excluded1],
+  queryParameters: [Parameters.excluded],
   urlParameters: [Parameters.$host, Parameters.thing],
   headerParameters: [Parameters.contentType1],
   serializer


### PR DESCRIPTION
**Problem:**

Some Swaggers would take for ever to generate. For example Network

This is caused by our parameter equality comparison, which uses lodash deep isEqual. The problem is that our ParameterDetails object contains a reference to the raw parameter which can be quite deep, in these cases deep comparison was taking very very long.

The fix is to exclude the parameter property when checking equality. I decided to include rather than exclude the properties to get more control on what gets compared, if in the future some other property is added to ParameterDetails it wouldn't impact the comparison unless specifically included