### PR TITLE
[v6] Better support for x-ms-enum - Part I

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -385,7 +385,7 @@ const writeChoices = (
   modelsIndexFile: SourceFile
 ) =>
   clientDetails.unions.forEach(choice => {
-    const values = [...choice.values];
+    const values = choice.properties.map(p => p.value);
     if (choice.schemaType === SchemaType.Choice) {
       values.push("string");
     }

--- a/src/models/unionDetails.ts
+++ b/src/models/unionDetails.ts
@@ -10,6 +10,7 @@ export interface UnionDetails {
   name: string;
   description: string;
   serializedName: string;
+  names: string[];
   values: string[];
   schemaType: SchemaType;
 }

--- a/src/models/unionDetails.ts
+++ b/src/models/unionDetails.ts
@@ -10,7 +10,11 @@ export interface UnionDetails {
   name: string;
   description: string;
   serializedName: string;
-  names: string[];
-  values: string[];
+  properties: NameValuePair[];
   schemaType: SchemaType;
+}
+
+export interface NameValuePair {
+  name: string;
+  value: string;
 }

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -51,6 +51,11 @@ export function transformChoice(
     schemaType,
     description: `Defines values for ${metadata.name}.`,
     serializedName: metadata.name,
+    names: choice.choices.map(c =>
+      c.language.javascript
+        ? c.language.javascript.name
+        : c.language.default.name
+    ),
     values: choice.choices.map(c =>
       getStringForValue(c.value, choice?.choiceType?.type ?? SchemaType.String)
     )

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-features-2015-12/temp/arm-package-features-2015-12.api.json
+++ b/test/smoke/generated/arm-package-features-2015-12/temp/arm-package-features-2015-12.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-links-2016-09/temp/arm-package-links-2016-09.api.json
+++ b/test/smoke/generated/arm-package-links-2016-09/temp/arm-package-links-2016-09.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-resources-2019-08/temp/arm-package-resources-2019-08.api.json
+++ b/test/smoke/generated/arm-package-resources-2019-08/temp/arm-package-resources-2019-08.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/temp/arm-package-subscriptions-2019-06.api.json
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/temp/arm-package-subscriptions-2019-06.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.json
+++ b/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
+++ b/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.json
+++ b/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/monitor-data-plane/temp/monitor-data-plane.api.json
+++ b/test/smoke/generated/monitor-data-plane/temp/monitor-data-plane.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/msi-resource-manager/temp/msi-resource-manager.api.json
+++ b/test/smoke/generated/msi-resource-manager/temp/msi-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.json
+++ b/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/sql-resource-manager/temp/sql-resource-manager.api.json
+++ b/test/smoke/generated/sql-resource-manager/temp/sql-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.json
+++ b/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.9.4",
+    "toolVersion": "7.9.10",
     "schemaVersion": 1003,
     "oldestForwardsCompatibleVersion": 1001
   },

--- a/test/unit/transforms/transforms.spec.ts
+++ b/test/unit/transforms/transforms.spec.ts
@@ -100,7 +100,10 @@ describe("Transforms", () => {
 
       assert.strictEqual(colorUnion.name, "Color");
       assert.strictEqual(colorUnion.description, "Defines values for Color.");
-      assert.deepEqual(colorUnion.values, [`"red"`, `"green"`, `"blue"`]);
+      assert.deepEqual(
+        colorUnion.properties.map(p => p.value),
+        [`"red"`, `"green"`, `"blue"`]
+      );
     });
   });
 });


### PR DESCRIPTION
This PR is Part I of PRs to support issue https://github.com/Azure/autorest.typescript/issues/718. 

If the swagger mentions customized names for each enum value (thru x-ms-enum options), then we need to support it in our generator. How are we going to support it? Is it through classes with static properties/enum values/some other option? That is a seperate discussion and will be covered in the next set of PRs. 

However, before we decide the method to handle the names, we need to be able to access the names in the transformed code model (which will be passed to the model generator). This PR is to handle that issue. 

@josecons-msft @daviwil Please review and approve.

@ramya-rao-a FYI.... 