### PR TITLE
[v6] Separate Xml serializer and fix optional grouped parameters

### DIFF
--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -151,7 +151,9 @@ function buildSpec(spec: OperationSpecDetails): string {
   const mediaType = buildMediaType(spec);
 
   const isXML = spec.isXML ? "isXML: true," : "";
-  const serializerName = spec.isXML ? "xmlSerializer" : "serializer";
+  const serializerName = spec.isXML
+    ? "serializer: xmlSerializer"
+    : "serializer";
 
   return `{ path: "${spec.path}", httpMethod: "${
     spec.httpMethod
@@ -966,8 +968,8 @@ export function addOperationSpecs(
     o.mediaTypes.has(KnownMediaType.Xml)
   );
 
-  const hasJson = operationGroupDetails.operations.some(o =>
-    o.mediaTypes.has(KnownMediaType.Json)
+  const hasNonXml = operationGroupDetails.operations.some(
+    o => !o.mediaTypes.has(KnownMediaType.Xml)
   );
   file.addStatements("// Operation Specifications");
 
@@ -975,7 +977,7 @@ export function addOperationSpecs(
     writeSerializer(hasMappers, file, SerializerKind.Xml);
   }
 
-  if (hasJson) {
+  if (hasNonXml) {
     writeSerializer(hasMappers, file, SerializerKind.Json);
   }
 
@@ -1014,7 +1016,7 @@ function writeSerializer(
     declarationKind: VariableDeclarationKind.Const,
     declarations: [
       {
-        name: "serializer",
+        name,
         initializer: `new coreHttp.Serializer(${mappers}, /* isXml */ ${isXml});`
       }
     ]

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -954,6 +954,17 @@ function generateOperationJSDoc(
   }${paramJSDoc}`;
 }
 
+function hasMediaType(
+  operationDetails: OperationDetails,
+  mediaType: KnownMediaType
+) {
+  if (!operationDetails.requests) {
+    return operationDetails.mediaTypes.has(mediaType);
+  }
+
+  return operationDetails.requests.some(r => r.mediaType === mediaType);
+}
+
 /**
  * Generates and inserts into the file the operation specs
  * for a given operation group
@@ -964,13 +975,14 @@ export function addOperationSpecs(
   parameters: ParameterDetails[],
   hasMappers: boolean
 ): void {
-  const hasXml = operationGroupDetails.operations.some(o =>
-    o.mediaTypes.has(KnownMediaType.Xml)
+  const hasXml = operationGroupDetails.operations.some(operation =>
+    hasMediaType(operation, KnownMediaType.Xml)
   );
 
   const hasNonXml = operationGroupDetails.operations.some(
-    o => !o.mediaTypes.has(KnownMediaType.Xml)
+    operation => !hasMediaType(operation, KnownMediaType.Xml)
   );
+
   file.addStatements("// Operation Specifications");
 
   if (hasXml) {

--- a/src/transforms/parameterTransforms.ts
+++ b/src/transforms/parameterTransforms.ts
@@ -300,6 +300,7 @@ function getParameterPath(parameter: Parameter) {
     const groupedByName = getLanguageMetadata(parameter.groupedBy.language)
       .name;
     return [
+      ...(!parameter.required ? ["options"] : []),
       normalizeName(groupedByName, NameType.Parameter, true /** shouldGuard */),
       name
     ];

