### PR TITLE
Support for Parameter flattening

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ modelerfour:
   prenamer: true
   # this will flatten modelers marked with 'x-ms-client-flatten'
   flatten-models: true
+  # this will flatten parameters marked with 'x-ms-client-flatten'
+  flatten-payloads: true
   # this will make the content-type parameter always specified
   always-create-content-type-parameter: true
+
   # enables parameter grouping via x-ms-parameter-grouping
   group-parameters: true
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ modelerfour:
   flatten-payloads: true
   # this will make the content-type parameter always specified
   always-create-content-type-parameter: true
-
   # enables parameter grouping via x-ms-parameter-grouping
   group-parameters: true
 

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -129,7 +129,7 @@ function writeOptionsParameter(
   );
 
   const optionalParams = operationParameters.filter(
-    ({ required }) => !required
+    ({ required, isFlattened }) => !required && !isFlattened
   );
 
   const operationName = normalizeName(operation.name, NameType.Interface);
@@ -514,7 +514,10 @@ function getOptionalGroups(
   let optionalGroups: Parameter[] = [];
 
   optionalParams
-    .filter(({ parameter: { groupedBy } }) => groupedBy && !groupedBy.required)
+    .filter(
+      ({ parameter: { groupedBy, flattened } }) =>
+        groupedBy && !groupedBy.required && !flattened
+    )
     .forEach(p => {
       const { parameter } = p;
       const groupName = getLanguageMetadata(parameter.groupedBy!.language).name;

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -143,7 +143,7 @@ export function writeGetOperationOptions(
  * Generates a string representation of an Operation spec
  * the output is to be inserted in the Operation group file
  */
-function writeSpec(spec: OperationSpecDetails, writer: CodeBlockWriter) {
+function writeSpec(spec: OperationSpecDetails, writer: CodeBlockWriter): void {
   const responses = buildResponses(spec);
   const requestBody = buildRequestBody(spec);
   const queryParams = buildParameters(spec, "queryParameters");
@@ -217,18 +217,6 @@ function writeSpec(spec: OperationSpecDetails, writer: CodeBlockWriter) {
       writer.write(", ");
     }
   });
-
-  return {
-    responses,
-    requestBody,
-    queryParams,
-    urlParams,
-    headerParams,
-    formDataParams,
-    contentType,
-    mediaType,
-    isXml: !!spec.isXML
-  };
 }
 
 function buildMediaType({ requestBody }: OperationSpecDetails) {

--- a/src/generators/operationGenerator.ts
+++ b/src/generators/operationGenerator.ts
@@ -47,12 +47,7 @@ import {
   getResponseTypeName
 } from "./utils/responseTypeUtils";
 import { getParameterDescription } from "../utils/getParameterDescription";
-import {
-  BaseMapper,
-  CompositeMapper,
-  Mapper,
-  ParameterPath
-} from "@azure/core-http";
+import { Mapper, ParameterPath } from "@azure/core-http";
 
 /**
  * Function that writes the code for all the operations.
@@ -142,18 +137,6 @@ export function writeGetOperationOptions(
     return coreHttp.operationOptionsToRequestOptionsBase(operationOptions);
     `
   });
-}
-
-interface Spec {
-  responses: string[];
-  requestBody: string | RequestBody;
-  queryParams: string;
-  urlParams: string;
-  headerParams: string;
-  formDataParams: string;
-  contentType: string;
-  mediaType: string;
-  isXml: boolean;
 }
 
 /**
@@ -250,7 +233,11 @@ function writeSpec(spec: OperationSpecDetails, writer: CodeBlockWriter) {
 
 function buildMediaType({ requestBody }: OperationSpecDetails) {
   let targetMediaType: string | undefined = "";
+
+  // requestBody may be an array of parameters, this is the scenario
+  // where the body parameter has been flattened.
   if (Array.isArray(requestBody)) {
+    // We just need to take the first know targetMediaType as all others would be the same
     targetMediaType = requestBody[0]?.targetMediaType;
   } else {
     targetMediaType = requestBody?.targetMediaType;
@@ -259,6 +246,7 @@ function buildMediaType({ requestBody }: OperationSpecDetails) {
   if (targetMediaType) {
     return `mediaType: '${targetMediaType}'`;
   }
+
   return "";
 }
 
@@ -268,6 +256,9 @@ function buildContentType({ requestBody, isXML }: OperationSpecDetails) {
     : "";
 }
 
+/**
+ * Internal type that represents the shape of a RequestBody which contains a parameter path and a mapper
+ */
 type RequestBody = {
   parameterPath: {
     [propertyName: string]: ParameterPath;
@@ -277,7 +268,9 @@ type RequestBody = {
 
 /**
  * This function transforms the requestBody of OperationSpecDetails into its string representation
- * to insert in generated files
+ * to insert in generated files.
+ * Whenever the request body parameter has been flattened this function will return the ResponseBody as a complex
+ * object.
  */
 function buildRequestBody({
   requestBody,
@@ -287,21 +280,38 @@ function buildRequestBody({
     return "";
   }
 
+  // No flattened parameters so we can just return the simple representation
   if (isSingleRequestBody(requestBody)) {
     return `requestBody: Parameters.${requestBody.nameRef},`;
   }
+
+  // Request body has been flattened so we need to represent it as a complex RequestBody
+  // object in which we'll describe the parameter name and where to find it in the operation parameters
+
+  // First get the mapper, this will be the mapper for the parameter before flattening
   const mapper = requestBody[0].mapper;
+
+  // Generate the request body from the parameters
   const parameters = requestBody.reduce((acc, curr) => {
+    // We ignore any Grouped or Flattened parameters
     if (curr.schemaType === SchemaType.Group || curr.parameter.flattened) {
       return acc;
     }
+
     const name = curr.name;
+
+    // Figure out how to find the parameter, if the parameter belongs to a group we need to access the group object so the
+    // path would be ["groupName", "parameterName"] to tell the serialized to get it from groupName.parameterName.
+    // If it is a regular parameter the path would be its name.
     const sourcePath = curr.parameter.groupedBy
       ? [getLanguageMetadata(curr.parameter.groupedBy.language).name, name]
       : [name];
+
     const isRequired = curr.required || curr.parameter.groupedBy?.required;
 
     let parameterPath: ParameterPath;
+
+    // If the parameter is optional it will be put in the "options" parameter bag, so add "options" to the path.
     if (isRequired) {
       parameterPath = sourcePath;
     } else {
@@ -314,12 +324,10 @@ function buildRequestBody({
     };
   }, {} as { [propertyName: string]: ParameterPath });
 
-  const body = {
+  return {
     parameterPath: parameters,
     mapper
   };
-
-  return body;
 }
 
 function isSingleRequestBody(

--- a/src/generators/parametersGenerator.ts
+++ b/src/generators/parametersGenerator.ts
@@ -51,7 +51,7 @@ export function generateParameters(
 
   clientDetails.parameters
     .filter(p => !p.isSynthetic)
-    // No need to generate parameters for flattened ones, as the would never get used
+    // No need to generate parameters for flattened ones, as the will never get used
     .filter(p => !p.isFlattened)
     .forEach(param => {
       parametersFile.addVariableStatement({

--- a/src/generators/parametersGenerator.ts
+++ b/src/generators/parametersGenerator.ts
@@ -51,6 +51,7 @@ export function generateParameters(
 
   clientDetails.parameters
     .filter(p => !p.isSynthetic)
+    .filter(p => !p.isFlattened)
     .forEach(param => {
       parametersFile.addVariableStatement({
         isExported: true,

--- a/src/generators/parametersGenerator.ts
+++ b/src/generators/parametersGenerator.ts
@@ -51,6 +51,7 @@ export function generateParameters(
 
   clientDetails.parameters
     .filter(p => !p.isSynthetic)
+    // No need to generate parameters for flattened ones, as the would never get used
     .filter(p => !p.isFlattened)
     .forEach(param => {
       parametersFile.addVariableStatement({

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -81,7 +81,7 @@ export interface OperationSpecDetails {
   path: string;
   httpMethod: string;
   responses: OperationSpecResponses;
-  requestBody?: ParameterDetails;
+  requestBody?: ParameterDetails | ParameterDetails[];
   formDataParameters?: ParameterDetails[];
   queryParameters?: ParameterDetails[];
   urlParameters?: ParameterDetails[];

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { HttpMethod, Parameter } from "@azure-tools/codemodel";
+import {
+  HttpMethod,
+  Parameter,
+  VirtualParameter
+} from "@azure-tools/codemodel";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper } from "@azure/core-http";
 import { ParameterDetails } from "./parameterDetails";
@@ -14,7 +18,8 @@ export interface OperationRequestDetails {
   path: string;
   method: HttpMethod;
   mediaType?: KnownMediaType;
-  parameters?: Parameter[];
+  parameters?: (Parameter | VirtualParameter)[];
+  signatureParameters: (Parameter | VirtualParameter)[];
 }
 
 export type OperationResponseMapper = Mapper | string;

--- a/src/models/operationDetails.ts
+++ b/src/models/operationDetails.ts
@@ -19,7 +19,6 @@ export interface OperationRequestDetails {
   method: HttpMethod;
   mediaType?: KnownMediaType;
   parameters?: (Parameter | VirtualParameter)[];
-  signatureParameters: (Parameter | VirtualParameter)[];
 }
 
 export type OperationResponseMapper = Mapper | string;

--- a/src/models/parameterDetails.ts
+++ b/src/models/parameterDetails.ts
@@ -5,7 +5,8 @@ import {
   Parameter,
   ParameterLocation,
   AllSchemaTypes,
-  ImplementationLocation
+  ImplementationLocation,
+  VirtualParameter
 } from "@azure-tools/codemodel";
 import { Mapper } from "@azure/core-http";
 import { TypeDetails } from "./modelDetails";
@@ -23,7 +24,7 @@ export interface ParameterDetails {
   parameterPath: string | string[];
   mapper: string | Mapper;
   isGlobal: boolean;
-  parameter: Parameter;
+  parameter: Parameter | VirtualParameter;
   operationsIn?: { [operationName: string]: { description: string } };
   collectionFormat?: string;
   schemaType: AllSchemaTypes;

--- a/src/models/parameterDetails.ts
+++ b/src/models/parameterDetails.ts
@@ -32,6 +32,7 @@ export interface ParameterDetails {
   typeDetails: TypeDetails;
   skipEncoding?: boolean;
   isSynthetic?: boolean;
+  isFlattened: boolean;
   /**
    * Only specified when an operation has multiple requests.
    * This is used to identify which request a parameter belongs to.

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -13,10 +13,7 @@ import {
   OperationGroup,
   ParameterLocation,
   ConstantSchema,
-  CodeModel,
-  ImplementationLocation,
-  Parameter,
-  VirtualParameter
+  CodeModel
 } from "@azure-tools/codemodel";
 import {
   normalizeName,
@@ -255,8 +252,7 @@ export function transformOperationRequest(
     path: request.protocol.http.path,
     method: request.protocol.http.method,
     mediaType: request.protocol.http.knownMediaType,
-    parameters: request.parameters,
-    signatureParameters: request.signatureParameters || []
+    parameters: request.parameters
   };
 }
 
@@ -497,18 +493,24 @@ function getGroupedParameters(
     mediaType &&
     (mediaType == KnownMediaType.Multipart || mediaType == KnownMediaType.Form);
 
+  // Extract parameters that are located in the operation body
   const bodyParams = operationParams.filter(
     p => p.location === ParameterLocation.Body
   );
 
-  let requestBody: ParameterDetails | ParameterDetails[] | undefined;
+  let requestBody:
+    | ParameterDetails
+    | ParameterDetails[]
+    | undefined = bodyParams;
 
+  // If we have an empty array make the request boyd undefined
   if (bodyParams.length === 0) {
     requestBody = undefined;
-  } else if (bodyParams.length === 1) {
+  }
+
+  // Flatten the bodyParams array if it only contains a single parameter
+  if (bodyParams.length === 1) {
     requestBody = bodyParams[0];
-  } else {
-    requestBody = bodyParams;
   }
 
   return {

--- a/src/transforms/operationTransforms.ts
+++ b/src/transforms/operationTransforms.ts
@@ -493,6 +493,20 @@ function getGroupedParameters(
     mediaType &&
     (mediaType == KnownMediaType.Multipart || mediaType == KnownMediaType.Form);
 
+  const bodyParams = operationParams.filter(
+    p => p.location === ParameterLocation.Body
+  );
+
+  let requestBody: ParameterDetails | ParameterDetails[] | undefined;
+
+  if (bodyParams.length === 0) {
+    requestBody = undefined;
+  } else if (bodyParams.length === 1) {
+    requestBody = bodyParams[0];
+  } else {
+    requestBody = bodyParams;
+  }
+
   return {
     ...(hasFormDataParameters
       ? {
@@ -501,9 +515,7 @@ function getGroupedParameters(
           )
         }
       : {
-          requestBody: operationParams.find(
-            p => p.location === ParameterLocation.Body
-          )
+          requestBody
         }),
     queryParameters: operationParams.filter(
       p => p.location === ParameterLocation.Query

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -90,22 +90,14 @@ export async function transformCodeModel(
 
   const [uberParents, operationGroups] = await Promise.all([
     getUberParents(codeModel),
-
     transformOperationGroups(codeModel)
   ]);
 
   const options = await transformOptions(host, operationGroups);
+  const groups = transformGroups(codeModel);
 
-  const [
-    objects,
-    groups,
-    mappers,
-    unions,
-    parameters,
-    baseUrl
-  ] = await Promise.all([
+  const [objects, mappers, unions, parameters, baseUrl] = await Promise.all([
     transformObjects(codeModel, uberParents),
-    transformGroups(codeModel),
     transformMappers(codeModel, uberParents, options),
     transformChoices(codeModel),
     transformParameters(codeModel, options),

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -90,14 +90,22 @@ export async function transformCodeModel(
 
   const [uberParents, operationGroups] = await Promise.all([
     getUberParents(codeModel),
+
     transformOperationGroups(codeModel)
   ]);
 
   const options = await transformOptions(host, operationGroups);
-  const groups = transformGroups(codeModel);
 
-  const [objects, mappers, unions, parameters, baseUrl] = await Promise.all([
+  const [
+    objects,
+    groups,
+    mappers,
+    unions,
+    parameters,
+    baseUrl
+  ] = await Promise.all([
     transformObjects(codeModel, uberParents),
+    transformGroups(codeModel),
     transformMappers(codeModel, uberParents, options),
     transformChoices(codeModel),
     transformParameters(codeModel, options),

--- a/test/integration/generated/arrayConstraints/src/arrayConstraintsClient.ts
+++ b/test/integration/generated/arrayConstraints/src/arrayConstraintsClient.ts
@@ -105,6 +105,6 @@ const apiV1ValueGetOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.pageRange],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.apiVersion, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.apiVersion],
   serializer
 };

--- a/test/integration/generated/arrayConstraints/src/models/parameters.ts
+++ b/test/integration/generated/arrayConstraints/src/models/parameters.ts
@@ -97,15 +97,3 @@ export const pageRange: OperationQueryParameter = {
   },
   collectionFormat: QueryCollectionFormat.Csv
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/azureParameterGrouping/src/models/parameters.ts
+++ b/test/integration/generated/azureParameterGrouping/src/models/parameters.ts
@@ -60,11 +60,7 @@ export const $host: OperationURLParameter = {
 };
 
 export const customHeader: OperationParameter = {
-  parameterPath: [
-    "options",
-    "parameterGroupingPostRequiredParameters",
-    "customHeader"
-  ],
+  parameterPath: ["parameterGroupingPostRequiredParameters", "customHeader"],
   mapper: {
     serializedName: "customHeader",
     type: {
@@ -74,11 +70,7 @@ export const customHeader: OperationParameter = {
 };
 
 export const query: OperationQueryParameter = {
-  parameterPath: [
-    "options",
-    "parameterGroupingPostRequiredParameters",
-    "query"
-  ],
+  parameterPath: ["parameterGroupingPostRequiredParameters", "query"],
   mapper: {
     defaultValue: 30,
     serializedName: "query",
@@ -93,18 +85,6 @@ export const path: OperationURLParameter = {
   mapper: {
     serializedName: "path",
     required: true,
-    type: {
-      name: "String"
-    }
-  }
-};
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
     type: {
       name: "String"
     }

--- a/test/integration/generated/azureParameterGrouping/src/operations/parameterGrouping.ts
+++ b/test/integration/generated/azureParameterGrouping/src/operations/parameterGrouping.ts
@@ -132,7 +132,7 @@ const postOptionalOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.query1],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1, Parameters.customHeader1],
+  headerParameters: [Parameters.accept, Parameters.customHeader1],
   serializer
 };
 const postMultiParamGroupsOperationSpec: coreHttp.OperationSpec = {
@@ -147,7 +147,7 @@ const postMultiParamGroupsOperationSpec: coreHttp.OperationSpec = {
   queryParameters: [Parameters.queryOne, Parameters.queryTwo],
   urlParameters: [Parameters.$host],
   headerParameters: [
-    Parameters.accept1,
+    Parameters.accept,
     Parameters.headerOne,
     Parameters.headerTwo
   ],
@@ -164,6 +164,6 @@ const postSharedParameterGroupObjectOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.queryOne],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1, Parameters.headerOne],
+  headerParameters: [Parameters.accept, Parameters.headerOne],
   serializer
 };

--- a/test/integration/generated/bodyArray/src/models/parameters.ts
+++ b/test/integration/generated/bodyArray/src/models/parameters.ts
@@ -60,18 +60,6 @@ export const arrayBody: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const arrayBody1: OperationParameter = {
   parameterPath: "arrayBody",
   mapper: {

--- a/test/integration/generated/bodyArray/src/operations/array.ts
+++ b/test/integration/generated/bodyArray/src/operations/array.ts
@@ -1308,7 +1308,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1340,7 +1340,7 @@ const putBooleanTfftOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1406,7 +1406,7 @@ const putIntegerValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1472,7 +1472,7 @@ const putLongValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1538,7 +1538,7 @@ const putFloatValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1604,7 +1604,7 @@ const putDoubleValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1670,7 +1670,7 @@ const putStringValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1707,7 +1707,7 @@ const putEnumValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody3,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1739,7 +1739,7 @@ const putStringEnumValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody4,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1805,7 +1805,7 @@ const putUuidValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody5,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1854,7 +1854,7 @@ const putDateValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody6,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1920,7 +1920,7 @@ const putDateTimeValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody7,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1989,7 +1989,7 @@ const putDateTimeRfc1123ValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody8,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2021,7 +2021,7 @@ const putDurationValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody9,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2053,7 +2053,7 @@ const putByteValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody10,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2202,7 +2202,7 @@ const putComplexValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody11,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2327,7 +2327,7 @@ const putArrayValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody12,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2452,7 +2452,7 @@ const putDictionaryValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody13,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyBoolean/src/models/parameters.ts
+++ b/test/integration/generated/bodyBoolean/src/models/parameters.ts
@@ -56,18 +56,6 @@ export const boolBody: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const boolBody1: OperationParameter = {
   parameterPath: "boolBody",
   mapper: {

--- a/test/integration/generated/bodyBoolean/src/operations/bool.ts
+++ b/test/integration/generated/bodyBoolean/src/operations/bool.ts
@@ -149,7 +149,7 @@ const putTrueOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.boolBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -179,7 +179,7 @@ const putFalseOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.boolBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyBooleanQuirks/src/models/parameters.ts
+++ b/test/integration/generated/bodyBooleanQuirks/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const boolBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyBooleanQuirks/src/operations/bool.ts
+++ b/test/integration/generated/bodyBooleanQuirks/src/operations/bool.ts
@@ -155,7 +155,7 @@ const putTrueOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.boolBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -185,7 +185,7 @@ const putFalseOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.boolBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyByte/src/models/parameters.ts
+++ b/test/integration/generated/bodyByte/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const byteBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyByte/src/operations/byte.ts
+++ b/test/integration/generated/bodyByte/src/operations/byte.ts
@@ -169,7 +169,7 @@ const putNonAsciiOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.byteBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/models/parameters.ts
+++ b/test/integration/generated/bodyComplex/src/models/parameters.ts
@@ -73,18 +73,6 @@ export const complexBody: OperationParameter = {
   mapper: BasicMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const apiVersion: OperationQueryParameter = {
   parameterPath: "apiVersion",
   mapper: {

--- a/test/integration/generated/bodyComplex/src/operations/array.ts
+++ b/test/integration/generated/bodyComplex/src/operations/array.ts
@@ -146,7 +146,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody12,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -176,7 +176,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody12,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/basic.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basic.ts
@@ -160,7 +160,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.complexBody,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyComplex/src/operations/dictionary.ts
@@ -163,7 +163,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody13,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -193,7 +193,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody13,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/inheritance.ts
+++ b/test/integration/generated/bodyComplex/src/operations/inheritance.ts
@@ -92,7 +92,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody14,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphicrecursive.ts
@@ -142,7 +142,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody15,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
+++ b/test/integration/generated/bodyComplex/src/operations/polymorphism.ts
@@ -282,7 +282,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody15,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -357,7 +357,7 @@ const putComplicatedOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody16,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -374,7 +374,7 @@ const putMissingDiscriminatorOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody16,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -389,7 +389,7 @@ const putValidMissingRequiredOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody15,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/primitive.ts
+++ b/test/integration/generated/bodyComplex/src/operations/primitive.ts
@@ -454,7 +454,7 @@ const putIntOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -484,7 +484,7 @@ const putLongOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -514,7 +514,7 @@ const putFloatOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody3,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -544,7 +544,7 @@ const putDoubleOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody4,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -574,7 +574,7 @@ const putBoolOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody5,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -604,7 +604,7 @@ const putStringOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody6,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -634,7 +634,7 @@ const putDateOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody7,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -664,7 +664,7 @@ const putDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody8,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -694,7 +694,7 @@ const putDateTimeRfc1123OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody9,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -724,7 +724,7 @@ const putDurationOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody10,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -754,7 +754,7 @@ const putByteOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody11,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
+++ b/test/integration/generated/bodyComplex/src/operations/readonlyproperty.ts
@@ -90,7 +90,7 @@ const putValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.complexBody17,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyDate/src/models/parameters.ts
+++ b/test/integration/generated/bodyDate/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const dateBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyDate/src/operations/date.ts
+++ b/test/integration/generated/bodyDate/src/operations/date.ts
@@ -238,7 +238,7 @@ const putMaxDateOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.dateBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -268,7 +268,7 @@ const putMinDateOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.dateBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyDateTime/src/models/parameters.ts
+++ b/test/integration/generated/bodyDateTime/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const datetimeBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyDateTime/src/operations/datetime.ts
+++ b/test/integration/generated/bodyDateTime/src/operations/datetime.ts
@@ -485,7 +485,7 @@ const putUtcMaxDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -500,7 +500,7 @@ const putUtcMaxDateTime7DigitsOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -560,7 +560,7 @@ const putLocalPositiveOffsetMaxDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -605,7 +605,7 @@ const putLocalNegativeOffsetMaxDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -650,7 +650,7 @@ const putUtcMinDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -680,7 +680,7 @@ const putLocalPositiveOffsetMinDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -710,7 +710,7 @@ const putLocalNegativeOffsetMinDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyDateTimeRfc1123/src/models/parameters.ts
+++ b/test/integration/generated/bodyDateTimeRfc1123/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const datetimeBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyDateTimeRfc1123/src/operations/datetimerfc1123.ts
+++ b/test/integration/generated/bodyDateTimeRfc1123/src/operations/datetimerfc1123.ts
@@ -257,7 +257,7 @@ const putUtcMaxDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -302,7 +302,7 @@ const putUtcMinDateTimeOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.datetimeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyDictionary/src/models/parameters.ts
+++ b/test/integration/generated/bodyDictionary/src/models/parameters.ts
@@ -56,18 +56,6 @@ export const arrayBody: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const arrayBody1: OperationParameter = {
   parameterPath: "arrayBody",
   mapper: {

--- a/test/integration/generated/bodyDictionary/src/operations/dictionary.ts
+++ b/test/integration/generated/bodyDictionary/src/operations/dictionary.ts
@@ -1221,7 +1221,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1321,7 +1321,7 @@ const putBooleanTfftOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1387,7 +1387,7 @@ const putIntegerValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1453,7 +1453,7 @@ const putLongValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1519,7 +1519,7 @@ const putFloatValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1585,7 +1585,7 @@ const putDoubleValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1651,7 +1651,7 @@ const putStringValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1717,7 +1717,7 @@ const putDateValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody3,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1783,7 +1783,7 @@ const putDateTimeValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody4,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1852,7 +1852,7 @@ const putDateTimeRfc1123ValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody5,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1884,7 +1884,7 @@ const putDurationValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody6,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1916,7 +1916,7 @@ const putByteValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody7,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2065,7 +2065,7 @@ const putComplexValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody8,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2190,7 +2190,7 @@ const putArrayValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody9,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2290,7 +2290,7 @@ const putDictionaryValidOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.arrayBody10,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyDuration/src/models/parameters.ts
+++ b/test/integration/generated/bodyDuration/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const durationBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyDuration/src/operations/duration.ts
+++ b/test/integration/generated/bodyDuration/src/operations/duration.ts
@@ -126,7 +126,7 @@ const putPositiveDurationOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.durationBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyInteger/src/models/parameters.ts
+++ b/test/integration/generated/bodyInteger/src/models/parameters.ts
@@ -55,18 +55,6 @@ export const intBody: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const intBody1: OperationParameter = {
   parameterPath: "intBody",
   mapper: {

--- a/test/integration/generated/bodyInteger/src/operations/int.ts
+++ b/test/integration/generated/bodyInteger/src/operations/int.ts
@@ -373,7 +373,7 @@ const putMax32OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.intBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -388,7 +388,7 @@ const putMax64OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.intBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -403,7 +403,7 @@ const putMin32OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.intBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -418,7 +418,7 @@ const putMin64OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.intBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -448,7 +448,7 @@ const putUnixTimeDateOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.intBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyNumber/src/models/parameters.ts
+++ b/test/integration/generated/bodyNumber/src/models/parameters.ts
@@ -55,18 +55,6 @@ export const numberBody: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const numberBody1: OperationParameter = {
   parameterPath: "numberBody",
   mapper: {

--- a/test/integration/generated/bodyNumber/src/operations/number.ts
+++ b/test/integration/generated/bodyNumber/src/operations/number.ts
@@ -510,7 +510,7 @@ const putBigFloatOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -540,7 +540,7 @@ const putBigDoubleOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -570,7 +570,7 @@ const putBigDoublePositiveDecimalOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -600,7 +600,7 @@ const putBigDoubleNegativeDecimalOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -630,7 +630,7 @@ const putBigDecimalOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -660,7 +660,7 @@ const putBigDecimalPositiveDecimalOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -690,7 +690,7 @@ const putBigDecimalNegativeDecimalOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -720,7 +720,7 @@ const putSmallFloatOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -750,7 +750,7 @@ const putSmallDoubleOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -780,7 +780,7 @@ const putSmallDecimalOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.numberBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyString/src/models/parameters.ts
+++ b/test/integration/generated/bodyString/src/models/parameters.ts
@@ -55,18 +55,6 @@ export const stringBody: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const stringBody1: OperationParameter = {
   parameterPath: "stringBody",
   mapper: {

--- a/test/integration/generated/bodyString/src/operations/enum.ts
+++ b/test/integration/generated/bodyString/src/operations/enum.ts
@@ -169,7 +169,7 @@ const putNotExpandableOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.stringBody5,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -204,7 +204,7 @@ const putReferencedOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.enumStringBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -234,7 +234,7 @@ const putReferencedConstantOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.enumStringBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyString/src/operations/string.ts
+++ b/test/integration/generated/bodyString/src/operations/string.ts
@@ -272,7 +272,7 @@ const putNullOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.stringBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -302,7 +302,7 @@ const putEmptyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.stringBody1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -332,7 +332,7 @@ const putMbcsOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.stringBody2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -362,7 +362,7 @@ const putWhitespaceOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.stringBody3,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -422,7 +422,7 @@ const putBase64UrlEncodedOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.stringBody4,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/bodyTime/src/models/parameters.ts
+++ b/test/integration/generated/bodyTime/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const timeBody: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/bodyTime/src/operations/time.ts
+++ b/test/integration/generated/bodyTime/src/operations/time.ts
@@ -92,7 +92,7 @@ const putOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.timeBody,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/extensibleEnums/src/models/parameters.ts
+++ b/test/integration/generated/extensibleEnums/src/models/parameters.ts
@@ -60,15 +60,3 @@ export const petParam: OperationParameter = {
   parameterPath: ["options", "petParam"],
   mapper: PetMapper
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/extensibleEnums/src/operations/pet.ts
+++ b/test/integration/generated/extensibleEnums/src/operations/pet.ts
@@ -88,7 +88,7 @@ const addPetOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.petParam,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/httpInfrastructure/src/models/parameters.ts
+++ b/test/integration/generated/httpInfrastructure/src/models/parameters.ts
@@ -55,15 +55,3 @@ export const booleanValue: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/httpInfrastructure/src/operations/httpClientFailure.ts
+++ b/test/integration/generated/httpInfrastructure/src/operations/httpClientFailure.ts
@@ -457,7 +457,7 @@ const put400OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -471,7 +471,7 @@ const patch400OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -485,7 +485,7 @@ const post400OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -499,7 +499,7 @@ const delete400OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -561,7 +561,7 @@ const put404OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -575,7 +575,7 @@ const patch405OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -589,7 +589,7 @@ const post406OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -603,7 +603,7 @@ const delete407OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -617,7 +617,7 @@ const put409OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -679,7 +679,7 @@ const put413OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -693,7 +693,7 @@ const patch414OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -707,7 +707,7 @@ const post415OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -733,7 +733,7 @@ const delete417OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/httpInfrastructure/src/operations/httpRedirects.ts
+++ b/test/integration/generated/httpInfrastructure/src/operations/httpRedirects.ts
@@ -386,7 +386,7 @@ const put301OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -435,7 +435,7 @@ const patch302OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -453,7 +453,7 @@ const post303OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -519,7 +519,7 @@ const put307OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -537,7 +537,7 @@ const patch307OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -555,7 +555,7 @@ const post307OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -573,7 +573,7 @@ const delete307OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/httpInfrastructure/src/operations/httpRetry.ts
+++ b/test/integration/generated/httpInfrastructure/src/operations/httpRetry.ts
@@ -188,7 +188,7 @@ const put500OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -203,7 +203,7 @@ const patch500OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -246,7 +246,7 @@ const post503OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -261,7 +261,7 @@ const delete503OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -276,7 +276,7 @@ const put504OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -291,7 +291,7 @@ const patch504OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/httpInfrastructure/src/operations/httpServerFailure.ts
+++ b/test/integration/generated/httpInfrastructure/src/operations/httpServerFailure.ts
@@ -121,7 +121,7 @@ const post505OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -135,7 +135,7 @@ const delete505OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/httpInfrastructure/src/operations/httpSuccess.ts
+++ b/test/integration/generated/httpInfrastructure/src/operations/httpSuccess.ts
@@ -369,7 +369,7 @@ const put200OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -384,7 +384,7 @@ const patch200OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -399,7 +399,7 @@ const post200OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -414,7 +414,7 @@ const delete200OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -429,7 +429,7 @@ const put201OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -444,7 +444,7 @@ const post201OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -459,7 +459,7 @@ const put202OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -474,7 +474,7 @@ const patch202OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -489,7 +489,7 @@ const post202OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -504,7 +504,7 @@ const delete202OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -532,7 +532,7 @@ const put204OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -547,7 +547,7 @@ const patch204OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -562,7 +562,7 @@ const post204OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -577,7 +577,7 @@ const delete204OperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.booleanValue,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/lro/src/models/parameters.ts
+++ b/test/integration/generated/lro/src/models/parameters.ts
@@ -54,18 +54,6 @@ export const $host: OperationURLParameter = {
   skipEncoding: true
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const sku: OperationParameter = {
   parameterPath: ["options", "sku"],
   mapper: SkuMapper

--- a/test/integration/generated/lro/src/operations/lRORetrys.ts
+++ b/test/integration/generated/lro/src/operations/lRORetrys.ts
@@ -369,7 +369,7 @@ const deleteProvisioning202Accepted200SucceededOperationSpec: coreHttp.Operation
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const delete202Retry200OperationSpec: coreHttp.OperationSpec = {
@@ -393,7 +393,7 @@ const delete202Retry200OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRelativeRetrySucceededOperationSpec: coreHttp.OperationSpec = {
@@ -417,7 +417,7 @@ const deleteAsyncRelativeRetrySucceededOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const post202Retry200OperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/generated/lro/src/operations/lROs.ts
+++ b/test/integration/generated/lro/src/operations/lROs.ts
@@ -1572,7 +1572,7 @@ const post202ListOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const put200SucceededNoStateOperationSpec: coreHttp.OperationSpec = {
@@ -2036,7 +2036,7 @@ const deleteProvisioning202Accepted200SucceededOperationSpec: coreHttp.Operation
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteProvisioning202DeletingFailed200OperationSpec: coreHttp.OperationSpec = {
@@ -2060,7 +2060,7 @@ const deleteProvisioning202DeletingFailed200OperationSpec: coreHttp.OperationSpe
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteProvisioning202Deletingcanceled200OperationSpec: coreHttp.OperationSpec = {
@@ -2084,7 +2084,7 @@ const deleteProvisioning202Deletingcanceled200OperationSpec: coreHttp.OperationS
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const delete204SucceededOperationSpec: coreHttp.OperationSpec = {
@@ -2100,7 +2100,7 @@ const delete204SucceededOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const delete202Retry200OperationSpec: coreHttp.OperationSpec = {
@@ -2124,7 +2124,7 @@ const delete202Retry200OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const delete202NoRetry204OperationSpec: coreHttp.OperationSpec = {
@@ -2148,7 +2148,7 @@ const delete202NoRetry204OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteNoHeaderInRetryOperationSpec: coreHttp.OperationSpec = {
@@ -2172,7 +2172,7 @@ const deleteNoHeaderInRetryOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncNoHeaderInRetryOperationSpec: coreHttp.OperationSpec = {
@@ -2196,7 +2196,7 @@ const deleteAsyncNoHeaderInRetryOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRetrySucceededOperationSpec: coreHttp.OperationSpec = {
@@ -2220,7 +2220,7 @@ const deleteAsyncRetrySucceededOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncNoRetrySucceededOperationSpec: coreHttp.OperationSpec = {
@@ -2244,7 +2244,7 @@ const deleteAsyncNoRetrySucceededOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRetryFailedOperationSpec: coreHttp.OperationSpec = {
@@ -2268,7 +2268,7 @@ const deleteAsyncRetryFailedOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRetrycanceledOperationSpec: coreHttp.OperationSpec = {
@@ -2292,7 +2292,7 @@ const deleteAsyncRetrycanceledOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const post200WithPayloadOperationSpec: coreHttp.OperationSpec = {
@@ -2316,7 +2316,7 @@ const post200WithPayloadOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const post202Retry200OperationSpec: coreHttp.OperationSpec = {
@@ -2396,7 +2396,7 @@ const postDoubleHeadersFinalLocationGetOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const postDoubleHeadersFinalAzureHeaderGetOperationSpec: coreHttp.OperationSpec = {
@@ -2420,7 +2420,7 @@ const postDoubleHeadersFinalAzureHeaderGetOperationSpec: coreHttp.OperationSpec 
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const postDoubleHeadersFinalAzureHeaderGetDefaultOperationSpec: coreHttp.OperationSpec = {
@@ -2444,7 +2444,7 @@ const postDoubleHeadersFinalAzureHeaderGetDefaultOperationSpec: coreHttp.Operati
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const postAsyncRetrySucceededOperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/generated/lro/src/operations/lrosaDs.ts
+++ b/test/integration/generated/lro/src/operations/lrosaDs.ts
@@ -1078,7 +1078,7 @@ const deleteNonRetry400OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const delete202NonRetry400OperationSpec: coreHttp.OperationSpec = {
@@ -1102,7 +1102,7 @@ const delete202NonRetry400OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRelativeRetry400OperationSpec: coreHttp.OperationSpec = {
@@ -1126,7 +1126,7 @@ const deleteAsyncRelativeRetry400OperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const postNonRetry400OperationSpec: coreHttp.OperationSpec = {
@@ -1306,7 +1306,7 @@ const delete204SucceededOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRelativeRetryNoStatusOperationSpec: coreHttp.OperationSpec = {
@@ -1330,7 +1330,7 @@ const deleteAsyncRelativeRetryNoStatusOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const post202NoLocationOperationSpec: coreHttp.OperationSpec = {
@@ -1496,7 +1496,7 @@ const delete202RetryInvalidHeaderOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRelativeRetryInvalidHeaderOperationSpec: coreHttp.OperationSpec = {
@@ -1520,7 +1520,7 @@ const deleteAsyncRelativeRetryInvalidHeaderOperationSpec: coreHttp.OperationSpec
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteAsyncRelativeRetryInvalidJsonPollingOperationSpec: coreHttp.OperationSpec = {
@@ -1548,7 +1548,7 @@ const deleteAsyncRelativeRetryInvalidJsonPollingOperationSpec: coreHttp.Operatio
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const post202RetryInvalidHeaderOperationSpec: coreHttp.OperationSpec = {

--- a/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
+++ b/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
@@ -233,11 +233,11 @@ const putArrayOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
+  requestBody: Parameters.resourceArray,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer,
-  requestBody: Parameters.resourceArray
+  serializer
 };
 const getArrayOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/array",
@@ -270,11 +270,11 @@ const putWrappedArrayOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
+  requestBody: Parameters.resourceArray1,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer,
-  requestBody: Parameters.resourceArray1
+  serializer
 };
 const getWrappedArrayOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/wrappedarray",
@@ -305,11 +305,11 @@ const putDictionaryOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
+  requestBody: Parameters.resourceDictionary,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer,
-  requestBody: Parameters.resourceDictionary
+  serializer
 };
 const getDictionaryOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/dictionary",
@@ -340,11 +340,11 @@ const putResourceCollectionOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
+  requestBody: Parameters.resourceComplexObject,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer,
-  requestBody: Parameters.resourceComplexObject
+  serializer
 };
 const getResourceCollectionOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/resourcecollection",
@@ -372,11 +372,11 @@ const putSimpleProductOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
+  requestBody: Parameters.simpleBodyProduct,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer,
-  requestBody: Parameters.simpleBodyProduct
+  serializer
 };
 const postFlattenedSimpleProductOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/customFlattening",
@@ -389,21 +389,21 @@ const postFlattenedSimpleProductOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept],
-  mediaType: "json",
-  serializer,
   requestBody: {
     parameterPath: {
       productId: ["productId"],
       description: ["options", "description"],
       maxProductDisplayName: ["options", "maxProductDisplayName"],
+      capacity: ["options", "capacity"],
       genericValue: ["options", "genericValue"],
-      odataValue: ["options", "odataValue"],
-      capacity: ["options", "capacity"]
+      odataValue: ["options", "odataValue"]
     },
     mapper: Mappers.SimpleProduct
-  }
+  },
+  urlParameters: [Parameters.$host],
+  headerParameters: [Parameters.contentType, Parameters.accept],
+  mediaType: "json",
+  serializer
 };
 const putSimpleProductWithGroupingOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/customFlattening/parametergrouping/{name}/",
@@ -416,19 +416,19 @@ const putSimpleProductWithGroupingOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  urlParameters: [Parameters.$host, Parameters.name],
-  headerParameters: [Parameters.contentType, Parameters.accept],
-  mediaType: "json",
-  serializer,
   requestBody: {
     parameterPath: {
+      capacity: ["options", "capacity"],
       productId: ["flattenParameterGroup", "productId"],
       description: ["flattenParameterGroup", "description"],
       maxProductDisplayName: ["flattenParameterGroup", "maxProductDisplayName"],
       genericValue: ["flattenParameterGroup", "genericValue"],
-      odataValue: ["flattenParameterGroup", "odataValue"],
-      capacity: ["options", "capacity"]
+      odataValue: ["flattenParameterGroup", "odataValue"]
     },
     mapper: Mappers.SimpleProduct
-  }
+  },
+  urlParameters: [Parameters.$host, Parameters.name],
+  headerParameters: [Parameters.contentType, Parameters.accept],
+  mediaType: "json",
+  serializer
 };

--- a/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
+++ b/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
@@ -258,7 +258,7 @@ const getArrayOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const putWrappedArrayOperationSpec: coreHttp.OperationSpec = {
@@ -293,7 +293,7 @@ const getWrappedArrayOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const putDictionaryOperationSpec: coreHttp.OperationSpec = {
@@ -328,7 +328,7 @@ const getDictionaryOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const putResourceCollectionOperationSpec: coreHttp.OperationSpec = {
@@ -358,7 +358,7 @@ const getResourceCollectionOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const putSimpleProductOperationSpec: coreHttp.OperationSpec = {
@@ -395,12 +395,12 @@ const postFlattenedSimpleProductOperationSpec: coreHttp.OperationSpec = {
   serializer,
   requestBody: {
     parameterPath: {
-      productId: "productId",
+      productId: ["productId"],
       description: ["options", "description"],
       maxProductDisplayName: ["options", "maxProductDisplayName"],
-      capacity: ["options", "capacity"],
       genericValue: ["options", "genericValue"],
-      odataValue: ["options", "odataValue"]
+      odataValue: ["options", "odataValue"],
+      capacity: ["options", "capacity"]
     },
     mapper: Mappers.SimpleProduct
   }
@@ -422,12 +422,12 @@ const putSimpleProductWithGroupingOperationSpec: coreHttp.OperationSpec = {
   serializer,
   requestBody: {
     parameterPath: {
-      capacity: ["options", "capacity"],
-      productId: "productId",
-      description: ["options", "description"],
-      maxProductDisplayName: ["options", "maxProductDisplayName"],
-      genericValue: ["options", "genericValue"],
-      odataValue: ["options", "odataValue"]
+      productId: ["flattenParameterGroup", "productId"],
+      description: ["flattenParameterGroup", "description"],
+      maxProductDisplayName: ["flattenParameterGroup", "maxProductDisplayName"],
+      genericValue: ["flattenParameterGroup", "genericValue"],
+      odataValue: ["flattenParameterGroup", "odataValue"],
+      capacity: ["options", "capacity"]
     },
     mapper: Mappers.SimpleProduct
   }

--- a/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
+++ b/test/integration/generated/modelFlattening/src/modelFlatteningClient.ts
@@ -185,16 +185,19 @@ export class ModelFlatteningClient extends ModelFlatteningClientContext {
 
   /**
    * Put Flattened Simple Product with client flattening true on the parameter
+   * @param productId Unique identifier representing a specific product for a given latitude & longitude.
+   *                  For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
    * @param options The options parameters.
    */
   postFlattenedSimpleProduct(
+    productId: string,
     options?: ModelFlatteningClientPostFlattenedSimpleProductOptionalParams
   ): Promise<ModelFlatteningClientPostFlattenedSimpleProductResponse> {
     const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
       options || {}
     );
     return this.sendOperationRequest(
-      { options: operationOptions },
+      { productId, options: operationOptions },
       postFlattenedSimpleProductOperationSpec
     ) as Promise<ModelFlatteningClientPostFlattenedSimpleProductResponse>;
   }
@@ -230,11 +233,11 @@ const putArrayOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.resourceArray,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: Parameters.resourceArray
 };
 const getArrayOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/array",
@@ -267,11 +270,11 @@ const putWrappedArrayOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.resourceArray1,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: Parameters.resourceArray1
 };
 const getWrappedArrayOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/wrappedarray",
@@ -302,11 +305,11 @@ const putDictionaryOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.resourceDictionary,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: Parameters.resourceDictionary
 };
 const getDictionaryOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/dictionary",
@@ -337,11 +340,11 @@ const putResourceCollectionOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.resourceComplexObject,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: Parameters.resourceComplexObject
 };
 const getResourceCollectionOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/resourcecollection",
@@ -369,11 +372,11 @@ const putSimpleProductOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.simpleBodyProduct,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: Parameters.simpleBodyProduct
 };
 const postFlattenedSimpleProductOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/customFlattening",
@@ -386,11 +389,21 @@ const postFlattenedSimpleProductOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.simpleBodyProduct,
   urlParameters: [Parameters.$host],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: {
+    parameterPath: {
+      productId: "productId",
+      description: ["options", "description"],
+      maxProductDisplayName: ["options", "maxProductDisplayName"],
+      capacity: ["options", "capacity"],
+      genericValue: ["options", "genericValue"],
+      odataValue: ["options", "odataValue"]
+    },
+    mapper: Mappers.SimpleProduct
+  }
 };
 const putSimpleProductWithGroupingOperationSpec: coreHttp.OperationSpec = {
   path: "/model-flatten/customFlattening/parametergrouping/{name}/",
@@ -403,9 +416,19 @@ const putSimpleProductWithGroupingOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.ErrorModel
     }
   },
-  requestBody: Parameters.simpleBodyProduct1,
   urlParameters: [Parameters.$host, Parameters.name],
   headerParameters: [Parameters.contentType, Parameters.accept],
   mediaType: "json",
-  serializer
+  serializer,
+  requestBody: {
+    parameterPath: {
+      capacity: ["options", "capacity"],
+      productId: "productId",
+      description: ["options", "description"],
+      maxProductDisplayName: ["options", "maxProductDisplayName"],
+      genericValue: ["options", "genericValue"],
+      odataValue: ["options", "odataValue"]
+    },
+    mapper: Mappers.SimpleProduct
+  }
 };

--- a/test/integration/generated/modelFlattening/src/models/index.ts
+++ b/test/integration/generated/modelFlattening/src/models/index.ts
@@ -355,6 +355,10 @@ export type ModelFlatteningClientPutSimpleProductResponse = SimpleProduct & {
 export interface ModelFlatteningClientPostFlattenedSimpleProductOptionalParams
   extends coreHttp.OperationOptions {
   /**
+   * Simple body product to post
+   */
+  simpleBodyProduct?: SimpleProduct;
+  /**
    * Description of product.
    */
   description?: string;
@@ -397,6 +401,10 @@ export type ModelFlatteningClientPostFlattenedSimpleProductResponse = SimpleProd
  */
 export interface ModelFlatteningClientPutSimpleProductWithGroupingOptionalParams
   extends coreHttp.OperationOptions {
+  /**
+   * Simple body product to put
+   */
+  simpleBodyProduct?: SimpleProduct;
   /**
    * Description of product.
    */

--- a/test/integration/generated/modelFlattening/src/models/index.ts
+++ b/test/integration/generated/modelFlattening/src/models/index.ts
@@ -355,10 +355,6 @@ export type ModelFlatteningClientPutSimpleProductResponse = SimpleProduct & {
 export interface ModelFlatteningClientPostFlattenedSimpleProductOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * Simple body product to post
-   */
-  simpleBodyProduct?: SimpleProduct;
-  /**
    * Description of product.
    */
   description?: string;
@@ -401,10 +397,6 @@ export type ModelFlatteningClientPostFlattenedSimpleProductResponse = SimpleProd
  */
 export interface ModelFlatteningClientPutSimpleProductWithGroupingOptionalParams
   extends coreHttp.OperationOptions {
-  /**
-   * Simple body product to put
-   */
-  simpleBodyProduct?: SimpleProduct;
   /**
    * Description of product.
    */

--- a/test/integration/generated/modelFlattening/src/models/index.ts
+++ b/test/integration/generated/modelFlattening/src/models/index.ts
@@ -153,6 +153,26 @@ export interface FlattenParameterGroup {
    * Simple body product to put
    */
   simpleBodyProduct?: SimpleProduct;
+  /**
+   * Unique identifier representing a specific product for a given latitude & longitude. For example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.
+   */
+  productId: string;
+  /**
+   * Description of product.
+   */
+  description?: string;
+  /**
+   * Display name of product.
+   */
+  maxProductDisplayName?: string;
+  /**
+   * Generic URL value.
+   */
+  genericValue?: string;
+  /**
+   * URL value.
+   */
+  odataValue?: string;
 }
 
 /**
@@ -335,9 +355,21 @@ export type ModelFlatteningClientPutSimpleProductResponse = SimpleProduct & {
 export interface ModelFlatteningClientPostFlattenedSimpleProductOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * Simple body product to post
+   * Description of product.
    */
-  simpleBodyProduct?: SimpleProduct;
+  description?: string;
+  /**
+   * Display name of product.
+   */
+  maxProductDisplayName?: string;
+  /**
+   * Generic URL value.
+   */
+  genericValue?: string;
+  /**
+   * URL value.
+   */
+  odataValue?: string;
 }
 
 /**
@@ -366,9 +398,21 @@ export type ModelFlatteningClientPostFlattenedSimpleProductResponse = SimpleProd
 export interface ModelFlatteningClientPutSimpleProductWithGroupingOptionalParams
   extends coreHttp.OperationOptions {
   /**
-   * Simple body product to put
+   * Description of product.
    */
-  simpleBodyProduct?: SimpleProduct;
+  description?: string;
+  /**
+   * Display name of product.
+   */
+  maxProductDisplayName?: string;
+  /**
+   * Generic URL value.
+   */
+  genericValue?: string;
+  /**
+   * URL value.
+   */
+  odataValue?: string;
 }
 
 /**

--- a/test/integration/generated/modelFlattening/src/models/parameters.ts
+++ b/test/integration/generated/modelFlattening/src/models/parameters.ts
@@ -64,18 +64,6 @@ export const $host: OperationURLParameter = {
   skipEncoding: true
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceArray1: OperationParameter = {
   parameterPath: ["options", "resourceArray"],
   mapper: {
@@ -113,6 +101,11 @@ export const simpleBodyProduct: OperationParameter = {
   mapper: SimpleProductMapper
 };
 
+export const simpleBodyProduct1: OperationParameter = {
+  parameterPath: ["options", "simpleBodyProduct"],
+  mapper: SimpleProductMapper
+};
+
 export const productId: OperationParameter = {
   parameterPath: "productId",
   mapper: SimpleProductMapper
@@ -143,28 +136,38 @@ export const odataValue: OperationParameter = {
   mapper: SimpleProductMapper
 };
 
+export const simpleBodyProduct2: OperationParameter = {
+  parameterPath: ["flattenParameterGroup", "simpleBodyProduct"],
+  mapper: SimpleProductMapper
+};
+
 export const productId1: OperationParameter = {
   parameterPath: ["flattenParameterGroup", "productId"],
   mapper: SimpleProductMapper
 };
 
 export const description1: OperationParameter = {
-  parameterPath: ["options", "flattenParameterGroup", "description"],
+  parameterPath: ["flattenParameterGroup", "description"],
   mapper: SimpleProductMapper
 };
 
 export const maxProductDisplayName1: OperationParameter = {
-  parameterPath: ["options", "flattenParameterGroup", "maxProductDisplayName"],
+  parameterPath: ["flattenParameterGroup", "maxProductDisplayName"],
+  mapper: SimpleProductMapper
+};
+
+export const capacity1: OperationParameter = {
+  parameterPath: ["options", "capacity"],
   mapper: SimpleProductMapper
 };
 
 export const genericValue1: OperationParameter = {
-  parameterPath: ["options", "flattenParameterGroup", "genericValue"],
+  parameterPath: ["flattenParameterGroup", "genericValue"],
   mapper: SimpleProductMapper
 };
 
 export const odataValue1: OperationParameter = {
-  parameterPath: ["options", "flattenParameterGroup", "odataValue"],
+  parameterPath: ["flattenParameterGroup", "odataValue"],
   mapper: SimpleProductMapper
 };
 

--- a/test/integration/generated/modelFlattening/src/models/parameters.ts
+++ b/test/integration/generated/modelFlattening/src/models/parameters.ts
@@ -101,11 +101,6 @@ export const simpleBodyProduct: OperationParameter = {
   mapper: SimpleProductMapper
 };
 
-export const simpleBodyProduct1: OperationParameter = {
-  parameterPath: ["options", "simpleBodyProduct"],
-  mapper: SimpleProductMapper
-};
-
 export const productId: OperationParameter = {
   parameterPath: "productId",
   mapper: SimpleProductMapper
@@ -136,11 +131,6 @@ export const odataValue: OperationParameter = {
   mapper: SimpleProductMapper
 };
 
-export const simpleBodyProduct2: OperationParameter = {
-  parameterPath: ["flattenParameterGroup", "simpleBodyProduct"],
-  mapper: SimpleProductMapper
-};
-
 export const productId1: OperationParameter = {
   parameterPath: ["flattenParameterGroup", "productId"],
   mapper: SimpleProductMapper
@@ -153,11 +143,6 @@ export const description1: OperationParameter = {
 
 export const maxProductDisplayName1: OperationParameter = {
   parameterPath: ["flattenParameterGroup", "maxProductDisplayName"],
-  mapper: SimpleProductMapper
-};
-
-export const capacity1: OperationParameter = {
-  parameterPath: ["options", "capacity"],
   mapper: SimpleProductMapper
 };
 

--- a/test/integration/generated/modelFlattening/src/models/parameters.ts
+++ b/test/integration/generated/modelFlattening/src/models/parameters.ts
@@ -113,8 +113,58 @@ export const simpleBodyProduct: OperationParameter = {
   mapper: SimpleProductMapper
 };
 
-export const simpleBodyProduct1: OperationParameter = {
-  parameterPath: ["options", "flattenParameterGroup", "simpleBodyProduct"],
+export const productId: OperationParameter = {
+  parameterPath: "productId",
+  mapper: SimpleProductMapper
+};
+
+export const description: OperationParameter = {
+  parameterPath: ["options", "description"],
+  mapper: SimpleProductMapper
+};
+
+export const maxProductDisplayName: OperationParameter = {
+  parameterPath: ["options", "maxProductDisplayName"],
+  mapper: SimpleProductMapper
+};
+
+export const capacity: OperationParameter = {
+  parameterPath: ["options", "capacity"],
+  mapper: SimpleProductMapper
+};
+
+export const genericValue: OperationParameter = {
+  parameterPath: ["options", "genericValue"],
+  mapper: SimpleProductMapper
+};
+
+export const odataValue: OperationParameter = {
+  parameterPath: ["options", "odataValue"],
+  mapper: SimpleProductMapper
+};
+
+export const productId1: OperationParameter = {
+  parameterPath: ["flattenParameterGroup", "productId"],
+  mapper: SimpleProductMapper
+};
+
+export const description1: OperationParameter = {
+  parameterPath: ["options", "flattenParameterGroup", "description"],
+  mapper: SimpleProductMapper
+};
+
+export const maxProductDisplayName1: OperationParameter = {
+  parameterPath: ["options", "flattenParameterGroup", "maxProductDisplayName"],
+  mapper: SimpleProductMapper
+};
+
+export const genericValue1: OperationParameter = {
+  parameterPath: ["options", "flattenParameterGroup", "genericValue"],
+  mapper: SimpleProductMapper
+};
+
+export const odataValue1: OperationParameter = {
+  parameterPath: ["options", "flattenParameterGroup", "odataValue"],
   mapper: SimpleProductMapper
 };
 

--- a/test/integration/generated/multipleInheritance/src/models/parameters.ts
+++ b/test/integration/generated/multipleInheritance/src/models/parameters.ts
@@ -56,18 +56,6 @@ export const horse: OperationParameter = {
   mapper: HorseMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const pet: OperationParameter = {
   parameterPath: "pet",
   mapper: PetMapper

--- a/test/integration/generated/multipleInheritance/src/multipleInheritanceClient.ts
+++ b/test/integration/generated/multipleInheritance/src/multipleInheritanceClient.ts
@@ -239,7 +239,7 @@ const putHorseOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.horse,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -268,7 +268,7 @@ const putPetOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.pet,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -297,7 +297,7 @@ const putFelineOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.feline,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -326,7 +326,7 @@ const putCatOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.cat,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -355,7 +355,7 @@ const putKittenOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.kitten,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/nonStringEnum/src/models/parameters.ts
+++ b/test/integration/generated/nonStringEnum/src/models/parameters.ts
@@ -54,18 +54,6 @@ export const $host: OperationURLParameter = {
   skipEncoding: true
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const input1: OperationParameter = {
   parameterPath: ["options", "input"],
   mapper: {

--- a/test/integration/generated/nonStringEnum/src/operations/float.ts
+++ b/test/integration/generated/nonStringEnum/src/operations/float.ts
@@ -84,6 +84,6 @@ const getOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/integration/generated/nonStringEnum/src/operations/int.ts
+++ b/test/integration/generated/nonStringEnum/src/operations/int.ts
@@ -84,6 +84,6 @@ const getOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/integration/generated/objectType/src/models/parameters.ts
+++ b/test/integration/generated/objectType/src/models/parameters.ts
@@ -54,15 +54,3 @@ export const putObject: OperationParameter = {
     }
   }
 };
-
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};

--- a/test/integration/generated/objectType/src/objectTypeClient.ts
+++ b/test/integration/generated/objectType/src/objectTypeClient.ts
@@ -89,7 +89,7 @@ const putOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.putObject,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/paging/src/models/parameters.ts
+++ b/test/integration/generated/paging/src/models/parameters.ts
@@ -116,11 +116,7 @@ export const timeout1: OperationParameter = {
 };
 
 export const maxresults2: OperationParameter = {
-  parameterPath: [
-    "options",
-    "pagingGetMultiplePagesWithOffsetOptions",
-    "maxresults"
-  ],
+  parameterPath: ["pagingGetMultiplePagesWithOffsetOptions", "maxresults"],
   mapper: {
     serializedName: "maxresults",
     type: {
@@ -141,11 +137,7 @@ export const offset: OperationURLParameter = {
 };
 
 export const timeout2: OperationParameter = {
-  parameterPath: [
-    "options",
-    "pagingGetMultiplePagesWithOffsetOptions",
-    "timeout"
-  ],
+  parameterPath: ["pagingGetMultiplePagesWithOffsetOptions", "timeout"],
   mapper: {
     defaultValue: 30,
     serializedName: "timeout",

--- a/test/integration/generated/requiredOptional/src/models/parameters.ts
+++ b/test/integration/generated/requiredOptional/src/models/parameters.ts
@@ -100,18 +100,6 @@ export const bodyParameter: OperationParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const requiredGlobalPath: OperationURLParameter = {
   parameterPath: "requiredGlobalPath",
   mapper: {

--- a/test/integration/generated/requiredOptional/src/operations/explicit.ts
+++ b/test/integration/generated/requiredOptional/src/operations/explicit.ts
@@ -443,7 +443,7 @@ const postRequiredIntegerParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter1,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -458,7 +458,7 @@ const postOptionalIntegerParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter2,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -473,7 +473,7 @@ const postRequiredIntegerPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter3,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -488,7 +488,7 @@ const postOptionalIntegerPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter4,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -529,7 +529,7 @@ const postRequiredStringParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter5,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -544,7 +544,7 @@ const postOptionalStringParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -559,7 +559,7 @@ const postRequiredStringPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter6,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -574,7 +574,7 @@ const postOptionalStringPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter7,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -615,7 +615,7 @@ const postRequiredClassParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter9,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -630,7 +630,7 @@ const postOptionalClassParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter10,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -645,7 +645,7 @@ const postRequiredClassPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter11,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -660,7 +660,7 @@ const postOptionalClassPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter12,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -675,7 +675,7 @@ const postRequiredArrayParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter13,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -690,7 +690,7 @@ const postOptionalArrayParameterOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter14,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -705,7 +705,7 @@ const postRequiredArrayPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter15,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -720,7 +720,7 @@ const postOptionalArrayPropertyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter16,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/requiredOptional/src/operations/implicit.ts
+++ b/test/integration/generated/requiredOptional/src/operations/implicit.ts
@@ -199,7 +199,7 @@ const putOptionalBodyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.bodyParameter,
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/generated/validation/src/models/parameters.ts
+++ b/test/integration/generated/validation/src/models/parameters.ts
@@ -109,18 +109,6 @@ export const body: OperationParameter = {
   mapper: ProductMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceGroupName1: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {

--- a/test/integration/generated/validation/src/validationClient.ts
+++ b/test/integration/generated/validation/src/validationClient.ts
@@ -146,7 +146,7 @@ const validationOfBodyOperationSpec: coreHttp.OperationSpec = {
     Parameters.id,
     Parameters.resourceGroupName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -167,7 +167,7 @@ const postWithConstantInBodyOperationSpec: coreHttp.OperationSpec = {
   },
   requestBody: Parameters.body,
   urlParameters: [Parameters.$host, Parameters.constantParam],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/integration/mediaTypesV3.spec.ts
+++ b/test/integration/mediaTypesV3.spec.ts
@@ -5,17 +5,25 @@ describe("OpenAPI V3 model that supports multiple media-types", () => {
     const client = new MediaTypesV3Client("http://localhost:3000");
     // excluded is an optional parameter that exists on both overloads.
     // TypeScript complains if we attempt to set `excluded` but the models lack it.
-    client.fooApi.postSend(
-      "thingA",
-      "application/octet-stream",
-      Buffer.from("data"),
-      {
+
+    // Wrapping in operation to avoid sending the request because this doesn't have a real test-server endpoint
+    // we have this in place to verify that we get the expected TS static analysis
+    const operation1 = () =>
+      client.fooApi.postSend(
+        "thingA",
+        "application/octet-stream",
+        Buffer.from("data"),
+        {
+          excluded: ["id1", "id2"]
+        }
+      );
+
+    // Wrapping in operation to avoid sending the request because this doesn't have a real test-server endpoint
+    // we have this in place to verify that we get the expected TS static analysis
+    const operation2 = () =>
+      client.fooApi.postSend("thingB", "text/plain", "data", {
         excluded: ["id1", "id2"]
-      }
-    );
-    client.fooApi.postSend("thingB", "text/plain", "data", {
-      excluded: ["id1", "id2"]
-    });
+      });
     assert.isDefined(client);
   });
 });

--- a/test/integration/modelFlattening.spec.ts
+++ b/test/integration/modelFlattening.spec.ts
@@ -1,7 +1,9 @@
 import { assert } from "chai";
+import { response } from "express";
 import { ModelFlatteningClient } from "./generated/modelFlattening/src";
 import {
   FlattenedProduct,
+  FlattenParameterGroup,
   ResourceCollection,
   SimpleProduct
 } from "./generated/modelFlattening/src/models";
@@ -251,14 +253,32 @@ describe("ModelFlatteningClient", () => {
       capacity: "Large",
       odataValue: "http://foo"
     };
-    const result = await client.postFlattenedSimpleProduct({
-      simpleBodyProduct
+    const result = await client.postFlattenedSimpleProduct("123", {
+      description: "product description",
+      maxProductDisplayName: "max name",
+      odataValue: "http://foo"
     });
     assert.deepEqual(result, simpleBodyProduct);
   });
 
-  // TODO: Support for parameter grouping
-  it.skip("should put flattened and grouped product", async () => {
-    // const result = await client.putSimpleProductWithGrouping()
+  it("should put flattened and grouped product", async () => {
+    const paramGroup: FlattenParameterGroup = {
+      productId: "123",
+      description: "product description",
+      maxProductDisplayName: "max name",
+      odataValue: "http://foo",
+      name: "groupproduct"
+    };
+    const { _response, ...result } = await client.putSimpleProductWithGrouping(
+      paramGroup
+    );
+
+    assert.deepEqual(result, {
+      capacity: "Large",
+      description: "product description",
+      maxProductDisplayName: "max name",
+      odataValue: "http://foo",
+      productId: "123"
+    });
   });
 });

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/models/parameters.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/models/parameters.ts
@@ -116,18 +116,6 @@ export const deploymentScript1: OperationParameter = {
   mapper: DeploymentScriptUpdateParameterMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const tail: OperationQueryParameter = {
   parameterPath: ["options", "tail"],
   mapper: {

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/operations/deploymentScripts.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/operations/deploymentScripts.ts
@@ -347,7 +347,7 @@ const getOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.scriptName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const deleteOperationSpec: coreHttp.OperationSpec = {
@@ -368,7 +368,7 @@ const deleteOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.scriptName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listBySubscriptionOperationSpec: coreHttp.OperationSpec = {
@@ -385,7 +385,7 @@ const listBySubscriptionOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const getLogsOperationSpec: coreHttp.OperationSpec = {
@@ -407,7 +407,7 @@ const getLogsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.scriptName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const getLogsDefaultOperationSpec: coreHttp.OperationSpec = {
@@ -429,7 +429,7 @@ const getLogsDefaultOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.scriptName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
@@ -450,7 +450,7 @@ const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listBySubscriptionNextOperationSpec: coreHttp.OperationSpec = {
@@ -470,7 +470,7 @@ const listBySubscriptionNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.nextLink
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
@@ -491,6 +491,6 @@ const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.nextLink
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/smoke/generated/arm-package-links-2016-09/src/models/parameters.ts
+++ b/test/smoke/generated/arm-package-links-2016-09/src/models/parameters.ts
@@ -90,18 +90,6 @@ export const parameters: OperationParameter = {
   mapper: ResourceLinkMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const filter: OperationQueryParameter = {
   parameterPath: ["options", "filter"],
   mapper: {

--- a/test/smoke/generated/arm-package-links-2016-09/src/operations/resourceLinks.ts
+++ b/test/smoke/generated/arm-package-links-2016-09/src/operations/resourceLinks.ts
@@ -201,7 +201,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.linkId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-locks-2016-09/src/models/parameters.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/models/parameters.ts
@@ -78,18 +78,6 @@ export const parameters: OperationParameter = {
   mapper: ManagementLockObjectMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceGroupName: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {

--- a/test/smoke/generated/arm-package-locks-2016-09/src/operations/managementLocks.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/operations/managementLocks.ts
@@ -582,7 +582,7 @@ const createOrUpdateAtResourceGroupLevelOperationSpec: coreHttp.OperationSpec = 
     Parameters.lockName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -633,7 +633,7 @@ const createOrUpdateByScopeOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.lockName, Parameters.scope],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -682,7 +682,7 @@ const createOrUpdateAtResourceLevelOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceType,
     Parameters.resourceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -746,7 +746,7 @@ const createOrUpdateAtSubscriptionLevelOperationSpec: coreHttp.OperationSpec = {
     Parameters.lockName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/models/parameters.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/models/parameters.ts
@@ -111,18 +111,6 @@ export const parameters: OperationParameter = {
   mapper: ApplicationMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const parameters1: OperationParameter = {
   parameterPath: ["options", "parameters"],
   mapper: ApplicationMapper

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applicationDefinitions.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applicationDefinitions.ts
@@ -375,7 +375,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.applicationDefinitionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -457,7 +457,7 @@ const createOrUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters2,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.applicationDefinitionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applications.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/operations/applications.ts
@@ -450,7 +450,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.applicationName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -474,7 +474,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.applicationName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -573,7 +573,7 @@ const createOrUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.applicationId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -591,7 +591,7 @@ const updateByIdOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters1,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.applicationId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-policy-2019-09/src/models/parameters.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/models/parameters.ts
@@ -93,18 +93,6 @@ export const parameters: OperationParameter = {
   mapper: PolicyAssignmentMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceGroupName: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {

--- a/test/smoke/generated/arm-package-policy-2019-09/src/operations/policyAssignments.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/operations/policyAssignments.ts
@@ -483,7 +483,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.scope,
     Parameters.policyAssignmentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -619,7 +619,7 @@ const createByIdOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.policyAssignmentId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-policy-2019-09/src/operations/policyDefinitions.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/operations/policyDefinitions.ts
@@ -310,7 +310,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.policyDefinitionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -391,7 +391,7 @@ const createOrUpdateAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
     Parameters.managementGroupId,
     Parameters.policyDefinitionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-policy-2019-09/src/operations/policySetDefinitions.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/operations/policySetDefinitions.ts
@@ -315,7 +315,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.policySetDefinitionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -432,7 +432,7 @@ const createOrUpdateAtManagementGroupOperationSpec: coreHttp.OperationSpec = {
     Parameters.managementGroupId,
     Parameters.policySetDefinitionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-resources-2019-08/src/models/parameters.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/models/parameters.ts
@@ -114,18 +114,6 @@ export const parameters: OperationParameter = {
   mapper: DeploymentMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const filter: OperationQueryParameter = {
   parameterPath: ["options", "filter"],
   mapper: {

--- a/test/smoke/generated/arm-package-resources-2019-08/src/operations/deployments.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/operations/deployments.ts
@@ -1399,7 +1399,7 @@ const createOrUpdateAtScopeOperationSpec: coreHttp.OperationSpec = {
     Parameters.scope,
     Parameters.deploymentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1464,7 +1464,7 @@ const validateAtScopeOperationSpec: coreHttp.OperationSpec = {
     Parameters.scope,
     Parameters.deploymentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1560,7 +1560,7 @@ const createOrUpdateAtTenantScopeOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters1,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.deploymentName],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1611,7 +1611,7 @@ const validateAtTenantScopeOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters1,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.deploymentName],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1718,7 +1718,7 @@ const createOrUpdateAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec 
     Parameters.deploymentName,
     Parameters.groupId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1784,7 +1784,7 @@ const validateAtManagementGroupScopeOperationSpec: coreHttp.OperationSpec = {
     Parameters.deploymentName,
     Parameters.groupId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1896,7 +1896,7 @@ const createOrUpdateAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
     Parameters.deploymentName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1962,7 +1962,7 @@ const validateAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
     Parameters.deploymentName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1994,7 +1994,7 @@ const whatIfAtSubscriptionScopeOperationSpec: coreHttp.OperationSpec = {
     Parameters.deploymentName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2109,7 +2109,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2178,7 +2178,7 @@ const validateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2211,7 +2211,7 @@ const whatIfOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2272,7 +2272,7 @@ const calculateTemplateHashOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.template,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-resources-2019-08/src/operations/resourceGroups.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/operations/resourceGroups.ts
@@ -289,7 +289,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -352,7 +352,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -384,7 +384,7 @@ const exportTemplateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/arm-package-resources-2019-08/src/operations/resources.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/operations/resources.ts
@@ -679,7 +679,7 @@ const moveResourcesOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.sourceResourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -703,7 +703,7 @@ const validateMoveResourcesOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.sourceResourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -810,7 +810,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceType,
     Parameters.resourceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -846,7 +846,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceType,
     Parameters.resourceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -930,7 +930,7 @@ const createOrUpdateByIdOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters4,
   queryParameters: [Parameters.apiVersion1],
   urlParameters: [Parameters.$host, Parameters.resourceId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -957,7 +957,7 @@ const updateByIdOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters4,
   queryParameters: [Parameters.apiVersion1],
   urlParameters: [Parameters.$host, Parameters.resourceId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/compute-resource-manager/src/models/parameters.ts
@@ -116,18 +116,6 @@ export const parameters: OperationParameter = {
   mapper: AvailabilitySetMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceGroupName: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
@@ -481,7 +469,7 @@ export const parameters14: OperationParameter = {
   mapper: RunCommandInputMapper
 };
 
-export const accept2: OperationParameter = {
+export const accept1: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/json, text/json",
@@ -642,18 +630,6 @@ export const parameters22: OperationParameter = {
 export const parameters23: OperationParameter = {
   parameterPath: "parameters",
   mapper: LogAnalyticsInputBaseMapper
-};
-
-export const accept3: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json, text/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
 };
 
 export const commandId: OperationURLParameter = {

--- a/test/smoke/generated/compute-resource-manager/src/operations/availabilitySets.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/availabilitySets.ts
@@ -247,7 +247,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.availabilitySetName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -268,7 +268,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.availabilitySetName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/containerServices.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/containerServices.ts
@@ -279,7 +279,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.containerServiceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/dedicatedHostGroups.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/dedicatedHostGroups.ts
@@ -229,7 +229,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.hostGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -250,7 +250,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.hostGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/dedicatedHosts.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/dedicatedHosts.ts
@@ -278,7 +278,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.hostGroupName,
     Parameters.hostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -309,7 +309,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.hostGroupName,
     Parameters.hostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/diskEncryptionSets.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/diskEncryptionSets.ts
@@ -310,7 +310,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.diskEncryptionSetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -343,7 +343,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.diskEncryptionSetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/disks.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/disks.ts
@@ -396,7 +396,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.diskName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -426,7 +426,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.diskName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -520,7 +520,7 @@ const grantAccessOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.diskName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/galleries.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/galleries.ts
@@ -300,7 +300,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.galleryName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -333,7 +333,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.galleryName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/galleryApplicationVersions.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/galleryApplicationVersions.ts
@@ -335,7 +335,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryApplicationName,
     Parameters.galleryApplicationVersionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -370,7 +370,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryApplicationName,
     Parameters.galleryApplicationVersionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/galleryApplications.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/galleryApplications.ts
@@ -295,7 +295,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryName,
     Parameters.galleryApplicationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -329,7 +329,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryName,
     Parameters.galleryApplicationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/galleryImageVersions.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/galleryImageVersions.ts
@@ -323,7 +323,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryImageName,
     Parameters.galleryImageVersionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -358,7 +358,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryImageName,
     Parameters.galleryImageVersionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/galleryImages.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/galleryImages.ts
@@ -295,7 +295,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryName,
     Parameters.galleryImageName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -329,7 +329,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.galleryName,
     Parameters.galleryImageName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/images.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/images.ts
@@ -297,7 +297,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.imageName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -327,7 +327,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.imageName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/logAnalytics.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/logAnalytics.ts
@@ -158,7 +158,7 @@ const exportRequestRateByIntervalOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.location1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -187,7 +187,7 @@ const exportThrottledRequestsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.location1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/proximityPlacementGroups.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/proximityPlacementGroups.ts
@@ -235,7 +235,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.proximityPlacementGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -256,7 +256,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.proximityPlacementGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/snapshots.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/snapshots.ts
@@ -396,7 +396,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.snapshotName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -426,7 +426,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.snapshotName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -520,7 +520,7 @@ const grantAccessOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.snapshotName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/sshPublicKeys.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/sshPublicKeys.ts
@@ -283,7 +283,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.sshPublicKeyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -304,7 +304,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.sshPublicKeyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineExtensions.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineExtensions.ts
@@ -256,7 +256,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmName,
     Parameters.vmExtensionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -287,7 +287,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmName,
     Parameters.vmExtensionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineRunCommands.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineRunCommands.ts
@@ -107,7 +107,7 @@ const listOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.location1
   ],
-  headerParameters: [Parameters.accept3],
+  headerParameters: [Parameters.accept1],
   serializer
 };
 const getOperationSpec: coreHttp.OperationSpec = {
@@ -126,7 +126,7 @@ const getOperationSpec: coreHttp.OperationSpec = {
     Parameters.location1,
     Parameters.commandId
   ],
-  headerParameters: [Parameters.accept3],
+  headerParameters: [Parameters.accept1],
   serializer
 };
 const listNextOperationSpec: coreHttp.OperationSpec = {
@@ -144,6 +144,6 @@ const listNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.nextLink,
     Parameters.location1
   ],
-  headerParameters: [Parameters.accept3],
+  headerParameters: [Parameters.accept1],
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetExtensions.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetExtensions.ts
@@ -290,7 +290,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmScaleSetName,
     Parameters.vmssExtensionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -321,7 +321,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmScaleSetName,
     Parameters.vmssExtensionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMExtensions.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMExtensions.ts
@@ -286,7 +286,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmScaleSetName,
     Parameters.instanceId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -321,7 +321,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmScaleSetName,
     Parameters.instanceId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMs.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSetVMs.ts
@@ -751,7 +751,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmScaleSetName,
     Parameters.instanceId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -951,7 +951,7 @@ const runCommandOperationSpec: coreHttp.OperationSpec = {
     Parameters.vmScaleSetName,
     Parameters.instanceId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept2],
+  headerParameters: [Parameters.contentType, Parameters.accept1],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSets.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachineScaleSets.ts
@@ -950,7 +950,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vmScaleSetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -980,7 +980,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vmScaleSetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/compute-resource-manager/src/operations/virtualMachines.ts
+++ b/test/smoke/generated/compute-resource-manager/src/operations/virtualMachines.ts
@@ -908,7 +908,7 @@ const captureOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vmName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -938,7 +938,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vmName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -968,7 +968,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vmName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1267,7 +1267,7 @@ const runCommandOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vmName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept2],
+  headerParameters: [Parameters.contentType, Parameters.accept1],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/models/parameters.ts
@@ -133,18 +133,6 @@ export const updateParameters: OperationParameter = {
   mapper: DatabaseAccountUpdateParametersMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const createUpdateParameters: OperationParameter = {
   parameterPath: "createUpdateParameters",
   mapper: DatabaseAccountCreateUpdateParametersMapper

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraResources.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/cassandraResources.ts
@@ -576,7 +576,7 @@ const createUpdateCassandraKeyspaceOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.keyspaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -642,7 +642,7 @@ const updateCassandraKeyspaceThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.keyspaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -715,7 +715,7 @@ const createUpdateCassandraTableOperationSpec: coreHttp.OperationSpec = {
     Parameters.tableName,
     Parameters.keyspaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -784,7 +784,7 @@ const updateCassandraTableThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.tableName,
     Parameters.keyspaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/databaseAccounts.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/databaseAccounts.ts
@@ -627,7 +627,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -657,7 +657,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -783,7 +783,7 @@ const offlineRegionOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -808,7 +808,7 @@ const onlineRegionOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/gremlinResources.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/gremlinResources.ts
@@ -571,7 +571,7 @@ const createUpdateGremlinDatabaseOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -637,7 +637,7 @@ const updateGremlinDatabaseThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -710,7 +710,7 @@ const createUpdateGremlinGraphOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.graphName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -779,7 +779,7 @@ const updateGremlinGraphThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.graphName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/mongoDBResources.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/mongoDBResources.ts
@@ -574,7 +574,7 @@ const createUpdateMongoDBDatabaseOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -640,7 +640,7 @@ const updateMongoDBDatabaseThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -713,7 +713,7 @@ const createUpdateMongoDBCollectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.collectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -782,7 +782,7 @@ const updateMongoDBCollectionThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.collectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/notebookWorkspaces.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/notebookWorkspaces.ts
@@ -375,7 +375,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.notebookWorkspaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/privateEndpointConnections.ts
@@ -253,7 +253,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.privateEndpointConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/sqlResources.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/sqlResources.ts
@@ -1074,7 +1074,7 @@ const createUpdateSqlDatabaseOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1140,7 +1140,7 @@ const updateSqlDatabaseThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1213,7 +1213,7 @@ const createUpdateSqlContainerOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1282,7 +1282,7 @@ const updateSqlContainerThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1358,7 +1358,7 @@ const createUpdateSqlStoredProcedureOperationSpec: coreHttp.OperationSpec = {
     Parameters.containerName,
     Parameters.storedProcedureName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1451,7 +1451,7 @@ const createUpdateSqlUserDefinedFunctionOperationSpec: coreHttp.OperationSpec = 
     Parameters.containerName,
     Parameters.userDefinedFunctionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1544,7 +1544,7 @@ const createUpdateSqlTriggerOperationSpec: coreHttp.OperationSpec = {
     Parameters.containerName,
     Parameters.triggerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/cosmos-db-resource-manager/src/operations/tableResources.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/operations/tableResources.ts
@@ -318,7 +318,7 @@ const createUpdateTableOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.tableName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -384,7 +384,7 @@ const updateTableThroughputOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName,
     Parameters.tableName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/models/parameters.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/models/parameters.ts
@@ -106,18 +106,6 @@ export const parameters: OperationParameter = {
   mapper: ApplicationCreateParametersMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json, text/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const filter: OperationQueryParameter = {
   parameterPath: ["options", "filter"],
   mapper: {
@@ -296,7 +284,7 @@ export const domainName: OperationURLParameter = {
   }
 };
 
-export const accept2: OperationParameter = {
+export const accept1: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/json",
@@ -311,16 +299,4 @@ export const accept2: OperationParameter = {
 export const body: OperationParameter = {
   parameterPath: ["options", "body"],
   mapper: OAuth2PermissionGrantMapper
-};
-
-export const accept3: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/operations/applications.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/operations/applications.ts
@@ -341,7 +341,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -415,7 +415,7 @@ const patchOperationSpec: coreHttp.OperationSpec = {
     Parameters.tenantID,
     Parameters.applicationObjectId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -455,7 +455,7 @@ const addOwnerOperationSpec: coreHttp.OperationSpec = {
     Parameters.tenantID,
     Parameters.applicationObjectId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -515,7 +515,7 @@ const updateKeyCredentialsOperationSpec: coreHttp.OperationSpec = {
     Parameters.tenantID,
     Parameters.applicationObjectId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -555,7 +555,7 @@ const updatePasswordCredentialsOperationSpec: coreHttp.OperationSpec = {
     Parameters.tenantID,
     Parameters.applicationObjectId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/operations/groups.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/operations/groups.ts
@@ -342,7 +342,7 @@ const isMemberOfOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters5,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -381,7 +381,7 @@ const addMemberOperationSpec: coreHttp.OperationSpec = {
     Parameters.tenantID,
     Parameters.groupObjectId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -399,7 +399,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters7,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -479,7 +479,7 @@ const getMemberGroupsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters8,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID, Parameters.objectId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -511,7 +511,7 @@ const addOwnerOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters2,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID, Parameters.objectId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/operations/oAuth2PermissionGrant.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/operations/oAuth2PermissionGrant.ts
@@ -114,7 +114,7 @@ const listOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion, Parameters.filter],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.accept2],
+  headerParameters: [Parameters.accept1],
   serializer
 };
 const createOperationSpec: coreHttp.OperationSpec = {
@@ -128,7 +128,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.body,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept3],
+  headerParameters: [Parameters.contentType, Parameters.accept1],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/operations/objects.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/operations/objects.ts
@@ -82,7 +82,7 @@ const getObjectsByObjectIdsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters14,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/operations/servicePrincipals.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/operations/servicePrincipals.ts
@@ -281,7 +281,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters9,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -313,7 +313,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters10,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID, Parameters.objectId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -391,7 +391,7 @@ const updateKeyCredentialsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters3,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID, Parameters.objectId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -423,7 +423,7 @@ const updatePasswordCredentialsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters4,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID, Parameters.objectId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/graphrbac-data-plane/src/operations/users.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/operations/users.ts
@@ -180,7 +180,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters11,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -240,7 +240,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.tenantID,
     Parameters.upnOrObjectId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -276,7 +276,7 @@ const getMemberGroupsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters13,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.tenantID, Parameters.objectId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/keyvault-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/models/parameters.ts
@@ -124,18 +124,6 @@ export const vaultName1: OperationURLParameter = {
   }
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const parameters2: OperationParameter = {
   parameterPath: "parameters",
   mapper: VaultAccessPolicyParametersMapper

--- a/test/smoke/generated/keyvault-resource-manager/src/operations/operations.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/operations/operations.ts
@@ -72,7 +72,7 @@ const listOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listNextOperationSpec: coreHttp.OperationSpec = {
@@ -85,6 +85,6 @@ const listNextOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.nextLink],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/smoke/generated/keyvault-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/operations/privateEndpointConnections.ts
@@ -171,7 +171,7 @@ const getOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.privateEndpointConnectionName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const putOperationSpec: coreHttp.OperationSpec = {
@@ -229,6 +229,6 @@ const deleteOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.privateEndpointConnectionName
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/smoke/generated/keyvault-resource-manager/src/operations/privateLinkResources.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/operations/privateLinkResources.ts
@@ -69,6 +69,6 @@ const listByVaultOperationSpec: coreHttp.OperationSpec = {
     Parameters.vaultName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/smoke/generated/keyvault-resource-manager/src/operations/vaults.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/operations/vaults.ts
@@ -505,7 +505,7 @@ const getOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vaultName1
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const updateAccessPolicyOperationSpec: coreHttp.OperationSpec = {
@@ -548,7 +548,7 @@ const listByResourceGroupOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listBySubscriptionOperationSpec: coreHttp.OperationSpec = {
@@ -561,7 +561,7 @@ const listBySubscriptionOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion, Parameters.top],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listDeletedOperationSpec: coreHttp.OperationSpec = {
@@ -575,7 +575,7 @@ const listDeletedOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const getDeletedOperationSpec: coreHttp.OperationSpec = {
@@ -594,7 +594,7 @@ const getDeletedOperationSpec: coreHttp.OperationSpec = {
     Parameters.vaultName1,
     Parameters.location
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const purgeDeletedOperationSpec: coreHttp.OperationSpec = {
@@ -621,7 +621,7 @@ const listOperationSpec: coreHttp.OperationSpec = {
   },
   queryParameters: [Parameters.apiVersion, Parameters.top, Parameters.filter],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const checkNameAvailabilityOperationSpec: coreHttp.OperationSpec = {
@@ -655,7 +655,7 @@ const listByResourceGroupNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.nextLink
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listBySubscriptionNextOperationSpec: coreHttp.OperationSpec = {
@@ -672,7 +672,7 @@ const listBySubscriptionNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.nextLink
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listDeletedNextOperationSpec: coreHttp.OperationSpec = {
@@ -689,7 +689,7 @@ const listDeletedNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.nextLink
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };
 const listNextOperationSpec: coreHttp.OperationSpec = {
@@ -706,6 +706,6 @@ const listNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.nextLink
   ],
-  headerParameters: [Parameters.accept1],
+  headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/smoke/generated/msi-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/msi-resource-manager/src/models/parameters.ts
@@ -115,18 +115,6 @@ export const parameters: OperationParameter = {
   mapper: IdentityMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceName: OperationURLParameter = {
   parameterPath: "resourceName",
   mapper: {

--- a/test/smoke/generated/msi-resource-manager/src/operations/userAssignedIdentities.ts
+++ b/test/smoke/generated/msi-resource-manager/src/operations/userAssignedIdentities.ts
@@ -267,7 +267,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.resourceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -291,7 +291,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.resourceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/network-resource-manager/src/models/parameters.ts
@@ -196,18 +196,6 @@ export const parameters: OperationParameter = {
   mapper: ApplicationGatewayMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const parameters1: OperationParameter = {
   parameterPath: "parameters",
   mapper: TagsObjectMapper
@@ -360,18 +348,6 @@ export const virtualWANName: OperationURLParameter = {
 export const vpnClientParams: OperationParameter = {
   parameterPath: "vpnClientParams",
   mapper: VirtualWanVpnProfileParametersMapper
-};
-
-export const nextLink1: OperationURLParameter = {
-  parameterPath: "nextLink",
-  mapper: {
-    serializedName: "nextLink",
-    required: true,
-    type: {
-      name: "String"
-    }
-  },
-  skipEncoding: true
 };
 
 export const ddosCustomPolicyName: OperationURLParameter = {

--- a/test/smoke/generated/network-resource-manager/src/networkManagementClient.ts
+++ b/test/smoke/generated/network-resource-manager/src/networkManagementClient.ts
@@ -807,7 +807,7 @@ const putBastionShareableLinkOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -832,7 +832,7 @@ const deleteBastionShareableLinkOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -856,7 +856,7 @@ const getBastionShareableLinkOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -911,7 +911,7 @@ const disconnectActiveSessionsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -987,7 +987,7 @@ const generatevirtualwanvpnserverconfigurationvpnprofileOperationSpec: coreHttp.
     Parameters.subscriptionId,
     Parameters.virtualWANName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1008,10 +1008,10 @@ const putBastionShareableLinkNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.$host,
     Parameters.resourceGroupName,
     Parameters.subscriptionId,
-    Parameters.bastionHostName,
-    Parameters.nextLink1
+    Parameters.nextLink,
+    Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1031,10 +1031,10 @@ const getBastionShareableLinkNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.$host,
     Parameters.resourceGroupName,
     Parameters.subscriptionId,
-    Parameters.bastionHostName,
-    Parameters.nextLink1
+    Parameters.nextLink,
+    Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1077,10 +1077,10 @@ const disconnectActiveSessionsNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.$host,
     Parameters.resourceGroupName,
     Parameters.subscriptionId,
-    Parameters.bastionHostName,
-    Parameters.nextLink1
+    Parameters.nextLink,
+    Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/applicationGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/applicationGateways.ts
@@ -652,7 +652,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.applicationGatewayName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -676,7 +676,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.applicationGatewayName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -824,7 +824,7 @@ const backendHealthOnDemandOperationSpec: coreHttp.OperationSpec = {
     Parameters.applicationGatewayName,
     Parameters.subscriptionId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/applicationSecurityGroups.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/applicationSecurityGroups.ts
@@ -337,7 +337,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.applicationSecurityGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -361,7 +361,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.applicationSecurityGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/azureFirewalls.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/azureFirewalls.ts
@@ -351,7 +351,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.azureFirewallName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -384,7 +384,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.azureFirewallName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/bastionHosts.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/bastionHosts.ts
@@ -302,7 +302,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.bastionHostName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/connectionMonitors.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/connectionMonitors.ts
@@ -383,7 +383,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.networkWatcherName,
     Parameters.connectionMonitorName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -455,7 +455,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.networkWatcherName,
     Parameters.connectionMonitorName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/ddosCustomPolicies.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/ddosCustomPolicies.ts
@@ -257,7 +257,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ddosCustomPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -281,7 +281,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ddosCustomPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/ddosProtectionPlans.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/ddosProtectionPlans.ts
@@ -333,7 +333,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ddosProtectionPlanName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -357,7 +357,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ddosProtectionPlanName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitAuthorizations.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitAuthorizations.ts
@@ -291,7 +291,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.circuitName,
     Parameters.authorizationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitConnections.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitConnections.ts
@@ -316,7 +316,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.peeringName,
     Parameters.connectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitPeerings.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuitPeerings.ts
@@ -289,7 +289,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.circuitName,
     Parameters.peeringName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuits.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteCircuits.ts
@@ -527,7 +527,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.circuitName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -551,7 +551,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.circuitName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteConnections.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteConnections.ts
@@ -219,7 +219,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.connectionName,
     Parameters.expressRouteGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnectionPeerings.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnectionPeerings.ts
@@ -318,7 +318,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.peeringName,
     Parameters.crossConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnections.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteCrossConnections.ts
@@ -457,7 +457,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.crossConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -481,7 +481,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.crossConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRouteGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRouteGateways.ts
@@ -259,7 +259,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.expressRouteGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/expressRoutePorts.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/expressRoutePorts.ts
@@ -333,7 +333,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.expressRoutePortName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -357,7 +357,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.expressRoutePortName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/firewallPolicies.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/firewallPolicies.ts
@@ -305,7 +305,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.firewallPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/firewallPolicyRuleGroups.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/firewallPolicyRuleGroups.ts
@@ -293,7 +293,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.firewallPolicyName,
     Parameters.ruleGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/flowLogs.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/flowLogs.ts
@@ -246,7 +246,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.networkWatcherName,
     Parameters.flowLogName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/hubRouteTables.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/hubRouteTables.ts
@@ -246,7 +246,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.routeTableName,
     Parameters.virtualHubName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/inboundNatRules.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/inboundNatRules.ts
@@ -317,7 +317,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.loadBalancerName,
     Parameters.inboundNatRuleName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/ipAllocations.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/ipAllocations.ts
@@ -334,7 +334,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ipAllocationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -358,7 +358,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ipAllocationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/ipGroups.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/ipGroups.ts
@@ -309,7 +309,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ipGroupsName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -333,7 +333,7 @@ const updateGroupsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.ipGroupsName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/loadBalancerBackendAddressPools.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/loadBalancerBackendAddressPools.ts
@@ -292,7 +292,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.loadBalancerName,
     Parameters.backendAddressPoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/loadBalancers.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/loadBalancers.ts
@@ -334,7 +334,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.loadBalancerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -358,7 +358,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.loadBalancerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/localNetworkGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/localNetworkGateways.ts
@@ -252,7 +252,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.localNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -321,7 +321,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.localNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/natGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/natGateways.ts
@@ -334,7 +334,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.natGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -358,7 +358,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.natGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/networkInterfaceTapConfigurations.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/networkInterfaceTapConfigurations.ts
@@ -296,7 +296,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.networkInterfaceName,
     Parameters.tapConfigurationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/networkInterfaces.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/networkInterfaces.ts
@@ -703,7 +703,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkInterfaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -727,7 +727,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkInterfaceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/networkProfiles.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/networkProfiles.ts
@@ -310,7 +310,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkProfileName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -334,7 +334,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkProfileName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/networkSecurityGroups.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/networkSecurityGroups.ts
@@ -338,7 +338,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkSecurityGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -362,7 +362,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkSecurityGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/networkVirtualAppliances.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/networkVirtualAppliances.ts
@@ -329,7 +329,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkVirtualApplianceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -362,7 +362,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkVirtualApplianceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/networkWatchers.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/networkWatchers.ts
@@ -780,7 +780,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -849,7 +849,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -911,7 +911,7 @@ const getTopologyOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -944,7 +944,7 @@ const verifyIPFlowOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -977,7 +977,7 @@ const getNextHopOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1010,7 +1010,7 @@ const getVMSecurityRulesOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1043,7 +1043,7 @@ const getTroubleshootingOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1076,7 +1076,7 @@ const getTroubleshootingResultOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1109,7 +1109,7 @@ const setFlowLogConfigurationOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1142,7 +1142,7 @@ const getFlowLogStatusOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1175,7 +1175,7 @@ const checkConnectivityOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1208,7 +1208,7 @@ const getAzureReachabilityReportOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1241,7 +1241,7 @@ const listAvailableProvidersOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1274,7 +1274,7 @@ const getNetworkConfigurationDiagnosticOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.networkWatcherName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/p2SVpnGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/p2SVpnGateways.ts
@@ -498,7 +498,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -522,7 +522,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -616,7 +616,7 @@ const generateVpnProfileOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -680,7 +680,7 @@ const getP2SVpnConnectionHealthDetailedOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -705,7 +705,7 @@ const disconnectP2SVpnConnectionsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.p2SVpnGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/packetCaptures.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/packetCaptures.ts
@@ -306,7 +306,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.networkWatcherName,
     Parameters.packetCaptureName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/privateDnsZoneGroups.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/privateDnsZoneGroups.ts
@@ -293,7 +293,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.privateEndpointName,
     Parameters.privateDnsZoneGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/privateEndpoints.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/privateEndpoints.ts
@@ -305,7 +305,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.privateEndpointName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/privateLinkServices.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/privateLinkServices.ts
@@ -608,7 +608,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.serviceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -694,7 +694,7 @@ const updatePrivateEndpointConnectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.serviceName,
     Parameters.peConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -763,7 +763,7 @@ const checkPrivateLinkServiceVisibilityOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.location
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -787,7 +787,7 @@ const checkPrivateLinkServiceVisibilityByResourceGroupOperationSpec: coreHttp.Op
     Parameters.subscriptionId,
     Parameters.location
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/publicIPAddresses.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/publicIPAddresses.ts
@@ -519,7 +519,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.publicIpAddressName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -543,7 +543,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.publicIpAddressName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/publicIPPrefixes.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/publicIPPrefixes.ts
@@ -334,7 +334,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.publicIpPrefixName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -358,7 +358,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.publicIpPrefixName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/routeFilterRules.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/routeFilterRules.ts
@@ -294,7 +294,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.routeFilterName,
     Parameters.ruleName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/routeFilters.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/routeFilters.ts
@@ -332,7 +332,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.routeFilterName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -356,7 +356,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.routeFilterName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/routeTables.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/routeTables.ts
@@ -334,7 +334,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.routeTableName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -358,7 +358,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.routeTableName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/routes.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/routes.ts
@@ -293,7 +293,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.routeTableName,
     Parameters.routeName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/securityPartnerProviders.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/securityPartnerProviders.ts
@@ -337,7 +337,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.securityPartnerProviderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -361,7 +361,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.securityPartnerProviderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/securityRules.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/securityRules.ts
@@ -298,7 +298,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.networkSecurityGroupName,
     Parameters.securityRuleName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicies.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicies.ts
@@ -338,7 +338,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.serviceEndpointPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -362,7 +362,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.serviceEndpointPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicyDefinitions.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/serviceEndpointPolicyDefinitions.ts
@@ -302,7 +302,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serviceEndpointPolicyName,
     Parameters.serviceEndpointPolicyDefinitionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/subnets.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/subnets.ts
@@ -394,7 +394,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.virtualNetworkName,
     Parameters.subnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -420,7 +420,7 @@ const prepareNetworkPoliciesOperationSpec: coreHttp.OperationSpec = {
     Parameters.virtualNetworkName,
     Parameters.subnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -446,7 +446,7 @@ const unprepareNetworkPoliciesOperationSpec: coreHttp.OperationSpec = {
     Parameters.virtualNetworkName,
     Parameters.subnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualHubRouteTableV2S.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualHubRouteTableV2S.ts
@@ -271,7 +271,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.routeTableName,
     Parameters.virtualHubName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualHubs.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualHubs.ts
@@ -308,7 +308,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualHubName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -332,7 +332,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualHubName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGatewayConnections.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGatewayConnections.ts
@@ -503,7 +503,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -581,7 +581,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -614,7 +614,7 @@ const setSharedKeyOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -690,7 +690,7 @@ const resetSharedKeyOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -723,7 +723,7 @@ const startPacketCaptureOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -756,7 +756,7 @@ const stopPacketCaptureOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkGateways.ts
@@ -1028,7 +1028,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1106,7 +1106,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1236,7 +1236,7 @@ const generatevpnclientpackageOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1269,7 +1269,7 @@ const generateVpnProfileOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1448,7 +1448,7 @@ const setVpnclientIpsecParametersOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1503,7 +1503,7 @@ const vpnDeviceConfigurationScriptOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1536,7 +1536,7 @@ const startPacketCaptureOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1569,7 +1569,7 @@ const stopPacketCaptureOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1625,7 +1625,7 @@ const disconnectVirtualNetworkGatewayVpnConnectionsOperationSpec: coreHttp.Opera
     Parameters.subscriptionId,
     Parameters.virtualNetworkGatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkPeerings.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkPeerings.ts
@@ -294,7 +294,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.virtualNetworkName,
     Parameters.virtualNetworkPeeringName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkTaps.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualNetworkTaps.ts
@@ -328,7 +328,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.tapName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -352,7 +352,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.tapName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualNetworks.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualNetworks.ts
@@ -411,7 +411,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -435,7 +435,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualNetworkName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualRouterPeerings.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualRouterPeerings.ts
@@ -293,7 +293,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.peeringName,
     Parameters.virtualRouterName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualRouters.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualRouters.ts
@@ -305,7 +305,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualRouterName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/virtualWans.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/virtualWans.ts
@@ -308,7 +308,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualWANName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -332,7 +332,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualWANName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/vpnConnections.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/vpnConnections.ts
@@ -265,7 +265,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.connectionName,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/vpnGateways.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/vpnGateways.ts
@@ -351,7 +351,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -375,7 +375,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/vpnServerConfigurations.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/vpnServerConfigurations.ts
@@ -316,7 +316,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vpnServerConfigurationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -340,7 +340,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vpnServerConfigurationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/vpnSites.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/vpnSites.ts
@@ -308,7 +308,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vpnSiteName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -332,7 +332,7 @@ const updateTagsOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.vpnSiteName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/vpnSitesConfiguration.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/vpnSitesConfiguration.ts
@@ -109,7 +109,7 @@ const downloadOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.virtualWANName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/network-resource-manager/src/operations/webApplicationFirewallPolicies.ts
+++ b/test/smoke/generated/network-resource-manager/src/operations/webApplicationFirewallPolicies.ts
@@ -290,7 +290,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.policyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/sql-resource-manager/src/models/parameters.ts
@@ -193,18 +193,6 @@ export const parameters: OperationParameter = {
   mapper: ServerConnectionPolicyMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const connectionPolicyName: OperationURLParameter = {
   parameterPath: "connectionPolicyName",
   mapper: {

--- a/test/smoke/generated/sql-resource-manager/src/operations/backupLongTermRetentionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/backupLongTermRetentionPolicies.ts
@@ -209,7 +209,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.policyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/backupShortTermRetentionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/backupShortTermRetentionPolicies.ts
@@ -294,7 +294,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.policyName2
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -327,7 +327,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.policyName2
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/dataMaskingPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/dataMaskingPolicies.ts
@@ -112,7 +112,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.dataMaskingPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/dataMaskingRules.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/dataMaskingRules.ts
@@ -119,7 +119,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.dataMaskingPolicyName,
     Parameters.dataMaskingRuleName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/databaseAutomaticTuning.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/databaseAutomaticTuning.ts
@@ -133,7 +133,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/databaseBlobAuditingPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/databaseBlobAuditingPolicies.ts
@@ -199,7 +199,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.blobAuditingPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/databaseThreatDetectionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/databaseThreatDetectionPolicies.ts
@@ -145,7 +145,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.securityAlertPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/databaseVulnerabilityAssessmentRuleBaselines.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/databaseVulnerabilityAssessmentRuleBaselines.ts
@@ -206,7 +206,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.ruleId,
     Parameters.baselineName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/databaseVulnerabilityAssessments.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/databaseVulnerabilityAssessments.ts
@@ -239,7 +239,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.vulnerabilityAssessmentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/databases.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/databases.ts
@@ -769,7 +769,7 @@ const importOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.serverName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -801,7 +801,7 @@ const createImportOperationOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.extensionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -832,7 +832,7 @@ const exportOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -945,7 +945,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -992,7 +992,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/elasticPools.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/elasticPools.ts
@@ -477,7 +477,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.elasticPoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -524,7 +524,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.elasticPoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/encryptionProtectors.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/encryptionProtectors.ts
@@ -297,7 +297,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.encryptionProtectorName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/extendedDatabaseBlobAuditingPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/extendedDatabaseBlobAuditingPolicies.ts
@@ -201,7 +201,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.blobAuditingPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/extendedServerBlobAuditingPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/extendedServerBlobAuditingPolicies.ts
@@ -209,7 +209,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.blobAuditingPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/failoverGroups.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/failoverGroups.ts
@@ -400,7 +400,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.failoverGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -447,7 +447,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.failoverGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/firewallRules.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/firewallRules.ts
@@ -164,7 +164,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.firewallRuleName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/geoBackupPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/geoBackupPolicies.ts
@@ -151,7 +151,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.geoBackupPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/instanceFailoverGroups.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/instanceFailoverGroups.ts
@@ -354,7 +354,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.failoverGroupName,
     Parameters.locationName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/instancePools.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/instancePools.ts
@@ -324,7 +324,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.instancePoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -369,7 +369,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.instancePoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/jobAgents.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/jobAgents.ts
@@ -330,7 +330,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.jobAgentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -377,7 +377,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.jobAgentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/jobCredentials.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/jobCredentials.ts
@@ -257,7 +257,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.jobAgentName,
     Parameters.credentialName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/jobSteps.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/jobSteps.ts
@@ -433,7 +433,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.jobName,
     Parameters.stepName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/jobTargetGroups.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/jobTargetGroups.ts
@@ -257,7 +257,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.jobAgentName,
     Parameters.targetGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/jobs.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/jobs.ts
@@ -257,7 +257,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.jobAgentName,
     Parameters.jobName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedBackupShortTermRetentionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedBackupShortTermRetentionPolicies.ts
@@ -298,7 +298,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.managedInstanceName,
     Parameters.policyName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -331,7 +331,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.managedInstanceName,
     Parameters.policyName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseSecurityAlertPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseSecurityAlertPolicies.ts
@@ -210,7 +210,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.securityAlertPolicyName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseSensitivityLabels.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseSensitivityLabels.ts
@@ -417,7 +417,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.columnName,
     Parameters.sensitivityLabelSource2
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseVulnerabilityAssessmentRuleBaselines.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseVulnerabilityAssessmentRuleBaselines.ts
@@ -208,7 +208,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.baselineName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseVulnerabilityAssessments.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedDatabaseVulnerabilityAssessments.ts
@@ -241,7 +241,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vulnerabilityAssessmentName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedDatabases.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedDatabases.ts
@@ -435,7 +435,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -482,7 +482,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceAdministrators.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceAdministrators.ts
@@ -273,7 +273,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.managedInstanceName,
     Parameters.administratorName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceEncryptionProtectors.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceEncryptionProtectors.ts
@@ -304,7 +304,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.encryptionProtectorName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceKeys.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceKeys.ts
@@ -288,7 +288,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.keyName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceLongTermRetentionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceLongTermRetentionPolicies.ts
@@ -249,7 +249,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.managedInstanceName,
     Parameters.policyName3
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceVulnerabilityAssessments.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedInstanceVulnerabilityAssessments.ts
@@ -225,7 +225,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.vulnerabilityAssessmentName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedInstances.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedInstances.ts
@@ -414,7 +414,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -459,7 +459,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.managedInstanceName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedRestorableDroppedDatabaseBackupShortTermRetentionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedRestorableDroppedDatabaseBackupShortTermRetentionPolicies.ts
@@ -313,7 +313,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.policyName1,
     Parameters.restorableDroppedDatabaseId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -346,7 +346,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.policyName1,
     Parameters.restorableDroppedDatabaseId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/managedServerSecurityAlertPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/managedServerSecurityAlertPolicies.ts
@@ -225,7 +225,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.managedInstanceName,
     Parameters.securityAlertPolicyName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/privateEndpointConnections.ts
@@ -261,7 +261,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.privateEndpointConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/restorePoints.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/restorePoints.ts
@@ -234,7 +234,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.databaseName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/sensitivityLabels.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/sensitivityLabels.ts
@@ -490,7 +490,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.columnName,
     Parameters.sensitivityLabelSource2
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverAutomaticTuning.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverAutomaticTuning.ts
@@ -116,7 +116,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.serverName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverAzureADAdministrators.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverAzureADAdministrators.ts
@@ -309,7 +309,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.administratorName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverBlobAuditingPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverBlobAuditingPolicies.ts
@@ -207,7 +207,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.blobAuditingPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverCommunicationLinks.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverCommunicationLinks.ts
@@ -234,7 +234,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.communicationLinkName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverConnectionPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverConnectionPolicies.ts
@@ -115,7 +115,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.connectionPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverKeys.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverKeys.ts
@@ -279,7 +279,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.keyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverSecurityAlertPolicies.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverSecurityAlertPolicies.ts
@@ -218,7 +218,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.securityAlertPolicyName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/serverVulnerabilityAssessments.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/serverVulnerabilityAssessments.ts
@@ -211,7 +211,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.vulnerabilityAssessmentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/servers.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/servers.ts
@@ -361,7 +361,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.serverName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -406,7 +406,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.serverName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -437,7 +437,7 @@ const checkNameAvailabilityOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters63,
   queryParameters: [Parameters.apiVersion5],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/syncAgents.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/syncAgents.ts
@@ -351,7 +351,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.syncAgentName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/syncGroups.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/syncGroups.ts
@@ -759,7 +759,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.syncGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -808,7 +808,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.syncGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/syncMembers.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/syncMembers.ts
@@ -481,7 +481,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.syncGroupName,
     Parameters.syncMemberName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -532,7 +532,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.syncGroupName,
     Parameters.syncMemberName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/transparentDataEncryptions.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/transparentDataEncryptions.ts
@@ -123,7 +123,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.transparentDataEncryptionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/virtualClusters.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/virtualClusters.ts
@@ -326,7 +326,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.virtualClusterName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/virtualNetworkRules.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/virtualNetworkRules.ts
@@ -261,7 +261,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.serverName,
     Parameters.virtualNetworkRuleName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/workloadClassifiers.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/workloadClassifiers.ts
@@ -304,7 +304,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.workloadGroupName,
     Parameters.workloadClassifierName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/sql-resource-manager/src/operations/workloadGroups.ts
+++ b/test/smoke/generated/sql-resource-manager/src/operations/workloadGroups.ts
@@ -287,7 +287,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.databaseName,
     Parameters.workloadGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/storage-resource-manager/src/models/parameters.ts
@@ -100,18 +100,6 @@ export const accountName: OperationParameter = {
   mapper: StorageAccountCheckNameAvailabilityParametersMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const parameters: OperationParameter = {
   parameterPath: "parameters",
   mapper: StorageAccountCreateParametersMapper

--- a/test/smoke/generated/storage-resource-manager/src/operations/blobContainers.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/blobContainers.ts
@@ -581,7 +581,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -603,7 +603,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -660,7 +660,7 @@ const setLegalHoldOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -682,7 +682,7 @@ const clearLegalHoldOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -708,8 +708,8 @@ const createOrUpdateImmutabilityPolicyOperationSpec: coreHttp.OperationSpec = {
     Parameters.immutabilityPolicyName
   ],
   headerParameters: [
+    Parameters.accept,
     Parameters.contentType,
-    Parameters.accept1,
     Parameters.ifMatch
   ],
   mediaType: "json",
@@ -800,8 +800,8 @@ const extendImmutabilityPolicyOperationSpec: coreHttp.OperationSpec = {
     Parameters.containerName
   ],
   headerParameters: [
+    Parameters.accept,
     Parameters.contentType,
-    Parameters.accept1,
     Parameters.ifMatch1
   ],
   mediaType: "json",
@@ -825,7 +825,7 @@ const leaseOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.containerName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/blobServices.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/blobServices.ts
@@ -146,7 +146,7 @@ const setServicePropertiesOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.blobServicesName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/encryptionScopes.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/encryptionScopes.ts
@@ -217,7 +217,7 @@ const putOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.encryptionScopeName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -242,7 +242,7 @@ const patchOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.encryptionScopeName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/fileServices.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/fileServices.ts
@@ -152,7 +152,7 @@ const setServicePropertiesOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.fileServicesName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/fileShares.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/fileShares.ts
@@ -301,7 +301,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.shareName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -326,7 +326,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.shareName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -394,7 +394,7 @@ const restoreOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.shareName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/managementPolicies.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/managementPolicies.ts
@@ -169,7 +169,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.managementPolicyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/objectReplicationPolicies.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/objectReplicationPolicies.ts
@@ -221,7 +221,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.objectReplicationPolicyId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/privateEndpointConnections.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/privateEndpointConnections.ts
@@ -217,7 +217,7 @@ const putOperationSpec: coreHttp.OperationSpec = {
     Parameters.accountName1,
     Parameters.privateEndpointConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/storage-resource-manager/src/operations/storageAccounts.ts
+++ b/test/smoke/generated/storage-resource-manager/src/operations/storageAccounts.ts
@@ -501,7 +501,7 @@ const checkNameAvailabilityOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.accountName,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -531,7 +531,7 @@ const createOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -585,7 +585,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -657,7 +657,7 @@ const regenerateKeyOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -678,7 +678,7 @@ const listAccountSASOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -699,7 +699,7 @@ const listServiceSASOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -743,7 +743,7 @@ const restoreBlobRangesOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.accountName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/review/web-resource-manager.api.md
+++ b/test/smoke/generated/web-resource-manager/review/web-resource-manager.api.md
@@ -8051,7 +8051,7 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
     //
     // (undocumented)
     certificates: Certificates;
-    checkNameAvailability(request: ResourceNameAvailabilityRequest, options?: coreHttp.OperationOptions): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
+    checkNameAvailability(request: ResourceNameAvailabilityRequest, name: string, typeParam: CheckNameResourceTypes, options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
     // Warning: (ae-forgotten-export) The symbol "DeletedWebApps" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -8112,6 +8112,11 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
     //
     // (undocumented)
     webApps: WebApps;
+}
+
+// @public
+export interface WebSiteManagementClientCheckNameAvailabilityOptionalParams extends coreHttp.OperationOptions {
+    isFqdn?: boolean;
 }
 
 // @public

--- a/test/smoke/generated/web-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/web-resource-manager/src/models/index.ts
@@ -11755,6 +11755,17 @@ export type WebSiteManagementClientListBillingMetersResponse = BillingMeterColle
 };
 
 /**
+ * Optional parameters.
+ */
+export interface WebSiteManagementClientCheckNameAvailabilityOptionalParams
+  extends coreHttp.OperationOptions {
+  /**
+   * Is fully qualified domain name.
+   */
+  isFqdn?: boolean;
+}
+
+/**
  * Contains response data for the checkNameAvailability operation.
  */
 export type WebSiteManagementClientCheckNameAvailabilityResponse = ResourceNameAvailability & {

--- a/test/smoke/generated/web-resource-manager/src/models/parameters.ts
+++ b/test/smoke/generated/web-resource-manager/src/models/parameters.ts
@@ -149,18 +149,6 @@ export const appServiceCertificateOrder: OperationParameter = {
   mapper: AppServiceCertificateOrderMapper
 };
 
-export const accept1: OperationParameter = {
-  parameterPath: "accept",
-  mapper: {
-    defaultValue: "application/json",
-    isConstant: true,
-    serializedName: "Accept",
-    type: {
-      name: "String"
-    }
-  }
-};
-
 export const resourceGroupName: OperationURLParameter = {
   parameterPath: "resourceGroupName",
   mapper: {
@@ -316,19 +304,6 @@ export const domain1: OperationParameter = {
 export const domainOwnershipIdentifier: OperationParameter = {
   parameterPath: "domainOwnershipIdentifier",
   mapper: DomainOwnershipIdentifierMapper
-};
-
-export const nextLink1: OperationURLParameter = {
-  parameterPath: "nextLink",
-  mapper: {
-    serializedName: "nextLink",
-    required: true,
-    xmlName: "nextLink",
-    type: {
-      name: "String"
-    }
-  },
-  skipEncoding: true
 };
 
 export const agreementOption: OperationParameter = {
@@ -612,8 +587,18 @@ export const osType: OperationQueryParameter = {
   }
 };
 
-export const request: OperationParameter = {
-  parameterPath: "request",
+export const name1: OperationParameter = {
+  parameterPath: "name",
+  mapper: ResourceNameAvailabilityRequestMapper
+};
+
+export const typeParam: OperationParameter = {
+  parameterPath: "typeParam",
+  mapper: ResourceNameAvailabilityRequestMapper
+};
+
+export const isFqdn: OperationParameter = {
+  parameterPath: ["options", "isFqdn"],
   mapper: ResourceNameAvailabilityRequestMapper
 };
 
@@ -826,7 +811,7 @@ export const snapshotId: OperationURLParameter = {
   }
 };
 
-export const accept2: OperationParameter = {
+export const accept1: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/octet-stream",
@@ -838,7 +823,7 @@ export const accept2: OperationParameter = {
   }
 };
 
-export const accept3: OperationParameter = {
+export const accept2: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/zip",
@@ -1179,7 +1164,7 @@ export const publishingProfileOptions: OperationParameter = {
   mapper: CsmPublishingProfileOptionsMapper
 };
 
-export const accept4: OperationParameter = {
+export const accept3: OperationParameter = {
   parameterPath: "accept",
   mapper: {
     defaultValue: "application/xml",

--- a/test/smoke/generated/web-resource-manager/src/operations/appServiceCertificateOrders.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/appServiceCertificateOrders.ts
@@ -668,7 +668,7 @@ const validatePurchaseInformationOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.appServiceCertificateOrder,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -744,7 +744,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.certificateOrderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -792,7 +792,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.certificateOrderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -871,7 +871,7 @@ const createOrUpdateCertificateOperationSpec: coreHttp.OperationSpec = {
     Parameters.certificateOrderName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -921,7 +921,7 @@ const updateCertificateOperationSpec: coreHttp.OperationSpec = {
     Parameters.certificateOrderName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -943,7 +943,7 @@ const reissueOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.certificateOrderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -965,7 +965,7 @@ const renewOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.certificateOrderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1007,7 +1007,7 @@ const resendRequestEmailsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.certificateOrderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1031,7 +1031,7 @@ const retrieveSiteSealOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.certificateOrderName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/appServiceEnvironments.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/appServiceEnvironments.ts
@@ -1668,7 +1668,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1721,7 +1721,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1798,7 +1798,7 @@ const changeVnetOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1952,7 +1952,7 @@ const createOrUpdateMultiRolePoolOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1979,7 +1979,7 @@ const updateMultiRolePoolOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2344,7 +2344,7 @@ const createOrUpdateWorkerPoolOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.workerPoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2372,7 +2372,7 @@ const updateWorkerPoolOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.workerPoolName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -2552,9 +2552,9 @@ const changeVnetNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName,
     Parameters.name,
-    Parameters.nextLink1
+    Parameters.nextLink
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/appServicePlans.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/appServicePlans.ts
@@ -984,7 +984,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1032,7 +1032,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1390,7 +1390,7 @@ const updateVnetGatewayOperationSpec: coreHttp.OperationSpec = {
     Parameters.vnetName,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1476,7 +1476,7 @@ const createOrUpdateVnetRouteOperationSpec: coreHttp.OperationSpec = {
     Parameters.vnetName,
     Parameters.routeName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1527,7 +1527,7 @@ const updateVnetRouteOperationSpec: coreHttp.OperationSpec = {
     Parameters.vnetName,
     Parameters.routeName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/certificates.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/certificates.ts
@@ -283,7 +283,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -328,7 +328,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/domains.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/domains.ts
@@ -497,7 +497,7 @@ const checkAvailabilityOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.identifier,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -550,7 +550,7 @@ const listRecommendationsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -626,7 +626,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.domainName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -674,7 +674,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.domainName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -744,7 +744,7 @@ const createOrUpdateOwnershipIdentifierOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.domainName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -791,7 +791,7 @@ const updateOwnershipIdentifierOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.domainName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -852,9 +852,9 @@ const listRecommendationsNextOperationSpec: coreHttp.OperationSpec = {
   urlParameters: [
     Parameters.$host,
     Parameters.subscriptionId,
-    Parameters.nextLink1
+    Parameters.nextLink
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/staticSites.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/staticSites.ts
@@ -901,7 +901,7 @@ const createOrUpdateStaticSiteOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -949,7 +949,7 @@ const updateStaticSiteOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1020,7 +1020,7 @@ const updateStaticSiteUserOperationSpec: coreHttp.OperationSpec = {
     Parameters.authprovider,
     Parameters.userid
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1115,7 +1115,7 @@ const createOrUpdateStaticSiteBuildFunctionAppSettingsOperationSpec: coreHttp.Op
     Parameters.name,
     Parameters.prId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1191,7 +1191,7 @@ const createOrUpdateStaticSiteFunctionAppSettingsOperationSpec: coreHttp.Operati
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1215,7 +1215,7 @@ const createUserRolesInvitationLinkOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -1419,7 +1419,7 @@ const resetStaticSiteApiKeyOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/topLevelDomains.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/topLevelDomains.ts
@@ -180,7 +180,7 @@ const listAgreementsOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.agreementOption,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId, Parameters.name],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -220,9 +220,9 @@ const listAgreementsNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.$host,
     Parameters.subscriptionId,
     Parameters.name,
-    Parameters.nextLink1
+    Parameters.nextLink
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/operations/webApps.ts
+++ b/test/smoke/generated/web-resource-manager/src/operations/webApps.ts
@@ -11830,7 +11830,7 @@ const createOrUpdateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -11883,7 +11883,7 @@ const updateOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -11927,7 +11927,7 @@ const applySlotConfigToProductionOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -11951,7 +11951,7 @@ const backupOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12043,7 +12043,7 @@ const listBackupStatusSecretsOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.backupId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12069,7 +12069,7 @@ const restoreOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.backupId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12115,7 +12115,7 @@ const updateApplicationSettingsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12161,7 +12161,7 @@ const updateAuthSettingsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12207,7 +12207,7 @@ const updateAzureStorageAccountsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12253,7 +12253,7 @@ const updateBackupConfigurationOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12364,7 +12364,7 @@ const updateConnectionStringsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12432,7 +12432,7 @@ const updateDiagnosticLogsConfigOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12456,7 +12456,7 @@ const updateMetadataOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12533,7 +12533,7 @@ const updateSitePushSettingsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12601,7 +12601,7 @@ const updateSlotConfigurationNamesOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12647,7 +12647,7 @@ const createOrUpdateConfigurationOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12671,7 +12671,7 @@ const updateConfigurationOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -12759,7 +12759,7 @@ const getWebSiteContainerLogsOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.accept2],
+  headerParameters: [Parameters.accept1],
   serializer
 };
 const getContainerLogsZipOperationSpec: coreHttp.OperationSpec = {
@@ -12780,7 +12780,7 @@ const getContainerLogsZipOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.accept3],
+  headerParameters: [Parameters.accept2],
   serializer
 };
 const listContinuousWebJobsOperationSpec: coreHttp.OperationSpec = {
@@ -12961,7 +12961,7 @@ const createDeploymentOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.id
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13030,7 +13030,7 @@ const discoverBackupOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13100,7 +13100,7 @@ const createOrUpdateDomainOwnershipIdentifierOperationSpec: coreHttp.OperationSp
     Parameters.name,
     Parameters.domainOwnershipIdentifierName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13147,7 +13147,7 @@ const updateDomainOwnershipIdentifierOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.domainOwnershipIdentifierName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13202,7 +13202,7 @@ const createMSDeployOperationOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13328,7 +13328,7 @@ const createFunctionOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.functionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13379,7 +13379,7 @@ const createOrUpdateFunctionSecretOperationSpec: coreHttp.OperationSpec = {
     Parameters.functionName,
     Parameters.keyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13539,7 +13539,7 @@ const createOrUpdateHostSecretOperationSpec: coreHttp.OperationSpec = {
     Parameters.keyName,
     Parameters.keyType
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13632,7 +13632,7 @@ const createOrUpdateHostNameBindingOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.hostName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13704,7 +13704,7 @@ const createOrUpdateHybridConnectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.namespaceName,
     Parameters.relayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13753,7 +13753,7 @@ const updateHybridConnectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.namespaceName,
     Parameters.relayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13845,7 +13845,7 @@ const createOrUpdateRelayServiceConnectionOperationSpec: coreHttp.OperationSpec 
     Parameters.name,
     Parameters.entityName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13892,7 +13892,7 @@ const updateRelayServiceConnectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.entityName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -13994,7 +13994,7 @@ const createInstanceMSDeployOperationOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.instanceId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14290,7 +14290,7 @@ const migrateStorageOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14323,7 +14323,7 @@ const migrateMySqlOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14391,7 +14391,7 @@ const createOrUpdateSwiftVirtualNetworkConnectionOperationSpec: coreHttp.Operati
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14436,7 +14436,7 @@ const updateSwiftVirtualNetworkConnectionOperationSpec: coreHttp.OperationSpec =
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14827,7 +14827,7 @@ const addPremierAddOnOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.premierAddOnName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14873,7 +14873,7 @@ const updatePremierAddOnOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.premierAddOnName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -14919,7 +14919,7 @@ const putPrivateAccessVnetOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15155,7 +15155,7 @@ const createOrUpdatePublicCertificateOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.publicCertificateName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15201,7 +15201,7 @@ const listPublishingProfileXmlWithSecretsOperationSpec: coreHttp.OperationSpec =
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept4],
+  headerParameters: [Parameters.contentType, Parameters.accept3],
   mediaType: "json",
   serializer
 };
@@ -15270,7 +15270,7 @@ const restoreFromBackupBlobOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15295,7 +15295,7 @@ const restoreFromDeletedAppOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15320,7 +15320,7 @@ const restoreSnapshotOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15446,7 +15446,7 @@ const copyProductionSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15526,7 +15526,7 @@ const createOrUpdateSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15581,7 +15581,7 @@ const updateSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15627,7 +15627,7 @@ const applySlotConfigurationSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15652,7 +15652,7 @@ const backupSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15748,7 +15748,7 @@ const listBackupStatusSecretsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.backupId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15775,7 +15775,7 @@ const restoreSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.backupId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15823,7 +15823,7 @@ const updateApplicationSettingsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15871,7 +15871,7 @@ const updateAuthSettingsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15919,7 +15919,7 @@ const updateAzureStorageAccountsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -15967,7 +15967,7 @@ const updateBackupConfigurationSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16036,7 +16036,7 @@ const updateConnectionStringsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16107,7 +16107,7 @@ const updateDiagnosticLogsConfigSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16132,7 +16132,7 @@ const updateMetadataSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16212,7 +16212,7 @@ const updateSitePushSettingsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16283,7 +16283,7 @@ const createOrUpdateConfigurationSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16308,7 +16308,7 @@ const updateConfigurationSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16400,7 +16400,7 @@ const getWebSiteContainerLogsSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.accept2],
+  headerParameters: [Parameters.accept1],
   serializer
 };
 const getContainerLogsZipSlotOperationSpec: coreHttp.OperationSpec = {
@@ -16422,7 +16422,7 @@ const getContainerLogsZipSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.accept3],
+  headerParameters: [Parameters.accept2],
   serializer
 };
 const listContinuousWebJobsSlotOperationSpec: coreHttp.OperationSpec = {
@@ -16611,7 +16611,7 @@ const createDeploymentSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.id
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16683,7 +16683,7 @@ const discoverBackupSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16756,7 +16756,7 @@ const createOrUpdateDomainOwnershipIdentifierSlotOperationSpec: coreHttp.Operati
     Parameters.slot,
     Parameters.domainOwnershipIdentifierName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16805,7 +16805,7 @@ const updateDomainOwnershipIdentifierSlotOperationSpec: coreHttp.OperationSpec =
     Parameters.slot,
     Parameters.domainOwnershipIdentifierName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16862,7 +16862,7 @@ const createMSDeployOperationSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -16993,7 +16993,7 @@ const createInstanceFunctionSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.functionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17046,7 +17046,7 @@ const createOrUpdateFunctionSecretSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.functionName,
     Parameters.keyName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17213,7 +17213,7 @@ const createOrUpdateHostSecretSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.keyName,
     Parameters.keyType
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17310,7 +17310,7 @@ const createOrUpdateHostNameBindingSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.hostName1
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17385,7 +17385,7 @@ const createOrUpdateHybridConnectionSlotOperationSpec: coreHttp.OperationSpec = 
     Parameters.namespaceName,
     Parameters.relayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17436,7 +17436,7 @@ const updateHybridConnectionSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.namespaceName,
     Parameters.relayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17532,7 +17532,7 @@ const createOrUpdateRelayServiceConnectionSlotOperationSpec: coreHttp.OperationS
     Parameters.slot,
     Parameters.entityName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17581,7 +17581,7 @@ const updateRelayServiceConnectionSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.entityName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -17687,7 +17687,7 @@ const createInstanceMSDeployOperationSlotOperationSpec: coreHttp.OperationSpec =
     Parameters.slot,
     Parameters.instanceId
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18032,7 +18032,7 @@ const createOrUpdateSwiftVirtualNetworkConnectionSlotOperationSpec: coreHttp.Ope
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18079,7 +18079,7 @@ const updateSwiftVirtualNetworkConnectionSlotOperationSpec: coreHttp.OperationSp
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18484,7 +18484,7 @@ const addPremierAddOnSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.premierAddOnName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18532,7 +18532,7 @@ const updatePremierAddOnSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.premierAddOnName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18580,7 +18580,7 @@ const putPrivateAccessVnetSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18637,7 +18637,7 @@ const approveOrRejectPrivateEndpointConnectionOperationSpec: coreHttp.OperationS
     Parameters.name,
     Parameters.privateEndpointConnectionName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18937,7 +18937,7 @@ const createOrUpdatePublicCertificateSlotOperationSpec: coreHttp.OperationSpec =
     Parameters.slot,
     Parameters.publicCertificateName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -18985,7 +18985,7 @@ const listPublishingProfileXmlWithSecretsSlotOperationSpec: coreHttp.OperationSp
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept4],
+  headerParameters: [Parameters.contentType, Parameters.accept3],
   mediaType: "json",
   serializer
 };
@@ -19057,7 +19057,7 @@ const restoreFromBackupBlobSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19083,7 +19083,7 @@ const restoreFromDeletedAppSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19109,7 +19109,7 @@ const restoreSnapshotSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19240,7 +19240,7 @@ const copySlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19265,7 +19265,7 @@ const listSlotDifferencesSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19291,7 +19291,7 @@ const swapSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19400,7 +19400,7 @@ const createOrUpdateSourceControlSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19454,7 +19454,7 @@ const updateSourceControlSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19863,7 +19863,7 @@ const createOrUpdateVnetConnectionSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.vnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19912,7 +19912,7 @@ const updateVnetConnectionSlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.slot,
     Parameters.vnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19965,7 +19965,7 @@ const createOrUpdateVnetConnectionGatewaySlotOperationSpec: coreHttp.OperationSp
     Parameters.vnetName,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -19992,7 +19992,7 @@ const updateVnetConnectionGatewaySlotOperationSpec: coreHttp.OperationSpec = {
     Parameters.vnetName,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20063,7 +20063,7 @@ const listSlotDifferencesFromProductionOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20088,7 +20088,7 @@ const swapSlotWithProductionOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20193,7 +20193,7 @@ const createOrUpdateSourceControlOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20245,7 +20245,7 @@ const updateSourceControlOperationSpec: coreHttp.OperationSpec = {
     Parameters.resourceGroupName,
     Parameters.name
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20638,7 +20638,7 @@ const createOrUpdateVnetConnectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.vnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20685,7 +20685,7 @@ const updateVnetConnectionOperationSpec: coreHttp.OperationSpec = {
     Parameters.name,
     Parameters.vnetName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20736,7 +20736,7 @@ const createOrUpdateVnetConnectionGatewayOperationSpec: coreHttp.OperationSpec =
     Parameters.vnetName,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -20762,7 +20762,7 @@ const updateVnetConnectionGatewayOperationSpec: coreHttp.OperationSpec = {
     Parameters.vnetName,
     Parameters.gatewayName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -21776,10 +21776,10 @@ const listSlotDifferencesSlotNextOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName,
     Parameters.name,
-    Parameters.nextLink1,
+    Parameters.nextLink,
     Parameters.slot
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -21940,9 +21940,9 @@ const listSlotDifferencesFromProductionNextOperationSpec: coreHttp.OperationSpec
     Parameters.subscriptionId,
     Parameters.resourceGroupName,
     Parameters.name,
-    Parameters.nextLink1
+    Parameters.nextLink
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
@@ -40,6 +40,8 @@ import {
   WebSiteManagementClientListBillingMetersOptionalParams,
   WebSiteManagementClientListBillingMetersResponse,
   ResourceNameAvailabilityRequest,
+  CheckNameResourceTypes,
+  WebSiteManagementClientCheckNameAvailabilityOptionalParams,
   WebSiteManagementClientCheckNameAvailabilityResponse,
   WebSiteManagementClientGetSubscriptionDeploymentLocationsResponse,
   WebSiteManagementClientListGeoRegionsOptionalParams,
@@ -214,17 +216,21 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
   /**
    * Description for Check if a resource name is available.
    * @param request Name availability request.
+   * @param name Resource name to verify.
+   * @param typeParam Resource type used for verification.
    * @param options The options parameters.
    */
   checkNameAvailability(
     request: ResourceNameAvailabilityRequest,
-    options?: coreHttp.OperationOptions
+    name: string,
+    typeParam: CheckNameResourceTypes,
+    options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams
   ): Promise<WebSiteManagementClientCheckNameAvailabilityResponse> {
     const operationOptions: coreHttp.RequestOptionsBase = coreHttp.operationOptionsToRequestOptionsBase(
       options || {}
     );
     return this.sendOperationRequest(
-      { request, options: operationOptions },
+      { request, name, typeParam, options: operationOptions },
       checkNameAvailabilityOperationSpec
     ) as Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
   }
@@ -545,7 +551,7 @@ const updatePublishingUserOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.userDetails,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -595,7 +601,7 @@ const updateSourceControlOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.requestMessage,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.sourceControlType],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -631,10 +637,17 @@ const checkNameAvailabilityOperationSpec: coreHttp.OperationSpec = {
       bodyMapper: Mappers.DefaultErrorResponse
     }
   },
-  requestBody: Parameters.request,
+  requestBody: {
+    parameterPath: {
+      name: ["name"],
+      typeParam: ["typeParam"],
+      isFqdn: ["options", "isFqdn"]
+    },
+    mapper: Mappers.ResourceNameAvailabilityRequest
+  },
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -692,7 +705,7 @@ const listSiteIdentifiersAssignedToHostNameOperationSpec: coreHttp.OperationSpec
   requestBody: Parameters.nameIdentifier,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -744,7 +757,7 @@ const verifyHostingEnvironmentVnetOperationSpec: coreHttp.OperationSpec = {
   requestBody: Parameters.parameters1,
   queryParameters: [Parameters.apiVersion],
   urlParameters: [Parameters.$host, Parameters.subscriptionId],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -765,7 +778,7 @@ const moveOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -788,7 +801,7 @@ const validateOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -809,7 +822,7 @@ const validateMoveOperationSpec: coreHttp.OperationSpec = {
     Parameters.subscriptionId,
     Parameters.resourceGroupName
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };
@@ -894,9 +907,9 @@ const listSiteIdentifiersAssignedToHostNameNextOperationSpec: coreHttp.Operation
   urlParameters: [
     Parameters.$host,
     Parameters.subscriptionId,
-    Parameters.nextLink1
+    Parameters.nextLink
   ],
-  headerParameters: [Parameters.contentType, Parameters.accept1],
+  headerParameters: [Parameters.accept, Parameters.contentType],
   mediaType: "json",
   serializer
 };

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
@@ -61699,7 +61699,7 @@
             {
               "kind": "Method",
               "canonicalReference": "web-resource-manager!WebSiteManagementClient#checkNameAvailability:member(1)",
-              "docComment": "/**\n * Description for Check if a resource name is available.\n *\n * @param request - Name availability request.\n *\n * @param options - The options parameters.\n */\n",
+              "docComment": "/**\n * Description for Check if a resource name is available.\n *\n * @param request - Name availability request.\n *\n * @param name - Resource name to verify.\n *\n * @param typeParam - Resource type used for verification.\n *\n * @param options - The options parameters.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
@@ -61712,16 +61712,29 @@
                 },
                 {
                   "kind": "Content",
-                  "text": ", options?: "
+                  "text": ", name: "
                 },
                 {
                   "kind": "Content",
-                  "text": "coreHttp."
+                  "text": "string"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", typeParam: "
                 },
                 {
                   "kind": "Reference",
-                  "text": "OperationOptions",
-                  "canonicalReference": "@azure/core-http!OperationOptions:interface"
+                  "text": "CheckNameResourceTypes",
+                  "canonicalReference": "web-resource-manager!CheckNameResourceTypes:type"
+                },
+                {
+                  "kind": "Content",
+                  "text": ", options?: "
+                },
+                {
+                  "kind": "Reference",
+                  "text": "WebSiteManagementClientCheckNameAvailabilityOptionalParams",
+                  "canonicalReference": "web-resource-manager!WebSiteManagementClientCheckNameAvailabilityOptionalParams:interface"
                 },
                 {
                   "kind": "Content",
@@ -61752,8 +61765,8 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 6,
-                "endIndex": 10
+                "startIndex": 9,
+                "endIndex": 13
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
@@ -61766,10 +61779,24 @@
                   }
                 },
                 {
-                  "parameterName": "options",
+                  "parameterName": "name",
                   "parameterTypeTokenRange": {
                     "startIndex": 3,
-                    "endIndex": 5
+                    "endIndex": 4
+                  }
+                },
+                {
+                  "parameterName": "typeParam",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 5,
+                    "endIndex": 6
+                  }
+                },
+                {
+                  "parameterName": "options",
+                  "parameterTypeTokenRange": {
+                    "startIndex": 7,
+                    "endIndex": 8
                   }
                 }
               ],
@@ -63573,6 +63600,65 @@
             "endIndex": 3
           },
           "implementsTokenRanges": []
+        },
+        {
+          "kind": "Interface",
+          "canonicalReference": "web-resource-manager!WebSiteManagementClientCheckNameAvailabilityOptionalParams:interface",
+          "docComment": "/**\n * Optional parameters.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export interface WebSiteManagementClientCheckNameAvailabilityOptionalParams extends "
+            },
+            {
+              "kind": "Content",
+              "text": "coreHttp."
+            },
+            {
+              "kind": "Reference",
+              "text": "OperationOptions",
+              "canonicalReference": "@azure/core-http!OperationOptions:interface"
+            },
+            {
+              "kind": "Content",
+              "text": " "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "WebSiteManagementClientCheckNameAvailabilityOptionalParams",
+          "members": [
+            {
+              "kind": "PropertySignature",
+              "canonicalReference": "web-resource-manager!WebSiteManagementClientCheckNameAvailabilityOptionalParams#isFqdn:member",
+              "docComment": "/**\n * Is fully qualified domain name.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "isFqdn?: "
+                },
+                {
+                  "kind": "Content",
+                  "text": "boolean"
+                },
+                {
+                  "kind": "Content",
+                  "text": ";"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "isFqdn",
+              "propertyTypeTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ],
+          "extendsTokenRanges": [
+            {
+              "startIndex": 1,
+              "endIndex": 4
+            }
+          ]
         },
         {
           "kind": "TypeAlias",

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.md
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.md
@@ -8051,7 +8051,7 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
     //
     // (undocumented)
     certificates: Certificates;
-    checkNameAvailability(request: ResourceNameAvailabilityRequest, options?: coreHttp.OperationOptions): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
+    checkNameAvailability(request: ResourceNameAvailabilityRequest, name: string, typeParam: CheckNameResourceTypes, options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
     // Warning: (ae-forgotten-export) The symbol "DeletedWebApps" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
@@ -8112,6 +8112,11 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
     //
     // (undocumented)
     webApps: WebApps;
+}
+
+// @public
+export interface WebSiteManagementClientCheckNameAvailabilityOptionalParams extends coreHttp.OperationOptions {
+    isFqdn?: boolean;
 }
 
 // @public

--- a/test/unit/generators/utils/parameterUtils.spec.ts
+++ b/test/unit/generators/utils/parameterUtils.spec.ts
@@ -169,7 +169,8 @@ const getParameter = ({
     new StringSchema("mock_string", "")
   ),
   operationsIn = {},
-  implementationLocation = ImplementationLocation.Method
+  implementationLocation = ImplementationLocation.Method,
+  isFlattened = false
 }: Partial<ParameterDetails & { sufix: string }>): ParameterDetails => ({
   nameRef: nameRef || `MockParameter${sufix}`,
   description: description || `mock parameter description${sufix}`,
@@ -189,5 +190,6 @@ const getParameter = ({
   required,
   operationsIn,
   collectionFormat,
-  implementationLocation
+  implementationLocation,
+  isFlattened
 });

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -129,6 +129,7 @@ describe("OperationTransforms", () => {
           requests: [
             {
               parameters,
+              signatureParameters: parameters,
               protocol: {
                 http: {
                   path: operationPath,

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -23,6 +23,7 @@ import { KnownMediaType } from "@azure-tools/codegen";
 import { Mapper } from "@azure/core-http";
 import { OperationSpecDetails } from "../../../src/models/operationDetails";
 import { PropertyKind } from "../../../src/models/modelDetails";
+import { ParameterDetails } from "../../../dist/src/models/parameterDetails";
 
 const choice = new ChoiceSchema("mockChoice", "", {
   choices: [
@@ -235,7 +236,10 @@ describe("OperationTransforms", () => {
           }
         ])[0];
         checkHttpMethodAndPath(operationSpec);
-        assert.deepEqual(operationSpec.requestBody!.nameRef, "MockOperation");
+        assert.deepEqual(
+          (operationSpec.requestBody as ParameterDetails)!.nameRef,
+          "MockOperation"
+        );
       });
 
       it("should create an operation spec with correct responses spec and cosntant schema response", async () => {

--- a/test/unit/transforms/operationTransforms.spec.ts
+++ b/test/unit/transforms/operationTransforms.spec.ts
@@ -233,7 +233,8 @@ describe("OperationTransforms", () => {
             name: "MockOperation",
             description: "",
             schemaType: SchemaType.String,
-            implementationLocation: ImplementationLocation.Method
+            implementationLocation: ImplementationLocation.Method,
+            isFlattened: false
           }
         ])[0];
         checkHttpMethodAndPath(operationSpec);


### PR DESCRIPTION
Our current support of model flattening didn't support parameter flattening. This PR adds:

* Support for Parameter Flattening and Parameter Grouping
* Fixes generator to avoid generating un-needed parameter definitions

**Note:** there are many files in the PR, most of them are under `test/integration/generated/*` in the form of removing duplicate parameter definitions for `accept` and `content-type`. The main interesting file to review are: 

* everything under `src/*`
* `test/**/*.spec.ts`
* `test/integration/generated/modelFlattening` - For an example of how the generated code will change with this PR