### PR TITLE
[v6]  Use CodeModel language metadata for Client Name

### DIFF
--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -58,11 +58,13 @@ export async function transformCodeModel(
   codeModel: CodeModel,
   host: Host
 ): Promise<ClientDetails> {
+  const { name: clientName } = getLanguageMetadata(codeModel.language);
   const className = normalizeName(
-    codeModel.info.title,
+    clientName,
     NameType.Class,
     true /** shouldGuard */
   );
+
   normalizeModelWithExtensions(codeModel);
 
   const [uberParents, operationGroups] = await Promise.all([


### PR DESCRIPTION
Instead of using `codeModel.info.title` use language metadata to leverage M4 pre-namer.

Fixes #673 which is caused by info.title containing `()` and not correctly normalizing for use as ClassName.