### PR TITLE
[v6] Make requestOptions a parameter reseved name

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -473,7 +473,7 @@ function getOptionalGroups(
   return optionalGroups.map(group => {
     const { name, description } = getLanguageMetadata(group.language);
     return {
-      name: name,
+      name: normalizeName(name, NameType.Parameter, true),
       hasQuestionToken: !group.required,
       type: normalizeName(name, NameType.Interface),
       docs: [description],

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -65,6 +65,7 @@ const ReservedModelNames: ReservedName[] = [
   { name: "private", reservedFor: [NameType.Parameter] },
   { name: "protected", reservedFor: [NameType.Parameter] },
   { name: "public", reservedFor: [NameType.Parameter] },
+  { name: "requestoptions", reservedFor: [NameType.Parameter] },
   { name: "require", reservedFor: [NameType.Parameter] },
   { name: "return", reservedFor: [NameType.Parameter] },
   { name: "set", reservedFor: [NameType.Parameter, ...Newable] },


### PR DESCRIPTION
requestOptions parameter name can collide with core-http's OperationOptions. Making it a reserved workd