### PR TITLE
[v6] Fix duplicate mappers and Response type name collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ More information about these can be found [here](https://github.com/Azure/autore
 ```yaml
 version: 3.0.6258
 use-extension:
-  "@autorest/modelerfour": "4.13.346"
+  "@autorest/modelerfour": "4.13.348"
 
 modelerfour:
   # this runs a pre-namer step to clean up names

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ More information about these can be found [here](https://github.com/Azure/autore
 ```yaml
 version: 3.0.6258
 use-extension:
-  "@autorest/modelerfour": "4.12.301"
+  "@autorest/modelerfour": "4.13.346"
 
 modelerfour:
   # this runs a pre-namer step to clean up names

--- a/src/generators/clientFileGenerator.ts
+++ b/src/generators/clientFileGenerator.ts
@@ -24,6 +24,7 @@ import { ImplementationLocation, SchemaType } from "@azure-tools/codemodel";
 import { OperationGroupDetails } from "../models/operationDetails";
 import { formatJsDocParam } from "./utils/parameterUtils";
 import { shouldImportParameters } from "./utils/importUtils";
+import { getAllModelsNames } from "./utils/responseTypeUtils";
 
 type OperationDeclarationDetails = { name: string; typeName: string };
 
@@ -212,6 +213,7 @@ function writeClientOperations(
   clientDetails: ClientDetails,
   hasLRO: boolean
 ) {
+  const allModelsNames = getAllModelsNames(clientDetails);
   const topLevelGroup = clientDetails.operationGroups.find(og => og.isTopLevel);
   const hasMappers = !!clientDetails.mappers.length;
   // Add top level operation groups as client properties
@@ -226,7 +228,8 @@ function writeClientOperations(
       classDeclaration,
       importedModels,
       clientDetails.parameters,
-      true // isInline
+      allModelsNames,
+      true // isInline,
     );
 
     addOperationSpecs(

--- a/src/generators/utils/responseTypeUtils.ts
+++ b/src/generators/utils/responseTypeUtils.ts
@@ -1,0 +1,34 @@
+import { ClientDetails } from "../../models/clientDetails";
+import { normalizeName, NameType } from "../../utils/nameUtils";
+
+/**
+ * Helper function that gets a set of object model names,
+ * this can be used to check for possible duplicate names
+ * while generating other models
+ */
+export function getAllModelsNames(clientDetails: ClientDetails) {
+  return clientDetails.objects.reduce<Set<string>>((acc, { name }) => {
+    acc.add(name);
+    return acc;
+  }, new Set<string>());
+}
+
+/**
+ * Determines the correct name to use for a response type
+ * taking in consideration the already existing object models
+ * to avoid name collisions
+ * @param responseName The raw response name
+ * @param modelNames Set of existing model names
+ */
+export function getResponseTypeName(
+  responseName: string,
+  modelNames: Set<string>
+) {
+  const operationResponseName = normalizeName(responseName, NameType.Interface);
+
+  let typeName = `${operationResponseName}Response`;
+
+  return modelNames.has(typeName)
+    ? `${operationResponseName}OperationResponse`
+    : typeName;
+}

--- a/test/smoke/generated/msi-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/msi-resource-manager/src/models/index.ts
@@ -24,14 +24,9 @@ export interface Resource {
 }
 
 /**
- * The resource model definition for a ARM proxy resource. It will have everything other than required location and tags
- */
-export type ProxyResource = Resource & {};
-
-/**
  * Describes a system assigned identity resource.
  */
-export type SystemAssignedIdentity = ProxyResource & {
+export type SystemAssignedIdentity = Resource & {
   /**
    * The geo-location where the resource lives
    */
@@ -211,6 +206,11 @@ export type IdentityUpdate = Resource & {
    */
   readonly clientId?: string;
 };
+
+/**
+ * The resource model definition for a ARM proxy resource. It will have everything other than required location and tags
+ */
+export type ProxyResource = Resource & {};
 
 /**
  * Contains response data for the getByScope operation.

--- a/test/smoke/generated/msi-resource-manager/src/models/mappers.ts
+++ b/test/smoke/generated/msi-resource-manager/src/models/mappers.ts
@@ -38,22 +38,12 @@ export const Resource: coreHttp.CompositeMapper = {
   }
 };
 
-export const ProxyResource: coreHttp.CompositeMapper = {
-  type: {
-    name: "Composite",
-    className: "ProxyResource",
-    modelProperties: {
-      ...Resource.type.modelProperties
-    }
-  }
-};
-
 export const SystemAssignedIdentity: coreHttp.CompositeMapper = {
   type: {
     name: "Composite",
     className: "SystemAssignedIdentity",
     modelProperties: {
-      ...ProxyResource.type.modelProperties,
+      ...Resource.type.modelProperties,
       location: {
         serializedName: "location",
         required: true,
@@ -344,6 +334,16 @@ export const IdentityUpdate: coreHttp.CompositeMapper = {
           name: "Uuid"
         }
       }
+    }
+  }
+};
+
+export const ProxyResource: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ProxyResource",
+    modelProperties: {
+      ...Resource.type.modelProperties
     }
   }
 };


### PR DESCRIPTION
While trying to generate Table Storage swagger, I found that the generator has 2 issues:

1. When there are multiple success responses defined, we'd get duplicate mappers. This is similar to the bug fixed on PR #633. The difference is that in this scenario, the response types are defined inline instead of being references ([see here](https://github.com/Azure/azure-rest-api-specs/blob/f5cb6fb416ae0a06329599db9dc17c8fdd7f95c7/specification/cosmos-db/data-plane/Microsoft.TablesStorage/preview/2019-02-02/table.json#L137))

As in the previous fix, if we find an operation with multiple success responses but different mappers we throw an error as we don't  support that scenario yet.

2. There can be collisions between Response type names and properties inside the response. For example this operation is named `Table_Query` which would end up with an autogenerated response type `TableQueryResponse` however it's response's schema ([link](https://github.com/Azure/azure-rest-api-specs/blob/f5cb6fb416ae0a06329599db9dc17c8fdd7f95c7/specification/cosmos-db/data-plane/Microsoft.TablesStorage/preview/2019-02-02/table.json#L103)) is also named `TableQueryResponse`. In this case we end up with a name collision when generation the Response Body type and the Response Type 