### PR TITLE
Enable redirect tests

### DIFF
--- a/test/integration/httpInfrastructure.spec.ts
+++ b/test/integration/httpInfrastructure.spec.ts
@@ -444,7 +444,7 @@ describe("Http infrastructure Client", () => {
       assert.equal(result._response.status, 200);
     });
 
-    it("patch302 should return 200", async function() {
+    it("patch302 should return 302", async function() {
       // Manual redirection is not supported by the xhr in browser
       // browsers will perform default redirect
       if (!isNode) {
@@ -452,7 +452,7 @@ describe("Http infrastructure Client", () => {
       }
 
       const result = await client.httpRedirects.patch302();
-      assert.equal(result._response.status, 200);
+      assert.equal(result._response.status, 302);
     });
 
     it("patch307 should return 200", async () => {

--- a/test/integration/httpInfrastructure.spec.ts
+++ b/test/integration/httpInfrastructure.spec.ts
@@ -444,8 +444,13 @@ describe("Http infrastructure Client", () => {
       assert.equal(result._response.status, 200);
     });
 
-    // Enable when Azure/azure-sdk-for-js/issues/10103 is fixed
-    it.skip("patch302 should return 200", async () => {
+    it("patch302 should return 200", async function() {
+      // Manual redirection is not supported by the xhr in browser
+      // browsers will perform default redirect
+      if (!isNode) {
+        this.skip();
+      }
+
       const result = await client.httpRedirects.patch302();
       assert.equal(result._response.status, 200);
     });
@@ -470,10 +475,14 @@ describe("Http infrastructure Client", () => {
       assert.equal(result._response.status, 200);
     });
 
-    // Enable when Azure/azure-sdk-for-js/issues/10103 is fixed
-    it.skip("put301 should return 200", async () => {
+    it("put301 should return 301", async function() {
+      // Manual redirection is not supported by the xhr in browser
+      // browsers will perform default redirect
+      if (!isNode) {
+        this.skip();
+      }
       const result = await client.httpRedirects.put301();
-      assert.equal(result._response.status, 200);
+      assert.equal(result._response.status, 301);
     });
   });
 


### PR DESCRIPTION
2 Redirect tests were disabled because of https://github.com/Azure/azure-sdk-for-js/issues/10103

This PR enables them as a fix for the original bug is in PR https://github.com/Azure/azure-sdk-for-js/pull/11863

This was tested with a local build of the changes in the core-http PR above