### PR TITLE
[v6] Use host default value

### DIFF
--- a/src/transforms/urlTransforms.ts
+++ b/src/transforms/urlTransforms.ts
@@ -14,7 +14,7 @@ export async function transformBaseUrl(
 
   const $host = (codeModel.globalParameters || []).find(p => {
     const { name } = getLanguageMetadata(p.language);
-    return name === "$host";
+    return name === "$host" && Boolean(p.clientDefaultValue);
   });
 
   if (!$host) {

--- a/src/transforms/urlTransforms.ts
+++ b/src/transforms/urlTransforms.ts
@@ -13,8 +13,8 @@ export async function transformBaseUrl(
   let isCustom = false;
 
   const $host = (codeModel.globalParameters || []).find(p => {
-    const { serializedName } = getLanguageMetadata(p.language);
-    serializedName === "$host";
+    const { name } = getLanguageMetadata(p.language);
+    return name === "$host";
   });
 
   if (!$host) {

--- a/test/integration/generated/additionalProperties/src/additionalPropertiesClientContext.ts
+++ b/test/integration/generated/additionalProperties/src/additionalPropertiesClientContext.ts
@@ -34,7 +34,7 @@ export class AdditionalPropertiesClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/azureParameterGrouping/src/azureParameterGroupingClientContext.ts
+++ b/test/integration/generated/azureParameterGrouping/src/azureParameterGroupingClientContext.ts
@@ -34,7 +34,7 @@ export class AzureParameterGroupingClientContext extends coreHttp.ServiceClient 
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/azureReport/src/reportClientContext.ts
+++ b/test/integration/generated/azureReport/src/reportClientContext.ts
@@ -34,7 +34,7 @@ export class ReportClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClientContext.ts
+++ b/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClientContext.ts
@@ -50,7 +50,7 @@ export class AzureSpecialPropertiesClientContext extends coreHttp.ServiceClient 
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/integration/generated/bodyArray/src/bodyArrayClientContext.ts
+++ b/test/integration/generated/bodyArray/src/bodyArrayClientContext.ts
@@ -34,7 +34,7 @@ export class BodyArrayClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyBoolean/src/bodyBooleanClientContext.ts
+++ b/test/integration/generated/bodyBoolean/src/bodyBooleanClientContext.ts
@@ -34,7 +34,7 @@ export class BodyBooleanClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyBooleanQuirks/src/bodyBooleanQuirksClientContext.ts
+++ b/test/integration/generated/bodyBooleanQuirks/src/bodyBooleanQuirksClientContext.ts
@@ -34,7 +34,7 @@ export class BodyBooleanQuirksClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyByte/src/bodyByteClientContext.ts
+++ b/test/integration/generated/bodyByte/src/bodyByteClientContext.ts
@@ -34,7 +34,7 @@ export class BodyByteClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClientContext.ts
@@ -35,7 +35,7 @@ export class BodyComplexClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyDate/src/bodyDateClientContext.ts
+++ b/test/integration/generated/bodyDate/src/bodyDateClientContext.ts
@@ -34,7 +34,7 @@ export class BodyDateClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyDateTime/src/bodyDateTimeClientContext.ts
+++ b/test/integration/generated/bodyDateTime/src/bodyDateTimeClientContext.ts
@@ -34,7 +34,7 @@ export class BodyDateTimeClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyDateTimeRfc1123/src/bodyDateTimeRfc1123ClientContext.ts
+++ b/test/integration/generated/bodyDateTimeRfc1123/src/bodyDateTimeRfc1123ClientContext.ts
@@ -34,7 +34,7 @@ export class BodyDateTimeRfc1123ClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyDictionary/src/bodyDictionaryClientContext.ts
+++ b/test/integration/generated/bodyDictionary/src/bodyDictionaryClientContext.ts
@@ -34,7 +34,7 @@ export class BodyDictionaryClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyDuration/src/bodyDurationClientContext.ts
+++ b/test/integration/generated/bodyDuration/src/bodyDurationClientContext.ts
@@ -34,7 +34,7 @@ export class BodyDurationClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyFile/src/bodyFileClientContext.ts
+++ b/test/integration/generated/bodyFile/src/bodyFileClientContext.ts
@@ -34,7 +34,7 @@ export class BodyFileClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyInteger/src/bodyIntegerClientContext.ts
+++ b/test/integration/generated/bodyInteger/src/bodyIntegerClientContext.ts
@@ -34,7 +34,7 @@ export class BodyIntegerClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyNumber/src/bodyNumberClientContext.ts
+++ b/test/integration/generated/bodyNumber/src/bodyNumberClientContext.ts
@@ -34,7 +34,7 @@ export class BodyNumberClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyString/src/bodyStringClientContext.ts
+++ b/test/integration/generated/bodyString/src/bodyStringClientContext.ts
@@ -34,7 +34,7 @@ export class BodyStringClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/bodyTime/src/bodyTimeClientContext.ts
+++ b/test/integration/generated/bodyTime/src/bodyTimeClientContext.ts
@@ -34,7 +34,7 @@ export class BodyTimeClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/header/src/headerClientContext.ts
+++ b/test/integration/generated/header/src/headerClientContext.ts
@@ -34,7 +34,7 @@ export class HeaderClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/httpInfrastructure/src/httpInfrastructureClientContext.ts
+++ b/test/integration/generated/httpInfrastructure/src/httpInfrastructureClientContext.ts
@@ -34,7 +34,7 @@ export class HttpInfrastructureClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/lro/src/lROClientContext.ts
+++ b/test/integration/generated/lro/src/lROClientContext.ts
@@ -43,7 +43,7 @@ export class LROClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/mediaTypes/src/mediaTypesClientContext.ts
+++ b/test/integration/generated/mediaTypes/src/mediaTypesClientContext.ts
@@ -34,7 +34,7 @@ export class MediaTypesClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/mediaTypesV3/src/mediaTypesV3ClientContext.ts
+++ b/test/integration/generated/mediaTypesV3/src/mediaTypesV3ClientContext.ts
@@ -39,7 +39,7 @@ export class MediaTypesV3ClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint;
+    this.baseUri = options.endpoint || "{$host}";
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/mediaTypesV3/src/mediaTypesV3ClientContext.ts
+++ b/test/integration/generated/mediaTypesV3/src/mediaTypesV3ClientContext.ts
@@ -39,7 +39,7 @@ export class MediaTypesV3ClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint;
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
@@ -48,7 +48,7 @@ export class MediaTypesV3LROClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint;
+    this.baseUri = options.endpoint || "{$host}";
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
@@ -48,7 +48,7 @@ export class MediaTypesV3LROClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint;
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/modelFlattening/src/modelFlatteningClientContext.ts
+++ b/test/integration/generated/modelFlattening/src/modelFlatteningClientContext.ts
@@ -34,7 +34,7 @@ export class ModelFlatteningClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/multipleInheritance/src/multipleInheritanceClientContext.ts
+++ b/test/integration/generated/multipleInheritance/src/multipleInheritanceClientContext.ts
@@ -34,7 +34,7 @@ export class MultipleInheritanceClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/noMappers/src/noMappersClientContext.ts
+++ b/test/integration/generated/noMappers/src/noMappersClientContext.ts
@@ -48,7 +48,7 @@ export class NoMappersClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint;
+    this.baseUri = options.endpoint || "{$host}";
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/noMappers/src/noMappersClientContext.ts
+++ b/test/integration/generated/noMappers/src/noMappersClientContext.ts
@@ -48,7 +48,7 @@ export class NoMappersClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint;
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/paging/src/pagingClientContext.ts
+++ b/test/integration/generated/paging/src/pagingClientContext.ts
@@ -43,7 +43,7 @@ export class PagingClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/regexConstraint/src/regexConstraintContext.ts
+++ b/test/integration/generated/regexConstraint/src/regexConstraintContext.ts
@@ -39,7 +39,7 @@ export class RegexConstraintContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint;
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/regexConstraint/src/regexConstraintContext.ts
+++ b/test/integration/generated/regexConstraint/src/regexConstraintContext.ts
@@ -39,7 +39,7 @@ export class RegexConstraintContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint;
+    this.baseUri = options.endpoint || "{$host}";
 
     // Parameter assignments
     this.$host = $host;

--- a/test/integration/generated/report/src/reportClientContext.ts
+++ b/test/integration/generated/report/src/reportClientContext.ts
@@ -34,7 +34,7 @@ export class ReportClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/integration/generated/url/src/urlClientContext.ts
+++ b/test/integration/generated/url/src/urlClientContext.ts
@@ -41,7 +41,7 @@ export class UrlClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Parameter assignments
     this.globalStringPath = globalStringPath;

--- a/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
+++ b/test/integration/generated/xmlservice/src/xmlServiceClientContext.ts
@@ -34,7 +34,7 @@ export class XmlServiceClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "http://localhost:3000";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "http://localhost:3000";

--- a/test/smoke/generated/adhybridhealthservice-resource-manager/src/aDHybridHealthServiceContext.ts
+++ b/test/smoke/generated/adhybridhealthservice-resource-manager/src/aDHybridHealthServiceContext.ts
@@ -43,7 +43,7 @@ export class ADHybridHealthServiceContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "https://management.azure.com";

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClientContext.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClientContext.ts
@@ -58,7 +58,7 @@ export class DeploymentScriptsClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-features-2015-12/src/featureClientContext.ts
+++ b/test/smoke/generated/arm-package-features-2015-12/src/featureClientContext.ts
@@ -49,7 +49,7 @@ export class FeatureClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClientContext.ts
+++ b/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClientContext.ts
@@ -49,7 +49,7 @@ export class ManagementLinkClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClientContext.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClientContext.ts
@@ -49,7 +49,7 @@ export class ManagementLockClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClientContext.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClientContext.ts
@@ -58,7 +58,7 @@ export class ApplicationClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-policy-2019-09/src/policyClientContext.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/policyClientContext.ts
@@ -49,7 +49,7 @@ export class PolicyClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClientContext.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClientContext.ts
@@ -58,7 +58,7 @@ export class ResourceManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClientContext.ts
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClientContext.ts
@@ -43,7 +43,7 @@ export class SubscriptionClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "https://management.azure.com";

--- a/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
+++ b/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
@@ -58,7 +58,7 @@ export class ComputeManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
@@ -57,7 +57,7 @@ export class CosmosDBManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClientContext.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClientContext.ts
@@ -49,7 +49,7 @@ export class GraphRbacManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://graph.windows.net";
 
     // Parameter assignments
     this.tenantID = tenantID;

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
@@ -59,7 +59,7 @@ export class KeyVaultManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/monitor-data-plane/src/monitorClientContext.ts
+++ b/test/smoke/generated/monitor-data-plane/src/monitorClientContext.ts
@@ -42,7 +42,7 @@ export class MonitorClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://monitoring.azure.com";
 
     // Assigning values to Constant parameters
     this.$host = options.$host || "https://monitoring.azure.com";

--- a/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClientContext.ts
+++ b/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClientContext.ts
@@ -49,7 +49,7 @@ export class ManagedServiceIdentityClientContext extends coreHttp.ServiceClient 
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
+++ b/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
@@ -58,7 +58,7 @@ export class NetworkManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/sql-resource-manager/src/sqlManagementClientContext.ts
+++ b/test/smoke/generated/sql-resource-manager/src/sqlManagementClientContext.ts
@@ -57,7 +57,7 @@ export class SqlManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
@@ -58,7 +58,7 @@ export class StorageManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClientContext.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClientContext.ts
@@ -59,7 +59,7 @@ export class WebSiteManagementClientContext extends coreHttp.ServiceClient {
 
     this.requestContentType = "application/json; charset=utf-8";
 
-    this.baseUri = options.endpoint || "{$host}";
+    this.baseUri = options.endpoint || "https://management.azure.com";
 
     // Parameter assignments
     this.subscriptionId = subscriptionId;


### PR DESCRIPTION
When $host has a default value specified use it as the endpoint.

We have a bug when finding the `$host` parameter in which the `find` function always returned undefined 😞 

Fixing this to actually set endpoint with the $host default value if available.

This fix will also workaround Issue Azure/azure-sdk-for-js/issues/9700  as `replaceAll` won't be called for the host since we'd effectivly be filling out `{$host}` in Autorest by setting the endpoint