--- a/test/integration/generated/azureParameterGrouping/src/models/parameters.ts
+++ b/test/integration/generated/azureParameterGrouping/src/models/parameters.ts
@@ -48,7 +48,11 @@ export const $host: OperationURLParameter = {
 };
 
 export const customHeader: OperationParameter = {
-  parameterPath: ["parameterGroupingPostRequiredParameters", "customHeader"],
+  parameterPath: [
+    "options",
+    "parameterGroupingPostRequiredParameters",
+    "customHeader"
+  ],
   mapper: {
     serializedName: "customHeader",
     type: {
@@ -58,7 +62,11 @@ export const customHeader: OperationParameter = {
 };
 
 export const query: OperationQueryParameter = {
-  parameterPath: ["parameterGroupingPostRequiredParameters", "query"],
+  parameterPath: [
+    "options",
+    "parameterGroupingPostRequiredParameters",
+    "query"
+  ],
   mapper: {
     defaultValue: 30,
     serializedName: "query",
@@ -80,7 +88,11 @@ export const path: OperationURLParameter = {
 };
 
 export const customHeader1: OperationParameter = {
-  parameterPath: ["parameterGroupingPostOptionalParameters", "customHeader"],
+  parameterPath: [
+    "options",
+    "parameterGroupingPostOptionalParameters",
+    "customHeader"
+  ],
   mapper: {
     serializedName: "customHeader",
     type: {
@@ -90,7 +102,11 @@ export const customHeader1: OperationParameter = {
 };
 
 export const query1: OperationQueryParameter = {
-  parameterPath: ["parameterGroupingPostOptionalParameters", "query"],
+  parameterPath: [
+    "options",
+    "parameterGroupingPostOptionalParameters",
+    "query"
+  ],
   mapper: {
     defaultValue: 30,
     serializedName: "query",
@@ -101,7 +117,7 @@ export const query1: OperationQueryParameter = {
 };
 
 export const headerOne: OperationParameter = {
-  parameterPath: ["firstParameterGroup", "headerOne"],
+  parameterPath: ["options", "firstParameterGroup", "headerOne"],
   mapper: {
     serializedName: "header-one",
     type: {
@@ -111,7 +127,7 @@ export const headerOne: OperationParameter = {
 };
 
 export const queryOne: OperationQueryParameter = {
-  parameterPath: ["firstParameterGroup", "queryOne"],
+  parameterPath: ["options", "firstParameterGroup", "queryOne"],
   mapper: {
     defaultValue: 30,
     serializedName: "query-one",
@@ -123,6 +139,7 @@ export const queryOne: OperationQueryParameter = {
 
 export const headerTwo: OperationParameter = {
   parameterPath: [
+    "options",
     "parameterGroupingPostMultiParamGroupsSecondParamGroup",
     "headerTwo"
   ],
@@ -136,6 +153,7 @@ export const headerTwo: OperationParameter = {
 
 export const queryTwo: OperationQueryParameter = {
   parameterPath: [
+    "options",
     "parameterGroupingPostMultiParamGroupsSecondParamGroup",
     "queryTwo"
   ],

--- a/test/integration/generated/modelFlattening/src/models/parameters.ts
+++ b/test/integration/generated/modelFlattening/src/models/parameters.ts
@@ -80,7 +80,7 @@ export const simpleBodyProduct: OperationParameter = {
 };
 
 export const simpleBodyProduct1: OperationParameter = {
-  parameterPath: ["flattenParameterGroup", "simpleBodyProduct"],
+  parameterPath: ["options", "flattenParameterGroup", "simpleBodyProduct"],
   mapper: SimpleProductMapper
 };
 

--- a/test/integration/generated/paging/src/models/parameters.ts
+++ b/test/integration/generated/paging/src/models/parameters.ts
@@ -35,7 +35,7 @@ export const clientRequestId: OperationParameter = {
 };
 
 export const maxresults: OperationParameter = {
-  parameterPath: ["pagingGetMultiplePagesOptions", "maxresults"],
+  parameterPath: ["options", "pagingGetMultiplePagesOptions", "maxresults"],
   mapper: {
     serializedName: "maxresults",
     type: {
@@ -45,7 +45,7 @@ export const maxresults: OperationParameter = {
 };
 
 export const timeout: OperationParameter = {
-  parameterPath: ["pagingGetMultiplePagesOptions", "timeout"],
+  parameterPath: ["options", "pagingGetMultiplePagesOptions", "timeout"],
   mapper: {
     defaultValue: 30,
     serializedName: "timeout",
@@ -79,7 +79,11 @@ export const queryConstant: OperationQueryParameter = {
 };
 
 export const maxresults1: OperationParameter = {
-  parameterPath: ["pagingGetOdataMultiplePagesOptions", "maxresults"],
+  parameterPath: [
+    "options",
+    "pagingGetOdataMultiplePagesOptions",
+    "maxresults"
+  ],
   mapper: {
     serializedName: "maxresults",
     type: {
@@ -89,7 +93,7 @@ export const maxresults1: OperationParameter = {
 };
 
 export const timeout1: OperationParameter = {
-  parameterPath: ["pagingGetOdataMultiplePagesOptions", "timeout"],
+  parameterPath: ["options", "pagingGetOdataMultiplePagesOptions", "timeout"],
   mapper: {
     defaultValue: 30,
     serializedName: "timeout",
@@ -100,7 +104,11 @@ export const timeout1: OperationParameter = {
 };
 
 export const maxresults2: OperationParameter = {
-  parameterPath: ["pagingGetMultiplePagesWithOffsetOptions", "maxresults"],
+  parameterPath: [
+    "options",
+    "pagingGetMultiplePagesWithOffsetOptions",
+    "maxresults"
+  ],
   mapper: {
     serializedName: "maxresults",
     type: {
@@ -121,7 +129,11 @@ export const offset: OperationURLParameter = {
 };
 
 export const timeout2: OperationParameter = {
-  parameterPath: ["pagingGetMultiplePagesWithOffsetOptions", "timeout"],
+  parameterPath: [
+    "options",
+    "pagingGetMultiplePagesWithOffsetOptions",
+    "timeout"
+  ],
   mapper: {
     defaultValue: 30,
     serializedName: "timeout",
@@ -176,7 +188,7 @@ export const tenant1: OperationURLParameter = {
 };
 
 export const maxresults3: OperationParameter = {
-  parameterPath: ["pagingGetMultiplePagesLroOptions", "maxresults"],
+  parameterPath: ["options", "pagingGetMultiplePagesLroOptions", "maxresults"],
   mapper: {
     serializedName: "maxresults",
     type: {
@@ -186,7 +198,7 @@ export const maxresults3: OperationParameter = {
 };
 
 export const timeout3: OperationParameter = {
-  parameterPath: ["pagingGetMultiplePagesLroOptions", "timeout"],
+  parameterPath: ["options", "pagingGetMultiplePagesLroOptions", "timeout"],
   mapper: {
     defaultValue: 30,
     serializedName: "timeout",

--- a/test/integration/generated/xmlservice/src/operations/xml.ts
+++ b/test/integration/generated/xmlservice/src/operations/xml.ts
@@ -542,7 +542,9 @@ export class Xml {
 }
 // Operation Specifications
 
-const serializer = new coreHttp.Serializer(Mappers, /* isXml */ true);
+const xmlSerializer = new coreHttp.Serializer(Mappers, /* isXml */ true);
+
+const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
 
 const getComplexTypeRefNoMetaOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/complex-type-ref-no-meta",
@@ -554,7 +556,7 @@ const getComplexTypeRefNoMetaOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putComplexTypeRefNoMetaOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/complex-type-ref-no-meta",
@@ -566,7 +568,7 @@ const putComplexTypeRefNoMetaOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getComplexTypeRefWithMetaOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/complex-type-ref-with-meta",
@@ -578,7 +580,7 @@ const getComplexTypeRefWithMetaOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putComplexTypeRefWithMetaOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/complex-type-ref-with-meta",
@@ -590,7 +592,7 @@ const putComplexTypeRefWithMetaOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getSimpleOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/simple",
@@ -605,7 +607,7 @@ const getSimpleOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putSimpleOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/simple",
@@ -622,7 +624,7 @@ const putSimpleOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getWrappedListsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/wrapped-lists",
@@ -634,7 +636,7 @@ const getWrappedListsOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putWrappedListsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/wrapped-lists",
@@ -651,7 +653,7 @@ const putWrappedListsOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getHeadersOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/headers",
@@ -674,7 +676,7 @@ const getEmptyListOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putEmptyListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-list",
@@ -686,7 +688,7 @@ const putEmptyListOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getEmptyWrappedListsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-wrapped-lists",
@@ -698,7 +700,7 @@ const getEmptyWrappedListsOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putEmptyWrappedListsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-wrapped-lists",
@@ -710,7 +712,7 @@ const putEmptyWrappedListsOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getRootListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/root-list",
@@ -730,7 +732,7 @@ const getRootListOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putRootListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/root-list",
@@ -742,7 +744,7 @@ const putRootListOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/root-list-single-item",
@@ -762,7 +764,7 @@ const getRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/root-list-single-item",
@@ -774,7 +776,7 @@ const putRootListSingleItemOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getEmptyRootListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-root-list",
@@ -794,7 +796,7 @@ const getEmptyRootListOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putEmptyRootListOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-root-list",
@@ -806,7 +808,7 @@ const putEmptyRootListOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getEmptyChildElementOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-child-element",
@@ -818,7 +820,7 @@ const getEmptyChildElementOperationSpec: coreHttp.OperationSpec = {
   },
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putEmptyChildElementOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/empty-child-element",
@@ -830,7 +832,7 @@ const putEmptyChildElementOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const listContainersOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/",
@@ -843,7 +845,7 @@ const listContainersOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.comp],
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const getServicePropertiesOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/",
@@ -856,7 +858,7 @@ const getServicePropertiesOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.comp1, Parameters.restype],
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putServicePropertiesOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/",
@@ -869,7 +871,7 @@ const putServicePropertiesOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const getAclsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/mycontainer",
@@ -893,7 +895,7 @@ const getAclsOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.comp2, Parameters.restype1],
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const putAclsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/mycontainer",
@@ -906,7 +908,7 @@ const putAclsOperationSpec: coreHttp.OperationSpec = {
   isXML: true,
   contentType: "application/xml; charset=utf-8",
   mediaType: "xml",
-  serializer
+  serializer: xmlSerializer
 };
 const listBlobsOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/mycontainer",
@@ -919,7 +921,7 @@ const listBlobsOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.comp, Parameters.restype1],
   urlParameters: [Parameters.$host],
   isXML: true,
-  serializer
+  serializer: xmlSerializer
 };
 const jsonInputOperationSpec: coreHttp.OperationSpec = {
   path: "/xml/jsoninput",

--- a/test/smoke/generated/web-resource-manager/src/operations/webApps.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/webApps.ts
@@ -11739,7 +11739,7 @@ export class WebApps {
 }
 // Operation Specifications
 
-const serializer = new coreHttp.Serializer(Mappers, /* isXml */ true);
+const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
 
 const listOperationSpec: coreHttp.OperationSpec = {
   path: "/subscriptions/{subscriptionId}/providers/Microsoft.Web/sites",


### PR DESCRIPTION
2 issues surfaced when working with Tables Swagger

1.  If an operation group contains both XML and non-XML operations, a serializer is instantiated with isXml parameter **true**. This confuses our serialization/deserialization when handling a non-XML operation spec. **Fix:** Create an additional xmlSerializer to use with Xml operationSpecs

2. optional grouped parameters need to have "options" part in the ParameterPath since we group them in "options", otherwise the serializer won't find it.

Fixes #692