### PR TITLE
Http Responses add missing test scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -134,9 +134,9 @@
             }
         },
         "@azure/core-http": {
-            "version": "1.2.0-alpha.20201019.1",
-            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.0-alpha.20201019.1.tgz",
-            "integrity": "sha512-Ns0J0kQf+d2lVutb9AdMefmEBFL/lCKqFrNtGa++3rcRTbX2QWci/vAFS2a1WJbZMGLIt2tQpSYHbMqJasQXog==",
+            "version": "1.2.0-alpha.20201030.2",
+            "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.0-alpha.20201030.2.tgz",
+            "integrity": "sha512-d3tXi2lPb7kRV74PtIfICSGI9OxSovzXt0My6BrM3xwRF6RI46CbGE0QN14g2cY+uCaEEmFeff1lUPsUN8JD8Q==",
             "requires": {
                 "@azure/abort-controller": "^1.0.0",
                 "@azure/core-auth": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
         "@azure-tools/autorest-extension-base": "^3.1.246",
         "@azure-tools/codegen": "^2.4.267",
         "@azure-tools/codemodel": "^4.13.339",
-        "@azure/core-http": "1.2.0-alpha.20201019.1",
+        "@azure/core-http": "1.2.0-alpha.20201030.2",
         "@azure/core-lro": "^1.0.1",
         "@azure/core-paging": "^1.0.0",
         "@azure/logger": "^1.0.0",

--- a/test/integration/httpInfrastructure.spec.ts
+++ b/test/integration/httpInfrastructure.spec.ts
@@ -786,8 +786,7 @@ describe("Http infrastructure Client", () => {
       assert.strictEqual(result._response.status, 204);
     });
 
-    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
-    it.skip("should handle get200ModelA202Valid", async () => {
+    it("should handle get200ModelA202Valid", async () => {
       try {
         await client.multipleResponses.get200ModelA202Valid();
         assert.fail("Expected get200ModelA202Valid to throw");
@@ -798,8 +797,7 @@ describe("Http infrastructure Client", () => {
       }
     });
 
-    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
-    it.skip("should handle get200ModelA400Invalid", async () => {
+    it("should handle get200ModelA400Invalid", async () => {
       try {
         await client.multipleResponses.get200ModelA400Invalid();
         assert.fail("Expected get200ModelA400Invalid to throw");
@@ -810,8 +808,7 @@ describe("Http infrastructure Client", () => {
       }
     });
 
-    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
-    it.skip("should handle get200ModelA400Valid", async () => {
+    it("should handle get200ModelA400Valid", async () => {
       try {
         await client.multipleResponses.get200ModelA400Valid();
         assert.fail("Expected get200ModelA400Valid to throw");
@@ -822,8 +819,7 @@ describe("Http infrastructure Client", () => {
       }
     });
 
-    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
-    it.skip("should handle get200ModelA400None", async () => {
+    it("should handle get200ModelA400None", async () => {
       try {
         await client.multipleResponses.get200ModelA400None();
         assert.fail("Expected get200ModelA400None to throw");
@@ -835,7 +831,7 @@ describe("Http infrastructure Client", () => {
   });
 
   describe("Failure scenarios", () => {
-    it.skip("getEmptyError should throw error", async () => {
+    it("getEmptyError should throw error", async () => {
       try {
         await client.httpFailure.getEmptyError();
         assert.fail("Expected error");
@@ -844,8 +840,7 @@ describe("Http infrastructure Client", () => {
       }
     });
 
-    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
-    it.skip("getNoModelEmpty should throw 400", async () => {
+    it("getNoModelEmpty should throw 400", async () => {
       try {
         await client.httpFailure.getNoModelEmpty();
         assert.fail("Expected getNoModelEmpty to throw");
@@ -855,8 +850,7 @@ describe("Http infrastructure Client", () => {
       }
     });
 
-    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
-    it.skip("getNoModelError should throw 400", async () => {
+    it("getNoModelError should throw 400", async () => {
       try {
         await client.httpFailure.getNoModelError();
         assert.fail("Expected getNoModelError to throw");

--- a/test/integration/httpInfrastructure.spec.ts
+++ b/test/integration/httpInfrastructure.spec.ts
@@ -5,7 +5,8 @@ import {
   redirectPolicy,
   exponentialRetryPolicy,
   deserializationPolicy,
-  isNode
+  isNode,
+  RestError
 } from "@azure/core-http";
 describe("Http infrastructure Client", () => {
   let client: HttpInfrastructureClient;
@@ -757,10 +758,84 @@ describe("Http infrastructure Client", () => {
         assert.equal(error.statusCode, 400);
       }
     });
+
+    it("should handle get200Model204NoModelDefaultError200Valid", async () => {
+      const result = await client.multipleResponses.get200Model204NoModelDefaultError200Valid();
+      assert.strictEqual(result.statusCode, "200");
+    });
+
+    it("should handle ResponsesScenarioD400DefaultModel", async () => {
+      try {
+        await client.multipleResponses.get202None204NoneDefaultError400Valid();
+        assert.fail(
+          "Expected get202None204NoneDefaultError400Valid to throw an error"
+        );
+      } catch (error) {
+        assert.strictEqual(error.message, "client error");
+        assert.strictEqual(error.statusCode, 400);
+      }
+    });
+
+    it("should handle get202None204NoneDefaultNone202Invalid", async () => {
+      const result = await client.multipleResponses.get202None204NoneDefaultNone202Invalid();
+      assert.strictEqual(result._response.status, 202);
+    });
+
+    it("should handle get202None204NoneDefaultNone204None", async () => {
+      const result = await client.multipleResponses.get202None204NoneDefaultNone204None();
+      assert.strictEqual(result._response.status, 204);
+    });
+
+    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
+    it.skip("should handle get200ModelA202Valid", async () => {
+      try {
+        await client.multipleResponses.get200ModelA202Valid();
+        assert.fail("Expected get200ModelA202Valid to throw");
+      } catch (e) {
+        const error: RestError = e;
+        assert.strictEqual(error.statusCode, 202);
+        assert.include(error.message, "202");
+      }
+    });
+
+    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
+    it.skip("should handle get200ModelA400Invalid", async () => {
+      try {
+        await client.multipleResponses.get200ModelA400Invalid();
+        assert.fail("Expected get200ModelA400Invalid to throw");
+      } catch (e) {
+        const error: RestError = e;
+        assert.strictEqual(error.statusCode, 400);
+        assert.include(error.message, "400");
+      }
+    });
+
+    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
+    it.skip("should handle get200ModelA400Valid", async () => {
+      try {
+        await client.multipleResponses.get200ModelA400Valid();
+        assert.fail("Expected get200ModelA400Valid to throw");
+      } catch (e) {
+        const error: RestError = e;
+        assert.strictEqual(error.statusCode, 400);
+        assert.include(error.message, "400");
+      }
+    });
+
+    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
+    it.skip("should handle get200ModelA400None", async () => {
+      try {
+        await client.multipleResponses.get200ModelA400None();
+        assert.fail("Expected get200ModelA400None to throw");
+      } catch (e) {
+        const error: RestError = e;
+        assert.strictEqual(error.statusCode, 400);
+      }
+    });
   });
 
   describe("Failure scenarios", () => {
-    it("getEmptyError should throw error", async () => {
+    it.skip("getEmptyError should throw error", async () => {
       try {
         await client.httpFailure.getEmptyError();
         assert.fail("Expected error");
@@ -769,14 +844,27 @@ describe("Http infrastructure Client", () => {
       }
     });
 
-    it("getNoModelEmpty should return 400", async () => {
-      const result = await client.httpFailure.getNoModelEmpty();
-      assert.equal(result._response.status, 400);
+    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
+    it.skip("getNoModelEmpty should throw 400", async () => {
+      try {
+        await client.httpFailure.getNoModelEmpty();
+        assert.fail("Expected getNoModelEmpty to throw");
+      } catch (e) {
+        const error: RestError = e;
+        assert.strictEqual(error.statusCode, 400);
+      }
     });
 
-    it("getNoModelError should return 400", async () => {
-      const result = await client.httpFailure.getNoModelError();
-      assert.deepEqual(result, { status: 400, message: "NoErrorModel" } as any);
+    // Enable when https://github.com/Azure/azure-sdk-for-js/pull/12153 is merged
+    it.skip("getNoModelError should throw 400", async () => {
+      try {
+        await client.httpFailure.getNoModelError();
+        assert.fail("Expected getNoModelError to throw");
+      } catch (e) {
+        const error: RestError = e;
+        assert.strictEqual(error.statusCode, 400);
+        assert.include(error.message, "NoErrorModel");
+      }
     });
   });
 });


### PR DESCRIPTION
Adding missing scenarios for the HTTP response tests. Found an issue in `core-http` which treats any statusCode that is not defined in the swagger as a success when there is no "default" status code. This will be fixed by https://github.com/Azure/azure-sdk-for-js/pull/12153
