### PR TITLE
[v4] Make sure that the interface also extends the base model when generat…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.4.0",
+  "version": "4.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.4.0",
+  "version": "4.3.1",
   "description": "The typescript extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "The typescript extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.2.4",
+  "version": "4.3.0",
   "description": "The typescript extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/src/azure/Model/PageCompositeTypeTSa.cs
+++ b/src/azure/Model/PageCompositeTypeTSa.cs
@@ -22,7 +22,8 @@ namespace AutoRest.TypeScript.Azure.Model
 
         public string ItemName { get; private set; }
 
-        public IModelType ItemType {
+        public IModelType ItemType
+        {
             get
             {
                 if (Properties == null)
@@ -59,6 +60,13 @@ namespace AutoRest.TypeScript.Azure.Model
         {
             TSBuilder builder = new TSBuilder();
 
+            string extends = $"Array{ConstructTSItemTypeName()}";
+
+            if (BaseModelType != null && !BaseIsPolymorphic)
+            {
+                extends += $", {BaseModelType.Name}";
+            }
+
             builder.DocumentationComment(comment =>
             {
                 comment.Interface();
@@ -69,9 +77,9 @@ namespace AutoRest.TypeScript.Azure.Model
                 }
                 comment.Description(description);
                 comment.Summary(Summary);
-                comment.Extends($"Array{ConstructTSItemTypeName()}");
+                comment.Extends(extends);
             });
-            builder.ExportInterface(Name, $"Array{ConstructTSItemTypeName()}", tsInterface =>
+            builder.ExportInterface(Name, extends, tsInterface =>
             {
                 foreach (Property property in InterfaceProperties)
                 {


### PR DESCRIPTION
Port of #616 

Make sure that the interface also extends the base model when generating PageCompositeTypes.

For example in [this swagger](https://github.com/Azure/azure-rest-api-specs/blob/0c0880833da9d695140d140071aea579fdc3da38/specification/recoveryservicesbackup/resource-manager/Microsoft.RecoveryServices/stable/2019-06-15/bms.json#L3610-L3627) `ResourceList` is dropped when generating `JobResourceList`

```typescript
export interface JobResourceList extends Array<JobResource> {
}
```

Where it should generate the following in order to honor the swagger definition
```typescript
export interface JobResourceList extends Array<JobResource>, JobResourceList {
}
```
