### PR TITLE
[v4x] Polymorphic uber parent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-<<<<<<< HEAD
-<<<<<<< HEAD
-  "version": "4.3.1",
-=======
-  "version": "4.4.0",
->>>>>>> 4.4.0
-=======
   "version": "4.4.1",
->>>>>>> 4.4.1
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,10 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
+<<<<<<< HEAD
   "version": "4.3.1",
+=======
+  "version": "4.4.0",
+>>>>>>> 4.4.0
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,14 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
 <<<<<<< HEAD
+<<<<<<< HEAD
   "version": "4.3.1",
 =======
   "version": "4.4.0",
 >>>>>>> 4.4.0
+=======
+  "version": "4.4.1",
+>>>>>>> 4.4.1
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "The typescript extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft.azure/autorest.typescript",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "The typescript extension for classic generators in AutoRest.",
   "scripts": {
     "autorest": "autorest",

--- a/src/vanilla/ClientModelExtensions.cs
+++ b/src/vanilla/ClientModelExtensions.cs
@@ -88,7 +88,8 @@ namespace AutoRest.TypeScript
                 return "string";
             else if (primary.KnownPrimaryType == KnownPrimaryType.Credentials)
                 return "msRest.ServiceClientCredentials"; //TODO: test this, add include for it
-            else {
+            else
+            {
                 throw new NotImplementedException($"Type '{primary}' not implemented");
             }
         }
@@ -120,7 +121,8 @@ namespace AutoRest.TypeScript
         /// <param name="type">IType to query</param>
         /// <param name="inModelsModule">Pass true if generating the code for the models module, thus model types don't need a "models." prefix</param>
         /// <returns>TypeScript type string for type</returns>
-        public static string TSType(this IModelType type, bool inModelsModule) {
+        public static string TSType(this IModelType type, bool inModelsModule)
+        {
             CompositeTypeTS composite = type as CompositeTypeTS;
             SequenceType sequence = type as SequenceType;
             DictionaryType dictionary = type as DictionaryType;
@@ -428,12 +430,12 @@ namespace AutoRest.TypeScript
 
             void applyConstraints(TSObject obj)
             {
-                bool useClientSideValidation = (bool) (Settings.Instance?.CustomSettings[CodeModelTS.ClientSideValidationSettingName] ?? false);
+                bool useClientSideValidation = (bool)(Settings.Instance?.CustomSettings[CodeModelTS.ClientSideValidationSettingName] ?? false);
                 if (useClientSideValidation && constraints != null && constraints.Any())
                 {
                     obj.ObjectProperty("constraints", constraintsObject =>
                     {
-                        foreach (KeyValuePair<Constraint,string> constraintEntry in constraints)
+                        foreach (KeyValuePair<Constraint, string> constraintEntry in constraints)
                         {
                             Constraint constraint = constraintEntry.Key;
                             string constraintValue = constraintEntry.Value;
@@ -537,11 +539,7 @@ namespace AutoRest.TypeScript
                 {
                     if (expandComposite)
                     {
-                        CompositeType baseType = composite;
-                        while (baseType.BaseModelType != null)
-                        {
-                            baseType = baseType.BaseModelType;
-                        }
+                        CompositeType baseType = GetUberParent(composite);
                         if (composite.IsPolymorphic)
                         {
                             // Note: If the polymorphicDiscriminator has a dot in it's name then do not escape that dot for
@@ -617,7 +615,7 @@ namespace AutoRest.TypeScript
                         CompositeTypeTS baseType = composite;
                         while (true)
                         {
-                            baseType = (CompositeTypeTS) baseType.BaseModelType;
+                            baseType = (CompositeTypeTS)baseType.BaseModelType;
                             if (baseType == null)
                             {
                                 break;
@@ -635,6 +633,24 @@ namespace AutoRest.TypeScript
             {
                 throw new NotImplementedException($"{type} is not a supported Type.");
             }
+        }
+
+
+        /// <summary>
+        /// Finds the UberParent for a given Composite type.
+        /// An uber parent is the closest parent that defines the polymorphicDiscriminator
+        /// </summary>
+        /// <param name="composite">The composite type to find the uberParent for</param>
+        /// <returns>The uberParent or itself if it has no uberParent</returns>
+        private static CompositeType GetUberParent(CompositeTypeTS composite)
+        {
+            CompositeType uberParent = composite;
+            while (uberParent.BaseModelType != null && string.IsNullOrWhiteSpace(uberParent.PolymorphicDiscriminator))
+            {
+                uberParent = uberParent.BaseModelType;
+            }
+
+            return uberParent;
         }
 
         private static void AddTypeProperty(TSObject mapper, string mapperTypeName, Action<TSObject> additionalTypeObjectPropertiesAction = null)

--- a/src/vanilla/Model/CodeModelTS.cs
+++ b/src/vanilla/Model/CodeModelTS.cs
@@ -320,9 +320,9 @@ namespace AutoRest.TypeScript.Model
                 {
                     string discriminatorField = polymorphicTypes.ElementAt(i).SerializedName;
                     var polymorphicType = polymorphicTypes.ElementAt(i) as CompositeType;
-                    if (polymorphicType.BaseModelType != null)
+                    if (polymorphicType.BaseModelType != null && string.IsNullOrWhiteSpace(polymorphicType.PolymorphicDiscriminator))
                     {
-                        while (polymorphicType.BaseModelType != null)
+                        while (polymorphicType.BaseModelType != null && string.IsNullOrWhiteSpace(polymorphicType.PolymorphicDiscriminator))
                         {
                             polymorphicType = polymorphicType.BaseModelType;
                         }

--- a/test/vanilla/generated/XMSErrorResponses/models/mappers.ts
+++ b/test/vanilla/generated/XMSErrorResponses/models/mappers.ts
@@ -205,9 +205,9 @@ export const PetHungryOrThirstyError: msRest.CompositeMapper = {
 };
 
 export const discriminators = {
-  'BaseError.NotFoundErrorBase' : NotFoundErrorBase,
-  'BaseError.InvalidResourceLink' : LinkNotFound,
-  'BaseError.AnimalNotFound' : AnimalNotFound,
+  'NotFoundErrorBase' : NotFoundErrorBase,
+  'NotFoundErrorBase.InvalidResourceLink' : LinkNotFound,
+  'NotFoundErrorBase.AnimalNotFound' : AnimalNotFound,
   'PetActionError' : PetActionError,
   'PetActionError.PetSadError' : PetSadError,
   'PetActionError.PetHungryOrThirstyError' : PetHungryOrThirstyError

--- a/test/vanilla/generated/XMSErrorResponses/models/mappers.ts
+++ b/test/vanilla/generated/XMSErrorResponses/models/mappers.ts
@@ -67,7 +67,7 @@ export const NotFoundErrorBase: msRest.CompositeMapper = {
       serializedName: "whatNotFound",
       clientName: "whatNotFound"
     },
-    uberParent: "BaseError",
+    uberParent: "NotFoundErrorBase",
     className: "NotFoundErrorBase",
     modelProperties: {
       ...BaseError.type.modelProperties,
@@ -92,6 +92,8 @@ export const LinkNotFound: msRest.CompositeMapper = {
   serializedName: "InvalidResourceLink",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: NotFoundErrorBase.type.polymorphicDiscriminator,
+    uberParent: "NotFoundErrorBase",
     className: "LinkNotFound",
     modelProperties: {
       ...NotFoundErrorBase.type.modelProperties,
@@ -109,6 +111,8 @@ export const AnimalNotFound: msRest.CompositeMapper = {
   serializedName: "AnimalNotFound",
   type: {
     name: "Composite",
+    polymorphicDiscriminator: NotFoundErrorBase.type.polymorphicDiscriminator,
+    uberParent: "NotFoundErrorBase",
     className: "AnimalNotFound",
     modelProperties: {
       ...NotFoundErrorBase.type.modelProperties,


### PR DESCRIPTION
In short the problem seems to be in the way we currently figure out the `uberParent` when building the `discriminators` object, which is used by `core-http` to select the mapper to use for serialization.

This `discriminators` object is a dictionary with key `{uberParent}.{discriminatorValue}` and a Mapper  as a value. When dealing with an operation `core-http` knows the `uberParent` or `base` object and needs to figure out which descendant it is dealing with at run time based on the value of a property defined as `discriminator` in the `uberParent`.

So the problem seems to be that in Autorest we're building the dictionary and assume that always the **topLevel parent** is the one which defines the polymorphic discriminator. However this is not always true. We could have this hierarchy

![image](https://user-images.githubusercontent.com/21109913/84191374-4381b880-aa4d-11ea-87b2-e6e42e452595.png)

In which the following dictionary would be built

```typescript
// Current, incorrect
const discriminators = {
  "A.Ba": BaMapper,
  "A.Bb": BbMapper,
  "A.Ca": CaMapper,
  "A.Cb": CbMapper
}
// Fixed, correct
const discriminators = {
  "B.Ba": BaMapper,
  "B.Bb": BbMapper,
  "C.Ca": CaMapper,
  "C.Cb": CbMapper
}
```

The problem becomes more evident when the extension `x-ms-discriminator-value`

![image](https://user-images.githubusercontent.com/21109913/84191331-3369d900-aa4d-11ea-83a8-4dcbe23eb4fc.png)

```typescript
// Current, incorrect
const discriminators = {
  "A.Foo": BaMapper,
  "A.Bar": BbMapper, // Duplicate Key makes it an invalid object :(
  "A.Foo": CaMapper,
  "A.Bar": CbMapper
}

// Fixed, correct
const discriminators = {
  "B.Foo": BaMapper,
  "B.Bar": BbMapper,
  "C.Foo": CaMapper,
  "C.Bar": CbMapper
}
```
**Fix**
So my fix is basically to stop crawling the parents when we find one that defines a polymorphic discriminator.
