### PR TITLE
Only add polymorphic parent to union if the parent is a valid value

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -66,7 +66,7 @@ const writeClientModels = (
   modelsIndexFile: SourceFile
 ) => {
   let clientOptionalParams = clientDetails.parameters.filter(
-    p =>
+    (p) =>
       (!p.required || p.defaultValue) &&
       p.implementationLocation === ImplementationLocation.Client
   );
@@ -85,8 +85,8 @@ const writeOperationModels = (
   modelsIndexFile: SourceFile
 ) => {
   const modelsNames = getAllModelsNames(clientDetails);
-  return clientDetails.operationGroups.forEach(operationGroup => {
-    operationGroup.operations.forEach(operation => {
+  return clientDetails.operationGroups.forEach((operationGroup) => {
+    operationGroup.operations.forEach((operation) => {
       writeOptionsParameter(
         clientDetails,
         operationGroup,
@@ -125,7 +125,7 @@ function writeOptionsParameter(
   const operationName = normalizeName(operation.name, NameType.Interface);
   const operationRequestMediaTypes = new Set<KnownMediaType>();
   operation.requests.forEach(
-    r => r.mediaType && operationRequestMediaTypes.add(r.mediaType)
+    (r) => r.mediaType && operationRequestMediaTypes.add(r.mediaType)
   );
   writeOptionalParameters(
     operationGroupName,
@@ -164,7 +164,7 @@ function writeResponseTypes(
       ({ isError, mappers }) =>
         !isError && (mappers.bodyMapper || mappers.headersMapper)
     )
-    .forEach(operation => {
+    .forEach((operation) => {
       const { statusCodes, ...coreResponse } = operation;
       if (addedResponses.length === 0) {
         // Define possible values for response
@@ -173,13 +173,13 @@ function writeResponseTypes(
           docs: [`Contains response data for the ${name} operation.`],
           isExported: true,
           type: buildResponseType(operation),
-          leadingTrivia: writer => writer.blankLine(),
+          leadingTrivia: (writer) => writer.blankLine(),
           kind: StructureKind.TypeAlias
         });
         addedResponses.push({ name: responseName, response: coreResponse });
       }
 
-      const existingResponse = addedResponses.find(r => r.name === name);
+      const existingResponse = addedResponses.find((r) => r.name === name);
       if (
         existingResponse &&
         isEqual(existingResponse.response, coreResponse)
@@ -234,14 +234,14 @@ function getBodyProperties({
       {
         name: "bodyAsText",
         type: "string",
-        leadingTrivia: writer => writer.blankLine(),
+        leadingTrivia: (writer) => writer.blankLine(),
         docs: ["The response body as text (string format)"]
       },
       {
         name: "parsedBody",
         docs: ["The response body as parsed JSON or XML"],
         type: bodyType.typeName,
-        leadingTrivia: writer => writer.blankLine()
+        leadingTrivia: (writer) => writer.blankLine()
       }
     );
   } else if (mediaType === KnownMediaType.Binary) {
@@ -336,7 +336,7 @@ function buildResponseType(
               })
             )
           : "coreHttp.HttpResponse",
-        leadingTrivia: writer => writer.blankLine()
+        leadingTrivia: (writer) => writer.blankLine()
       }
     ]
   });
@@ -384,8 +384,8 @@ const writeChoices = (
   clientDetails: ClientDetails,
   modelsIndexFile: SourceFile
 ) =>
-  clientDetails.unions.forEach(choice => {
-    const values = choice.properties.map(p => p.value);
+  clientDetails.unions.forEach((choice) => {
+    const values = choice.properties.map((p) => p.value);
     if (choice.schemaType === SchemaType.Choice) {
       const valueToPush = choice.itemType ? choice.itemType : "string";
       values.push(valueToPush);
@@ -396,7 +396,7 @@ const writeChoices = (
       docs: [choice.description],
       isExported: true,
       type: values.join(" | "),
-      trailingTrivia: writer => writer.newLine()
+      trailingTrivia: (writer) => writer.newLine()
     });
   });
 
@@ -409,7 +409,7 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
   model: ObjectDetails
 ) => {
   const properties = getPropertiesSignatures(model);
-  const parents = model.parents.map(p => p.name).join(" & ");
+  const parents = model.parents.map((p) => p.name).join(" & ");
 
   if (parents) {
     modelsIndexFile.addTypeAlias({
@@ -420,7 +420,7 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
         parents,
         Writers.objectType({ properties })
       ),
-      leadingTrivia: writer => writer.blankLine()
+      leadingTrivia: (writer) => writer.blankLine()
     });
   } else {
     modelsIndexFile.addInterface({
@@ -428,7 +428,7 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
       docs: model.description ? [model.description] : [],
       isExported: true,
       properties,
-      leadingTrivia: writer => writer.blankLine()
+      leadingTrivia: (writer) => writer.blankLine()
     });
   }
 };
@@ -439,27 +439,26 @@ const writeObjectSignature = (modelsIndexFile: SourceFile) => (
 function writeUniontypes({ objects }: ClientDetails, modelsFile: SourceFile) {
   objects
     .filter(
-      obj => obj.kind === ObjectKind.Polymorphic && obj.children.length > 0
+      (obj) => obj.kind === ObjectKind.Polymorphic && obj.children.length > 0
     )
-    .forEach(obj => {
+    .forEach((obj) => {
       const polymorphicObject = obj as PolymorphicObjectDetails;
       const childrenNames = [
-        ...polymorphicObject.children.map(c => {
+        ...(isPolymorphicParentInUnion(polymorphicObject)
+          ? [polymorphicObject.name]
+          : []),
+        ...polymorphicObject.children.map((c) => {
           return c.schema.children && c.schema.children.immediate.length
             ? `${c.name}Union`
             : c.name;
         })
       ];
 
-      if (isPolymorphicParentInUnion(polymorphicObject)) {
-        childrenNames.unshift(polymorphicObject.name);
-      }
-
       modelsFile.addTypeAlias({
         name: `${obj.name}Union`,
         isExported: true,
         type: childrenNames.join(" | "),
-        trailingTrivia: writer => writer.newLine()
+        trailingTrivia: (writer) => writer.newLine()
       });
     });
 }
@@ -471,9 +470,9 @@ function writeUniontypes({ objects }: ClientDetails, modelsFile: SourceFile) {
  * @param parent Plymorphic parent to check
  */
 function isPolymorphicParentInUnion(parent: PolymorphicObjectDetails): boolean {
-  return Object.keys(parent.discriminatorValues).some(property =>
+  return Object.keys(parent.discriminatorValues).some((property) =>
     parent.discriminatorValues[property].some(
-      discriminatorValue => discriminatorValue === parent.name
+      (discriminatorValue) => discriminatorValue === parent.name
     )
   );
 }
@@ -495,10 +494,10 @@ function getOptionalGroups(
 
   optionalParams
     .filter(({ parameter: { groupedBy } }) => groupedBy && !groupedBy.required)
-    .forEach(p => {
+    .forEach((p) => {
       const { parameter } = p;
       const groupName = getLanguageMetadata(parameter.groupedBy!.language).name;
-      const isAlreadyTracked = optionalGroups.some(p => {
+      const isAlreadyTracked = optionalGroups.some((p) => {
         const { name } = getLanguageMetadata(p.language);
         return name === groupName;
       });
@@ -509,7 +508,7 @@ function getOptionalGroups(
       pull(optionalParams, p);
     });
 
-  return optionalGroups.map(group => {
+  return optionalGroups.map((group) => {
     const { name, description } = getLanguageMetadata(group.language);
     return {
       name: normalizeName(name, NameType.Parameter, true),
@@ -549,8 +548,10 @@ function writeOptionalParameters(
         properties: [
           ...optionalGroupDeclarations,
           ...optionalParams
-            .filter(p => !p.targetMediaType || p.targetMediaType === mediaType)
-            .map<PropertySignatureStructure>(p => {
+            .filter(
+              (p) => !p.targetMediaType || p.targetMediaType === mediaType
+            )
+            .map<PropertySignatureStructure>((p) => {
               const description = getParameterDescription(p, operationFullName);
               return {
                 name: p.name,
@@ -571,7 +572,7 @@ function writeOptionalParameters(
       extends: [baseClass || "coreHttp.OperationOptions"],
       properties: [
         ...optionalGroupDeclarations,
-        ...optionalParams.map<PropertySignatureStructure>(p => {
+        ...optionalParams.map<PropertySignatureStructure>((p) => {
           const description = getParameterDescription(p, operationFullName);
           return {
             name: p.name,
@@ -609,8 +610,8 @@ function getProperties(
   };
 
   return properties
-    .filter(property => !property.isDiscriminator)
-    .map<PropertySignatureStructure>(property => ({
+    .filter((property) => !property.isDiscriminator)
+    .map<PropertySignatureStructure>((property) => ({
       name: property.name,
       hasQuestionToken: !property.required,
       isReadonly: property.readOnly,
@@ -636,21 +637,21 @@ function withDiscriminator(
   }
 
   const discProps = keys(discriminatorValues).map<PropertySignatureStructure>(
-    key => {
+    (key) => {
       const name = normalizeName(key, NameType.Property);
       return {
         docs: [
           `Polymorphic discriminator, which specifies the different types this object can be`
         ],
         name,
-        type: discriminatorValues[key].map(disc => `"${disc}"`).join(" | "),
+        type: discriminatorValues[key].map((disc) => `"${disc}"`).join(" | "),
         kind: StructureKind.PropertySignature
       };
     }
   );
 
   const propertiesWithoutDiscriminator = properties.filter(
-    p => !discProps.some(dp => dp.name === p.name)
+    (p) => !discProps.some((dp) => dp.name === p.name)
   );
 
   return [...discProps, ...propertiesWithoutDiscriminator];

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -8,11 +8,11 @@
 
 import * as coreHttp from "@azure/core-http";
 
-export type FishUnion = Fish | SalmonUnion | SharkUnion;
-export type DotFishUnion = DotFish | DotSalmon;
-export type MyBaseTypeUnion = MyBaseType | MyDerivedType;
-export type SalmonUnion = Salmon | SmartSalmon;
-export type SharkUnion = Shark | Sawshark | Goblinshark | Cookiecuttershark;
+export type FishUnion = SalmonUnion | SharkUnion;
+export type DotFishUnion = DotSalmon;
+export type MyBaseTypeUnion = MyDerivedType;
+export type SalmonUnion = SmartSalmon;
+export type SharkUnion = Sawshark | Goblinshark | Cookiecuttershark;
 
 export interface Basic {
   /**

--- a/test/integration/generated/xmsErrorResponses/src/models/index.ts
+++ b/test/integration/generated/xmsErrorResponses/src/models/index.ts
@@ -8,12 +8,9 @@
 
 import * as coreHttp from "@azure/core-http";
 
-export type NotFoundErrorBaseUnion =
-  | NotFoundErrorBase
-  | LinkNotFound
-  | AnimalNotFound;
-export type PetActionErrorUnion = PetActionError | PetSadErrorUnion;
-export type PetSadErrorUnion = PetSadError | PetHungryOrThirstyError;
+export type NotFoundErrorBaseUnion = LinkNotFound | AnimalNotFound;
+export type PetActionErrorUnion = PetSadErrorUnion;
+export type PetSadErrorUnion = PetHungryOrThirstyError;
 
 export interface Animal {
   aniType?: string;

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/review/arm-package-deploymentscripts-2019-10-preview.api.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/review/arm-package-deploymentscripts-2019-10-preview.api.md
@@ -226,7 +226,7 @@ export type DeploymentScriptsUpdateResponse = DeploymentScriptUnion & {
 };
 
 // @public (undocumented)
-export type DeploymentScriptUnion = DeploymentScript | AzurePowerShellScript | AzureCliScript;
+export type DeploymentScriptUnion = AzurePowerShellScript | AzureCliScript;
 
 // @public
 export type DeploymentScriptUpdateParameter = AzureResourceBase & {

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/models/index.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/models/index.ts
@@ -8,10 +8,7 @@
 
 import * as coreHttp from "@azure/core-http";
 
-export type DeploymentScriptUnion =
-  | DeploymentScript
-  | AzurePowerShellScript
-  | AzureCliScript;
+export type DeploymentScriptUnion = AzurePowerShellScript | AzureCliScript;
 
 /**
  * Managed identity generic object.

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
@@ -1772,15 +1772,6 @@
             },
             {
               "kind": "Reference",
-              "text": "DeploymentScript",
-              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!DeploymentScript:type"
-            },
-            {
-              "kind": "Content",
-              "text": " | "
-            },
-            {
-              "kind": "Reference",
               "text": "AzurePowerShellScript",
               "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!AzurePowerShellScript:type"
             },
@@ -1802,7 +1793,7 @@
           "name": "DeploymentScriptUnion",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 6
+            "endIndex": 4
           }
         },
         {

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.md
@@ -226,7 +226,7 @@ export type DeploymentScriptsUpdateResponse = DeploymentScriptUnion & {
 };
 
 // @public (undocumented)
-export type DeploymentScriptUnion = DeploymentScript | AzurePowerShellScript | AzureCliScript;
+export type DeploymentScriptUnion = AzurePowerShellScript | AzureCliScript;
 
 // @public
 export type DeploymentScriptUpdateParameter = AzureResourceBase & {

--- a/test/smoke/generated/graphrbac-data-plane/review/graphrbac-data-plane.api.md
+++ b/test/smoke/generated/graphrbac-data-plane/review/graphrbac-data-plane.api.md
@@ -255,7 +255,7 @@ export interface DirectoryObjectListResult {
 }
 
 // @public (undocumented)
-export type DirectoryObjectUnion = DirectoryObject | User | Application | ADGroup | ServicePrincipal;
+export type DirectoryObjectUnion = User | Application | ADGroup | ServicePrincipal;
 
 // @public
 export interface Domain {

--- a/test/smoke/generated/graphrbac-data-plane/src/models/index.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/models/index.ts
@@ -9,7 +9,6 @@
 import * as coreHttp from "@azure/core-http";
 
 export type DirectoryObjectUnion =
-  | DirectoryObject
   | User
   | Application
   | ADGroup

--- a/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
+++ b/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
@@ -2436,15 +2436,6 @@
             },
             {
               "kind": "Reference",
-              "text": "DirectoryObject",
-              "canonicalReference": "graphrbac-data-plane!DirectoryObject:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " | "
-            },
-            {
-              "kind": "Reference",
               "text": "User",
               "canonicalReference": "graphrbac-data-plane!User:type"
             },
@@ -2484,7 +2475,7 @@
           "name": "DirectoryObjectUnion",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 10
+            "endIndex": 8
           }
         },
         {

--- a/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.md
+++ b/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.md
@@ -255,7 +255,7 @@ export interface DirectoryObjectListResult {
 }
 
 // @public (undocumented)
-export type DirectoryObjectUnion = DirectoryObject | User | Application | ADGroup | ServicePrincipal;
+export type DirectoryObjectUnion = User | Application | ADGroup | ServicePrincipal;
 
 // @public
 export interface Domain {

--- a/test/smoke/generated/network-resource-manager/review/network-resource-manager.api.md
+++ b/test/smoke/generated/network-resource-manager/review/network-resource-manager.api.md
@@ -3137,7 +3137,7 @@ export type FirewallPolicyRuleConditionNetworkProtocol = "TCP" | "UDP" | "Any" |
 export type FirewallPolicyRuleConditionType = "ApplicationRuleCondition" | "NetworkRuleCondition" | "NatRuleCondition" | string;
 
 // @public (undocumented)
-export type FirewallPolicyRuleConditionUnion = FirewallPolicyRuleCondition | ApplicationRuleCondition | NatRuleCondition | NetworkRuleCondition;
+export type FirewallPolicyRuleConditionUnion = ApplicationRuleCondition | NatRuleCondition | NetworkRuleCondition;
 
 // @public
 export type FirewallPolicyRuleGroup = SubResource & {
@@ -3191,7 +3191,7 @@ export type FirewallPolicyRuleGroupsListResponse = FirewallPolicyRuleGroupListRe
 export type FirewallPolicyRuleType = "FirewallPolicyNatRule" | "FirewallPolicyFilterRule" | string;
 
 // @public (undocumented)
-export type FirewallPolicyRuleUnion = FirewallPolicyRule | FirewallPolicyNatRule | FirewallPolicyFilterRule;
+export type FirewallPolicyRuleUnion = FirewallPolicyNatRule | FirewallPolicyFilterRule;
 
 // @public
 export interface FirewallPolicyThreatIntelWhitelist {

--- a/test/smoke/generated/network-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/network-resource-manager/src/models/index.ts
@@ -9,11 +9,9 @@
 import * as coreHttp from "@azure/core-http";
 
 export type FirewallPolicyRuleUnion =
-  | FirewallPolicyRule
   | FirewallPolicyNatRule
   | FirewallPolicyFilterRule;
 export type FirewallPolicyRuleConditionUnion =
-  | FirewallPolicyRuleCondition
   | ApplicationRuleCondition
   | NatRuleCondition
   | NetworkRuleCondition;

--- a/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.json
+++ b/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.json
@@ -27955,15 +27955,6 @@
             },
             {
               "kind": "Reference",
-              "text": "FirewallPolicyRuleCondition",
-              "canonicalReference": "network-resource-manager!FirewallPolicyRuleCondition:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " | "
-            },
-            {
-              "kind": "Reference",
               "text": "ApplicationRuleCondition",
               "canonicalReference": "network-resource-manager!ApplicationRuleCondition:type"
             },
@@ -27994,7 +27985,7 @@
           "name": "FirewallPolicyRuleConditionUnion",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 8
+            "endIndex": 6
           }
         },
         {
@@ -28344,15 +28335,6 @@
             },
             {
               "kind": "Reference",
-              "text": "FirewallPolicyRule",
-              "canonicalReference": "network-resource-manager!FirewallPolicyRule:interface"
-            },
-            {
-              "kind": "Content",
-              "text": " | "
-            },
-            {
-              "kind": "Reference",
               "text": "FirewallPolicyNatRule",
               "canonicalReference": "network-resource-manager!FirewallPolicyNatRule:type"
             },
@@ -28374,7 +28356,7 @@
           "name": "FirewallPolicyRuleUnion",
           "typeTokenRange": {
             "startIndex": 1,
-            "endIndex": 6
+            "endIndex": 4
           }
         },
         {

--- a/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.md
+++ b/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.md
@@ -3137,7 +3137,7 @@ export type FirewallPolicyRuleConditionNetworkProtocol = "TCP" | "UDP" | "Any" |
 export type FirewallPolicyRuleConditionType = "ApplicationRuleCondition" | "NetworkRuleCondition" | "NatRuleCondition" | string;
 
 // @public (undocumented)
-export type FirewallPolicyRuleConditionUnion = FirewallPolicyRuleCondition | ApplicationRuleCondition | NatRuleCondition | NetworkRuleCondition;
+export type FirewallPolicyRuleConditionUnion = ApplicationRuleCondition | NatRuleCondition | NetworkRuleCondition;
 
 // @public
 export type FirewallPolicyRuleGroup = SubResource & {
@@ -3191,7 +3191,7 @@ export type FirewallPolicyRuleGroupsListResponse = FirewallPolicyRuleGroupListRe
 export type FirewallPolicyRuleType = "FirewallPolicyNatRule" | "FirewallPolicyFilterRule" | string;
 
 // @public (undocumented)
-export type FirewallPolicyRuleUnion = FirewallPolicyRule | FirewallPolicyNatRule | FirewallPolicyFilterRule;
+export type FirewallPolicyRuleUnion = FirewallPolicyNatRule | FirewallPolicyFilterRule;
 
 // @public
 export interface FirewallPolicyThreatIntelWhitelist {


### PR DESCRIPTION
Only include the base class in the union type if the polymorphic parent's name is a valid discriminator value. 