### PR TITLE
Enable MediaType test scenario

### DIFF
--- a/test/integration/mediaType.spec.ts
+++ b/test/integration/mediaType.spec.ts
@@ -6,7 +6,7 @@ describe("Integration tests for MediaTypes", () => {
 
   beforeEach(() => {
     client = new MediaTypesClient({
-      requestPolicyFactories: defaultPolicies => {
+      requestPolicyFactories: (defaultPolicies) => {
         defaultPolicies.push({
           create(nextPolicy) {
             return {
@@ -71,6 +71,10 @@ describe("Integration tests for MediaTypes", () => {
       expect(response._response.status).to.equal(
         200,
         `Unexpected status code.`
+      );
+
+      expect(response.body).to.equal(
+        "Nice job sending content type with encoding"
       );
     });
   });

--- a/test/integration/mediaType.spec.ts
+++ b/test/integration/mediaType.spec.ts
@@ -59,12 +59,13 @@ describe("Integration tests for MediaTypes", () => {
     });
   });
 
-  // https://github.com/Azure/autorest.typescript/issues/741
-  describe.skip("#contentTypeWithEncoding", () => {
+  describe("#contentTypeWithEncoding", () => {
     it("works with text/plain", async () => {
-      const response = await client.contentTypeWithEncoding(
-        "text/plain; encoding=UTF-8"
-      );
+      const response = await client.contentTypeWithEncoding("test", {
+        requestOptions: {
+          customHeaders: { "content-type": "text/plain; encoding=UTF-8" }
+        }
+      });
 
       expect(response._response.status).to.equal(
         200,

--- a/test/integration/mediaType.spec.ts
+++ b/test/integration/mediaType.spec.ts
@@ -61,6 +61,7 @@ describe("Integration tests for MediaTypes", () => {
 
   describe("#contentTypeWithEncoding", () => {
     it("works with text/plain", async () => {
+      client = new MediaTypesClient();
       const response = await client.contentTypeWithEncoding("test", {
         requestOptions: {
           customHeaders: { "content-type": "text/plain; encoding=UTF-8" }


### PR DESCRIPTION
Enabling skipped missing type for MediaType tests. This scenario is supposed to test that Content-Type can be overriden, we can do that by passing customHeaders in the options parameter. See https://github.com/Azure/autorest.testserver/pull/228 for a conversation about the expectations of the test.