### PR TITLE
[v6] Support xmlNamespace and xmlPrefix

### DIFF
--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -238,6 +238,8 @@ function getXmlMetadata(
   }
 
   let xmlElementName: string | undefined = undefined;
+  let xmlNamespace = schema.serialization?.xml?.namespace;
+  let xmlNamespacePrefix = schema.serialization?.xml?.prefix;
   if (schema.type === SchemaType.Array) {
     const elementSchema = (schema as ArraySchema).elementType;
     const languageMetadata = getLanguageMetadata(elementSchema.language);
@@ -258,7 +260,9 @@ function getXmlMetadata(
     ...(xmlName && { xmlName }),
     ...(xmlIsAttribute && { xmlIsAttribute }),
     ...(xmlIsWrapped && { xmlIsWrapped }),
-    ...(xmlElementName && { xmlElementName })
+    ...(xmlElementName && { xmlElementName }),
+    ...(xmlNamespace && { xmlNamespace }),
+    ...(xmlNamespacePrefix && { xmlNamespacePrefix })
   };
 }
 
@@ -531,7 +535,12 @@ function transformStringMapper(pipelineValue: PipelineValue) {
    */
   if (
     !isSchemaType(
-      [SchemaType.String, SchemaType.Choice, SchemaType.Credential, SchemaType.Uri],
+      [
+        SchemaType.String,
+        SchemaType.Choice,
+        SchemaType.Credential,
+        SchemaType.Uri
+      ],
       schema
     )
   ) {


### PR DESCRIPTION
OpenAPI specification supports [XML namespace and prefix](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#fixed-fields-22), however our generator doesn't and just ignores these properties. This PR picks up the metadata and exposes it in the mappers for `@azure/core-http` to do the required serialization.

Here's a [link ](https://github.com/Azure/azure-sdk-for-js/pull/11201)for core-http's PR