### PR TITLE
[v6] Fix missing client imports

### DIFF
--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -41,6 +41,6 @@ steps:
 
   - task: PublishPipelineArtifact@1
     inputs:
-      targetPath: "autorest-typescript-6.0.0-pr.$BUILD_BUILDNUMBER.tgz"
+      targetPath: "autorest-typescript-6.0.0-pr.$(BUILD_BUILDNUMBER).tgz"
       artifact: "packages"
       publishLocation: "pipeline"

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -30,8 +30,7 @@ steps:
   #   displayName: "Run Smoke Tests"
 
   - script: |
-      export DEV_VERSION=$(node -p -e "require('./package.json').version")-dev.$BUILD_BUILDNUMBER
-      npm version --no-git-tag-version $DEV_VERSION
+      npm version --no-git-tag-version 6.0.0-pr.$BUILD_BUILDNUMBER
       npm pack
     displayName: "Npm Pack"
 
@@ -42,6 +41,6 @@ steps:
 
   - task: PublishPipelineArtifact@1
     inputs:
-      targetPath: "autorest-typescript-$DEV_VERSION.tgz"
+      targetPath: "autorest-typescript-6.0.0-pr.$BUILD_BUILDNUMBER.tgz"
       artifact: "packages"
       publishLocation: "pipeline"

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -15,14 +15,14 @@ steps:
       npm run build
     displayName: "Build"
 
-  - script: |
-      npm run test
-      npm run check:tree
-    displayName: "Run Tests"
+  # - script: |
+  #     npm run test
+  #     npm run check:tree
+  #   displayName: "Run Tests"
 
-  - script: |
-      npm run clone:specs
-    displayName: "Clone Specs Repository"
+  # - script: |
+  #     npm run clone:specs
+  #   displayName: "Clone Specs Repository"
 
   # - script: |
   #     npm run smoke-test

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -2,45 +2,34 @@ trigger:
   - v6
 
 pool:
-  vmImage: "ubuntu-latest"
+  vmImage: 'ubuntu-latest'
 
 steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: "10.x"
-    displayName: "Install Node.js"
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.x'
+  displayName: 'Install Node.js'
 
-  - script: |
-      npm install
-      npm run build
-    displayName: "Build"
+- script: |
+    npm install
+    npm run build
+  displayName: 'Build'
 
-  # - script: |
-  #     npm run test
-  #     npm run check:tree
-  #   displayName: "Run Tests"
+- script: |
+    npm run test
+    npm run check:tree
+  displayName: 'Run Tests'
 
-  # - script: |
-  #     npm run clone:specs
-  #   displayName: "Clone Specs Repository"
+- script: |
+    npm run clone:specs
+  displayName: 'Clone Specs Repository'
 
-  # - script: |
-  #     npm run smoke-test
-  #     npm run check:tree
-  #   displayName: "Run Smoke Tests"
+- script: |
+    npm run smoke-test
+    npm run check:tree
+  displayName: 'Run Smoke Tests'
 
-  - script: |
-      npm version --no-git-tag-version 6.0.0-pr.$BUILD_BUILDNUMBER
-      npm pack
-    displayName: "Npm Pack"
-
-  - script: |
-      npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
-    workingDirectory: node_modules/@microsoft.azure/autorest.testserver
-    displayName: "Upload Coverage Report"
-
-  - task: PublishPipelineArtifact@1
-    inputs:
-      targetPath: "autorest-typescript-6.0.0-pr.$(Build.BuildNumber).tgz"
-      artifact: "packages"
-      publishLocation: "pipeline"
+- script: |
+    npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
+  workingDirectory: node_modules/@microsoft.azure/autorest.testserver
+  displayName: 'Upload Coverage Report'

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -2,34 +2,46 @@ trigger:
   - v6
 
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: "ubuntu-latest"
 
 steps:
-- task: NodeTool@0
-  inputs:
-    versionSpec: '10.x'
-  displayName: 'Install Node.js'
+  - task: NodeTool@0
+    inputs:
+      versionSpec: "10.x"
+    displayName: "Install Node.js"
 
-- script: |
-    npm install
-    npm run build
-  displayName: 'Build'
+  - script: |
+      npm install
+      npm run build
+    displayName: "Build"
 
-- script: |
-    npm run test
-    npm run check:tree
-  displayName: 'Run Tests'
+  - script: |
+      npm run test
+      npm run check:tree
+    displayName: "Run Tests"
 
-- script: |
-    npm run clone:specs
-  displayName: 'Clone Specs Repository'
+  - script: |
+      npm run clone:specs
+    displayName: "Clone Specs Repository"
 
-- script: |
-    npm run smoke-test
-    npm run check:tree
-  displayName: 'Run Smoke Tests'
+  # - script: |
+  #     npm run smoke-test
+  #     npm run check:tree
+  #   displayName: "Run Smoke Tests"
 
-- script: |
-    npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
-  workingDirectory: node_modules/@microsoft.azure/autorest.testserver
-  displayName: 'Upload Coverage Report'
+  - script: |
+      export DEV_VERSION=$(node -p -e "require('./package.json').version")-dev.$BUILD_BUILDNUMBER
+      npm version --no-git-tag-version $DEV_VERSION
+      npm pack
+    displayName: "Npm Pack"
+
+  - script: |
+      npm run coverage-push -- $(Build.Repository.Name) $(Build.SourceBranch) $(github-token) $(storage-coverage-user) $(storage-coverage-pass)
+    workingDirectory: node_modules/@microsoft.azure/autorest.testserver
+    displayName: "Upload Coverage Report"
+
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: "autorest-typescript-$DEV_VERSION.tgz"
+      artifact: "packages"
+      publishLocation: "pipeline"

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -41,6 +41,6 @@ steps:
 
   - task: PublishPipelineArtifact@1
     inputs:
-      targetPath: "autorest-typescript-6.0.0-pr.$(BUILD_BUILDNUMBER).tgz"
+      targetPath: "autorest-typescript-6.0.0-pr.$(Build.BuildNumber).tgz"
       artifact: "packages"
       publishLocation: "pipeline"

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -56,7 +56,8 @@ export async function generateTypeScriptLibrary(
   const clientDetails = await transformCodeModel(codeModel, host);
   clientDetails.srcPath = srcPath;
 
-  const packageName = await host.GetValue("package-name");
+  const packageName =
+    (await host.GetValue("package-name")) || clientDetails.name;
   const packageNameParts = packageName.match(/(^@(.*)\/)?(.*)/);
   const packageDetails: PackageDetails = {
     name: packageName,

--- a/src/utils/valueHelpers.ts
+++ b/src/utils/valueHelpers.ts
@@ -53,6 +53,7 @@ export function getStringForValue(
     case SchemaType.String:
     case MapperTypes.String:
     case MapperTypes.TimeSpan:
+    case SchemaType.Choice:
     case "Enum":
       const valueString = !!value ? value.toString() : "";
       return quotedStrings ? `"${valueString}"` : `${valueString}`;

--- a/test/integration/generated/additionalProperties/src/additionalPropertiesClient.ts
+++ b/test/integration/generated/additionalProperties/src/additionalPropertiesClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { AdditionalPropertiesClientContext } from "./additionalPropertiesClientContext";
+import { AdditionalPropertiesClientOptionalParams } from "./models";
 
 class AdditionalPropertiesClient extends AdditionalPropertiesClientContext {
   /**
    * Initializes a new instance of the AdditionalPropertiesClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.AdditionalPropertiesClientOptionalParams) {
+  constructor(options?: AdditionalPropertiesClientOptionalParams) {
     super(options);
     this.pets = new operations.Pets(this);
   }

--- a/test/integration/generated/additionalProperties/src/additionalPropertiesClientContext.ts
+++ b/test/integration/generated/additionalProperties/src/additionalPropertiesClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { AdditionalPropertiesClientOptionalParams } from "./models";
 
 const packageName = "additional-properties";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class AdditionalPropertiesClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the AdditionalPropertiesClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.AdditionalPropertiesClientOptionalParams) {
+  constructor(options?: AdditionalPropertiesClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/azureParameterGrouping/src/azureParameterGroupingClient.ts
+++ b/test/integration/generated/azureParameterGrouping/src/azureParameterGroupingClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { AzureParameterGroupingClientContext } from "./azureParameterGroupingClientContext";
+import { AzureParameterGroupingClientOptionalParams } from "./models";
 
 class AzureParameterGroupingClient extends AzureParameterGroupingClientContext {
   /**
    * Initializes a new instance of the AzureParameterGroupingClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.AzureParameterGroupingClientOptionalParams) {
+  constructor(options?: AzureParameterGroupingClientOptionalParams) {
     super(options);
     this.parameterGrouping = new operations.ParameterGrouping(this);
   }

--- a/test/integration/generated/azureParameterGrouping/src/azureParameterGroupingClientContext.ts
+++ b/test/integration/generated/azureParameterGrouping/src/azureParameterGroupingClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { AzureParameterGroupingClientOptionalParams } from "./models";
 
 const packageName = "azure-parameter-grouping";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class AzureParameterGroupingClientContext extends coreHttp.ServiceClient 
    * Initializes a new instance of the AzureParameterGroupingClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.AzureParameterGroupingClientOptionalParams) {
+  constructor(options?: AzureParameterGroupingClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/azureReport/src/reportClient.ts
+++ b/test/integration/generated/azureReport/src/reportClient.ts
@@ -12,6 +12,7 @@ import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { ReportClientContext } from "./reportClientContext";
 import {
+  ReportClientOptionalParams,
   ReportClientGetReportOptionalParams,
   ReportClientGetReportResponse
 } from "./models";
@@ -21,7 +22,7 @@ class ReportClient extends ReportClientContext {
    * Initializes a new instance of the ReportClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.ReportClientOptionalParams) {
+  constructor(options?: ReportClientOptionalParams) {
     super(options);
   }
 

--- a/test/integration/generated/azureReport/src/reportClientContext.ts
+++ b/test/integration/generated/azureReport/src/reportClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { ReportClientOptionalParams } from "./models";
 
 const packageName = "zzzAzureReport";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class ReportClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the ReportClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.ReportClientOptionalParams) {
+  constructor(options?: ReportClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClient.ts
+++ b/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { AzureSpecialPropertiesClientContext } from "./azureSpecialPropertiesClientContext";
+import { AzureSpecialPropertiesClientOptionalParams } from "./models";
 
 class AzureSpecialPropertiesClient extends AzureSpecialPropertiesClientContext {
   /**
@@ -23,7 +24,7 @@ class AzureSpecialPropertiesClient extends AzureSpecialPropertiesClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.AzureSpecialPropertiesClientOptionalParams
+    options?: AzureSpecialPropertiesClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.xMsClientRequestId = new operations.XMsClientRequestId(this);

--- a/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClientContext.ts
+++ b/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { AzureSpecialPropertiesClientOptionalParams } from "./models";
 
 const packageName = "azure-special-properties";
 const packageVersion = "1.0.0-preview1";
@@ -27,7 +27,7 @@ export class AzureSpecialPropertiesClientContext extends coreHttp.ServiceClient 
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.AzureSpecialPropertiesClientOptionalParams
+    options?: AzureSpecialPropertiesClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/integration/generated/bodyArray/src/bodyArrayClient.ts
+++ b/test/integration/generated/bodyArray/src/bodyArrayClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyArrayClientContext } from "./bodyArrayClientContext";
+import { BodyArrayClientOptionalParams } from "./models";
 
 class BodyArrayClient extends BodyArrayClientContext {
   /**
    * Initializes a new instance of the BodyArrayClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyArrayClientOptionalParams) {
+  constructor(options?: BodyArrayClientOptionalParams) {
     super(options);
     this.array = new operations.Array(this);
   }

--- a/test/integration/generated/bodyArray/src/bodyArrayClientContext.ts
+++ b/test/integration/generated/bodyArray/src/bodyArrayClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyArrayClientOptionalParams } from "./models";
 
 const packageName = "body-array";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyArrayClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyArrayClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyArrayClientOptionalParams) {
+  constructor(options?: BodyArrayClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyBoolean/src/bodyBooleanClient.ts
+++ b/test/integration/generated/bodyBoolean/src/bodyBooleanClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyBooleanClientContext } from "./bodyBooleanClientContext";
+import { BodyBooleanClientOptionalParams } from "./models";
 
 class BodyBooleanClient extends BodyBooleanClientContext {
   /**
    * Initializes a new instance of the BodyBooleanClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyBooleanClientOptionalParams) {
+  constructor(options?: BodyBooleanClientOptionalParams) {
     super(options);
     this.bool = new operations.Bool(this);
   }

--- a/test/integration/generated/bodyBoolean/src/bodyBooleanClientContext.ts
+++ b/test/integration/generated/bodyBoolean/src/bodyBooleanClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyBooleanClientOptionalParams } from "./models";
 
 const packageName = "body-boolean";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyBooleanClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyBooleanClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyBooleanClientOptionalParams) {
+  constructor(options?: BodyBooleanClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyBooleanQuirks/src/bodyBooleanQuirksClient.ts
+++ b/test/integration/generated/bodyBooleanQuirks/src/bodyBooleanQuirksClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyBooleanQuirksClientContext } from "./bodyBooleanQuirksClientContext";
+import { BodyBooleanQuirksClientOptionalParams } from "./models";
 
 class BodyBooleanQuirksClient extends BodyBooleanQuirksClientContext {
   /**
    * Initializes a new instance of the BodyBooleanQuirksClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyBooleanQuirksClientOptionalParams) {
+  constructor(options?: BodyBooleanQuirksClientOptionalParams) {
     super(options);
     this.bool = new operations.Bool(this);
   }

--- a/test/integration/generated/bodyBooleanQuirks/src/bodyBooleanQuirksClientContext.ts
+++ b/test/integration/generated/bodyBooleanQuirks/src/bodyBooleanQuirksClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyBooleanQuirksClientOptionalParams } from "./models";
 
 const packageName = "body-boolean-quirks";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyBooleanQuirksClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyBooleanQuirksClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyBooleanQuirksClientOptionalParams) {
+  constructor(options?: BodyBooleanQuirksClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyByte/src/bodyByteClient.ts
+++ b/test/integration/generated/bodyByte/src/bodyByteClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyByteClientContext } from "./bodyByteClientContext";
+import { BodyByteClientOptionalParams } from "./models";
 
 class BodyByteClient extends BodyByteClientContext {
   /**
    * Initializes a new instance of the BodyByteClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyByteClientOptionalParams) {
+  constructor(options?: BodyByteClientOptionalParams) {
     super(options);
     this.byte = new operations.Byte(this);
   }

--- a/test/integration/generated/bodyByte/src/bodyByteClientContext.ts
+++ b/test/integration/generated/bodyByte/src/bodyByteClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyByteClientOptionalParams } from "./models";
 
 const packageName = "body-byte";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyByteClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyByteClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyByteClientOptionalParams) {
+  constructor(options?: BodyByteClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyComplexClientContext } from "./bodyComplexClientContext";
+import { BodyComplexClientOptionalParams } from "./models";
 
 class BodyComplexClient extends BodyComplexClientContext {
   /**
    * Initializes a new instance of the BodyComplexClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyComplexClientOptionalParams) {
+  constructor(options?: BodyComplexClientOptionalParams) {
     super(options);
     this.basic = new operations.Basic(this);
     this.primitive = new operations.Primitive(this);

--- a/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyComplexClientOptionalParams } from "./models";
 
 const packageName = "body-complex";
 const packageVersion = "1.0.0-preview1";
@@ -20,7 +20,7 @@ export class BodyComplexClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyComplexClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyComplexClientOptionalParams) {
+  constructor(options?: BodyComplexClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyDate/src/bodyDateClient.ts
+++ b/test/integration/generated/bodyDate/src/bodyDateClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyDateClientContext } from "./bodyDateClientContext";
+import { BodyDateClientOptionalParams } from "./models";
 
 class BodyDateClient extends BodyDateClientContext {
   /**
    * Initializes a new instance of the BodyDateClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDateClientOptionalParams) {
+  constructor(options?: BodyDateClientOptionalParams) {
     super(options);
     this.date = new operations.DateOperations(this);
   }

--- a/test/integration/generated/bodyDate/src/bodyDateClientContext.ts
+++ b/test/integration/generated/bodyDate/src/bodyDateClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyDateClientOptionalParams } from "./models";
 
 const packageName = "body-date";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyDateClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyDateClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDateClientOptionalParams) {
+  constructor(options?: BodyDateClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyDateTime/src/bodyDateTimeClient.ts
+++ b/test/integration/generated/bodyDateTime/src/bodyDateTimeClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyDateTimeClientContext } from "./bodyDateTimeClientContext";
+import { BodyDateTimeClientOptionalParams } from "./models";
 
 class BodyDateTimeClient extends BodyDateTimeClientContext {
   /**
    * Initializes a new instance of the BodyDateTimeClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDateTimeClientOptionalParams) {
+  constructor(options?: BodyDateTimeClientOptionalParams) {
     super(options);
     this.datetime = new operations.Datetime(this);
   }

--- a/test/integration/generated/bodyDateTime/src/bodyDateTimeClientContext.ts
+++ b/test/integration/generated/bodyDateTime/src/bodyDateTimeClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyDateTimeClientOptionalParams } from "./models";
 
 const packageName = "body-datetime";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyDateTimeClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyDateTimeClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDateTimeClientOptionalParams) {
+  constructor(options?: BodyDateTimeClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyDateTimeRfc1123/src/bodyDateTimeRfc1123Client.ts
+++ b/test/integration/generated/bodyDateTimeRfc1123/src/bodyDateTimeRfc1123Client.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyDateTimeRfc1123ClientContext } from "./bodyDateTimeRfc1123ClientContext";
+import { BodyDateTimeRfc1123ClientOptionalParams } from "./models";
 
 class BodyDateTimeRfc1123Client extends BodyDateTimeRfc1123ClientContext {
   /**
    * Initializes a new instance of the BodyDateTimeRfc1123Client class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDateTimeRfc1123ClientOptionalParams) {
+  constructor(options?: BodyDateTimeRfc1123ClientOptionalParams) {
     super(options);
     this.datetimerfc1123 = new operations.Datetimerfc1123(this);
   }

--- a/test/integration/generated/bodyDateTimeRfc1123/src/bodyDateTimeRfc1123ClientContext.ts
+++ b/test/integration/generated/bodyDateTimeRfc1123/src/bodyDateTimeRfc1123ClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyDateTimeRfc1123ClientOptionalParams } from "./models";
 
 const packageName = "body-datetime-rfc1123";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyDateTimeRfc1123ClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyDateTimeRfc1123ClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDateTimeRfc1123ClientOptionalParams) {
+  constructor(options?: BodyDateTimeRfc1123ClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyDictionary/src/bodyDictionaryClient.ts
+++ b/test/integration/generated/bodyDictionary/src/bodyDictionaryClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyDictionaryClientContext } from "./bodyDictionaryClientContext";
+import { BodyDictionaryClientOptionalParams } from "./models";
 
 class BodyDictionaryClient extends BodyDictionaryClientContext {
   /**
    * Initializes a new instance of the BodyDictionaryClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDictionaryClientOptionalParams) {
+  constructor(options?: BodyDictionaryClientOptionalParams) {
     super(options);
     this.dictionary = new operations.Dictionary(this);
   }

--- a/test/integration/generated/bodyDictionary/src/bodyDictionaryClientContext.ts
+++ b/test/integration/generated/bodyDictionary/src/bodyDictionaryClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyDictionaryClientOptionalParams } from "./models";
 
 const packageName = "body-dictionary";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyDictionaryClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyDictionaryClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDictionaryClientOptionalParams) {
+  constructor(options?: BodyDictionaryClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyDuration/src/bodyDurationClient.ts
+++ b/test/integration/generated/bodyDuration/src/bodyDurationClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyDurationClientContext } from "./bodyDurationClientContext";
+import { BodyDurationClientOptionalParams } from "./models";
 
 class BodyDurationClient extends BodyDurationClientContext {
   /**
    * Initializes a new instance of the BodyDurationClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDurationClientOptionalParams) {
+  constructor(options?: BodyDurationClientOptionalParams) {
     super(options);
     this.duration = new operations.Duration(this);
   }

--- a/test/integration/generated/bodyDuration/src/bodyDurationClientContext.ts
+++ b/test/integration/generated/bodyDuration/src/bodyDurationClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyDurationClientOptionalParams } from "./models";
 
 const packageName = "body-duration";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyDurationClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyDurationClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyDurationClientOptionalParams) {
+  constructor(options?: BodyDurationClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyInteger/src/bodyIntegerClient.ts
+++ b/test/integration/generated/bodyInteger/src/bodyIntegerClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyIntegerClientContext } from "./bodyIntegerClientContext";
+import { BodyIntegerClientOptionalParams } from "./models";
 
 class BodyIntegerClient extends BodyIntegerClientContext {
   /**
    * Initializes a new instance of the BodyIntegerClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyIntegerClientOptionalParams) {
+  constructor(options?: BodyIntegerClientOptionalParams) {
     super(options);
     this.int = new operations.Int(this);
   }

--- a/test/integration/generated/bodyInteger/src/bodyIntegerClientContext.ts
+++ b/test/integration/generated/bodyInteger/src/bodyIntegerClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyIntegerClientOptionalParams } from "./models";
 
 const packageName = "body-integer";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyIntegerClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyIntegerClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyIntegerClientOptionalParams) {
+  constructor(options?: BodyIntegerClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyNumber/src/bodyNumberClient.ts
+++ b/test/integration/generated/bodyNumber/src/bodyNumberClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyNumberClientContext } from "./bodyNumberClientContext";
+import { BodyNumberClientOptionalParams } from "./models";
 
 class BodyNumberClient extends BodyNumberClientContext {
   /**
    * Initializes a new instance of the BodyNumberClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyNumberClientOptionalParams) {
+  constructor(options?: BodyNumberClientOptionalParams) {
     super(options);
     this.number = new operations.NumberOperations(this);
   }

--- a/test/integration/generated/bodyNumber/src/bodyNumberClientContext.ts
+++ b/test/integration/generated/bodyNumber/src/bodyNumberClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyNumberClientOptionalParams } from "./models";
 
 const packageName = "body-number";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyNumberClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyNumberClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyNumberClientOptionalParams) {
+  constructor(options?: BodyNumberClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyString/src/bodyStringClient.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyStringClientContext } from "./bodyStringClientContext";
+import { BodyStringClientOptionalParams } from "./models";
 
 class BodyStringClient extends BodyStringClientContext {
   /**
    * Initializes a new instance of the BodyStringClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyStringClientOptionalParams) {
+  constructor(options?: BodyStringClientOptionalParams) {
     super(options);
     this.string = new operations.StringOperations(this);
     this.enum = new operations.Enum(this);

--- a/test/integration/generated/bodyString/src/bodyStringClientContext.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyStringClientOptionalParams } from "./models";
 
 const packageName = "body-string";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyStringClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyStringClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyStringClientOptionalParams) {
+  constructor(options?: BodyStringClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/bodyTime/src/bodyTimeClient.ts
+++ b/test/integration/generated/bodyTime/src/bodyTimeClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { BodyTimeClientContext } from "./bodyTimeClientContext";
+import { BodyTimeClientOptionalParams } from "./models";
 
 class BodyTimeClient extends BodyTimeClientContext {
   /**
    * Initializes a new instance of the BodyTimeClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyTimeClientOptionalParams) {
+  constructor(options?: BodyTimeClientOptionalParams) {
     super(options);
     this.time = new operations.Time(this);
   }

--- a/test/integration/generated/bodyTime/src/bodyTimeClientContext.ts
+++ b/test/integration/generated/bodyTime/src/bodyTimeClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { BodyTimeClientOptionalParams } from "./models";
 
 const packageName = "body-time";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class BodyTimeClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the BodyTimeClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.BodyTimeClientOptionalParams) {
+  constructor(options?: BodyTimeClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/customUrl/src/customUrlClient.ts
+++ b/test/integration/generated/customUrl/src/customUrlClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { CustomUrlClientContext } from "./customUrlClientContext";
+import { CustomUrlClientOptionalParams } from "./models";
 
 class CustomUrlClient extends CustomUrlClientContext {
   /**
    * Initializes a new instance of the CustomUrlClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.CustomUrlClientOptionalParams) {
+  constructor(options?: CustomUrlClientOptionalParams) {
     super(options);
     this.paths = new operations.Paths(this);
   }

--- a/test/integration/generated/customUrl/src/customUrlClientContext.ts
+++ b/test/integration/generated/customUrl/src/customUrlClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { CustomUrlClientOptionalParams } from "./models";
 
 const packageName = "custom-url";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class CustomUrlClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the CustomUrlClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.CustomUrlClientOptionalParams) {
+  constructor(options?: CustomUrlClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/header/src/headerClient.ts
+++ b/test/integration/generated/header/src/headerClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { HeaderClientContext } from "./headerClientContext";
+import { HeaderClientOptionalParams } from "./models";
 
 class HeaderClient extends HeaderClientContext {
   /**
    * Initializes a new instance of the HeaderClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.HeaderClientOptionalParams) {
+  constructor(options?: HeaderClientOptionalParams) {
     super(options);
     this.header = new operations.Header(this);
   }

--- a/test/integration/generated/header/src/headerClientContext.ts
+++ b/test/integration/generated/header/src/headerClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { HeaderClientOptionalParams } from "./models";
 
 const packageName = "header";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class HeaderClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the HeaderClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.HeaderClientOptionalParams) {
+  constructor(options?: HeaderClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/lro/src/lROClient.ts
+++ b/test/integration/generated/lro/src/lROClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { LROClientContext } from "./lROClientContext";
+import { LROClientOptionalParams } from "./models";
 
 class LROClient extends LROClientContext {
   /**
    * Initializes a new instance of the LROClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.LROClientOptionalParams) {
+  constructor(options?: LROClientOptionalParams) {
     super(options);
     this.lROs = new operations.LROs(this);
     this.lRORetrys = new operations.LRORetrys(this);

--- a/test/integration/generated/lro/src/lROClientContext.ts
+++ b/test/integration/generated/lro/src/lROClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { LROClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "lro";
@@ -20,7 +20,7 @@ export class LROClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the LROClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.LROClientOptionalParams) {
+  constructor(options?: LROClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/mediaTypes/src/mediaTypesClient.ts
+++ b/test/integration/generated/mediaTypes/src/mediaTypesClient.ts
@@ -12,6 +12,7 @@ import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { MediaTypesClientContext } from "./mediaTypesClientContext";
 import {
+  MediaTypesClientOptionalParams,
   ContentType,
   MediaTypesClientAnalyzeBody$binaryOptionalParams,
   MediaTypesClientAnalyzeBody$jsonOptionalParams,
@@ -23,7 +24,7 @@ class MediaTypesClient extends MediaTypesClientContext {
    * Initializes a new instance of the MediaTypesClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.MediaTypesClientOptionalParams) {
+  constructor(options?: MediaTypesClientOptionalParams) {
     super(options);
   }
 

--- a/test/integration/generated/mediaTypes/src/mediaTypesClientContext.ts
+++ b/test/integration/generated/mediaTypes/src/mediaTypesClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { MediaTypesClientOptionalParams } from "./models";
 
 const packageName = "media-types-service";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class MediaTypesClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the MediaTypesClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.MediaTypesClientOptionalParams) {
+  constructor(options?: MediaTypesClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/mediaTypesV3/src/mediaTypesV3Client.ts
+++ b/test/integration/generated/mediaTypesV3/src/mediaTypesV3Client.ts
@@ -9,6 +9,7 @@
 import * as operations from "./operations";
 import * as Models from "./models";
 import { MediaTypesV3ClientContext } from "./mediaTypesV3ClientContext";
+import { MediaTypesV3ClientOptionalParams } from "./models";
 
 class MediaTypesV3Client extends MediaTypesV3ClientContext {
   /**
@@ -16,10 +17,7 @@ class MediaTypesV3Client extends MediaTypesV3ClientContext {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor(
-    $host: string,
-    options?: Models.MediaTypesV3ClientOptionalParams
-  ) {
+  constructor($host: string, options?: MediaTypesV3ClientOptionalParams) {
     super($host, options);
     this.fooApi = new operations.FooApi(this);
   }

--- a/test/integration/generated/mediaTypesV3/src/mediaTypesV3ClientContext.ts
+++ b/test/integration/generated/mediaTypesV3/src/mediaTypesV3ClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { MediaTypesV3ClientOptionalParams } from "./models";
 
 const packageName = "media-types-v3-client";
 const packageVersion = "1.0.0-preview1";
@@ -20,10 +20,7 @@ export class MediaTypesV3ClientContext extends coreHttp.ServiceClient {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor(
-    $host: string,
-    options?: Models.MediaTypesV3ClientOptionalParams
-  ) {
+  constructor($host: string, options?: MediaTypesV3ClientOptionalParams) {
     if ($host === undefined) {
       throw new Error("'$host' cannot be null");
     }

--- a/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClient.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClient.ts
@@ -12,6 +12,7 @@ import * as Parameters from "./models/parameters";
 import * as Models from "./models";
 import { MediaTypesV3LROClientContext } from "./mediaTypesV3LROClientContext";
 import {
+  MediaTypesV3LROClientOptionalParams,
   MediaTypesV3LROClientSendOnDefault$binaryOptionalParams,
   MediaTypesV3LROClientSendOnDefault$textOptionalParams,
   MediaTypesV3LROClientSend$binaryOptionalParams,
@@ -24,10 +25,7 @@ class MediaTypesV3LROClient extends MediaTypesV3LROClientContext {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor(
-    $host: string,
-    options?: Models.MediaTypesV3LROClientOptionalParams
-  ) {
+  constructor($host: string, options?: MediaTypesV3LROClientOptionalParams) {
     super($host, options);
   }
 

--- a/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { MediaTypesV3LROClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "media-types-v3-lro-client";
@@ -21,10 +21,7 @@ export class MediaTypesV3LROClientContext extends coreHttp.ServiceClient {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor(
-    $host: string,
-    options?: Models.MediaTypesV3LROClientOptionalParams
-  ) {
+  constructor($host: string, options?: MediaTypesV3LROClientOptionalParams) {
     if ($host === undefined) {
       throw new Error("'$host' cannot be null");
     }

--- a/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
+++ b/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
@@ -12,6 +12,7 @@ import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { ModelFlatteningClientContext } from "./modelFlatteningClientContext";
 import {
+  ModelFlatteningClientOptionalParams,
   ModelFlatteningClientPutArrayOptionalParams,
   ModelFlatteningClientGetArrayResponse,
   ModelFlatteningClientPutWrappedArrayOptionalParams,
@@ -33,7 +34,7 @@ class ModelFlatteningClient extends ModelFlatteningClientContext {
    * Initializes a new instance of the ModelFlatteningClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.ModelFlatteningClientOptionalParams) {
+  constructor(options?: ModelFlatteningClientOptionalParams) {
     super(options);
   }
 

--- a/test/integration/generated/modelFlattening/src/modelFlatteningClientContext.ts
+++ b/test/integration/generated/modelFlattening/src/modelFlatteningClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { ModelFlatteningClientOptionalParams } from "./models";
 
 const packageName = "model-flattening";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class ModelFlatteningClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the ModelFlatteningClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.ModelFlatteningClientOptionalParams) {
+  constructor(options?: ModelFlatteningClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/noMappers/src/models/index.ts
+++ b/test/integration/generated/noMappers/src/models/index.ts
@@ -9,6 +9,11 @@
 import * as coreHttp from "@azure/core-http";
 
 /**
+ * Defines values for Enum0.
+ */
+export type Enum0 = "one" | "two";
+
+/**
  * Contains response data for the apiV1ValueGet operation.
  */
 export type NoMappersClientApiV1ValueGetResponse = {

--- a/test/integration/generated/noMappers/src/models/parameters.ts
+++ b/test/integration/generated/noMappers/src/models/parameters.ts
@@ -19,3 +19,14 @@ export const $host: coreHttp.OperationURLParameter = {
   },
   skipEncoding: true
 };
+
+export const apiVersion: coreHttp.OperationParameter = {
+  parameterPath: "apiVersion",
+  mapper: {
+    serializedName: "api-version",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};

--- a/test/integration/generated/noMappers/src/noMappersClient.ts
+++ b/test/integration/generated/noMappers/src/noMappersClient.ts
@@ -12,6 +12,7 @@ import * as Models from "./models";
 import { NoMappersClientContext } from "./noMappersClientContext";
 import {
   NoMappersClientOptionalParams,
+  Enum0,
   NoMappersClientApiV1ValueGetResponse
 } from "./models";
 
@@ -19,10 +20,15 @@ class NoMappersClient extends NoMappersClientContext {
   /**
    * Initializes a new instance of the NoMappersClient class.
    * @param $host server parameter
+   * @param apiVersion
    * @param options The parameter options
    */
-  constructor($host: string, options?: NoMappersClientOptionalParams) {
-    super($host, options);
+  constructor(
+    $host: string,
+    apiVersion: Enum0,
+    options?: NoMappersClientOptionalParams
+  ) {
+    super($host, apiVersion, options);
   }
 
   /**
@@ -53,6 +59,7 @@ const apiV1ValueGetOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
+  headerParameters: [Parameters.apiVersion],
   serializer
 };
 

--- a/test/integration/generated/noMappers/src/noMappersClient.ts
+++ b/test/integration/generated/noMappers/src/noMappersClient.ts
@@ -10,7 +10,10 @@ import * as coreHttp from "@azure/core-http";
 import * as Parameters from "./models/parameters";
 import * as Models from "./models";
 import { NoMappersClientContext } from "./noMappersClientContext";
-import { NoMappersClientApiV1ValueGetResponse } from "./models";
+import {
+  NoMappersClientOptionalParams,
+  NoMappersClientApiV1ValueGetResponse
+} from "./models";
 
 class NoMappersClient extends NoMappersClientContext {
   /**
@@ -18,7 +21,7 @@ class NoMappersClient extends NoMappersClientContext {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor($host: string, options?: Models.NoMappersClientOptionalParams) {
+  constructor($host: string, options?: NoMappersClientOptionalParams) {
     super($host, options);
   }
 

--- a/test/integration/generated/noMappers/src/noMappersClientContext.ts
+++ b/test/integration/generated/noMappers/src/noMappersClientContext.ts
@@ -7,22 +7,31 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import { NoMappersClientOptionalParams } from "./models";
+import { Enum0, NoMappersClientOptionalParams } from "./models";
 
 const packageName = "no-mappers";
 const packageVersion = "1.0.0-preview1";
 
 export class NoMappersClientContext extends coreHttp.ServiceClient {
   $host: string;
+  apiVersion: Enum0;
 
   /**
    * Initializes a new instance of the NoMappersClientContext class.
    * @param $host server parameter
+   * @param apiVersion
    * @param options The parameter options
    */
-  constructor($host: string, options?: NoMappersClientOptionalParams) {
+  constructor(
+    $host: string,
+    apiVersion: Enum0,
+    options?: NoMappersClientOptionalParams
+  ) {
     if ($host === undefined) {
       throw new Error("'$host' cannot be null");
+    }
+    if (apiVersion === undefined) {
+      throw new Error("'apiVersion' cannot be null");
     }
 
     // Initializing default values for options
@@ -43,5 +52,6 @@ export class NoMappersClientContext extends coreHttp.ServiceClient {
 
     // Parameter assignments
     this.$host = $host;
+    this.apiVersion = apiVersion;
   }
 }

--- a/test/integration/generated/noMappers/src/noMappersClientContext.ts
+++ b/test/integration/generated/noMappers/src/noMappersClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { NoMappersClientOptionalParams } from "./models";
 
 const packageName = "no-mappers";
 const packageVersion = "1.0.0-preview1";
@@ -20,7 +20,7 @@ export class NoMappersClientContext extends coreHttp.ServiceClient {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor($host: string, options?: Models.NoMappersClientOptionalParams) {
+  constructor($host: string, options?: NoMappersClientOptionalParams) {
     if ($host === undefined) {
       throw new Error("'$host' cannot be null");
     }

--- a/test/integration/generated/paging/src/pagingClient.ts
+++ b/test/integration/generated/paging/src/pagingClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { PagingClientContext } from "./pagingClientContext";
+import { PagingClientOptionalParams } from "./models";
 
 class PagingClient extends PagingClientContext {
   /**
    * Initializes a new instance of the PagingClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.PagingClientOptionalParams) {
+  constructor(options?: PagingClientOptionalParams) {
     super(options);
     this.paging = new operations.Paging(this);
   }

--- a/test/integration/generated/paging/src/pagingClientContext.ts
+++ b/test/integration/generated/paging/src/pagingClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { PagingClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "paging-service";
@@ -20,7 +20,7 @@ export class PagingClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the PagingClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.PagingClientOptionalParams) {
+  constructor(options?: PagingClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/regexConstraint/src/regexConstraint.ts
+++ b/test/integration/generated/regexConstraint/src/regexConstraint.ts
@@ -10,7 +10,10 @@ import * as coreHttp from "@azure/core-http";
 import * as Parameters from "./models/parameters";
 import * as Models from "./models";
 import { RegexConstraintContext } from "./regexConstraintContext";
-import { RegexConstraintApiV1ValueGetResponse } from "./models";
+import {
+  RegexConstraintOptionalParams,
+  RegexConstraintApiV1ValueGetResponse
+} from "./models";
 
 class RegexConstraint extends RegexConstraintContext {
   /**
@@ -18,7 +21,7 @@ class RegexConstraint extends RegexConstraintContext {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor($host: string, options?: Models.RegexConstraintOptionalParams) {
+  constructor($host: string, options?: RegexConstraintOptionalParams) {
     super($host, options);
   }
 

--- a/test/integration/generated/regexConstraint/src/regexConstraintContext.ts
+++ b/test/integration/generated/regexConstraint/src/regexConstraintContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { RegexConstraintOptionalParams } from "./models";
 
 const packageName = "regex-constraint";
 const packageVersion = "1.0.0-preview1";
@@ -20,7 +20,7 @@ export class RegexConstraintContext extends coreHttp.ServiceClient {
    * @param $host server parameter
    * @param options The parameter options
    */
-  constructor($host: string, options?: Models.RegexConstraintOptionalParams) {
+  constructor($host: string, options?: RegexConstraintOptionalParams) {
     if ($host === undefined) {
       throw new Error("'$host' cannot be null");
     }

--- a/test/integration/generated/report/src/reportClient.ts
+++ b/test/integration/generated/report/src/reportClient.ts
@@ -12,6 +12,7 @@ import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { ReportClientContext } from "./reportClientContext";
 import {
+  ReportClientOptionalParams,
   ReportClientGetReportOptionalParams,
   ReportClientGetReportResponse,
   ReportClientGetOptionalReportOptionalParams,
@@ -23,7 +24,7 @@ class ReportClient extends ReportClientContext {
    * Initializes a new instance of the ReportClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.ReportClientOptionalParams) {
+  constructor(options?: ReportClientOptionalParams) {
     super(options);
   }
 

--- a/test/integration/generated/report/src/reportClientContext.ts
+++ b/test/integration/generated/report/src/reportClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { ReportClientOptionalParams } from "./models";
 
 const packageName = "zzzReport";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class ReportClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the ReportClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.ReportClientOptionalParams) {
+  constructor(options?: ReportClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/generated/url/src/urlClient.ts
+++ b/test/integration/generated/url/src/urlClient.ts
@@ -10,6 +10,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { UrlClientContext } from "./urlClientContext";
+import { UrlClientOptionalParams } from "./models";
 
 class UrlClient extends UrlClientContext {
   /**
@@ -17,10 +18,7 @@ class UrlClient extends UrlClientContext {
    * @param globalStringPath A string value 'globalItemStringPath' that appears in the path
    * @param options The parameter options
    */
-  constructor(
-    globalStringPath: string,
-    options?: Models.UrlClientOptionalParams
-  ) {
+  constructor(globalStringPath: string, options?: UrlClientOptionalParams) {
     super(globalStringPath, options);
     this.paths = new operations.Paths(this);
     this.queries = new operations.Queries(this);

--- a/test/integration/generated/url/src/urlClientContext.ts
+++ b/test/integration/generated/url/src/urlClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { UrlClientOptionalParams } from "./models";
 
 const packageName = "url";
 const packageVersion = "1.0.0-preview1";
@@ -22,10 +22,7 @@ export class UrlClientContext extends coreHttp.ServiceClient {
    * @param globalStringPath A string value 'globalItemStringPath' that appears in the path
    * @param options The parameter options
    */
-  constructor(
-    globalStringPath: string,
-    options?: Models.UrlClientOptionalParams
-  ) {
+  constructor(globalStringPath: string, options?: UrlClientOptionalParams) {
     if (globalStringPath === undefined) {
       throw new Error("'globalStringPath' cannot be null");
     }

--- a/test/integration/generated/xmlservice/src/xmlServiceClient.ts
+++ b/test/integration/generated/xmlservice/src/xmlServiceClient.ts
@@ -10,13 +10,14 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { XmlServiceClientContext } from "./xmlServiceClientContext";
+import { XmlServiceClientOptionalParams } from "./models";
 
 class XmlServiceClient extends XmlServiceClientContext {
   /**
    * Initializes a new instance of the XmlServiceClient class.
    * @param options The parameter options
    */
-  constructor(options?: Models.XmlServiceClientOptionalParams) {
+  constructor(options?: XmlServiceClientOptionalParams) {
     super(options);
     this.xml = new operations.Xml(this);
   }

--- a/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
+++ b/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { XmlServiceClientOptionalParams } from "./models";
 
 const packageName = "xml-service";
 const packageVersion = "1.0.0-preview1";
@@ -19,7 +19,7 @@ export class XmlServiceClientContext extends coreHttp.ServiceClient {
    * Initializes a new instance of the XmlServiceClientContext class.
    * @param options The parameter options
    */
-  constructor(options?: Models.XmlServiceClientOptionalParams) {
+  constructor(options?: XmlServiceClientOptionalParams) {
     // Initializing default values for options
     if (!options) {
       options = {};

--- a/test/integration/swaggers/no-mappers.json
+++ b/test/integration/swaggers/no-mappers.json
@@ -1,8 +1,22 @@
 {
   "swagger": "2.0",
   "info": { "version": "v1", "title": "My API" },
+  "parameters": {
+    "globalApiVersion": {
+      "name": "api-version",
+      "in": "header",
+      "type": "string",
+      "enum": ["one", "two"],
+      "required": true
+    }
+  },
   "paths": {
     "/api/v1/value": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/globalApiVersion"
+        }
+      ],
       "get": {
         "tags": ["ValueApi"],
         "operationId": "ApiV1ValueGet",

--- a/test/smoke/generated/adhybridhealthservice-resource-manager/src/aDHybridHealthService.ts
+++ b/test/smoke/generated/adhybridhealthservice-resource-manager/src/aDHybridHealthService.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { ADHybridHealthServiceContext } from "./aDHybridHealthServiceContext";
+import { ADHybridHealthServiceOptionalParams } from "./models";
 
 class ADHybridHealthService extends ADHybridHealthServiceContext {
   /**
@@ -20,7 +21,7 @@ class ADHybridHealthService extends ADHybridHealthServiceContext {
    */
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    options?: Models.ADHybridHealthServiceOptionalParams
+    options?: ADHybridHealthServiceOptionalParams
   ) {
     super(credentials, options);
     this.addsServices = new operations.AddsServices(this);

--- a/test/smoke/generated/adhybridhealthservice-resource-manager/src/aDHybridHealthServiceContext.ts
+++ b/test/smoke/generated/adhybridhealthservice-resource-manager/src/aDHybridHealthServiceContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { ADHybridHealthServiceOptionalParams } from "./models";
 
 const packageName = "adhybridhealthservice-resource-manager";
 const packageVersion = "1.0.0";
@@ -23,7 +23,7 @@ export class ADHybridHealthServiceContext extends coreHttp.ServiceClient {
    */
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    options?: Models.ADHybridHealthServiceOptionalParams
+    options?: ADHybridHealthServiceOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/compute-resource-manager/src/computeManagementClient.ts
+++ b/test/smoke/generated/compute-resource-manager/src/computeManagementClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { ComputeManagementClientContext } from "./computeManagementClientContext";
+import { ComputeManagementClientOptionalParams } from "./models";
 
 class ComputeManagementClient extends ComputeManagementClientContext {
   /**
@@ -23,7 +24,7 @@ class ComputeManagementClient extends ComputeManagementClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.ComputeManagementClientOptionalParams
+    options?: ComputeManagementClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.operations = new operations.Operations(this);

--- a/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
+++ b/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { ComputeManagementClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "compute-resource-manager";
@@ -27,7 +27,7 @@ export class ComputeManagementClientContext extends coreHttp.ServiceClient {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.ComputeManagementClientOptionalParams
+    options?: ComputeManagementClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { CosmosDBManagementClientContext } from "./cosmosDBManagementClientContext";
+import { CosmosDBManagementClientOptionalParams } from "./models";
 
 class CosmosDBManagementClient extends CosmosDBManagementClientContext {
   /**
@@ -22,7 +23,7 @@ class CosmosDBManagementClient extends CosmosDBManagementClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.CosmosDBManagementClientOptionalParams
+    options?: CosmosDBManagementClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.databaseAccounts = new operations.DatabaseAccounts(this);

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { CosmosDBManagementClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "cosmos-db-resource-manager";
@@ -26,7 +26,7 @@ export class CosmosDBManagementClientContext extends coreHttp.ServiceClient {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.CosmosDBManagementClientOptionalParams
+    options?: CosmosDBManagementClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { GraphRbacManagementClientContext } from "./graphRbacManagementClientContext";
+import { GraphRbacManagementClientOptionalParams } from "./models";
 
 class GraphRbacManagementClient extends GraphRbacManagementClientContext {
   /**
@@ -22,7 +23,7 @@ class GraphRbacManagementClient extends GraphRbacManagementClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     tenantID: string,
-    options?: Models.GraphRbacManagementClientOptionalParams
+    options?: GraphRbacManagementClientOptionalParams
   ) {
     super(credentials, tenantID, options);
     this.signedInUser = new operations.SignedInUser(this);

--- a/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClientContext.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { GraphRbacManagementClientOptionalParams } from "./models";
 
 const packageName = "graphrbac-data-plane";
 const packageVersion = "1.0.0";
@@ -26,7 +26,7 @@ export class GraphRbacManagementClientContext extends coreHttp.ServiceClient {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     tenantID: string,
-    options?: Models.GraphRbacManagementClientOptionalParams
+    options?: GraphRbacManagementClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { KeyVaultManagementClientContext } from "./keyVaultManagementClientContext";
+import { KeyVaultManagementClientOptionalParams } from "./models";
 
 class KeyVaultManagementClient extends KeyVaultManagementClientContext {
   /**
@@ -23,7 +24,7 @@ class KeyVaultManagementClient extends KeyVaultManagementClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.KeyVaultManagementClientOptionalParams
+    options?: KeyVaultManagementClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.vaults = new operations.Vaults(this);

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { KeyVaultManagementClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "keyvault-resource-manager";
@@ -28,7 +28,7 @@ export class KeyVaultManagementClientContext extends coreHttp.ServiceClient {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.KeyVaultManagementClientOptionalParams
+    options?: KeyVaultManagementClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/monitor-data-plane/src/monitorClient.ts
+++ b/test/smoke/generated/monitor-data-plane/src/monitorClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { MonitorClientContext } from "./monitorClientContext";
+import { MonitorClientOptionalParams } from "./models";
 
 class MonitorClient extends MonitorClientContext {
   /**
@@ -20,7 +21,7 @@ class MonitorClient extends MonitorClientContext {
    */
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    options?: Models.MonitorClientOptionalParams
+    options?: MonitorClientOptionalParams
   ) {
     super(credentials, options);
     this.metrics = new operations.Metrics(this);

--- a/test/smoke/generated/monitor-data-plane/src/monitorClientContext.ts
+++ b/test/smoke/generated/monitor-data-plane/src/monitorClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { MonitorClientOptionalParams } from "./models";
 
 const packageName = "monitor-data-plane";
 const packageVersion = "1.0.0";
@@ -22,7 +22,7 @@ export class MonitorClientContext extends coreHttp.ServiceClient {
    */
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
-    options?: Models.MonitorClientOptionalParams
+    options?: MonitorClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
+++ b/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { ManagedServiceIdentityClientContext } from "./managedServiceIdentityClientContext";
+import { ManagedServiceIdentityClientOptionalParams } from "./models";
 
 class ManagedServiceIdentityClient extends ManagedServiceIdentityClientContext {
   /**
@@ -22,7 +23,7 @@ class ManagedServiceIdentityClient extends ManagedServiceIdentityClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.ManagedServiceIdentityClientOptionalParams
+    options?: ManagedServiceIdentityClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.systemAssignedIdentities = new operations.SystemAssignedIdentities(

--- a/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClientContext.ts
+++ b/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { ManagedServiceIdentityClientOptionalParams } from "./models";
 
 const packageName = "msi-resource-manager";
 const packageVersion = "1.0.0";
@@ -26,7 +26,7 @@ export class ManagedServiceIdentityClientContext extends coreHttp.ServiceClient 
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.ManagedServiceIdentityClientOptionalParams
+    options?: ManagedServiceIdentityClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/network-resource-manager/src/networkManagementClient.ts
+++ b/test/smoke/generated/network-resource-manager/src/networkManagementClient.ts
@@ -14,6 +14,7 @@ import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { NetworkManagementClientContext } from "./networkManagementClientContext";
 import {
+  NetworkManagementClientOptionalParams,
   BastionShareableLinkListRequest,
   NetworkManagementClientPutBastionShareableLinkResponse,
   NetworkManagementClientGetBastionShareableLinkResponse,
@@ -41,7 +42,7 @@ class NetworkManagementClient extends NetworkManagementClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.NetworkManagementClientOptionalParams
+    options?: NetworkManagementClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.applicationGateways = new operations.ApplicationGateways(this);

--- a/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
+++ b/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { NetworkManagementClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "network-resource-manager";
@@ -27,7 +27,7 @@ export class NetworkManagementClientContext extends coreHttp.ServiceClient {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.NetworkManagementClientOptionalParams
+    options?: NetworkManagementClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
@@ -11,6 +11,7 @@ import * as operations from "./operations";
 import * as Models from "./models";
 import * as Mappers from "./models/mappers";
 import { StorageManagementClientContext } from "./storageManagementClientContext";
+import { StorageManagementClientOptionalParams } from "./models";
 
 class StorageManagementClient extends StorageManagementClientContext {
   /**
@@ -22,7 +23,7 @@ class StorageManagementClient extends StorageManagementClientContext {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.StorageManagementClientOptionalParams
+    options?: StorageManagementClientOptionalParams
   ) {
     super(credentials, subscriptionId, options);
     this.operations = new operations.Operations(this);

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
@@ -7,7 +7,7 @@
  */
 
 import * as coreHttp from "@azure/core-http";
-import * as Models from "./models";
+import { StorageManagementClientOptionalParams } from "./models";
 import { lroPolicy } from "./lro";
 
 const packageName = "storage-resource-manager";
@@ -27,7 +27,7 @@ export class StorageManagementClientContext extends coreHttp.ServiceClient {
   constructor(
     credentials: coreHttp.TokenCredential | coreHttp.ServiceClientCredentials,
     subscriptionId: string,
-    options?: Models.StorageManagementClientOptionalParams
+    options?: StorageManagementClientOptionalParams
   ) {
     if (credentials === undefined) {
       throw new Error("'credentials' cannot be null");


### PR DESCRIPTION
We're missing some named imports for client parameters in Client and ClientContext which causes build errors.

This problem surfaces particularly when the Client has Enum or Object parameters that require referencing the Models.

We were also missing a case for handling ShcemaType.Choice

This issue surfaced while generating cosmosdb data-plane swagger