### PR TITLE
Improving support for extensible enums

### DIFF
--- a/src/generators/static/tsConfigFileGenerator.ts
+++ b/src/generators/static/tsConfigFileGenerator.ts
@@ -15,6 +15,7 @@ export function generateTsConfig(project: Project) {
       esModuleInterop: true,
       allowSyntheticDefaultImports: true,
       forceConsistentCasingInFileNames: true,
+      preserveConstEnums: true,
       lib: ["es6", "dom"],
       declaration: true,
       outDir: "./esm",

--- a/src/models/unionDetails.ts
+++ b/src/models/unionDetails.ts
@@ -10,12 +10,13 @@ export interface UnionDetails {
   name: string;
   description: string;
   serializedName: string;
-  properties: NameValuePair[];
+  properties: UnionElement[];
   schemaType: SchemaType;
   itemType?: SchemaType;
 }
 
-export interface NameValuePair {
+export interface UnionElement {
   name: string;
   value: string;
+  description?: string;
 }

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { ClientDetails } from "../models/clientDetails";
-import { UnionDetails, NameValuePair } from "../models/unionDetails";
+import { UnionDetails, UnionElement } from "../models/unionDetails";
 
 import {
   CodeModel,
@@ -37,15 +37,17 @@ export async function transformChoices(codeModel: CodeModel) {
 
 function extractProperties(
   choice: ChoiceSchema | SealedChoiceSchema
-): NameValuePair[] {
+): UnionElement[] {
   return choice.choices.map(c => {
     const metadata = getLanguageMetadata(c.language);
     return {
       name: metadata.name,
       value: getStringForValue(
         c.value,
-        choice?.choiceType?.type ?? SchemaType.String
-      )
+        choice?.choiceType?.type ?? SchemaType.String,
+        false
+      ),
+      description: metadata.description
     };
   });
 }

--- a/test/integration/generated/additionalProperties/tsconfig.json
+++ b/test/integration/generated/additionalProperties/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/arrayConstraints/src/models/index.ts
+++ b/test/integration/generated/arrayConstraints/src/models/index.ts
@@ -14,9 +14,22 @@ export interface Product {
 }
 
 /**
- * Defines values for Enum0.
+ * Known values of {@link Enum0} that the service accepts.
  */
-export type Enum0 = "one" | "two" | string;
+export const enum KnownEnum0 {
+  One = "one",
+  Two = "two"
+}
+
+/**
+ * Defines values for Enum0. \
+ * {@link KnownEnum0} can be used interchangeably with Enum0,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **one** \
+ * **two**
+ */
+export type Enum0 = string;
 
 /**
  * Optional parameters.

--- a/test/integration/generated/arrayConstraints/tsconfig.json
+++ b/test/integration/generated/arrayConstraints/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/azureParameterGrouping/tsconfig.json
+++ b/test/integration/generated/azureParameterGrouping/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/azureReport/tsconfig.json
+++ b/test/integration/generated/azureReport/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/azureSpecialProperties/tsconfig.json
+++ b/test/integration/generated/azureSpecialProperties/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyArray/src/models/index.ts
+++ b/test/integration/generated/bodyArray/src/models/index.ts
@@ -19,13 +19,44 @@ export interface Product {
 }
 
 /**
- * Defines values for Enum0.
+ * Known values of {@link Enum0} that the service accepts.
  */
-export type Enum0 = "foo1" | "foo2" | "foo3" | string;
+export const enum KnownEnum0 {
+  Foo1 = "foo1",
+  Foo2 = "foo2",
+  Foo3 = "foo3"
+}
+
 /**
- * Defines values for Enum1.
+ * Defines values for Enum0. \
+ * {@link KnownEnum0} can be used interchangeably with Enum0,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **foo1** \
+ * **foo2** \
+ * **foo3**
  */
-export type Enum1 = "foo1" | "foo2" | "foo3" | string;
+export type Enum0 = string;
+
+/**
+ * Known values of {@link Enum1} that the service accepts.
+ */
+export const enum KnownEnum1 {
+  Foo1 = "foo1",
+  Foo2 = "foo2",
+  Foo3 = "foo3"
+}
+
+/**
+ * Defines values for Enum1. \
+ * {@link KnownEnum1} can be used interchangeably with Enum1,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **foo1** \
+ * **foo2** \
+ * **foo3**
+ */
+export type Enum1 = string;
 /**
  * Defines values for FooEnum.
  */

--- a/test/integration/generated/bodyArray/tsconfig.json
+++ b/test/integration/generated/bodyArray/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyBoolean/tsconfig.json
+++ b/test/integration/generated/bodyBoolean/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyBooleanQuirks/tsconfig.json
+++ b/test/integration/generated/bodyBooleanQuirks/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyByte/tsconfig.json
+++ b/test/integration/generated/bodyByte/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -202,24 +202,74 @@ export type Goblinshark = Shark & {
 };
 
 export type Cookiecuttershark = Shark & {};
+
 /**
- * Defines values for CMYKColors.
+ * Known values of {@link CMYKColors} that the service accepts.
  */
-export type CMYKColors = "cyan" | "Magenta" | "YELLOW" | "blacK" | string;
+export const enum KnownCMYKColors {
+  Cyan = "cyan",
+  Magenta = "Magenta",
+  Yellow = "YELLOW",
+  BlacK = "blacK"
+}
+
 /**
- * Defines values for MyKind.
+ * Defines values for CMYKColors. \
+ * {@link KnownCMYKColors} can be used interchangeably with CMYKColors,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **cyan** \
+ * **Magenta** \
+ * **YELLOW** \
+ * **blacK**
  */
-export type MyKind = "Kind1" | string;
+export type CMYKColors = string;
+
 /**
- * Defines values for GoblinSharkColor.
+ * Known values of {@link MyKind} that the service accepts.
  */
-export type GoblinSharkColor =
-  | "pink"
-  | "gray"
-  | "brown"
-  | "RED"
-  | "red"
-  | string;
+export const enum KnownMyKind {
+  Kind1 = "Kind1"
+}
+
+/**
+ * Defines values for MyKind. \
+ * {@link KnownMyKind} can be used interchangeably with MyKind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Kind1**
+ */
+export type MyKind = string;
+
+/**
+ * Known values of {@link GoblinSharkColor} that the service accepts.
+ */
+export const enum KnownGoblinSharkColor {
+  Pink = "pink",
+  Gray = "gray",
+  Brown = "brown",
+  /**
+   * Uppercase RED
+   */
+  UpperRed = "RED",
+  /**
+   * Lowercase RED
+   */
+  LowerRed = "red"
+}
+
+/**
+ * Defines values for GoblinSharkColor. \
+ * {@link KnownGoblinSharkColor} can be used interchangeably with GoblinSharkColor,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **pink** \
+ * **gray** \
+ * **brown** \
+ * **RED**: Uppercase RED \
+ * **red**: Lowercase RED
+ */
+export type GoblinSharkColor = string;
 
 /**
  * Contains response data for the getValid operation.

--- a/test/integration/generated/bodyComplex/tsconfig.json
+++ b/test/integration/generated/bodyComplex/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyComplexWithTracing/src/models/index.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/models/index.ts
@@ -202,24 +202,74 @@ export type Goblinshark = Shark & {
 };
 
 export type Cookiecuttershark = Shark & {};
+
 /**
- * Defines values for CMYKColors.
+ * Known values of {@link CMYKColors} that the service accepts.
  */
-export type CMYKColors = "cyan" | "Magenta" | "YELLOW" | "blacK" | string;
+export const enum KnownCMYKColors {
+  Cyan = "cyan",
+  Magenta = "Magenta",
+  Yellow = "YELLOW",
+  BlacK = "blacK"
+}
+
 /**
- * Defines values for MyKind.
+ * Defines values for CMYKColors. \
+ * {@link KnownCMYKColors} can be used interchangeably with CMYKColors,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **cyan** \
+ * **Magenta** \
+ * **YELLOW** \
+ * **blacK**
  */
-export type MyKind = "Kind1" | string;
+export type CMYKColors = string;
+
 /**
- * Defines values for GoblinSharkColor.
+ * Known values of {@link MyKind} that the service accepts.
  */
-export type GoblinSharkColor =
-  | "pink"
-  | "gray"
-  | "brown"
-  | "RED"
-  | "red"
-  | string;
+export const enum KnownMyKind {
+  Kind1 = "Kind1"
+}
+
+/**
+ * Defines values for MyKind. \
+ * {@link KnownMyKind} can be used interchangeably with MyKind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Kind1**
+ */
+export type MyKind = string;
+
+/**
+ * Known values of {@link GoblinSharkColor} that the service accepts.
+ */
+export const enum KnownGoblinSharkColor {
+  Pink = "pink",
+  Gray = "gray",
+  Brown = "brown",
+  /**
+   * Uppercase RED
+   */
+  UpperRed = "RED",
+  /**
+   * Lowercase RED
+   */
+  LowerRed = "red"
+}
+
+/**
+ * Defines values for GoblinSharkColor. \
+ * {@link KnownGoblinSharkColor} can be used interchangeably with GoblinSharkColor,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **pink** \
+ * **gray** \
+ * **brown** \
+ * **RED**: Uppercase RED \
+ * **red**: Lowercase RED
+ */
+export type GoblinSharkColor = string;
 
 /**
  * Contains response data for the getValid operation.

--- a/test/integration/generated/bodyComplexWithTracing/tsconfig.json
+++ b/test/integration/generated/bodyComplexWithTracing/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyDate/tsconfig.json
+++ b/test/integration/generated/bodyDate/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyDateTime/tsconfig.json
+++ b/test/integration/generated/bodyDateTime/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyDateTimeRfc1123/tsconfig.json
+++ b/test/integration/generated/bodyDateTimeRfc1123/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyDictionary/tsconfig.json
+++ b/test/integration/generated/bodyDictionary/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyDuration/tsconfig.json
+++ b/test/integration/generated/bodyDuration/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyFile/tsconfig.json
+++ b/test/integration/generated/bodyFile/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyFormData/tsconfig.json
+++ b/test/integration/generated/bodyFormData/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyInteger/tsconfig.json
+++ b/test/integration/generated/bodyInteger/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyNumber/tsconfig.json
+++ b/test/integration/generated/bodyNumber/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyString/tsconfig.json
+++ b/test/integration/generated/bodyString/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/bodyTime/tsconfig.json
+++ b/test/integration/generated/bodyTime/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/customUrl/tsconfig.json
+++ b/test/integration/generated/customUrl/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/customUrlMoreOptions/tsconfig.json
+++ b/test/integration/generated/customUrlMoreOptions/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/customUrlPaging/tsconfig.json
+++ b/test/integration/generated/customUrlPaging/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/extensibleEnums/src/models/index.ts
+++ b/test/integration/generated/extensibleEnums/src/models/index.ts
@@ -21,21 +21,61 @@ export interface Pet {
 }
 
 /**
- * Defines values for DaysOfWeekExtensibleEnum.
+ * Known values of {@link DaysOfWeekExtensibleEnum} that the service accepts.
  */
-export type DaysOfWeekExtensibleEnum =
-  | "Monday"
-  | "Tuesday"
-  | "Wednesday"
-  | "Thursday"
-  | "Friday"
-  | "Saturday"
-  | "Sunday"
-  | string;
+export const enum KnownDaysOfWeekExtensibleEnum {
+  Monday = "Monday",
+  Tuesday = "Tuesday",
+  Wednesday = "Wednesday",
+  Thursday = "Thursday",
+  Friday = "Friday",
+  Saturday = "Saturday",
+  Sunday = "Sunday"
+}
+
 /**
- * Defines values for IntEnum.
+ * Defines values for DaysOfWeekExtensibleEnum. \
+ * {@link KnownDaysOfWeekExtensibleEnum} can be used interchangeably with DaysOfWeekExtensibleEnum,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Monday** \
+ * **Tuesday** \
+ * **Wednesday** \
+ * **Thursday** \
+ * **Friday** \
+ * **Saturday** \
+ * **Sunday**
  */
-export type IntEnum = "1" | "2" | "3" | string;
+export type DaysOfWeekExtensibleEnum = string;
+
+/**
+ * Known values of {@link IntEnum} that the service accepts.
+ */
+export const enum KnownIntEnum {
+  /**
+   * one
+   */
+  One = "1",
+  /**
+   * two
+   */
+  Two = "2",
+  /**
+   * three
+   */
+  Three = "3"
+}
+
+/**
+ * Defines values for IntEnum. \
+ * {@link KnownIntEnum} can be used interchangeably with IntEnum,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **1**: one \
+ * **2**: two \
+ * **3**: three
+ */
+export type IntEnum = string;
 
 /**
  * Contains response data for the getByPetId operation.

--- a/test/integration/generated/extensibleEnums/tsconfig.json
+++ b/test/integration/generated/extensibleEnums/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/header/tsconfig.json
+++ b/test/integration/generated/header/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/httpInfrastructure/tsconfig.json
+++ b/test/integration/generated/httpInfrastructure/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/licenseHeader/src/models/index.ts
+++ b/test/integration/generated/licenseHeader/src/models/index.ts
@@ -9,9 +9,22 @@
 import * as coreHttp from "@azure/core-http";
 
 /**
- * Defines values for Enum0.
+ * Known values of {@link Enum0} that the service accepts.
  */
-export type Enum0 = "one" | "two" | string;
+export const enum KnownEnum0 {
+  One = "one",
+  Two = "two"
+}
+
+/**
+ * Defines values for Enum0. \
+ * {@link KnownEnum0} can be used interchangeably with Enum0,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **one** \
+ * **two**
+ */
+export type Enum0 = string;
 
 /**
  * Contains response data for the apiV1ValueGet operation.

--- a/test/integration/generated/licenseHeader/tsconfig.json
+++ b/test/integration/generated/licenseHeader/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/lro/src/models/index.ts
+++ b/test/integration/generated/lro/src/models/index.ts
@@ -924,53 +924,112 @@ export interface LROsCustomHeaderPostAsyncRetrySucceededHeaders {
 }
 
 /**
- * Defines values for ProductPropertiesProvisioningStateValues.
+ * Known values of {@link ProductPropertiesProvisioningStateValues} that the service accepts.
  */
-export type ProductPropertiesProvisioningStateValues =
-  | "Succeeded"
-  | "Failed"
-  | "canceled"
-  | "Accepted"
-  | "Creating"
-  | "Created"
-  | "Updating"
-  | "Updated"
-  | "Deleting"
-  | "Deleted"
-  | "OK"
-  | string;
+export const enum KnownProductPropertiesProvisioningStateValues {
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "canceled",
+  Accepted = "Accepted",
+  Creating = "Creating",
+  Created = "Created",
+  Updating = "Updating",
+  Updated = "Updated",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  OK = "OK"
+}
+
 /**
- * Defines values for SubProductPropertiesProvisioningStateValues.
+ * Defines values for ProductPropertiesProvisioningStateValues. \
+ * {@link KnownProductPropertiesProvisioningStateValues} can be used interchangeably with ProductPropertiesProvisioningStateValues,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Failed** \
+ * **canceled** \
+ * **Accepted** \
+ * **Creating** \
+ * **Created** \
+ * **Updating** \
+ * **Updated** \
+ * **Deleting** \
+ * **Deleted** \
+ * **OK**
  */
-export type SubProductPropertiesProvisioningStateValues =
-  | "Succeeded"
-  | "Failed"
-  | "canceled"
-  | "Accepted"
-  | "Creating"
-  | "Created"
-  | "Updating"
-  | "Updated"
-  | "Deleting"
-  | "Deleted"
-  | "OK"
-  | string;
+export type ProductPropertiesProvisioningStateValues = string;
+
 /**
- * Defines values for OperationResultStatus.
+ * Known values of {@link SubProductPropertiesProvisioningStateValues} that the service accepts.
  */
-export type OperationResultStatus =
-  | "Succeeded"
-  | "Failed"
-  | "canceled"
-  | "Accepted"
-  | "Creating"
-  | "Created"
-  | "Updating"
-  | "Updated"
-  | "Deleting"
-  | "Deleted"
-  | "OK"
-  | string;
+export const enum KnownSubProductPropertiesProvisioningStateValues {
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "canceled",
+  Accepted = "Accepted",
+  Creating = "Creating",
+  Created = "Created",
+  Updating = "Updating",
+  Updated = "Updated",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  OK = "OK"
+}
+
+/**
+ * Defines values for SubProductPropertiesProvisioningStateValues. \
+ * {@link KnownSubProductPropertiesProvisioningStateValues} can be used interchangeably with SubProductPropertiesProvisioningStateValues,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Failed** \
+ * **canceled** \
+ * **Accepted** \
+ * **Creating** \
+ * **Created** \
+ * **Updating** \
+ * **Updated** \
+ * **Deleting** \
+ * **Deleted** \
+ * **OK**
+ */
+export type SubProductPropertiesProvisioningStateValues = string;
+
+/**
+ * Known values of {@link OperationResultStatus} that the service accepts.
+ */
+export const enum KnownOperationResultStatus {
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "canceled",
+  Accepted = "Accepted",
+  Creating = "Creating",
+  Created = "Created",
+  Updating = "Updating",
+  Updated = "Updated",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  OK = "OK"
+}
+
+/**
+ * Defines values for OperationResultStatus. \
+ * {@link KnownOperationResultStatus} can be used interchangeably with OperationResultStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Failed** \
+ * **canceled** \
+ * **Accepted** \
+ * **Creating** \
+ * **Created** \
+ * **Updating** \
+ * **Updated** \
+ * **Deleting** \
+ * **Deleted** \
+ * **OK**
+ */
+export type OperationResultStatus = string;
 
 /**
  * Optional parameters.

--- a/test/integration/generated/lro/tsconfig.json
+++ b/test/integration/generated/lro/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/lroParametrizedEndpoints/tsconfig.json
+++ b/test/integration/generated/lroParametrizedEndpoints/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/mediaTypes/tsconfig.json
+++ b/test/integration/generated/mediaTypes/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/mediaTypesV3/tsconfig.json
+++ b/test/integration/generated/mediaTypesV3/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/mediaTypesV3Lro/tsconfig.json
+++ b/test/integration/generated/mediaTypesV3Lro/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/mediaTypesWithTracing/tsconfig.json
+++ b/test/integration/generated/mediaTypesWithTracing/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/modelFlattening/src/models/index.ts
+++ b/test/integration/generated/modelFlattening/src/models/index.ts
@@ -176,21 +176,40 @@ export interface FlattenParameterGroup {
 }
 
 /**
- * Defines values for FlattenedProductPropertiesProvisioningStateValues.
+ * Known values of {@link FlattenedProductPropertiesProvisioningStateValues} that the service accepts.
  */
-export type FlattenedProductPropertiesProvisioningStateValues =
-  | "Succeeded"
-  | "Failed"
-  | "canceled"
-  | "Accepted"
-  | "Creating"
-  | "Created"
-  | "Updating"
-  | "Updated"
-  | "Deleting"
-  | "Deleted"
-  | "OK"
-  | string;
+export const enum KnownFlattenedProductPropertiesProvisioningStateValues {
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "canceled",
+  Accepted = "Accepted",
+  Creating = "Creating",
+  Created = "Created",
+  Updating = "Updating",
+  Updated = "Updated",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  OK = "OK"
+}
+
+/**
+ * Defines values for FlattenedProductPropertiesProvisioningStateValues. \
+ * {@link KnownFlattenedProductPropertiesProvisioningStateValues} can be used interchangeably with FlattenedProductPropertiesProvisioningStateValues,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Failed** \
+ * **canceled** \
+ * **Accepted** \
+ * **Creating** \
+ * **Created** \
+ * **Updating** \
+ * **Updated** \
+ * **Deleting** \
+ * **Deleted** \
+ * **OK**
+ */
+export type FlattenedProductPropertiesProvisioningStateValues = string;
 
 /**
  * Optional parameters.

--- a/test/integration/generated/modelFlattening/tsconfig.json
+++ b/test/integration/generated/modelFlattening/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/multipleInheritance/tsconfig.json
+++ b/test/integration/generated/multipleInheritance/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/noLicenseHeader/src/models/index.ts
+++ b/test/integration/generated/noLicenseHeader/src/models/index.ts
@@ -1,9 +1,22 @@
 import * as coreHttp from "@azure/core-http";
 
 /**
- * Defines values for Enum0.
+ * Known values of {@link Enum0} that the service accepts.
  */
-export type Enum0 = "one" | "two" | string;
+export const enum KnownEnum0 {
+  One = "one",
+  Two = "two"
+}
+
+/**
+ * Defines values for Enum0. \
+ * {@link KnownEnum0} can be used interchangeably with Enum0,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **one** \
+ * **two**
+ */
+export type Enum0 = string;
 
 /**
  * Contains response data for the apiV1ValueGet operation.

--- a/test/integration/generated/noLicenseHeader/tsconfig.json
+++ b/test/integration/generated/noLicenseHeader/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/noMappers/src/models/index.ts
+++ b/test/integration/generated/noMappers/src/models/index.ts
@@ -9,9 +9,22 @@
 import * as coreHttp from "@azure/core-http";
 
 /**
- * Defines values for Enum0.
+ * Known values of {@link Enum0} that the service accepts.
  */
-export type Enum0 = "one" | "two" | string;
+export const enum KnownEnum0 {
+  One = "one",
+  Two = "two"
+}
+
+/**
+ * Defines values for Enum0. \
+ * {@link KnownEnum0} can be used interchangeably with Enum0,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **one** \
+ * **two**
+ */
+export type Enum0 = string;
 
 /**
  * Contains response data for the apiV1ValueGet operation.

--- a/test/integration/generated/noMappers/tsconfig.json
+++ b/test/integration/generated/noMappers/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/nonStringEnum/src/models/index.ts
+++ b/test/integration/generated/nonStringEnum/src/models/index.ts
@@ -9,13 +9,52 @@
 import * as coreHttp from "@azure/core-http";
 
 /**
- * Defines values for IntEnum.
+ * Known values of {@link IntEnum} that the service accepts.
  */
-export type IntEnum = 200 | 403 | 405 | 406 | 429 | number;
+export const enum KnownIntEnum {
+  TwoHundred = 200,
+  FourHundredThree = 403,
+  FourHundredFive = 405,
+  FourHundredSix = 406,
+  FourHundredTwentyNine = 429
+}
+
 /**
- * Defines values for FloatEnum.
+ * Defines values for IntEnum. \
+ * {@link KnownIntEnum} can be used interchangeably with IntEnum,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **200** \
+ * **403** \
+ * **405** \
+ * **406** \
+ * **429**
  */
-export type FloatEnum = 200.4 | 403.4 | 405.3 | 406.2 | 429.1 | number;
+export type IntEnum = number;
+
+/**
+ * Known values of {@link FloatEnum} that the service accepts.
+ */
+export const enum KnownFloatEnum {
+  TwoHundred4 = 200.4,
+  FourHundredThree4 = 403.4,
+  FourHundredFive3 = 405.3,
+  FourHundredSix2 = 406.2,
+  FourHundredTwentyNine1 = 429.1
+}
+
+/**
+ * Defines values for FloatEnum. \
+ * {@link KnownFloatEnum} can be used interchangeably with FloatEnum,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **200.4** \
+ * **403.4** \
+ * **405.3** \
+ * **406.2** \
+ * **429.1**
+ */
+export type FloatEnum = number;
 
 /**
  * Optional parameters.

--- a/test/integration/generated/nonStringEnum/tsconfig.json
+++ b/test/integration/generated/nonStringEnum/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/objectType/tsconfig.json
+++ b/test/integration/generated/objectType/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/paging/src/models/index.ts
+++ b/test/integration/generated/paging/src/models/index.ts
@@ -120,21 +120,40 @@ export interface PagingGetMultiplePagesLroOptions {
 }
 
 /**
- * Defines values for OperationResultStatus.
+ * Known values of {@link OperationResultStatus} that the service accepts.
  */
-export type OperationResultStatus =
-  | "Succeeded"
-  | "Failed"
-  | "canceled"
-  | "Accepted"
-  | "Creating"
-  | "Created"
-  | "Updating"
-  | "Updated"
-  | "Deleting"
-  | "Deleted"
-  | "OK"
-  | string;
+export const enum KnownOperationResultStatus {
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "canceled",
+  Accepted = "Accepted",
+  Creating = "Creating",
+  Created = "Created",
+  Updating = "Updating",
+  Updated = "Updated",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  OK = "OK"
+}
+
+/**
+ * Defines values for OperationResultStatus. \
+ * {@link KnownOperationResultStatus} can be used interchangeably with OperationResultStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Failed** \
+ * **canceled** \
+ * **Accepted** \
+ * **Creating** \
+ * **Created** \
+ * **Updating** \
+ * **Updated** \
+ * **Deleting** \
+ * **Deleted** \
+ * **OK**
+ */
+export type OperationResultStatus = string;
 
 /**
  * Contains response data for the getNoItemNamePages operation.

--- a/test/integration/generated/paging/tsconfig.json
+++ b/test/integration/generated/paging/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/pagingNoIterators/src/models/index.ts
+++ b/test/integration/generated/pagingNoIterators/src/models/index.ts
@@ -120,21 +120,40 @@ export interface PagingGetMultiplePagesLroOptions {
 }
 
 /**
- * Defines values for OperationResultStatus.
+ * Known values of {@link OperationResultStatus} that the service accepts.
  */
-export type OperationResultStatus =
-  | "Succeeded"
-  | "Failed"
-  | "canceled"
-  | "Accepted"
-  | "Creating"
-  | "Created"
-  | "Updating"
-  | "Updated"
-  | "Deleting"
-  | "Deleted"
-  | "OK"
-  | string;
+export const enum KnownOperationResultStatus {
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "canceled",
+  Accepted = "Accepted",
+  Creating = "Creating",
+  Created = "Created",
+  Updating = "Updating",
+  Updated = "Updated",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  OK = "OK"
+}
+
+/**
+ * Defines values for OperationResultStatus. \
+ * {@link KnownOperationResultStatus} can be used interchangeably with OperationResultStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Failed** \
+ * **canceled** \
+ * **Accepted** \
+ * **Creating** \
+ * **Created** \
+ * **Updating** \
+ * **Updated** \
+ * **Deleting** \
+ * **Deleted** \
+ * **OK**
+ */
+export type OperationResultStatus = string;
 
 /**
  * Contains response data for the getNoItemNamePages operation.

--- a/test/integration/generated/pagingNoIterators/tsconfig.json
+++ b/test/integration/generated/pagingNoIterators/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/regexConstraint/tsconfig.json
+++ b/test/integration/generated/regexConstraint/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/report/tsconfig.json
+++ b/test/integration/generated/report/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/requiredOptional/tsconfig.json
+++ b/test/integration/generated/requiredOptional/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/subscriptionIdApiVersion/tsconfig.json
+++ b/test/integration/generated/subscriptionIdApiVersion/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/url/tsconfig.json
+++ b/test/integration/generated/url/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/url2/tsconfig.json
+++ b/test/integration/generated/url2/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/urlMulti/tsconfig.json
+++ b/test/integration/generated/urlMulti/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/uuid/tsconfig.json
+++ b/test/integration/generated/uuid/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/validation/tsconfig.json
+++ b/test/integration/generated/validation/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -396,31 +396,74 @@ export interface XmlGetHeadersHeaders {
 }
 
 /**
- * Defines values for PublicAccessType.
+ * Known values of {@link PublicAccessType} that the service accepts.
  */
-export type PublicAccessType = "container" | "blob" | string;
+export const enum KnownPublicAccessType {
+  Container = "container",
+  Blob = "blob"
+}
+
 /**
- * Defines values for AccessTier.
+ * Defines values for PublicAccessType. \
+ * {@link KnownPublicAccessType} can be used interchangeably with PublicAccessType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **container** \
+ * **blob**
  */
-export type AccessTier =
-  | "P4"
-  | "P6"
-  | "P10"
-  | "P20"
-  | "P30"
-  | "P40"
-  | "P50"
-  | "Hot"
-  | "Cool"
-  | "Archive"
-  | string;
+export type PublicAccessType = string;
+
 /**
- * Defines values for ArchiveStatus.
+ * Known values of {@link AccessTier} that the service accepts.
  */
-export type ArchiveStatus =
-  | "rehydrate-pending-to-hot"
-  | "rehydrate-pending-to-cool"
-  | string;
+export const enum KnownAccessTier {
+  P4 = "P4",
+  P6 = "P6",
+  P10 = "P10",
+  P20 = "P20",
+  P30 = "P30",
+  P40 = "P40",
+  P50 = "P50",
+  Hot = "Hot",
+  Cool = "Cool",
+  Archive = "Archive"
+}
+
+/**
+ * Defines values for AccessTier. \
+ * {@link KnownAccessTier} can be used interchangeably with AccessTier,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **P4** \
+ * **P6** \
+ * **P10** \
+ * **P20** \
+ * **P30** \
+ * **P40** \
+ * **P50** \
+ * **Hot** \
+ * **Cool** \
+ * **Archive**
+ */
+export type AccessTier = string;
+
+/**
+ * Known values of {@link ArchiveStatus} that the service accepts.
+ */
+export const enum KnownArchiveStatus {
+  RehydratePendingToHot = "rehydrate-pending-to-hot",
+  RehydratePendingToCool = "rehydrate-pending-to-cool"
+}
+
+/**
+ * Defines values for ArchiveStatus. \
+ * {@link KnownArchiveStatus} can be used interchangeably with ArchiveStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **rehydrate-pending-to-hot** \
+ * **rehydrate-pending-to-cool**
+ */
+export type ArchiveStatus = string;
 /**
  * Defines values for LeaseStatusType.
  */

--- a/test/integration/generated/xmlservice/tsconfig.json
+++ b/test/integration/generated/xmlservice/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/integration/generated/xmsErrorResponses/tsconfig.json
+++ b/test/integration/generated/xmsErrorResponses/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/review/arm-package-deploymentscripts-2019-10-preview.api.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/review/arm-package-deploymentscripts-2019-10-preview.api.md
@@ -74,7 +74,7 @@ export interface AzureResourceBase {
 }
 
 // @public
-export type CleanupOptions = "Always" | "OnSuccess" | "OnExpiration" | string;
+export type CleanupOptions = string;
 
 // @public
 export interface ContainerConfiguration {
@@ -82,7 +82,7 @@ export interface ContainerConfiguration {
 }
 
 // @public
-export type CreatedByType = "User" | "Application" | "ManagedIdentity" | "Key" | string;
+export type CreatedByType = string;
 
 // @public
 export type DeploymentScript = AzureResourceBase & {
@@ -261,6 +261,58 @@ export interface ErrorResponse {
 }
 
 // @public
+export const enum KnownCleanupOptions {
+    // (undocumented)
+    Always = "Always",
+    // (undocumented)
+    OnExpiration = "OnExpiration",
+    // (undocumented)
+    OnSuccess = "OnSuccess"
+}
+
+// @public
+export const enum KnownCreatedByType {
+    // (undocumented)
+    Application = "Application",
+    // (undocumented)
+    Key = "Key",
+    // (undocumented)
+    ManagedIdentity = "ManagedIdentity",
+    // (undocumented)
+    User = "User"
+}
+
+// @public
+export const enum KnownManagedServiceIdentityType {
+    // (undocumented)
+    UserAssigned = "UserAssigned"
+}
+
+// @public
+export const enum KnownScriptProvisioningState {
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    ProvisioningResources = "ProvisioningResources",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownScriptType {
+    // (undocumented)
+    AzureCLI = "AzureCLI",
+    // (undocumented)
+    AzurePowerShell = "AzurePowerShell"
+}
+
+// @public
 export interface ManagedServiceIdentity {
     type?: ManagedServiceIdentityType;
     userAssignedIdentities?: {
@@ -269,7 +321,7 @@ export interface ManagedServiceIdentity {
 }
 
 // @public
-export type ManagedServiceIdentityType = "UserAssigned" | string;
+export type ManagedServiceIdentityType = string;
 
 // @public
 export interface ScriptConfigurationBase {
@@ -294,7 +346,7 @@ export interface ScriptLogsList {
 }
 
 // @public
-export type ScriptProvisioningState = "Creating" | "ProvisioningResources" | "Running" | "Succeeded" | "Failed" | "Canceled" | string;
+export type ScriptProvisioningState = string;
 
 // @public
 export interface ScriptStatus {
@@ -307,7 +359,7 @@ export interface ScriptStatus {
 }
 
 // @public
-export type ScriptType = "AzurePowerShell" | "AzureCLI" | string;
+export type ScriptType = string;
 
 // @public
 export interface StorageAccountConfiguration {
@@ -334,7 +386,7 @@ export interface UserAssignedIdentity {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:583:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:653:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/models/index.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/models/index.ts
@@ -527,38 +527,108 @@ export type AzureCliScript = DeploymentScript & {
    */
   azCliVersion: string;
 };
+
 /**
- * Defines values for ManagedServiceIdentityType.
+ * Known values of {@link ManagedServiceIdentityType} that the service accepts.
  */
-export type ManagedServiceIdentityType = "UserAssigned" | string;
+export const enum KnownManagedServiceIdentityType {
+  UserAssigned = "UserAssigned"
+}
+
 /**
- * Defines values for ScriptType.
+ * Defines values for ManagedServiceIdentityType. \
+ * {@link KnownManagedServiceIdentityType} can be used interchangeably with ManagedServiceIdentityType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **UserAssigned**
  */
-export type ScriptType = "AzurePowerShell" | "AzureCLI" | string;
+export type ManagedServiceIdentityType = string;
+
 /**
- * Defines values for CreatedByType.
+ * Known values of {@link ScriptType} that the service accepts.
  */
-export type CreatedByType =
-  | "User"
-  | "Application"
-  | "ManagedIdentity"
-  | "Key"
-  | string;
+export const enum KnownScriptType {
+  AzurePowerShell = "AzurePowerShell",
+  AzureCLI = "AzureCLI"
+}
+
 /**
- * Defines values for CleanupOptions.
+ * Defines values for ScriptType. \
+ * {@link KnownScriptType} can be used interchangeably with ScriptType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AzurePowerShell** \
+ * **AzureCLI**
  */
-export type CleanupOptions = "Always" | "OnSuccess" | "OnExpiration" | string;
+export type ScriptType = string;
+
 /**
- * Defines values for ScriptProvisioningState.
+ * Known values of {@link CreatedByType} that the service accepts.
  */
-export type ScriptProvisioningState =
-  | "Creating"
-  | "ProvisioningResources"
-  | "Running"
-  | "Succeeded"
-  | "Failed"
-  | "Canceled"
-  | string;
+export const enum KnownCreatedByType {
+  User = "User",
+  Application = "Application",
+  ManagedIdentity = "ManagedIdentity",
+  Key = "Key"
+}
+
+/**
+ * Defines values for CreatedByType. \
+ * {@link KnownCreatedByType} can be used interchangeably with CreatedByType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **User** \
+ * **Application** \
+ * **ManagedIdentity** \
+ * **Key**
+ */
+export type CreatedByType = string;
+
+/**
+ * Known values of {@link CleanupOptions} that the service accepts.
+ */
+export const enum KnownCleanupOptions {
+  Always = "Always",
+  OnSuccess = "OnSuccess",
+  OnExpiration = "OnExpiration"
+}
+
+/**
+ * Defines values for CleanupOptions. \
+ * {@link KnownCleanupOptions} can be used interchangeably with CleanupOptions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Always** \
+ * **OnSuccess** \
+ * **OnExpiration**
+ */
+export type CleanupOptions = string;
+
+/**
+ * Known values of {@link ScriptProvisioningState} that the service accepts.
+ */
+export const enum KnownScriptProvisioningState {
+  Creating = "Creating",
+  ProvisioningResources = "ProvisioningResources",
+  Running = "Running",
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "Canceled"
+}
+
+/**
+ * Defines values for ScriptProvisioningState. \
+ * {@link KnownScriptProvisioningState} can be used interchangeably with ScriptProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **ProvisioningResources** \
+ * **Running** \
+ * **Succeeded** \
+ * **Failed** \
+ * **Canceled**
+ */
+export type ScriptProvisioningState = string;
 
 /**
  * Contains response data for the create operation.

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
@@ -355,7 +355,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!CleanupOptions:type",
-          "docComment": "/**\n * Defines values for CleanupOptions.\n */\n",
+          "docComment": "/**\n * Defines values for CleanupOptions. \\ {@link KnownCleanupOptions} can be used interchangeably with CleanupOptions, this enum contains the known values that the service supports. ### Know values supported by the service **Always** \\ **OnSuccess** \\ **OnExpiration**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -363,7 +363,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Always\" | \"OnSuccess\" | \"OnExpiration\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -421,7 +421,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!CreatedByType:type",
-          "docComment": "/**\n * Defines values for CreatedByType.\n */\n",
+          "docComment": "/**\n * Defines values for CreatedByType. \\ {@link KnownCreatedByType} can be used interchangeably with CreatedByType, this enum contains the known values that the service supports. ### Know values supported by the service **User** \\ **Application** \\ **ManagedIdentity** \\ **Key**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -429,7 +429,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"User\" | \"Application\" | \"ManagedIdentity\" | \"Key\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2153,6 +2153,417 @@
           "extendsTokenRanges": []
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCleanupOptions:enum",
+          "docComment": "/**\n * Known values of {@link CleanupOptions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCleanupOptions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCleanupOptions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCleanupOptions.Always:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Always = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Always\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Always",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCleanupOptions.OnExpiration:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OnExpiration = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OnExpiration\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OnExpiration",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCleanupOptions.OnSuccess:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OnSuccess = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OnSuccess\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OnSuccess",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCreatedByType:enum",
+          "docComment": "/**\n * Known values of {@link CreatedByType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCreatedByType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCreatedByType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCreatedByType.Application:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Application = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Application\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Application",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCreatedByType.Key:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Key = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Key\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Key",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCreatedByType.ManagedIdentity:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ManagedIdentity = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ManagedIdentity\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ManagedIdentity",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownCreatedByType.User:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "User = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"User\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "User",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownManagedServiceIdentityType:enum",
+          "docComment": "/**\n * Known values of {@link ManagedServiceIdentityType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedServiceIdentityType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedServiceIdentityType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownManagedServiceIdentityType.UserAssigned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UserAssigned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UserAssigned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UserAssigned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link ScriptProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownScriptProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownScriptProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState.Canceled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Canceled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Canceled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Canceled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState.ProvisioningResources:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ProvisioningResources = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ProvisioningResources\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ProvisioningResources",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState.Running:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Running = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Running\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Running",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptType:enum",
+          "docComment": "/**\n * Known values of {@link ScriptType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownScriptType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownScriptType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptType.AzureCLI:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzureCLI = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzureCLI\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzureCLI",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!KnownScriptType.AzurePowerShell:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzurePowerShell = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzurePowerShell\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzurePowerShell",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "Interface",
           "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!ManagedServiceIdentity:interface",
           "docComment": "/**\n * Managed identity generic object.\n */\n",
@@ -2231,7 +2642,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!ManagedServiceIdentityType:type",
-          "docComment": "/**\n * Defines values for ManagedServiceIdentityType.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedServiceIdentityType. \\ {@link KnownManagedServiceIdentityType} can be used interchangeably with ManagedServiceIdentityType, this enum contains the known values that the service supports. ### Know values supported by the service **UserAssigned**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2239,7 +2650,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"UserAssigned\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2553,7 +2964,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!ScriptProvisioningState:type",
-          "docComment": "/**\n * Defines values for ScriptProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for ScriptProvisioningState. \\ {@link KnownScriptProvisioningState} can be used interchangeably with ScriptProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **ProvisioningResources** \\ **Running** \\ **Succeeded** \\ **Failed** \\ **Canceled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2561,7 +2972,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"ProvisioningResources\" | \"Running\" | \"Succeeded\" | \"Failed\" | \"Canceled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2748,7 +3159,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-deploymentscripts-2019-10-preview!ScriptType:type",
-          "docComment": "/**\n * Defines values for ScriptType.\n */\n",
+          "docComment": "/**\n * Defines values for ScriptType. \\ {@link KnownScriptType} can be used interchangeably with ScriptType, this enum contains the known values that the service supports. ### Know values supported by the service **AzurePowerShell** \\ **AzureCLI**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2756,7 +3167,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AzurePowerShell\" | \"AzureCLI\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.md
@@ -74,7 +74,7 @@ export interface AzureResourceBase {
 }
 
 // @public
-export type CleanupOptions = "Always" | "OnSuccess" | "OnExpiration" | string;
+export type CleanupOptions = string;
 
 // @public
 export interface ContainerConfiguration {
@@ -82,7 +82,7 @@ export interface ContainerConfiguration {
 }
 
 // @public
-export type CreatedByType = "User" | "Application" | "ManagedIdentity" | "Key" | string;
+export type CreatedByType = string;
 
 // @public
 export type DeploymentScript = AzureResourceBase & {
@@ -261,6 +261,58 @@ export interface ErrorResponse {
 }
 
 // @public
+export const enum KnownCleanupOptions {
+    // (undocumented)
+    Always = "Always",
+    // (undocumented)
+    OnExpiration = "OnExpiration",
+    // (undocumented)
+    OnSuccess = "OnSuccess"
+}
+
+// @public
+export const enum KnownCreatedByType {
+    // (undocumented)
+    Application = "Application",
+    // (undocumented)
+    Key = "Key",
+    // (undocumented)
+    ManagedIdentity = "ManagedIdentity",
+    // (undocumented)
+    User = "User"
+}
+
+// @public
+export const enum KnownManagedServiceIdentityType {
+    // (undocumented)
+    UserAssigned = "UserAssigned"
+}
+
+// @public
+export const enum KnownScriptProvisioningState {
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    ProvisioningResources = "ProvisioningResources",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownScriptType {
+    // (undocumented)
+    AzureCLI = "AzureCLI",
+    // (undocumented)
+    AzurePowerShell = "AzurePowerShell"
+}
+
+// @public
 export interface ManagedServiceIdentity {
     type?: ManagedServiceIdentityType;
     userAssignedIdentities?: {
@@ -269,7 +321,7 @@ export interface ManagedServiceIdentity {
 }
 
 // @public
-export type ManagedServiceIdentityType = "UserAssigned" | string;
+export type ManagedServiceIdentityType = string;
 
 // @public
 export interface ScriptConfigurationBase {
@@ -294,7 +346,7 @@ export interface ScriptLogsList {
 }
 
 // @public
-export type ScriptProvisioningState = "Creating" | "ProvisioningResources" | "Running" | "Succeeded" | "Failed" | "Canceled" | string;
+export type ScriptProvisioningState = string;
 
 // @public
 export interface ScriptStatus {
@@ -307,7 +359,7 @@ export interface ScriptStatus {
 }
 
 // @public
-export type ScriptType = "AzurePowerShell" | "AzureCLI" | string;
+export type ScriptType = string;
 
 // @public
 export interface StorageAccountConfiguration {
@@ -334,7 +386,7 @@ export interface UserAssignedIdentity {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:583:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:653:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/tsconfig.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-features-2015-12/tsconfig.json
+++ b/test/smoke/generated/arm-package-features-2015-12/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-links-2016-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-links-2016-09/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-locks-2016-09/review/arm-package-locks-2016-09.api.md
+++ b/test/smoke/generated/arm-package-locks-2016-09/review/arm-package-locks-2016-09.api.md
@@ -24,7 +24,17 @@ export type AuthorizationOperationsListResponse = OperationListResult & {
 };
 
 // @public
-export type LockLevel = "NotSpecified" | "CanNotDelete" | "ReadOnly" | string;
+export const enum KnownLockLevel {
+    // (undocumented)
+    CanNotDelete = "CanNotDelete",
+    // (undocumented)
+    NotSpecified = "NotSpecified",
+    // (undocumented)
+    ReadOnly = "ReadOnly"
+}
+
+// @public
+export type LockLevel = string;
 
 // @public (undocumented)
 export class ManagementLockClient extends ManagementLockClientContext {

--- a/test/smoke/generated/arm-package-locks-2016-09/src/models/index.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/models/index.ts
@@ -112,9 +112,24 @@ export interface ManagementLockListResult {
 }
 
 /**
- * Defines values for LockLevel.
+ * Known values of {@link LockLevel} that the service accepts.
  */
-export type LockLevel = "NotSpecified" | "CanNotDelete" | "ReadOnly" | string;
+export const enum KnownLockLevel {
+  NotSpecified = "NotSpecified",
+  CanNotDelete = "CanNotDelete",
+  ReadOnly = "ReadOnly"
+}
+
+/**
+ * Defines values for LockLevel. \
+ * {@link KnownLockLevel} can be used interchangeably with LockLevel,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotSpecified** \
+ * **CanNotDelete** \
+ * **ReadOnly**
+ */
+export type LockLevel = string;
 
 /**
  * Contains response data for the list operation.

--- a/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.json
@@ -112,9 +112,87 @@
           }
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-locks-2016-09!KnownLockLevel:enum",
+          "docComment": "/**\n * Known values of {@link LockLevel} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLockLevel "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLockLevel",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-locks-2016-09!KnownLockLevel.CanNotDelete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CanNotDelete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CanNotDelete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CanNotDelete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-locks-2016-09!KnownLockLevel.NotSpecified:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotSpecified = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotSpecified\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotSpecified",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-locks-2016-09!KnownLockLevel.ReadOnly:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ReadOnly = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ReadOnly\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ReadOnly",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-locks-2016-09!LockLevel:type",
-          "docComment": "/**\n * Defines values for LockLevel.\n */\n",
+          "docComment": "/**\n * Defines values for LockLevel. \\ {@link KnownLockLevel} can be used interchangeably with LockLevel, this enum contains the known values that the service supports. ### Know values supported by the service **NotSpecified** \\ **CanNotDelete** \\ **ReadOnly**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -122,7 +200,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotSpecified\" | \"CanNotDelete\" | \"ReadOnly\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.md
+++ b/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.md
@@ -24,7 +24,17 @@ export type AuthorizationOperationsListResponse = OperationListResult & {
 };
 
 // @public
-export type LockLevel = "NotSpecified" | "CanNotDelete" | "ReadOnly" | string;
+export const enum KnownLockLevel {
+    // (undocumented)
+    CanNotDelete = "CanNotDelete",
+    // (undocumented)
+    NotSpecified = "NotSpecified",
+    // (undocumented)
+    ReadOnly = "ReadOnly"
+}
+
+// @public
+export type LockLevel = string;
 
 // @public (undocumented)
 export class ManagementLockClient extends ManagementLockClientContext {

--- a/test/smoke/generated/arm-package-locks-2016-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/review/arm-package-managedapplications-2018-06.api.md
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/review/arm-package-managedapplications-2018-06.api.md
@@ -275,6 +275,32 @@ export interface Identity {
 }
 
 // @public
+export const enum KnownProvisioningState {
+    // (undocumented)
+    Accepted = "Accepted",
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Created = "Created",
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleted = "Deleted",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
 export interface Plan {
     name: string;
     product: string;
@@ -293,7 +319,7 @@ export interface PlanPatchable {
 }
 
 // @public
-export type ProvisioningState = "Accepted" | "Running" | "Ready" | "Creating" | "Created" | "Deleting" | "Deleted" | "Canceled" | "Failed" | "Succeeded" | "Updating" | string;
+export type ProvisioningState = string;
 
 // @public
 export interface Resource {
@@ -319,7 +345,7 @@ export interface Sku {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:711:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:731:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/models/index.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/models/index.ts
@@ -349,22 +349,42 @@ export type ApplicationPatchable = GenericResource & {
    */
   readonly provisioningState?: ProvisioningState;
 };
+
 /**
- * Defines values for ProvisioningState.
+ * Known values of {@link ProvisioningState} that the service accepts.
  */
-export type ProvisioningState =
-  | "Accepted"
-  | "Running"
-  | "Ready"
-  | "Creating"
-  | "Created"
-  | "Deleting"
-  | "Deleted"
-  | "Canceled"
-  | "Failed"
-  | "Succeeded"
-  | "Updating"
-  | string;
+export const enum KnownProvisioningState {
+  Accepted = "Accepted",
+  Running = "Running",
+  Ready = "Ready",
+  Creating = "Creating",
+  Created = "Created",
+  Deleting = "Deleting",
+  Deleted = "Deleted",
+  Canceled = "Canceled",
+  Failed = "Failed",
+  Succeeded = "Succeeded",
+  Updating = "Updating"
+}
+
+/**
+ * Defines values for ProvisioningState. \
+ * {@link KnownProvisioningState} can be used interchangeably with ProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Accepted** \
+ * **Running** \
+ * **Ready** \
+ * **Creating** \
+ * **Created** \
+ * **Deleting** \
+ * **Deleted** \
+ * **Canceled** \
+ * **Failed** \
+ * **Succeeded** \
+ * **Updating**
+ */
+export type ProvisioningState = string;
 /**
  * Defines values for ApplicationLockLevel.
  */

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.json
@@ -2162,6 +2162,252 @@
           "extendsTokenRanges": []
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link ProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Accepted:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Accepted = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Accepted\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Accepted",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Canceled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Canceled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Canceled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Canceled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Created:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Created = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Created\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Created",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Deleted:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleted = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleted\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleted",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Ready:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ready = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ready\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ready",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Running:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Running = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Running\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Running",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-managedapplications-2018-06!KnownProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "Interface",
           "canonicalReference": "arm-package-managedapplications-2018-06!Plan:interface",
           "docComment": "/**\n * Plan for the managed application.\n */\n",
@@ -2446,7 +2692,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-managedapplications-2018-06!ProvisioningState:type",
-          "docComment": "/**\n * Defines values for ProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for ProvisioningState. \\ {@link KnownProvisioningState} can be used interchangeably with ProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Accepted** \\ **Running** \\ **Ready** \\ **Creating** \\ **Created** \\ **Deleting** \\ **Deleted** \\ **Canceled** \\ **Failed** \\ **Succeeded** \\ **Updating**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2454,7 +2700,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Accepted\" | \"Running\" | \"Ready\" | \"Creating\" | \"Created\" | \"Deleting\" | \"Deleted\" | \"Canceled\" | \"Failed\" | \"Succeeded\" | \"Updating\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.md
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.md
@@ -275,6 +275,32 @@ export interface Identity {
 }
 
 // @public
+export const enum KnownProvisioningState {
+    // (undocumented)
+    Accepted = "Accepted",
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Created = "Created",
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleted = "Deleted",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
 export interface Plan {
     name: string;
     product: string;
@@ -293,7 +319,7 @@ export interface PlanPatchable {
 }
 
 // @public
-export type ProvisioningState = "Accepted" | "Running" | "Ready" | "Creating" | "Created" | "Deleting" | "Deleted" | "Canceled" | "Failed" | "Succeeded" | "Updating" | string;
+export type ProvisioningState = string;
 
 // @public
 export interface Resource {
@@ -319,7 +345,7 @@ export interface Sku {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:711:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:731:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/tsconfig.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-policy-2019-09/review/arm-package-policy-2019-09.api.md
+++ b/test/smoke/generated/arm-package-policy-2019-09/review/arm-package-policy-2019-09.api.md
@@ -13,7 +13,7 @@ export interface CloudError {
 }
 
 // @public
-export type EnforcementMode = "Default" | "DoNotEnforce" | string;
+export type EnforcementMode = string;
 
 // @public
 export interface ErrorAdditionalInfo {
@@ -38,6 +38,42 @@ export interface Identity {
 }
 
 // @public
+export const enum KnownEnforcementMode {
+    Default = "Default",
+    DoNotEnforce = "DoNotEnforce"
+}
+
+// @public
+export const enum KnownParameterType {
+    // (undocumented)
+    Array = "Array",
+    // (undocumented)
+    Boolean = "Boolean",
+    // (undocumented)
+    DateTime = "DateTime",
+    // (undocumented)
+    Float = "Float",
+    // (undocumented)
+    Integer = "Integer",
+    // (undocumented)
+    Object = "Object",
+    // (undocumented)
+    String = "String"
+}
+
+// @public
+export const enum KnownPolicyType {
+    // (undocumented)
+    BuiltIn = "BuiltIn",
+    // (undocumented)
+    Custom = "Custom",
+    // (undocumented)
+    NotSpecified = "NotSpecified",
+    // (undocumented)
+    Static = "Static"
+}
+
+// @public
 export interface ParameterDefinitionsValue {
     allowedValues?: any[];
     defaultValue?: any;
@@ -53,7 +89,7 @@ export interface ParameterDefinitionsValueMetadata {
 }
 
 // @public
-export type ParameterType = "String" | "Array" | "Object" | "Boolean" | "Integer" | "Float" | "DateTime" | string;
+export type ParameterType = string;
 
 // @public
 export interface ParameterValuesValue {
@@ -509,7 +545,7 @@ export interface PolicySku {
 }
 
 // @public
-export type PolicyType = "NotSpecified" | "BuiltIn" | "Custom" | "Static" | string;
+export type PolicyType = string;
 
 // @public
 export type ResourceIdentityType = "SystemAssigned" | "None";

--- a/test/smoke/generated/arm-package-policy-2019-09/src/models/index.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/models/index.ts
@@ -403,30 +403,78 @@ export interface PolicySetDefinitionListResult {
 }
 
 /**
- * Defines values for EnforcementMode.
+ * Known values of {@link EnforcementMode} that the service accepts.
  */
-export type EnforcementMode = "Default" | "DoNotEnforce" | string;
+export const enum KnownEnforcementMode {
+  /**
+   * The policy effect is enforced during resource creation or update.
+   */
+  Default = "Default",
+  /**
+   * The policy effect is not enforced during resource creation or update.
+   */
+  DoNotEnforce = "DoNotEnforce"
+}
+
 /**
- * Defines values for PolicyType.
+ * Defines values for EnforcementMode. \
+ * {@link KnownEnforcementMode} can be used interchangeably with EnforcementMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default**: The policy effect is enforced during resource creation or update. \
+ * **DoNotEnforce**: The policy effect is not enforced during resource creation or update.
  */
-export type PolicyType =
-  | "NotSpecified"
-  | "BuiltIn"
-  | "Custom"
-  | "Static"
-  | string;
+export type EnforcementMode = string;
+
 /**
- * Defines values for ParameterType.
+ * Known values of {@link PolicyType} that the service accepts.
  */
-export type ParameterType =
-  | "String"
-  | "Array"
-  | "Object"
-  | "Boolean"
-  | "Integer"
-  | "Float"
-  | "DateTime"
-  | string;
+export const enum KnownPolicyType {
+  NotSpecified = "NotSpecified",
+  BuiltIn = "BuiltIn",
+  Custom = "Custom",
+  Static = "Static"
+}
+
+/**
+ * Defines values for PolicyType. \
+ * {@link KnownPolicyType} can be used interchangeably with PolicyType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotSpecified** \
+ * **BuiltIn** \
+ * **Custom** \
+ * **Static**
+ */
+export type PolicyType = string;
+
+/**
+ * Known values of {@link ParameterType} that the service accepts.
+ */
+export const enum KnownParameterType {
+  String = "String",
+  Array = "Array",
+  Object = "Object",
+  Boolean = "Boolean",
+  Integer = "Integer",
+  Float = "Float",
+  DateTime = "DateTime"
+}
+
+/**
+ * Defines values for ParameterType. \
+ * {@link KnownParameterType} can be used interchangeably with ParameterType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **String** \
+ * **Array** \
+ * **Object** \
+ * **Boolean** \
+ * **Integer** \
+ * **Float** \
+ * **DateTime**
+ */
+export type ParameterType = string;
 /**
  * Defines values for ResourceIdentityType.
  */

--- a/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.json
@@ -60,7 +60,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-policy-2019-09!EnforcementMode:type",
-          "docComment": "/**\n * Defines values for EnforcementMode.\n */\n",
+          "docComment": "/**\n * Defines values for EnforcementMode. \\ {@link KnownEnforcementMode} can be used interchangeably with EnforcementMode, this enum contains the known values that the service supports. ### Know values supported by the service **Default**: The policy effect is enforced during resource creation or update. \\ **DoNotEnforce**: The policy effect is not enforced during resource creation or update.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -68,7 +68,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | \"DoNotEnforce\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -392,6 +392,324 @@
           "extendsTokenRanges": []
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-policy-2019-09!KnownEnforcementMode:enum",
+          "docComment": "/**\n * Known values of {@link EnforcementMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEnforcementMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEnforcementMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownEnforcementMode.Default:member",
+              "docComment": "/**\n * The policy effect is enforced during resource creation or update.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownEnforcementMode.DoNotEnforce:member",
+              "docComment": "/**\n * The policy effect is not enforced during resource creation or update.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DoNotEnforce = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DoNotEnforce\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DoNotEnforce",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-policy-2019-09!KnownParameterType:enum",
+          "docComment": "/**\n * Known values of {@link ParameterType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownParameterType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownParameterType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.Array:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Array = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Array\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Array",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.Boolean:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Boolean = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Boolean\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Boolean",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.DateTime:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DateTime = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DateTime\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DateTime",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.Float:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Float = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Float\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Float",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.Integer:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Integer = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Integer\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Integer",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.Object:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Object = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Object\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Object",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownParameterType.String:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "String = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"String\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "String",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "arm-package-policy-2019-09!KnownPolicyType:enum",
+          "docComment": "/**\n * Known values of {@link PolicyType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPolicyType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPolicyType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownPolicyType.BuiltIn:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BuiltIn = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BuiltIn\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BuiltIn",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownPolicyType.Custom:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Custom = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Custom\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Custom",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownPolicyType.NotSpecified:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotSpecified = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotSpecified\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotSpecified",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "arm-package-policy-2019-09!KnownPolicyType.Static:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Static = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Static\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Static",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "Interface",
           "canonicalReference": "arm-package-policy-2019-09!ParameterDefinitionsValue:interface",
           "docComment": "/**\n * The definition of a parameter that can be provided to the policy.\n */\n",
@@ -620,7 +938,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-policy-2019-09!ParameterType:type",
-          "docComment": "/**\n * Defines values for ParameterType.\n */\n",
+          "docComment": "/**\n * Defines values for ParameterType. \\ {@link KnownParameterType} can be used interchangeably with ParameterType, this enum contains the known values that the service supports. ### Know values supported by the service **String** \\ **Array** \\ **Object** \\ **Boolean** \\ **Integer** \\ **Float** \\ **DateTime**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -628,7 +946,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"String\" | \"Array\" | \"Object\" | \"Boolean\" | \"Integer\" | \"Float\" | \"DateTime\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4733,7 +5051,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "arm-package-policy-2019-09!PolicyType:type",
-          "docComment": "/**\n * Defines values for PolicyType.\n */\n",
+          "docComment": "/**\n * Defines values for PolicyType. \\ {@link KnownPolicyType} can be used interchangeably with PolicyType, this enum contains the known values that the service supports. ### Know values supported by the service **NotSpecified** \\ **BuiltIn** \\ **Custom** \\ **Static**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4741,7 +5059,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotSpecified\" | \"BuiltIn\" | \"Custom\" | \"Static\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.md
+++ b/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.md
@@ -13,7 +13,7 @@ export interface CloudError {
 }
 
 // @public
-export type EnforcementMode = "Default" | "DoNotEnforce" | string;
+export type EnforcementMode = string;
 
 // @public
 export interface ErrorAdditionalInfo {
@@ -38,6 +38,42 @@ export interface Identity {
 }
 
 // @public
+export const enum KnownEnforcementMode {
+    Default = "Default",
+    DoNotEnforce = "DoNotEnforce"
+}
+
+// @public
+export const enum KnownParameterType {
+    // (undocumented)
+    Array = "Array",
+    // (undocumented)
+    Boolean = "Boolean",
+    // (undocumented)
+    DateTime = "DateTime",
+    // (undocumented)
+    Float = "Float",
+    // (undocumented)
+    Integer = "Integer",
+    // (undocumented)
+    Object = "Object",
+    // (undocumented)
+    String = "String"
+}
+
+// @public
+export const enum KnownPolicyType {
+    // (undocumented)
+    BuiltIn = "BuiltIn",
+    // (undocumented)
+    Custom = "Custom",
+    // (undocumented)
+    NotSpecified = "NotSpecified",
+    // (undocumented)
+    Static = "Static"
+}
+
+// @public
 export interface ParameterDefinitionsValue {
     allowedValues?: any[];
     defaultValue?: any;
@@ -53,7 +89,7 @@ export interface ParameterDefinitionsValueMetadata {
 }
 
 // @public
-export type ParameterType = "String" | "Array" | "Object" | "Boolean" | "Integer" | "Float" | "DateTime" | string;
+export type ParameterType = string;
 
 // @public
 export interface ParameterValuesValue {
@@ -509,7 +545,7 @@ export interface PolicySku {
 }
 
 // @public
-export type PolicyType = "NotSpecified" | "BuiltIn" | "Custom" | "Static" | string;
+export type PolicyType = string;
 
 // @public
 export type ResourceIdentityType = "SystemAssigned" | "None";

--- a/test/smoke/generated/arm-package-policy-2019-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-resources-2019-08/tsconfig.json
+++ b/test/smoke/generated/arm-package-resources-2019-08/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/tsconfig.json
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/compute-resource-manager/review/compute-resource-manager.api.md
+++ b/test/smoke/generated/compute-resource-manager/review/compute-resource-manager.api.md
@@ -15,7 +15,7 @@ import { PollOperationState } from '@azure/core-lro';
 import { RestResponse } from '@azure/core-http';
 
 // @public
-export type AccessLevel = "None" | "Read" | "Write" | string;
+export type AccessLevel = string;
 
 // @public
 export interface AccessUri {
@@ -36,7 +36,7 @@ export interface AdditionalUnattendContent {
 }
 
 // @public
-export type AggregatedReplicationState = "Unknown" | "InProgress" | "Completed" | "Failed" | string;
+export type AggregatedReplicationState = string;
 
 // @public
 export interface ApiEntityReference {
@@ -109,7 +109,7 @@ export type AvailabilitySetsGetResponse = AvailabilitySet & {
 };
 
 // @public
-export type AvailabilitySetSkuTypes = "Classic" | "Aligned" | string;
+export type AvailabilitySetSkuTypes = string;
 
 // @public
 export type AvailabilitySetsListAvailableSizesResponse = VirtualMachineSizeListResult & {
@@ -503,7 +503,7 @@ export interface ContainerServiceVMDiagnostics {
 }
 
 // @public
-export type ContainerServiceVMSizeTypes = "Standard_A0" | "Standard_A1" | "Standard_A2" | "Standard_A3" | "Standard_A4" | "Standard_A5" | "Standard_A6" | "Standard_A7" | "Standard_A8" | "Standard_A9" | "Standard_A10" | "Standard_A11" | "Standard_D1" | "Standard_D2" | "Standard_D3" | "Standard_D4" | "Standard_D11" | "Standard_D12" | "Standard_D13" | "Standard_D14" | "Standard_D1_v2" | "Standard_D2_v2" | "Standard_D3_v2" | "Standard_D4_v2" | "Standard_D5_v2" | "Standard_D11_v2" | "Standard_D12_v2" | "Standard_D13_v2" | "Standard_D14_v2" | "Standard_G1" | "Standard_G2" | "Standard_G3" | "Standard_G4" | "Standard_G5" | "Standard_DS1" | "Standard_DS2" | "Standard_DS3" | "Standard_DS4" | "Standard_DS11" | "Standard_DS12" | "Standard_DS13" | "Standard_DS14" | "Standard_GS1" | "Standard_GS2" | "Standard_GS3" | "Standard_GS4" | "Standard_GS5" | string;
+export type ContainerServiceVMSizeTypes = string;
 
 // @public
 export interface ContainerServiceWindowsProfile {
@@ -725,10 +725,10 @@ export interface DiagnosticsProfile {
 }
 
 // @public
-export type DiffDiskOptions = "Local" | string;
+export type DiffDiskOptions = string;
 
 // @public
-export type DiffDiskPlacement = "CacheDisk" | "ResourceDisk" | string;
+export type DiffDiskPlacement = string;
 
 // @public
 export interface DiffDiskSettings {
@@ -767,10 +767,10 @@ export type Disk = Resource & {
 };
 
 // @public
-export type DiskCreateOption = "Empty" | "Attach" | "FromImage" | "Import" | "Copy" | "Restore" | "Upload" | string;
+export type DiskCreateOption = string;
 
 // @public
-export type DiskCreateOptionTypes = "FromImage" | "Empty" | "Attach" | string;
+export type DiskCreateOptionTypes = string;
 
 // @public
 export type DiskEncryptionSet = Resource & {
@@ -781,7 +781,7 @@ export type DiskEncryptionSet = Resource & {
 };
 
 // @public
-export type DiskEncryptionSetIdentityType = "SystemAssigned" | string;
+export type DiskEncryptionSetIdentityType = string;
 
 // @public
 export interface DiskEncryptionSetList {
@@ -948,10 +948,10 @@ export type DisksListResponse = DiskList & {
 };
 
 // @public
-export type DiskState = "Unattached" | "Attached" | "Reserved" | "ActiveSAS" | "ReadyToUpload" | "ActiveUpload" | string;
+export type DiskState = string;
 
 // @public
-export type DiskStorageAccountTypes = "Standard_LRS" | "Premium_LRS" | "StandardSSD_LRS" | "UltraSSD_LRS" | string;
+export type DiskStorageAccountTypes = string;
 
 // @public
 export type DisksUpdateResponse = Disk & {
@@ -1012,10 +1012,10 @@ export interface EncryptionSettingsElement {
 }
 
 // @public
-export type EncryptionType = "EncryptionAtRestWithPlatformKey" | "EncryptionAtRestWithCustomerKey" | string;
+export type EncryptionType = string;
 
 // @public
-export type Enum31 = 1 | 3 | 5 | number;
+export type Enum31 = number;
 
 // @public
 export type GalleriesCreateOrUpdateResponse = Gallery & {
@@ -1164,7 +1164,7 @@ export interface GalleryApplicationVersionList {
 }
 
 // @public
-export type GalleryApplicationVersionPropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryApplicationVersionPropertiesProvisioningState = string;
 
 // @public
 export type GalleryApplicationVersionPublishingProfile = GalleryArtifactPublishingProfileBase & {
@@ -1295,7 +1295,7 @@ export interface GalleryImageList {
 }
 
 // @public
-export type GalleryImagePropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryImagePropertiesProvisioningState = string;
 
 // @public
 export type GalleryImagesCreateOrUpdateResponse = GalleryImage & {
@@ -1371,7 +1371,7 @@ export interface GalleryImageVersionList {
 }
 
 // @public
-export type GalleryImageVersionPropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryImageVersionPropertiesProvisioningState = string;
 
 // @public
 export type GalleryImageVersionPublishingProfile = GalleryArtifactPublishingProfileBase & {};
@@ -1448,7 +1448,7 @@ export interface GalleryList {
 export type GalleryOSDiskImage = GalleryDiskImage & {};
 
 // @public
-export type GalleryPropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryPropertiesProvisioningState = string;
 
 // @public
 export type GalleryUpdate = UpdateResourceDefinition & {
@@ -1473,13 +1473,13 @@ export interface HardwareProfile {
 export type HostCaching = "None" | "ReadOnly" | "ReadWrite";
 
 // @public
-export type HyperVGeneration = "V1" | "V2" | string;
+export type HyperVGeneration = string;
 
 // @public
-export type HyperVGenerationType = "V1" | "V2" | string;
+export type HyperVGenerationType = string;
 
 // @public
-export type HyperVGenerationTypes = "V1" | "V2" | string;
+export type HyperVGenerationTypes = string;
 
 // @public
 type Image_2 = Resource & {
@@ -1638,7 +1638,7 @@ export interface InstanceViewStatus {
 export type IntervalInMins = "ThreeMins" | "FiveMins" | "ThirtyMins" | "SixtyMins";
 
 // @public
-export type IPVersion = "IPv4" | "IPv6" | string;
+export type IPVersion = string;
 
 // @public
 export interface KeyVaultAndKeyReference {
@@ -1662,6 +1662,748 @@ export interface KeyVaultKeyReference {
 export interface KeyVaultSecretReference {
     secretUrl: string;
     sourceVault: SubResource;
+}
+
+// @public
+export const enum KnownAccessLevel {
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Read = "Read",
+    // (undocumented)
+    Write = "Write"
+}
+
+// @public
+export const enum KnownAggregatedReplicationState {
+    // (undocumented)
+    Completed = "Completed",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownAvailabilitySetSkuTypes {
+    // (undocumented)
+    Aligned = "Aligned",
+    // (undocumented)
+    Classic = "Classic"
+}
+
+// @public
+export const enum KnownContainerServiceVMSizeTypes {
+    // (undocumented)
+    StandardA0 = "Standard_A0",
+    // (undocumented)
+    StandardA1 = "Standard_A1",
+    // (undocumented)
+    StandardA10 = "Standard_A10",
+    // (undocumented)
+    StandardA11 = "Standard_A11",
+    // (undocumented)
+    StandardA2 = "Standard_A2",
+    // (undocumented)
+    StandardA3 = "Standard_A3",
+    // (undocumented)
+    StandardA4 = "Standard_A4",
+    // (undocumented)
+    StandardA5 = "Standard_A5",
+    // (undocumented)
+    StandardA6 = "Standard_A6",
+    // (undocumented)
+    StandardA7 = "Standard_A7",
+    // (undocumented)
+    StandardA8 = "Standard_A8",
+    // (undocumented)
+    StandardA9 = "Standard_A9",
+    // (undocumented)
+    StandardD1 = "Standard_D1",
+    // (undocumented)
+    StandardD11 = "Standard_D11",
+    // (undocumented)
+    StandardD11V2 = "Standard_D11_v2",
+    // (undocumented)
+    StandardD12 = "Standard_D12",
+    // (undocumented)
+    StandardD12V2 = "Standard_D12_v2",
+    // (undocumented)
+    StandardD13 = "Standard_D13",
+    // (undocumented)
+    StandardD13V2 = "Standard_D13_v2",
+    // (undocumented)
+    StandardD14 = "Standard_D14",
+    // (undocumented)
+    StandardD14V2 = "Standard_D14_v2",
+    // (undocumented)
+    StandardD1V2 = "Standard_D1_v2",
+    // (undocumented)
+    StandardD2 = "Standard_D2",
+    // (undocumented)
+    StandardD2V2 = "Standard_D2_v2",
+    // (undocumented)
+    StandardD3 = "Standard_D3",
+    // (undocumented)
+    StandardD3V2 = "Standard_D3_v2",
+    // (undocumented)
+    StandardD4 = "Standard_D4",
+    // (undocumented)
+    StandardD4V2 = "Standard_D4_v2",
+    // (undocumented)
+    StandardD5V2 = "Standard_D5_v2",
+    // (undocumented)
+    StandardDS1 = "Standard_DS1",
+    // (undocumented)
+    StandardDS11 = "Standard_DS11",
+    // (undocumented)
+    StandardDS12 = "Standard_DS12",
+    // (undocumented)
+    StandardDS13 = "Standard_DS13",
+    // (undocumented)
+    StandardDS14 = "Standard_DS14",
+    // (undocumented)
+    StandardDS2 = "Standard_DS2",
+    // (undocumented)
+    StandardDS3 = "Standard_DS3",
+    // (undocumented)
+    StandardDS4 = "Standard_DS4",
+    // (undocumented)
+    StandardG1 = "Standard_G1",
+    // (undocumented)
+    StandardG2 = "Standard_G2",
+    // (undocumented)
+    StandardG3 = "Standard_G3",
+    // (undocumented)
+    StandardG4 = "Standard_G4",
+    // (undocumented)
+    StandardG5 = "Standard_G5",
+    // (undocumented)
+    StandardGS1 = "Standard_GS1",
+    // (undocumented)
+    StandardGS2 = "Standard_GS2",
+    // (undocumented)
+    StandardGS3 = "Standard_GS3",
+    // (undocumented)
+    StandardGS4 = "Standard_GS4",
+    // (undocumented)
+    StandardGS5 = "Standard_GS5"
+}
+
+// @public
+export const enum KnownDiffDiskOptions {
+    // (undocumented)
+    Local = "Local"
+}
+
+// @public
+export const enum KnownDiffDiskPlacement {
+    // (undocumented)
+    CacheDisk = "CacheDisk",
+    // (undocumented)
+    ResourceDisk = "ResourceDisk"
+}
+
+// @public
+export const enum KnownDiskCreateOption {
+    Attach = "Attach",
+    Copy = "Copy",
+    Empty = "Empty",
+    FromImage = "FromImage",
+    Import = "Import",
+    Restore = "Restore",
+    Upload = "Upload"
+}
+
+// @public
+export const enum KnownDiskCreateOptionTypes {
+    // (undocumented)
+    Attach = "Attach",
+    // (undocumented)
+    Empty = "Empty",
+    // (undocumented)
+    FromImage = "FromImage"
+}
+
+// @public
+export const enum KnownDiskEncryptionSetIdentityType {
+    // (undocumented)
+    SystemAssigned = "SystemAssigned"
+}
+
+// @public
+export const enum KnownDiskState {
+    ActiveSAS = "ActiveSAS",
+    ActiveUpload = "ActiveUpload",
+    Attached = "Attached",
+    ReadyToUpload = "ReadyToUpload",
+    Reserved = "Reserved",
+    Unattached = "Unattached"
+}
+
+// @public
+export const enum KnownDiskStorageAccountTypes {
+    PremiumLRS = "Premium_LRS",
+    StandardLRS = "Standard_LRS",
+    StandardSSDLRS = "StandardSSD_LRS",
+    UltraSSDLRS = "UltraSSD_LRS"
+}
+
+// @public
+export const enum KnownEncryptionType {
+    EncryptionAtRestWithCustomerKey = "EncryptionAtRestWithCustomerKey",
+    EncryptionAtRestWithPlatformKey = "EncryptionAtRestWithPlatformKey"
+}
+
+// @public
+export const enum KnownEnum31 {
+    // (undocumented)
+    Five = 5,
+    // (undocumented)
+    One = 1,
+    // (undocumented)
+    Three = 3
+}
+
+// @public
+export const enum KnownGalleryApplicationVersionPropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownGalleryImagePropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownGalleryImageVersionPropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownGalleryPropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownHyperVGeneration {
+    // (undocumented)
+    V1 = "V1",
+    // (undocumented)
+    V2 = "V2"
+}
+
+// @public
+export const enum KnownHyperVGenerationType {
+    // (undocumented)
+    V1 = "V1",
+    // (undocumented)
+    V2 = "V2"
+}
+
+// @public
+export const enum KnownHyperVGenerationTypes {
+    // (undocumented)
+    V1 = "V1",
+    // (undocumented)
+    V2 = "V2"
+}
+
+// @public
+export const enum KnownIPVersion {
+    // (undocumented)
+    IPv4 = "IPv4",
+    // (undocumented)
+    IPv6 = "IPv6"
+}
+
+// @public
+export const enum KnownOrchestrationServiceNames {
+    // (undocumented)
+    AutomaticRepairs = "AutomaticRepairs"
+}
+
+// @public
+export const enum KnownOrchestrationServiceState {
+    // (undocumented)
+    NotRunning = "NotRunning",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Suspended = "Suspended"
+}
+
+// @public
+export const enum KnownOrchestrationServiceStateAction {
+    // (undocumented)
+    Resume = "Resume",
+    // (undocumented)
+    Suspend = "Suspend"
+}
+
+// @public
+export const enum KnownProximityPlacementGroupType {
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    Ultra = "Ultra"
+}
+
+// @public
+export const enum KnownReplicationState {
+    // (undocumented)
+    Completed = "Completed",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Replicating = "Replicating",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownReplicationStatusTypes {
+    // (undocumented)
+    ReplicationStatus = "ReplicationStatus"
+}
+
+// @public
+export const enum KnownSnapshotStorageAccountTypes {
+    PremiumLRS = "Premium_LRS",
+    StandardLRS = "Standard_LRS",
+    StandardZRS = "Standard_ZRS"
+}
+
+// @public
+export const enum KnownStorageAccountType {
+    // (undocumented)
+    PremiumLRS = "Premium_LRS",
+    // (undocumented)
+    StandardLRS = "Standard_LRS",
+    // (undocumented)
+    StandardZRS = "Standard_ZRS"
+}
+
+// @public
+export const enum KnownStorageAccountTypes {
+    // (undocumented)
+    PremiumLRS = "Premium_LRS",
+    // (undocumented)
+    StandardLRS = "Standard_LRS",
+    // (undocumented)
+    StandardSSDLRS = "StandardSSD_LRS",
+    // (undocumented)
+    UltraSSDLRS = "UltraSSD_LRS"
+}
+
+// @public
+export const enum KnownVirtualMachineEvictionPolicyTypes {
+    // (undocumented)
+    Deallocate = "Deallocate",
+    // (undocumented)
+    Delete = "Delete"
+}
+
+// @public
+export const enum KnownVirtualMachinePriorityTypes {
+    // (undocumented)
+    Low = "Low",
+    // (undocumented)
+    Regular = "Regular",
+    // (undocumented)
+    Spot = "Spot"
+}
+
+// @public
+export const enum KnownVirtualMachineScaleSetScaleInRules {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    NewestVM = "NewestVM",
+    // (undocumented)
+    OldestVM = "OldestVM"
+}
+
+// @public
+export const enum KnownVirtualMachineSizeTypes {
+    // (undocumented)
+    BasicA0 = "Basic_A0",
+    // (undocumented)
+    BasicA1 = "Basic_A1",
+    // (undocumented)
+    BasicA2 = "Basic_A2",
+    // (undocumented)
+    BasicA3 = "Basic_A3",
+    // (undocumented)
+    BasicA4 = "Basic_A4",
+    // (undocumented)
+    StandardA0 = "Standard_A0",
+    // (undocumented)
+    StandardA1 = "Standard_A1",
+    // (undocumented)
+    StandardA10 = "Standard_A10",
+    // (undocumented)
+    StandardA11 = "Standard_A11",
+    // (undocumented)
+    StandardA1V2 = "Standard_A1_v2",
+    // (undocumented)
+    StandardA2 = "Standard_A2",
+    // (undocumented)
+    StandardA2MV2 = "Standard_A2m_v2",
+    // (undocumented)
+    StandardA2V2 = "Standard_A2_v2",
+    // (undocumented)
+    StandardA3 = "Standard_A3",
+    // (undocumented)
+    StandardA4 = "Standard_A4",
+    // (undocumented)
+    StandardA4MV2 = "Standard_A4m_v2",
+    // (undocumented)
+    StandardA4V2 = "Standard_A4_v2",
+    // (undocumented)
+    StandardA5 = "Standard_A5",
+    // (undocumented)
+    StandardA6 = "Standard_A6",
+    // (undocumented)
+    StandardA7 = "Standard_A7",
+    // (undocumented)
+    StandardA8 = "Standard_A8",
+    // (undocumented)
+    StandardA8MV2 = "Standard_A8m_v2",
+    // (undocumented)
+    StandardA8V2 = "Standard_A8_v2",
+    // (undocumented)
+    StandardA9 = "Standard_A9",
+    // (undocumented)
+    StandardB1Ms = "Standard_B1ms",
+    // (undocumented)
+    StandardB1S = "Standard_B1s",
+    // (undocumented)
+    StandardB2Ms = "Standard_B2ms",
+    // (undocumented)
+    StandardB2S = "Standard_B2s",
+    // (undocumented)
+    StandardB4Ms = "Standard_B4ms",
+    // (undocumented)
+    StandardB8Ms = "Standard_B8ms",
+    // (undocumented)
+    StandardD1 = "Standard_D1",
+    // (undocumented)
+    StandardD11 = "Standard_D11",
+    // (undocumented)
+    StandardD11V2 = "Standard_D11_v2",
+    // (undocumented)
+    StandardD12 = "Standard_D12",
+    // (undocumented)
+    StandardD12V2 = "Standard_D12_v2",
+    // (undocumented)
+    StandardD13 = "Standard_D13",
+    // (undocumented)
+    StandardD13V2 = "Standard_D13_v2",
+    // (undocumented)
+    StandardD14 = "Standard_D14",
+    // (undocumented)
+    StandardD14V2 = "Standard_D14_v2",
+    // (undocumented)
+    StandardD15V2 = "Standard_D15_v2",
+    // (undocumented)
+    StandardD16SV3 = "Standard_D16s_v3",
+    // (undocumented)
+    StandardD16V3 = "Standard_D16_v3",
+    // (undocumented)
+    StandardD1V2 = "Standard_D1_v2",
+    // (undocumented)
+    StandardD2 = "Standard_D2",
+    // (undocumented)
+    StandardD2SV3 = "Standard_D2s_v3",
+    // (undocumented)
+    StandardD2V2 = "Standard_D2_v2",
+    // (undocumented)
+    StandardD2V3 = "Standard_D2_v3",
+    // (undocumented)
+    StandardD3 = "Standard_D3",
+    // (undocumented)
+    StandardD32SV3 = "Standard_D32s_v3",
+    // (undocumented)
+    StandardD32V3 = "Standard_D32_v3",
+    // (undocumented)
+    StandardD3V2 = "Standard_D3_v2",
+    // (undocumented)
+    StandardD4 = "Standard_D4",
+    // (undocumented)
+    StandardD4SV3 = "Standard_D4s_v3",
+    // (undocumented)
+    StandardD4V2 = "Standard_D4_v2",
+    // (undocumented)
+    StandardD4V3 = "Standard_D4_v3",
+    // (undocumented)
+    StandardD5V2 = "Standard_D5_v2",
+    // (undocumented)
+    StandardD64SV3 = "Standard_D64s_v3",
+    // (undocumented)
+    StandardD64V3 = "Standard_D64_v3",
+    // (undocumented)
+    StandardD8SV3 = "Standard_D8s_v3",
+    // (undocumented)
+    StandardD8V3 = "Standard_D8_v3",
+    // (undocumented)
+    StandardDS1 = "Standard_DS1",
+    // (undocumented)
+    StandardDS11 = "Standard_DS11",
+    // (undocumented)
+    StandardDS11V2 = "Standard_DS11_v2",
+    // (undocumented)
+    StandardDS12 = "Standard_DS12",
+    // (undocumented)
+    StandardDS12V2 = "Standard_DS12_v2",
+    // (undocumented)
+    StandardDS13 = "Standard_DS13",
+    // (undocumented)
+    StandardDS132V2 = "Standard_DS13-2_v2",
+    // (undocumented)
+    StandardDS134V2 = "Standard_DS13-4_v2",
+    // (undocumented)
+    StandardDS13V2 = "Standard_DS13_v2",
+    // (undocumented)
+    StandardDS14 = "Standard_DS14",
+    // (undocumented)
+    StandardDS144V2 = "Standard_DS14-4_v2",
+    // (undocumented)
+    StandardDS148V2 = "Standard_DS14-8_v2",
+    // (undocumented)
+    StandardDS14V2 = "Standard_DS14_v2",
+    // (undocumented)
+    StandardDS15V2 = "Standard_DS15_v2",
+    // (undocumented)
+    StandardDS1V2 = "Standard_DS1_v2",
+    // (undocumented)
+    StandardDS2 = "Standard_DS2",
+    // (undocumented)
+    StandardDS2V2 = "Standard_DS2_v2",
+    // (undocumented)
+    StandardDS3 = "Standard_DS3",
+    // (undocumented)
+    StandardDS3V2 = "Standard_DS3_v2",
+    // (undocumented)
+    StandardDS4 = "Standard_DS4",
+    // (undocumented)
+    StandardDS4V2 = "Standard_DS4_v2",
+    // (undocumented)
+    StandardDS5V2 = "Standard_DS5_v2",
+    // (undocumented)
+    StandardE16SV3 = "Standard_E16s_v3",
+    // (undocumented)
+    StandardE16V3 = "Standard_E16_v3",
+    // (undocumented)
+    StandardE2SV3 = "Standard_E2s_v3",
+    // (undocumented)
+    StandardE2V3 = "Standard_E2_v3",
+    // (undocumented)
+    StandardE3216V3 = "Standard_E32-16_v3",
+    // (undocumented)
+    StandardE328SV3 = "Standard_E32-8s_v3",
+    // (undocumented)
+    StandardE32SV3 = "Standard_E32s_v3",
+    // (undocumented)
+    StandardE32V3 = "Standard_E32_v3",
+    // (undocumented)
+    StandardE4SV3 = "Standard_E4s_v3",
+    // (undocumented)
+    StandardE4V3 = "Standard_E4_v3",
+    // (undocumented)
+    StandardE6416SV3 = "Standard_E64-16s_v3",
+    // (undocumented)
+    StandardE6432SV3 = "Standard_E64-32s_v3",
+    // (undocumented)
+    StandardE64SV3 = "Standard_E64s_v3",
+    // (undocumented)
+    StandardE64V3 = "Standard_E64_v3",
+    // (undocumented)
+    StandardE8SV3 = "Standard_E8s_v3",
+    // (undocumented)
+    StandardE8V3 = "Standard_E8_v3",
+    // (undocumented)
+    StandardF1 = "Standard_F1",
+    // (undocumented)
+    StandardF16 = "Standard_F16",
+    // (undocumented)
+    StandardF16S = "Standard_F16s",
+    // (undocumented)
+    StandardF16SV2 = "Standard_F16s_v2",
+    // (undocumented)
+    StandardF1S = "Standard_F1s",
+    // (undocumented)
+    StandardF2 = "Standard_F2",
+    // (undocumented)
+    StandardF2S = "Standard_F2s",
+    // (undocumented)
+    StandardF2SV2 = "Standard_F2s_v2",
+    // (undocumented)
+    StandardF32SV2 = "Standard_F32s_v2",
+    // (undocumented)
+    StandardF4 = "Standard_F4",
+    // (undocumented)
+    StandardF4S = "Standard_F4s",
+    // (undocumented)
+    StandardF4SV2 = "Standard_F4s_v2",
+    // (undocumented)
+    StandardF64SV2 = "Standard_F64s_v2",
+    // (undocumented)
+    StandardF72SV2 = "Standard_F72s_v2",
+    // (undocumented)
+    StandardF8 = "Standard_F8",
+    // (undocumented)
+    StandardF8S = "Standard_F8s",
+    // (undocumented)
+    StandardF8SV2 = "Standard_F8s_v2",
+    // (undocumented)
+    StandardG1 = "Standard_G1",
+    // (undocumented)
+    StandardG2 = "Standard_G2",
+    // (undocumented)
+    StandardG3 = "Standard_G3",
+    // (undocumented)
+    StandardG4 = "Standard_G4",
+    // (undocumented)
+    StandardG5 = "Standard_G5",
+    // (undocumented)
+    StandardGS1 = "Standard_GS1",
+    // (undocumented)
+    StandardGS2 = "Standard_GS2",
+    // (undocumented)
+    StandardGS3 = "Standard_GS3",
+    // (undocumented)
+    StandardGS4 = "Standard_GS4",
+    // (undocumented)
+    StandardGS44 = "Standard_GS4-4",
+    // (undocumented)
+    StandardGS48 = "Standard_GS4-8",
+    // (undocumented)
+    StandardGS5 = "Standard_GS5",
+    // (undocumented)
+    StandardGS516 = "Standard_GS5-16",
+    // (undocumented)
+    StandardGS58 = "Standard_GS5-8",
+    // (undocumented)
+    StandardH16 = "Standard_H16",
+    // (undocumented)
+    StandardH16M = "Standard_H16m",
+    // (undocumented)
+    StandardH16Mr = "Standard_H16mr",
+    // (undocumented)
+    StandardH16R = "Standard_H16r",
+    // (undocumented)
+    StandardH8 = "Standard_H8",
+    // (undocumented)
+    StandardH8M = "Standard_H8m",
+    // (undocumented)
+    StandardL16S = "Standard_L16s",
+    // (undocumented)
+    StandardL32S = "Standard_L32s",
+    // (undocumented)
+    StandardL4S = "Standard_L4s",
+    // (undocumented)
+    StandardL8S = "Standard_L8s",
+    // (undocumented)
+    StandardM12832Ms = "Standard_M128-32ms",
+    // (undocumented)
+    StandardM12864Ms = "Standard_M128-64ms",
+    // (undocumented)
+    StandardM128Ms = "Standard_M128ms",
+    // (undocumented)
+    StandardM128S = "Standard_M128s",
+    // (undocumented)
+    StandardM6416Ms = "Standard_M64-16ms",
+    // (undocumented)
+    StandardM6432Ms = "Standard_M64-32ms",
+    // (undocumented)
+    StandardM64Ms = "Standard_M64ms",
+    // (undocumented)
+    StandardM64S = "Standard_M64s",
+    // (undocumented)
+    StandardNC12 = "Standard_NC12",
+    // (undocumented)
+    StandardNC12SV2 = "Standard_NC12s_v2",
+    // (undocumented)
+    StandardNC12SV3 = "Standard_NC12s_v3",
+    // (undocumented)
+    StandardNC24 = "Standard_NC24",
+    // (undocumented)
+    StandardNC24R = "Standard_NC24r",
+    // (undocumented)
+    StandardNC24RsV2 = "Standard_NC24rs_v2",
+    // (undocumented)
+    StandardNC24RsV3 = "Standard_NC24rs_v3",
+    // (undocumented)
+    StandardNC24SV2 = "Standard_NC24s_v2",
+    // (undocumented)
+    StandardNC24SV3 = "Standard_NC24s_v3",
+    // (undocumented)
+    StandardNC6 = "Standard_NC6",
+    // (undocumented)
+    StandardNC6SV2 = "Standard_NC6s_v2",
+    // (undocumented)
+    StandardNC6SV3 = "Standard_NC6s_v3",
+    // (undocumented)
+    StandardND12S = "Standard_ND12s",
+    // (undocumented)
+    StandardND24Rs = "Standard_ND24rs",
+    // (undocumented)
+    StandardND24S = "Standard_ND24s",
+    // (undocumented)
+    StandardND6S = "Standard_ND6s",
+    // (undocumented)
+    StandardNV12 = "Standard_NV12",
+    // (undocumented)
+    StandardNV24 = "Standard_NV24",
+    // (undocumented)
+    StandardNV6 = "Standard_NV6"
 }
 
 // @public
@@ -1765,13 +2507,13 @@ export type OperationsListResponse = ComputeOperationListResult & {
 };
 
 // @public
-export type OrchestrationServiceNames = "AutomaticRepairs" | string;
+export type OrchestrationServiceNames = string;
 
 // @public
-export type OrchestrationServiceState = "NotRunning" | "Running" | "Suspended" | string;
+export type OrchestrationServiceState = string;
 
 // @public
-export type OrchestrationServiceStateAction = "Resume" | "Suspend" | string;
+export type OrchestrationServiceStateAction = string;
 
 // @public
 export interface OrchestrationServiceStateInput {
@@ -1909,7 +2651,7 @@ export type ProximityPlacementGroupsUpdateResponse = ProximityPlacementGroup & {
 };
 
 // @public
-export type ProximityPlacementGroupType = "Standard" | "Ultra" | string;
+export type ProximityPlacementGroupType = string;
 
 // @public
 export type ProximityPlacementGroupUpdate = UpdateResource & {};
@@ -1942,7 +2684,7 @@ export interface RegionalReplicationStatus {
 }
 
 // @public
-export type ReplicationState = "Unknown" | "Replicating" | "Completed" | "Failed" | string;
+export type ReplicationState = string;
 
 // @public
 export interface ReplicationStatus {
@@ -1951,7 +2693,7 @@ export interface ReplicationStatus {
 }
 
 // @public
-export type ReplicationStatusTypes = "ReplicationStatus" | string;
+export type ReplicationStatusTypes = string;
 
 // @public
 export type RequestRateByIntervalInput = LogAnalyticsInputBase & {
@@ -2289,7 +3031,7 @@ export type SnapshotsListResponse = SnapshotList & {
 };
 
 // @public
-export type SnapshotStorageAccountTypes = "Standard_LRS" | "Premium_LRS" | "Standard_ZRS" | string;
+export type SnapshotStorageAccountTypes = string;
 
 // @public
 export type SnapshotsUpdateResponse = Snapshot & {
@@ -2419,10 +3161,10 @@ export type SshPublicKeyUpdateResource = UpdateResource & {
 export type StatusLevelTypes = "Info" | "Warning" | "Error";
 
 // @public
-export type StorageAccountType = "Standard_LRS" | "Standard_ZRS" | "Premium_LRS" | string;
+export type StorageAccountType = string;
 
 // @public
-export type StorageAccountTypes = "Standard_LRS" | "Premium_LRS" | "StandardSSD_LRS" | "UltraSSD_LRS" | string;
+export type StorageAccountTypes = string;
 
 // @public
 export interface StorageProfile {
@@ -2621,7 +3363,7 @@ export type VirtualMachineCaptureResult = SubResource & {
 };
 
 // @public
-export type VirtualMachineEvictionPolicyTypes = "Deallocate" | "Delete" | string;
+export type VirtualMachineEvictionPolicyTypes = string;
 
 // @public
 export type VirtualMachineExtension = Resource & {
@@ -2860,7 +3602,7 @@ export interface VirtualMachineListResult {
 }
 
 // @public
-export type VirtualMachinePriorityTypes = "Regular" | "Low" | "Spot" | string;
+export type VirtualMachinePriorityTypes = string;
 
 // @public
 export interface VirtualMachineReimageParameters {
@@ -3161,7 +3903,7 @@ export type VirtualMachineScaleSetRollingUpgradesGetLatestResponse = RollingUpgr
 };
 
 // @public
-export type VirtualMachineScaleSetScaleInRules = "Default" | "OldestVM" | "NewestVM" | string;
+export type VirtualMachineScaleSetScaleInRules = string;
 
 // @public
 export type VirtualMachineScaleSetsCreateOrUpdateResponse = VirtualMachineScaleSet & {
@@ -3690,7 +4432,7 @@ export type VirtualMachineSizesListResponse = VirtualMachineSizeListResult & {
 };
 
 // @public
-export type VirtualMachineSizeTypes = "Basic_A0" | "Basic_A1" | "Basic_A2" | "Basic_A3" | "Basic_A4" | "Standard_A0" | "Standard_A1" | "Standard_A2" | "Standard_A3" | "Standard_A4" | "Standard_A5" | "Standard_A6" | "Standard_A7" | "Standard_A8" | "Standard_A9" | "Standard_A10" | "Standard_A11" | "Standard_A1_v2" | "Standard_A2_v2" | "Standard_A4_v2" | "Standard_A8_v2" | "Standard_A2m_v2" | "Standard_A4m_v2" | "Standard_A8m_v2" | "Standard_B1s" | "Standard_B1ms" | "Standard_B2s" | "Standard_B2ms" | "Standard_B4ms" | "Standard_B8ms" | "Standard_D1" | "Standard_D2" | "Standard_D3" | "Standard_D4" | "Standard_D11" | "Standard_D12" | "Standard_D13" | "Standard_D14" | "Standard_D1_v2" | "Standard_D2_v2" | "Standard_D3_v2" | "Standard_D4_v2" | "Standard_D5_v2" | "Standard_D2_v3" | "Standard_D4_v3" | "Standard_D8_v3" | "Standard_D16_v3" | "Standard_D32_v3" | "Standard_D64_v3" | "Standard_D2s_v3" | "Standard_D4s_v3" | "Standard_D8s_v3" | "Standard_D16s_v3" | "Standard_D32s_v3" | "Standard_D64s_v3" | "Standard_D11_v2" | "Standard_D12_v2" | "Standard_D13_v2" | "Standard_D14_v2" | "Standard_D15_v2" | "Standard_DS1" | "Standard_DS2" | "Standard_DS3" | "Standard_DS4" | "Standard_DS11" | "Standard_DS12" | "Standard_DS13" | "Standard_DS14" | "Standard_DS1_v2" | "Standard_DS2_v2" | "Standard_DS3_v2" | "Standard_DS4_v2" | "Standard_DS5_v2" | "Standard_DS11_v2" | "Standard_DS12_v2" | "Standard_DS13_v2" | "Standard_DS14_v2" | "Standard_DS15_v2" | "Standard_DS13-4_v2" | "Standard_DS13-2_v2" | "Standard_DS14-8_v2" | "Standard_DS14-4_v2" | "Standard_E2_v3" | "Standard_E4_v3" | "Standard_E8_v3" | "Standard_E16_v3" | "Standard_E32_v3" | "Standard_E64_v3" | "Standard_E2s_v3" | "Standard_E4s_v3" | "Standard_E8s_v3" | "Standard_E16s_v3" | "Standard_E32s_v3" | "Standard_E64s_v3" | "Standard_E32-16_v3" | "Standard_E32-8s_v3" | "Standard_E64-32s_v3" | "Standard_E64-16s_v3" | "Standard_F1" | "Standard_F2" | "Standard_F4" | "Standard_F8" | "Standard_F16" | "Standard_F1s" | "Standard_F2s" | "Standard_F4s" | "Standard_F8s" | "Standard_F16s" | "Standard_F2s_v2" | "Standard_F4s_v2" | "Standard_F8s_v2" | "Standard_F16s_v2" | "Standard_F32s_v2" | "Standard_F64s_v2" | "Standard_F72s_v2" | "Standard_G1" | "Standard_G2" | "Standard_G3" | "Standard_G4" | "Standard_G5" | "Standard_GS1" | "Standard_GS2" | "Standard_GS3" | "Standard_GS4" | "Standard_GS5" | "Standard_GS4-8" | "Standard_GS4-4" | "Standard_GS5-16" | "Standard_GS5-8" | "Standard_H8" | "Standard_H16" | "Standard_H8m" | "Standard_H16m" | "Standard_H16r" | "Standard_H16mr" | "Standard_L4s" | "Standard_L8s" | "Standard_L16s" | "Standard_L32s" | "Standard_M64s" | "Standard_M64ms" | "Standard_M128s" | "Standard_M128ms" | "Standard_M64-32ms" | "Standard_M64-16ms" | "Standard_M128-64ms" | "Standard_M128-32ms" | "Standard_NC6" | "Standard_NC12" | "Standard_NC24" | "Standard_NC24r" | "Standard_NC6s_v2" | "Standard_NC12s_v2" | "Standard_NC24s_v2" | "Standard_NC24rs_v2" | "Standard_NC6s_v3" | "Standard_NC12s_v3" | "Standard_NC24s_v3" | "Standard_NC24rs_v3" | "Standard_ND6s" | "Standard_ND12s" | "Standard_ND24s" | "Standard_ND24rs" | "Standard_NV6" | "Standard_NV12" | "Standard_NV24" | string;
+export type VirtualMachineSizeTypes = string;
 
 // @public
 export interface VirtualMachinesListAllNextOptionalParams extends coreHttp.OperationOptions {
@@ -3844,7 +4586,7 @@ export interface WinRMListener {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:9774:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:10508:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/compute-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/compute-resource-manager/src/models/index.ts
@@ -5525,442 +5525,1176 @@ export type VirtualMachineImage = VirtualMachineImageResource & {
    */
   hyperVGeneration?: HyperVGenerationTypes;
 };
+
 /**
- * Defines values for ProximityPlacementGroupType.
+ * Known values of {@link ProximityPlacementGroupType} that the service accepts.
  */
-export type ProximityPlacementGroupType = "Standard" | "Ultra" | string;
+export const enum KnownProximityPlacementGroupType {
+  Standard = "Standard",
+  Ultra = "Ultra"
+}
+
 /**
- * Defines values for HyperVGenerationTypes.
+ * Defines values for ProximityPlacementGroupType. \
+ * {@link KnownProximityPlacementGroupType} can be used interchangeably with ProximityPlacementGroupType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard** \
+ * **Ultra**
  */
-export type HyperVGenerationTypes = "V1" | "V2" | string;
+export type ProximityPlacementGroupType = string;
+
 /**
- * Defines values for VirtualMachineSizeTypes.
+ * Known values of {@link HyperVGenerationTypes} that the service accepts.
  */
-export type VirtualMachineSizeTypes =
-  | "Basic_A0"
-  | "Basic_A1"
-  | "Basic_A2"
-  | "Basic_A3"
-  | "Basic_A4"
-  | "Standard_A0"
-  | "Standard_A1"
-  | "Standard_A2"
-  | "Standard_A3"
-  | "Standard_A4"
-  | "Standard_A5"
-  | "Standard_A6"
-  | "Standard_A7"
-  | "Standard_A8"
-  | "Standard_A9"
-  | "Standard_A10"
-  | "Standard_A11"
-  | "Standard_A1_v2"
-  | "Standard_A2_v2"
-  | "Standard_A4_v2"
-  | "Standard_A8_v2"
-  | "Standard_A2m_v2"
-  | "Standard_A4m_v2"
-  | "Standard_A8m_v2"
-  | "Standard_B1s"
-  | "Standard_B1ms"
-  | "Standard_B2s"
-  | "Standard_B2ms"
-  | "Standard_B4ms"
-  | "Standard_B8ms"
-  | "Standard_D1"
-  | "Standard_D2"
-  | "Standard_D3"
-  | "Standard_D4"
-  | "Standard_D11"
-  | "Standard_D12"
-  | "Standard_D13"
-  | "Standard_D14"
-  | "Standard_D1_v2"
-  | "Standard_D2_v2"
-  | "Standard_D3_v2"
-  | "Standard_D4_v2"
-  | "Standard_D5_v2"
-  | "Standard_D2_v3"
-  | "Standard_D4_v3"
-  | "Standard_D8_v3"
-  | "Standard_D16_v3"
-  | "Standard_D32_v3"
-  | "Standard_D64_v3"
-  | "Standard_D2s_v3"
-  | "Standard_D4s_v3"
-  | "Standard_D8s_v3"
-  | "Standard_D16s_v3"
-  | "Standard_D32s_v3"
-  | "Standard_D64s_v3"
-  | "Standard_D11_v2"
-  | "Standard_D12_v2"
-  | "Standard_D13_v2"
-  | "Standard_D14_v2"
-  | "Standard_D15_v2"
-  | "Standard_DS1"
-  | "Standard_DS2"
-  | "Standard_DS3"
-  | "Standard_DS4"
-  | "Standard_DS11"
-  | "Standard_DS12"
-  | "Standard_DS13"
-  | "Standard_DS14"
-  | "Standard_DS1_v2"
-  | "Standard_DS2_v2"
-  | "Standard_DS3_v2"
-  | "Standard_DS4_v2"
-  | "Standard_DS5_v2"
-  | "Standard_DS11_v2"
-  | "Standard_DS12_v2"
-  | "Standard_DS13_v2"
-  | "Standard_DS14_v2"
-  | "Standard_DS15_v2"
-  | "Standard_DS13-4_v2"
-  | "Standard_DS13-2_v2"
-  | "Standard_DS14-8_v2"
-  | "Standard_DS14-4_v2"
-  | "Standard_E2_v3"
-  | "Standard_E4_v3"
-  | "Standard_E8_v3"
-  | "Standard_E16_v3"
-  | "Standard_E32_v3"
-  | "Standard_E64_v3"
-  | "Standard_E2s_v3"
-  | "Standard_E4s_v3"
-  | "Standard_E8s_v3"
-  | "Standard_E16s_v3"
-  | "Standard_E32s_v3"
-  | "Standard_E64s_v3"
-  | "Standard_E32-16_v3"
-  | "Standard_E32-8s_v3"
-  | "Standard_E64-32s_v3"
-  | "Standard_E64-16s_v3"
-  | "Standard_F1"
-  | "Standard_F2"
-  | "Standard_F4"
-  | "Standard_F8"
-  | "Standard_F16"
-  | "Standard_F1s"
-  | "Standard_F2s"
-  | "Standard_F4s"
-  | "Standard_F8s"
-  | "Standard_F16s"
-  | "Standard_F2s_v2"
-  | "Standard_F4s_v2"
-  | "Standard_F8s_v2"
-  | "Standard_F16s_v2"
-  | "Standard_F32s_v2"
-  | "Standard_F64s_v2"
-  | "Standard_F72s_v2"
-  | "Standard_G1"
-  | "Standard_G2"
-  | "Standard_G3"
-  | "Standard_G4"
-  | "Standard_G5"
-  | "Standard_GS1"
-  | "Standard_GS2"
-  | "Standard_GS3"
-  | "Standard_GS4"
-  | "Standard_GS5"
-  | "Standard_GS4-8"
-  | "Standard_GS4-4"
-  | "Standard_GS5-16"
-  | "Standard_GS5-8"
-  | "Standard_H8"
-  | "Standard_H16"
-  | "Standard_H8m"
-  | "Standard_H16m"
-  | "Standard_H16r"
-  | "Standard_H16mr"
-  | "Standard_L4s"
-  | "Standard_L8s"
-  | "Standard_L16s"
-  | "Standard_L32s"
-  | "Standard_M64s"
-  | "Standard_M64ms"
-  | "Standard_M128s"
-  | "Standard_M128ms"
-  | "Standard_M64-32ms"
-  | "Standard_M64-16ms"
-  | "Standard_M128-64ms"
-  | "Standard_M128-32ms"
-  | "Standard_NC6"
-  | "Standard_NC12"
-  | "Standard_NC24"
-  | "Standard_NC24r"
-  | "Standard_NC6s_v2"
-  | "Standard_NC12s_v2"
-  | "Standard_NC24s_v2"
-  | "Standard_NC24rs_v2"
-  | "Standard_NC6s_v3"
-  | "Standard_NC12s_v3"
-  | "Standard_NC24s_v3"
-  | "Standard_NC24rs_v3"
-  | "Standard_ND6s"
-  | "Standard_ND12s"
-  | "Standard_ND24s"
-  | "Standard_ND24rs"
-  | "Standard_NV6"
-  | "Standard_NV12"
-  | "Standard_NV24"
-  | string;
+export const enum KnownHyperVGenerationTypes {
+  V1 = "V1",
+  V2 = "V2"
+}
+
 /**
- * Defines values for DiffDiskOptions.
+ * Defines values for HyperVGenerationTypes. \
+ * {@link KnownHyperVGenerationTypes} can be used interchangeably with HyperVGenerationTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **V1** \
+ * **V2**
  */
-export type DiffDiskOptions = "Local" | string;
+export type HyperVGenerationTypes = string;
+
 /**
- * Defines values for DiffDiskPlacement.
+ * Known values of {@link VirtualMachineSizeTypes} that the service accepts.
  */
-export type DiffDiskPlacement = "CacheDisk" | "ResourceDisk" | string;
+export const enum KnownVirtualMachineSizeTypes {
+  BasicA0 = "Basic_A0",
+  BasicA1 = "Basic_A1",
+  BasicA2 = "Basic_A2",
+  BasicA3 = "Basic_A3",
+  BasicA4 = "Basic_A4",
+  StandardA0 = "Standard_A0",
+  StandardA1 = "Standard_A1",
+  StandardA2 = "Standard_A2",
+  StandardA3 = "Standard_A3",
+  StandardA4 = "Standard_A4",
+  StandardA5 = "Standard_A5",
+  StandardA6 = "Standard_A6",
+  StandardA7 = "Standard_A7",
+  StandardA8 = "Standard_A8",
+  StandardA9 = "Standard_A9",
+  StandardA10 = "Standard_A10",
+  StandardA11 = "Standard_A11",
+  StandardA1V2 = "Standard_A1_v2",
+  StandardA2V2 = "Standard_A2_v2",
+  StandardA4V2 = "Standard_A4_v2",
+  StandardA8V2 = "Standard_A8_v2",
+  StandardA2MV2 = "Standard_A2m_v2",
+  StandardA4MV2 = "Standard_A4m_v2",
+  StandardA8MV2 = "Standard_A8m_v2",
+  StandardB1S = "Standard_B1s",
+  StandardB1Ms = "Standard_B1ms",
+  StandardB2S = "Standard_B2s",
+  StandardB2Ms = "Standard_B2ms",
+  StandardB4Ms = "Standard_B4ms",
+  StandardB8Ms = "Standard_B8ms",
+  StandardD1 = "Standard_D1",
+  StandardD2 = "Standard_D2",
+  StandardD3 = "Standard_D3",
+  StandardD4 = "Standard_D4",
+  StandardD11 = "Standard_D11",
+  StandardD12 = "Standard_D12",
+  StandardD13 = "Standard_D13",
+  StandardD14 = "Standard_D14",
+  StandardD1V2 = "Standard_D1_v2",
+  StandardD2V2 = "Standard_D2_v2",
+  StandardD3V2 = "Standard_D3_v2",
+  StandardD4V2 = "Standard_D4_v2",
+  StandardD5V2 = "Standard_D5_v2",
+  StandardD2V3 = "Standard_D2_v3",
+  StandardD4V3 = "Standard_D4_v3",
+  StandardD8V3 = "Standard_D8_v3",
+  StandardD16V3 = "Standard_D16_v3",
+  StandardD32V3 = "Standard_D32_v3",
+  StandardD64V3 = "Standard_D64_v3",
+  StandardD2SV3 = "Standard_D2s_v3",
+  StandardD4SV3 = "Standard_D4s_v3",
+  StandardD8SV3 = "Standard_D8s_v3",
+  StandardD16SV3 = "Standard_D16s_v3",
+  StandardD32SV3 = "Standard_D32s_v3",
+  StandardD64SV3 = "Standard_D64s_v3",
+  StandardD11V2 = "Standard_D11_v2",
+  StandardD12V2 = "Standard_D12_v2",
+  StandardD13V2 = "Standard_D13_v2",
+  StandardD14V2 = "Standard_D14_v2",
+  StandardD15V2 = "Standard_D15_v2",
+  StandardDS1 = "Standard_DS1",
+  StandardDS2 = "Standard_DS2",
+  StandardDS3 = "Standard_DS3",
+  StandardDS4 = "Standard_DS4",
+  StandardDS11 = "Standard_DS11",
+  StandardDS12 = "Standard_DS12",
+  StandardDS13 = "Standard_DS13",
+  StandardDS14 = "Standard_DS14",
+  StandardDS1V2 = "Standard_DS1_v2",
+  StandardDS2V2 = "Standard_DS2_v2",
+  StandardDS3V2 = "Standard_DS3_v2",
+  StandardDS4V2 = "Standard_DS4_v2",
+  StandardDS5V2 = "Standard_DS5_v2",
+  StandardDS11V2 = "Standard_DS11_v2",
+  StandardDS12V2 = "Standard_DS12_v2",
+  StandardDS13V2 = "Standard_DS13_v2",
+  StandardDS14V2 = "Standard_DS14_v2",
+  StandardDS15V2 = "Standard_DS15_v2",
+  StandardDS134V2 = "Standard_DS13-4_v2",
+  StandardDS132V2 = "Standard_DS13-2_v2",
+  StandardDS148V2 = "Standard_DS14-8_v2",
+  StandardDS144V2 = "Standard_DS14-4_v2",
+  StandardE2V3 = "Standard_E2_v3",
+  StandardE4V3 = "Standard_E4_v3",
+  StandardE8V3 = "Standard_E8_v3",
+  StandardE16V3 = "Standard_E16_v3",
+  StandardE32V3 = "Standard_E32_v3",
+  StandardE64V3 = "Standard_E64_v3",
+  StandardE2SV3 = "Standard_E2s_v3",
+  StandardE4SV3 = "Standard_E4s_v3",
+  StandardE8SV3 = "Standard_E8s_v3",
+  StandardE16SV3 = "Standard_E16s_v3",
+  StandardE32SV3 = "Standard_E32s_v3",
+  StandardE64SV3 = "Standard_E64s_v3",
+  StandardE3216V3 = "Standard_E32-16_v3",
+  StandardE328SV3 = "Standard_E32-8s_v3",
+  StandardE6432SV3 = "Standard_E64-32s_v3",
+  StandardE6416SV3 = "Standard_E64-16s_v3",
+  StandardF1 = "Standard_F1",
+  StandardF2 = "Standard_F2",
+  StandardF4 = "Standard_F4",
+  StandardF8 = "Standard_F8",
+  StandardF16 = "Standard_F16",
+  StandardF1S = "Standard_F1s",
+  StandardF2S = "Standard_F2s",
+  StandardF4S = "Standard_F4s",
+  StandardF8S = "Standard_F8s",
+  StandardF16S = "Standard_F16s",
+  StandardF2SV2 = "Standard_F2s_v2",
+  StandardF4SV2 = "Standard_F4s_v2",
+  StandardF8SV2 = "Standard_F8s_v2",
+  StandardF16SV2 = "Standard_F16s_v2",
+  StandardF32SV2 = "Standard_F32s_v2",
+  StandardF64SV2 = "Standard_F64s_v2",
+  StandardF72SV2 = "Standard_F72s_v2",
+  StandardG1 = "Standard_G1",
+  StandardG2 = "Standard_G2",
+  StandardG3 = "Standard_G3",
+  StandardG4 = "Standard_G4",
+  StandardG5 = "Standard_G5",
+  StandardGS1 = "Standard_GS1",
+  StandardGS2 = "Standard_GS2",
+  StandardGS3 = "Standard_GS3",
+  StandardGS4 = "Standard_GS4",
+  StandardGS5 = "Standard_GS5",
+  StandardGS48 = "Standard_GS4-8",
+  StandardGS44 = "Standard_GS4-4",
+  StandardGS516 = "Standard_GS5-16",
+  StandardGS58 = "Standard_GS5-8",
+  StandardH8 = "Standard_H8",
+  StandardH16 = "Standard_H16",
+  StandardH8M = "Standard_H8m",
+  StandardH16M = "Standard_H16m",
+  StandardH16R = "Standard_H16r",
+  StandardH16Mr = "Standard_H16mr",
+  StandardL4S = "Standard_L4s",
+  StandardL8S = "Standard_L8s",
+  StandardL16S = "Standard_L16s",
+  StandardL32S = "Standard_L32s",
+  StandardM64S = "Standard_M64s",
+  StandardM64Ms = "Standard_M64ms",
+  StandardM128S = "Standard_M128s",
+  StandardM128Ms = "Standard_M128ms",
+  StandardM6432Ms = "Standard_M64-32ms",
+  StandardM6416Ms = "Standard_M64-16ms",
+  StandardM12864Ms = "Standard_M128-64ms",
+  StandardM12832Ms = "Standard_M128-32ms",
+  StandardNC6 = "Standard_NC6",
+  StandardNC12 = "Standard_NC12",
+  StandardNC24 = "Standard_NC24",
+  StandardNC24R = "Standard_NC24r",
+  StandardNC6SV2 = "Standard_NC6s_v2",
+  StandardNC12SV2 = "Standard_NC12s_v2",
+  StandardNC24SV2 = "Standard_NC24s_v2",
+  StandardNC24RsV2 = "Standard_NC24rs_v2",
+  StandardNC6SV3 = "Standard_NC6s_v3",
+  StandardNC12SV3 = "Standard_NC12s_v3",
+  StandardNC24SV3 = "Standard_NC24s_v3",
+  StandardNC24RsV3 = "Standard_NC24rs_v3",
+  StandardND6S = "Standard_ND6s",
+  StandardND12S = "Standard_ND12s",
+  StandardND24S = "Standard_ND24s",
+  StandardND24Rs = "Standard_ND24rs",
+  StandardNV6 = "Standard_NV6",
+  StandardNV12 = "Standard_NV12",
+  StandardNV24 = "Standard_NV24"
+}
+
 /**
- * Defines values for DiskCreateOptionTypes.
+ * Defines values for VirtualMachineSizeTypes. \
+ * {@link KnownVirtualMachineSizeTypes} can be used interchangeably with VirtualMachineSizeTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic_A0** \
+ * **Basic_A1** \
+ * **Basic_A2** \
+ * **Basic_A3** \
+ * **Basic_A4** \
+ * **Standard_A0** \
+ * **Standard_A1** \
+ * **Standard_A2** \
+ * **Standard_A3** \
+ * **Standard_A4** \
+ * **Standard_A5** \
+ * **Standard_A6** \
+ * **Standard_A7** \
+ * **Standard_A8** \
+ * **Standard_A9** \
+ * **Standard_A10** \
+ * **Standard_A11** \
+ * **Standard_A1_v2** \
+ * **Standard_A2_v2** \
+ * **Standard_A4_v2** \
+ * **Standard_A8_v2** \
+ * **Standard_A2m_v2** \
+ * **Standard_A4m_v2** \
+ * **Standard_A8m_v2** \
+ * **Standard_B1s** \
+ * **Standard_B1ms** \
+ * **Standard_B2s** \
+ * **Standard_B2ms** \
+ * **Standard_B4ms** \
+ * **Standard_B8ms** \
+ * **Standard_D1** \
+ * **Standard_D2** \
+ * **Standard_D3** \
+ * **Standard_D4** \
+ * **Standard_D11** \
+ * **Standard_D12** \
+ * **Standard_D13** \
+ * **Standard_D14** \
+ * **Standard_D1_v2** \
+ * **Standard_D2_v2** \
+ * **Standard_D3_v2** \
+ * **Standard_D4_v2** \
+ * **Standard_D5_v2** \
+ * **Standard_D2_v3** \
+ * **Standard_D4_v3** \
+ * **Standard_D8_v3** \
+ * **Standard_D16_v3** \
+ * **Standard_D32_v3** \
+ * **Standard_D64_v3** \
+ * **Standard_D2s_v3** \
+ * **Standard_D4s_v3** \
+ * **Standard_D8s_v3** \
+ * **Standard_D16s_v3** \
+ * **Standard_D32s_v3** \
+ * **Standard_D64s_v3** \
+ * **Standard_D11_v2** \
+ * **Standard_D12_v2** \
+ * **Standard_D13_v2** \
+ * **Standard_D14_v2** \
+ * **Standard_D15_v2** \
+ * **Standard_DS1** \
+ * **Standard_DS2** \
+ * **Standard_DS3** \
+ * **Standard_DS4** \
+ * **Standard_DS11** \
+ * **Standard_DS12** \
+ * **Standard_DS13** \
+ * **Standard_DS14** \
+ * **Standard_DS1_v2** \
+ * **Standard_DS2_v2** \
+ * **Standard_DS3_v2** \
+ * **Standard_DS4_v2** \
+ * **Standard_DS5_v2** \
+ * **Standard_DS11_v2** \
+ * **Standard_DS12_v2** \
+ * **Standard_DS13_v2** \
+ * **Standard_DS14_v2** \
+ * **Standard_DS15_v2** \
+ * **Standard_DS13-4_v2** \
+ * **Standard_DS13-2_v2** \
+ * **Standard_DS14-8_v2** \
+ * **Standard_DS14-4_v2** \
+ * **Standard_E2_v3** \
+ * **Standard_E4_v3** \
+ * **Standard_E8_v3** \
+ * **Standard_E16_v3** \
+ * **Standard_E32_v3** \
+ * **Standard_E64_v3** \
+ * **Standard_E2s_v3** \
+ * **Standard_E4s_v3** \
+ * **Standard_E8s_v3** \
+ * **Standard_E16s_v3** \
+ * **Standard_E32s_v3** \
+ * **Standard_E64s_v3** \
+ * **Standard_E32-16_v3** \
+ * **Standard_E32-8s_v3** \
+ * **Standard_E64-32s_v3** \
+ * **Standard_E64-16s_v3** \
+ * **Standard_F1** \
+ * **Standard_F2** \
+ * **Standard_F4** \
+ * **Standard_F8** \
+ * **Standard_F16** \
+ * **Standard_F1s** \
+ * **Standard_F2s** \
+ * **Standard_F4s** \
+ * **Standard_F8s** \
+ * **Standard_F16s** \
+ * **Standard_F2s_v2** \
+ * **Standard_F4s_v2** \
+ * **Standard_F8s_v2** \
+ * **Standard_F16s_v2** \
+ * **Standard_F32s_v2** \
+ * **Standard_F64s_v2** \
+ * **Standard_F72s_v2** \
+ * **Standard_G1** \
+ * **Standard_G2** \
+ * **Standard_G3** \
+ * **Standard_G4** \
+ * **Standard_G5** \
+ * **Standard_GS1** \
+ * **Standard_GS2** \
+ * **Standard_GS3** \
+ * **Standard_GS4** \
+ * **Standard_GS5** \
+ * **Standard_GS4-8** \
+ * **Standard_GS4-4** \
+ * **Standard_GS5-16** \
+ * **Standard_GS5-8** \
+ * **Standard_H8** \
+ * **Standard_H16** \
+ * **Standard_H8m** \
+ * **Standard_H16m** \
+ * **Standard_H16r** \
+ * **Standard_H16mr** \
+ * **Standard_L4s** \
+ * **Standard_L8s** \
+ * **Standard_L16s** \
+ * **Standard_L32s** \
+ * **Standard_M64s** \
+ * **Standard_M64ms** \
+ * **Standard_M128s** \
+ * **Standard_M128ms** \
+ * **Standard_M64-32ms** \
+ * **Standard_M64-16ms** \
+ * **Standard_M128-64ms** \
+ * **Standard_M128-32ms** \
+ * **Standard_NC6** \
+ * **Standard_NC12** \
+ * **Standard_NC24** \
+ * **Standard_NC24r** \
+ * **Standard_NC6s_v2** \
+ * **Standard_NC12s_v2** \
+ * **Standard_NC24s_v2** \
+ * **Standard_NC24rs_v2** \
+ * **Standard_NC6s_v3** \
+ * **Standard_NC12s_v3** \
+ * **Standard_NC24s_v3** \
+ * **Standard_NC24rs_v3** \
+ * **Standard_ND6s** \
+ * **Standard_ND12s** \
+ * **Standard_ND24s** \
+ * **Standard_ND24rs** \
+ * **Standard_NV6** \
+ * **Standard_NV12** \
+ * **Standard_NV24**
  */
-export type DiskCreateOptionTypes = "FromImage" | "Empty" | "Attach" | string;
+export type VirtualMachineSizeTypes = string;
+
 /**
- * Defines values for StorageAccountTypes.
+ * Known values of {@link DiffDiskOptions} that the service accepts.
  */
-export type StorageAccountTypes =
-  | "Standard_LRS"
-  | "Premium_LRS"
-  | "StandardSSD_LRS"
-  | "UltraSSD_LRS"
-  | string;
+export const enum KnownDiffDiskOptions {
+  Local = "Local"
+}
+
 /**
- * Defines values for VirtualMachinePriorityTypes.
+ * Defines values for DiffDiskOptions. \
+ * {@link KnownDiffDiskOptions} can be used interchangeably with DiffDiskOptions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Local**
  */
-export type VirtualMachinePriorityTypes = "Regular" | "Low" | "Spot" | string;
+export type DiffDiskOptions = string;
+
 /**
- * Defines values for VirtualMachineEvictionPolicyTypes.
+ * Known values of {@link DiffDiskPlacement} that the service accepts.
  */
-export type VirtualMachineEvictionPolicyTypes =
-  | "Deallocate"
-  | "Delete"
-  | string;
+export const enum KnownDiffDiskPlacement {
+  CacheDisk = "CacheDisk",
+  ResourceDisk = "ResourceDisk"
+}
+
 /**
- * Defines values for HyperVGenerationType.
+ * Defines values for DiffDiskPlacement. \
+ * {@link KnownDiffDiskPlacement} can be used interchangeably with DiffDiskPlacement,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **CacheDisk** \
+ * **ResourceDisk**
  */
-export type HyperVGenerationType = "V1" | "V2" | string;
+export type DiffDiskPlacement = string;
+
 /**
- * Defines values for IPVersion.
+ * Known values of {@link DiskCreateOptionTypes} that the service accepts.
  */
-export type IPVersion = "IPv4" | "IPv6" | string;
+export const enum KnownDiskCreateOptionTypes {
+  FromImage = "FromImage",
+  Empty = "Empty",
+  Attach = "Attach"
+}
+
 /**
- * Defines values for VirtualMachineScaleSetScaleInRules.
+ * Defines values for DiskCreateOptionTypes. \
+ * {@link KnownDiskCreateOptionTypes} can be used interchangeably with DiskCreateOptionTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **FromImage** \
+ * **Empty** \
+ * **Attach**
  */
-export type VirtualMachineScaleSetScaleInRules =
-  | "Default"
-  | "OldestVM"
-  | "NewestVM"
-  | string;
+export type DiskCreateOptionTypes = string;
+
 /**
- * Defines values for OrchestrationServiceNames.
+ * Known values of {@link StorageAccountTypes} that the service accepts.
  */
-export type OrchestrationServiceNames = "AutomaticRepairs" | string;
+export const enum KnownStorageAccountTypes {
+  StandardLRS = "Standard_LRS",
+  PremiumLRS = "Premium_LRS",
+  StandardSSDLRS = "StandardSSD_LRS",
+  UltraSSDLRS = "UltraSSD_LRS"
+}
+
 /**
- * Defines values for OrchestrationServiceState.
+ * Defines values for StorageAccountTypes. \
+ * {@link KnownStorageAccountTypes} can be used interchangeably with StorageAccountTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_LRS** \
+ * **Premium_LRS** \
+ * **StandardSSD_LRS** \
+ * **UltraSSD_LRS**
  */
-export type OrchestrationServiceState =
-  | "NotRunning"
-  | "Running"
-  | "Suspended"
-  | string;
+export type StorageAccountTypes = string;
+
 /**
- * Defines values for OrchestrationServiceStateAction.
+ * Known values of {@link VirtualMachinePriorityTypes} that the service accepts.
  */
-export type OrchestrationServiceStateAction = "Resume" | "Suspend" | string;
+export const enum KnownVirtualMachinePriorityTypes {
+  Regular = "Regular",
+  Low = "Low",
+  Spot = "Spot"
+}
+
 /**
- * Defines values for DiskStorageAccountTypes.
+ * Defines values for VirtualMachinePriorityTypes. \
+ * {@link KnownVirtualMachinePriorityTypes} can be used interchangeably with VirtualMachinePriorityTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Regular** \
+ * **Low** \
+ * **Spot**
  */
-export type DiskStorageAccountTypes =
-  | "Standard_LRS"
-  | "Premium_LRS"
-  | "StandardSSD_LRS"
-  | "UltraSSD_LRS"
-  | string;
+export type VirtualMachinePriorityTypes = string;
+
 /**
- * Defines values for HyperVGeneration.
+ * Known values of {@link VirtualMachineEvictionPolicyTypes} that the service accepts.
  */
-export type HyperVGeneration = "V1" | "V2" | string;
+export const enum KnownVirtualMachineEvictionPolicyTypes {
+  Deallocate = "Deallocate",
+  Delete = "Delete"
+}
+
 /**
- * Defines values for DiskCreateOption.
+ * Defines values for VirtualMachineEvictionPolicyTypes. \
+ * {@link KnownVirtualMachineEvictionPolicyTypes} can be used interchangeably with VirtualMachineEvictionPolicyTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Deallocate** \
+ * **Delete**
  */
-export type DiskCreateOption =
-  | "Empty"
-  | "Attach"
-  | "FromImage"
-  | "Import"
-  | "Copy"
-  | "Restore"
-  | "Upload"
-  | string;
+export type VirtualMachineEvictionPolicyTypes = string;
+
 /**
- * Defines values for DiskState.
+ * Known values of {@link HyperVGenerationType} that the service accepts.
  */
-export type DiskState =
-  | "Unattached"
-  | "Attached"
-  | "Reserved"
-  | "ActiveSAS"
-  | "ReadyToUpload"
-  | "ActiveUpload"
-  | string;
+export const enum KnownHyperVGenerationType {
+  V1 = "V1",
+  V2 = "V2"
+}
+
 /**
- * Defines values for EncryptionType.
+ * Defines values for HyperVGenerationType. \
+ * {@link KnownHyperVGenerationType} can be used interchangeably with HyperVGenerationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **V1** \
+ * **V2**
  */
-export type EncryptionType =
-  | "EncryptionAtRestWithPlatformKey"
-  | "EncryptionAtRestWithCustomerKey"
-  | string;
+export type HyperVGenerationType = string;
+
 /**
- * Defines values for AccessLevel.
+ * Known values of {@link IPVersion} that the service accepts.
  */
-export type AccessLevel = "None" | "Read" | "Write" | string;
+export const enum KnownIPVersion {
+  IPv4 = "IPv4",
+  IPv6 = "IPv6"
+}
+
 /**
- * Defines values for SnapshotStorageAccountTypes.
+ * Defines values for IPVersion. \
+ * {@link KnownIPVersion} can be used interchangeably with IPVersion,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IPv4** \
+ * **IPv6**
  */
-export type SnapshotStorageAccountTypes =
-  | "Standard_LRS"
-  | "Premium_LRS"
-  | "Standard_ZRS"
-  | string;
+export type IPVersion = string;
+
 /**
- * Defines values for DiskEncryptionSetIdentityType.
+ * Known values of {@link VirtualMachineScaleSetScaleInRules} that the service accepts.
  */
-export type DiskEncryptionSetIdentityType = "SystemAssigned" | string;
+export const enum KnownVirtualMachineScaleSetScaleInRules {
+  Default = "Default",
+  OldestVM = "OldestVM",
+  NewestVM = "NewestVM"
+}
+
 /**
- * Defines values for GalleryPropertiesProvisioningState.
+ * Defines values for VirtualMachineScaleSetScaleInRules. \
+ * {@link KnownVirtualMachineScaleSetScaleInRules} can be used interchangeably with VirtualMachineScaleSetScaleInRules,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default** \
+ * **OldestVM** \
+ * **NewestVM**
  */
-export type GalleryPropertiesProvisioningState =
-  | "Creating"
-  | "Updating"
-  | "Failed"
-  | "Succeeded"
-  | "Deleting"
-  | "Migrating"
-  | string;
+export type VirtualMachineScaleSetScaleInRules = string;
+
 /**
- * Defines values for GalleryImagePropertiesProvisioningState.
+ * Known values of {@link OrchestrationServiceNames} that the service accepts.
  */
-export type GalleryImagePropertiesProvisioningState =
-  | "Creating"
-  | "Updating"
-  | "Failed"
-  | "Succeeded"
-  | "Deleting"
-  | "Migrating"
-  | string;
+export const enum KnownOrchestrationServiceNames {
+  AutomaticRepairs = "AutomaticRepairs"
+}
+
 /**
- * Defines values for StorageAccountType.
+ * Defines values for OrchestrationServiceNames. \
+ * {@link KnownOrchestrationServiceNames} can be used interchangeably with OrchestrationServiceNames,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AutomaticRepairs**
  */
-export type StorageAccountType =
-  | "Standard_LRS"
-  | "Standard_ZRS"
-  | "Premium_LRS"
-  | string;
+export type OrchestrationServiceNames = string;
+
 /**
- * Defines values for GalleryImageVersionPropertiesProvisioningState.
+ * Known values of {@link OrchestrationServiceState} that the service accepts.
  */
-export type GalleryImageVersionPropertiesProvisioningState =
-  | "Creating"
-  | "Updating"
-  | "Failed"
-  | "Succeeded"
-  | "Deleting"
-  | "Migrating"
-  | string;
+export const enum KnownOrchestrationServiceState {
+  NotRunning = "NotRunning",
+  Running = "Running",
+  Suspended = "Suspended"
+}
+
 /**
- * Defines values for AggregatedReplicationState.
+ * Defines values for OrchestrationServiceState. \
+ * {@link KnownOrchestrationServiceState} can be used interchangeably with OrchestrationServiceState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotRunning** \
+ * **Running** \
+ * **Suspended**
  */
-export type AggregatedReplicationState =
-  | "Unknown"
-  | "InProgress"
-  | "Completed"
-  | "Failed"
-  | string;
+export type OrchestrationServiceState = string;
+
 /**
- * Defines values for ReplicationState.
+ * Known values of {@link OrchestrationServiceStateAction} that the service accepts.
  */
-export type ReplicationState =
-  | "Unknown"
-  | "Replicating"
-  | "Completed"
-  | "Failed"
-  | string;
+export const enum KnownOrchestrationServiceStateAction {
+  Resume = "Resume",
+  Suspend = "Suspend"
+}
+
 /**
- * Defines values for ReplicationStatusTypes.
+ * Defines values for OrchestrationServiceStateAction. \
+ * {@link KnownOrchestrationServiceStateAction} can be used interchangeably with OrchestrationServiceStateAction,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Resume** \
+ * **Suspend**
  */
-export type ReplicationStatusTypes = "ReplicationStatus" | string;
+export type OrchestrationServiceStateAction = string;
+
 /**
- * Defines values for GalleryApplicationVersionPropertiesProvisioningState.
+ * Known values of {@link DiskStorageAccountTypes} that the service accepts.
  */
-export type GalleryApplicationVersionPropertiesProvisioningState =
-  | "Creating"
-  | "Updating"
-  | "Failed"
-  | "Succeeded"
-  | "Deleting"
-  | "Migrating"
-  | string;
+export const enum KnownDiskStorageAccountTypes {
+  /**
+   * Standard HDD locally redundant storage. Best for backup, non-critical, and infrequent access.
+   */
+  StandardLRS = "Standard_LRS",
+  /**
+   * Premium SSD locally redundant storage. Best for production and performance sensitive workloads.
+   */
+  PremiumLRS = "Premium_LRS",
+  /**
+   * Standard SSD locally redundant storage. Best for web servers, lightly used enterprise applications and dev/test.
+   */
+  StandardSSDLRS = "StandardSSD_LRS",
+  /**
+   * Ultra SSD locally redundant storage. Best for IO-intensive workloads such as SAP HANA, top tier databases (for example, SQL, Oracle), and other transaction-heavy workloads.
+   */
+  UltraSSDLRS = "UltraSSD_LRS"
+}
+
 /**
- * Defines values for Enum31.
+ * Defines values for DiskStorageAccountTypes. \
+ * {@link KnownDiskStorageAccountTypes} can be used interchangeably with DiskStorageAccountTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_LRS**: Standard HDD locally redundant storage. Best for backup, non-critical, and infrequent access. \
+ * **Premium_LRS**: Premium SSD locally redundant storage. Best for production and performance sensitive workloads. \
+ * **StandardSSD_LRS**: Standard SSD locally redundant storage. Best for web servers, lightly used enterprise applications and dev/test. \
+ * **UltraSSD_LRS**: Ultra SSD locally redundant storage. Best for IO-intensive workloads such as SAP HANA, top tier databases (for example, SQL, Oracle), and other transaction-heavy workloads.
  */
-export type Enum31 = 1 | 3 | 5 | number;
+export type DiskStorageAccountTypes = string;
+
 /**
- * Defines values for ContainerServiceVMSizeTypes.
+ * Known values of {@link HyperVGeneration} that the service accepts.
  */
-export type ContainerServiceVMSizeTypes =
-  | "Standard_A0"
-  | "Standard_A1"
-  | "Standard_A2"
-  | "Standard_A3"
-  | "Standard_A4"
-  | "Standard_A5"
-  | "Standard_A6"
-  | "Standard_A7"
-  | "Standard_A8"
-  | "Standard_A9"
-  | "Standard_A10"
-  | "Standard_A11"
-  | "Standard_D1"
-  | "Standard_D2"
-  | "Standard_D3"
-  | "Standard_D4"
-  | "Standard_D11"
-  | "Standard_D12"
-  | "Standard_D13"
-  | "Standard_D14"
-  | "Standard_D1_v2"
-  | "Standard_D2_v2"
-  | "Standard_D3_v2"
-  | "Standard_D4_v2"
-  | "Standard_D5_v2"
-  | "Standard_D11_v2"
-  | "Standard_D12_v2"
-  | "Standard_D13_v2"
-  | "Standard_D14_v2"
-  | "Standard_G1"
-  | "Standard_G2"
-  | "Standard_G3"
-  | "Standard_G4"
-  | "Standard_G5"
-  | "Standard_DS1"
-  | "Standard_DS2"
-  | "Standard_DS3"
-  | "Standard_DS4"
-  | "Standard_DS11"
-  | "Standard_DS12"
-  | "Standard_DS13"
-  | "Standard_DS14"
-  | "Standard_GS1"
-  | "Standard_GS2"
-  | "Standard_GS3"
-  | "Standard_GS4"
-  | "Standard_GS5"
-  | string;
+export const enum KnownHyperVGeneration {
+  V1 = "V1",
+  V2 = "V2"
+}
+
 /**
- * Defines values for AvailabilitySetSkuTypes.
+ * Defines values for HyperVGeneration. \
+ * {@link KnownHyperVGeneration} can be used interchangeably with HyperVGeneration,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **V1** \
+ * **V2**
  */
-export type AvailabilitySetSkuTypes = "Classic" | "Aligned" | string;
+export type HyperVGeneration = string;
+
+/**
+ * Known values of {@link DiskCreateOption} that the service accepts.
+ */
+export const enum KnownDiskCreateOption {
+  /**
+   * Create an empty data disk of a size given by diskSizeGB.
+   */
+  Empty = "Empty",
+  /**
+   * Disk will be attached to a VM.
+   */
+  Attach = "Attach",
+  /**
+   * Create a new disk from a platform image specified by the given imageReference or galleryImageReference.
+   */
+  FromImage = "FromImage",
+  /**
+   * Create a disk by importing from a blob specified by a sourceUri in a storage account specified by storageAccountId.
+   */
+  Import = "Import",
+  /**
+   * Create a new disk or snapshot by copying from a disk or snapshot specified by the given sourceResourceId.
+   */
+  Copy = "Copy",
+  /**
+   * Create a new disk by copying from a backup recovery point.
+   */
+  Restore = "Restore",
+  /**
+   * Create a new disk by obtaining a write token and using it to directly upload the contents of the disk.
+   */
+  Upload = "Upload"
+}
+
+/**
+ * Defines values for DiskCreateOption. \
+ * {@link KnownDiskCreateOption} can be used interchangeably with DiskCreateOption,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Empty**: Create an empty data disk of a size given by diskSizeGB. \
+ * **Attach**: Disk will be attached to a VM. \
+ * **FromImage**: Create a new disk from a platform image specified by the given imageReference or galleryImageReference. \
+ * **Import**: Create a disk by importing from a blob specified by a sourceUri in a storage account specified by storageAccountId. \
+ * **Copy**: Create a new disk or snapshot by copying from a disk or snapshot specified by the given sourceResourceId. \
+ * **Restore**: Create a new disk by copying from a backup recovery point. \
+ * **Upload**: Create a new disk by obtaining a write token and using it to directly upload the contents of the disk.
+ */
+export type DiskCreateOption = string;
+
+/**
+ * Known values of {@link DiskState} that the service accepts.
+ */
+export const enum KnownDiskState {
+  /**
+   * The disk is not being used and can be attached to a VM.
+   */
+  Unattached = "Unattached",
+  /**
+   * The disk is currently mounted to a running VM.
+   */
+  Attached = "Attached",
+  /**
+   * The disk is mounted to a stopped-deallocated VM
+   */
+  Reserved = "Reserved",
+  /**
+   * The disk currently has an Active SAS Uri associated with it.
+   */
+  ActiveSAS = "ActiveSAS",
+  /**
+   * A disk is ready to be created by upload by requesting a write token.
+   */
+  ReadyToUpload = "ReadyToUpload",
+  /**
+   * A disk is created for upload and a write token has been issued for uploading to it.
+   */
+  ActiveUpload = "ActiveUpload"
+}
+
+/**
+ * Defines values for DiskState. \
+ * {@link KnownDiskState} can be used interchangeably with DiskState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unattached**: The disk is not being used and can be attached to a VM. \
+ * **Attached**: The disk is currently mounted to a running VM. \
+ * **Reserved**: The disk is mounted to a stopped-deallocated VM \
+ * **ActiveSAS**: The disk currently has an Active SAS Uri associated with it. \
+ * **ReadyToUpload**: A disk is ready to be created by upload by requesting a write token. \
+ * **ActiveUpload**: A disk is created for upload and a write token has been issued for uploading to it.
+ */
+export type DiskState = string;
+
+/**
+ * Known values of {@link EncryptionType} that the service accepts.
+ */
+export const enum KnownEncryptionType {
+  /**
+   * Disk is encrypted with XStore managed key at rest. It is the default encryption type.
+   */
+  EncryptionAtRestWithPlatformKey = "EncryptionAtRestWithPlatformKey",
+  /**
+   * Disk is encrypted with Customer managed key at rest.
+   */
+  EncryptionAtRestWithCustomerKey = "EncryptionAtRestWithCustomerKey"
+}
+
+/**
+ * Defines values for EncryptionType. \
+ * {@link KnownEncryptionType} can be used interchangeably with EncryptionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **EncryptionAtRestWithPlatformKey**: Disk is encrypted with XStore managed key at rest. It is the default encryption type. \
+ * **EncryptionAtRestWithCustomerKey**: Disk is encrypted with Customer managed key at rest.
+ */
+export type EncryptionType = string;
+
+/**
+ * Known values of {@link AccessLevel} that the service accepts.
+ */
+export const enum KnownAccessLevel {
+  None = "None",
+  Read = "Read",
+  Write = "Write"
+}
+
+/**
+ * Defines values for AccessLevel. \
+ * {@link KnownAccessLevel} can be used interchangeably with AccessLevel,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **Read** \
+ * **Write**
+ */
+export type AccessLevel = string;
+
+/**
+ * Known values of {@link SnapshotStorageAccountTypes} that the service accepts.
+ */
+export const enum KnownSnapshotStorageAccountTypes {
+  /**
+   * Standard HDD locally redundant storage
+   */
+  StandardLRS = "Standard_LRS",
+  /**
+   * Premium SSD locally redundant storage
+   */
+  PremiumLRS = "Premium_LRS",
+  /**
+   * Standard zone redundant storage
+   */
+  StandardZRS = "Standard_ZRS"
+}
+
+/**
+ * Defines values for SnapshotStorageAccountTypes. \
+ * {@link KnownSnapshotStorageAccountTypes} can be used interchangeably with SnapshotStorageAccountTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_LRS**: Standard HDD locally redundant storage \
+ * **Premium_LRS**: Premium SSD locally redundant storage \
+ * **Standard_ZRS**: Standard zone redundant storage
+ */
+export type SnapshotStorageAccountTypes = string;
+
+/**
+ * Known values of {@link DiskEncryptionSetIdentityType} that the service accepts.
+ */
+export const enum KnownDiskEncryptionSetIdentityType {
+  SystemAssigned = "SystemAssigned"
+}
+
+/**
+ * Defines values for DiskEncryptionSetIdentityType. \
+ * {@link KnownDiskEncryptionSetIdentityType} can be used interchangeably with DiskEncryptionSetIdentityType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SystemAssigned**
+ */
+export type DiskEncryptionSetIdentityType = string;
+
+/**
+ * Known values of {@link GalleryPropertiesProvisioningState} that the service accepts.
+ */
+export const enum KnownGalleryPropertiesProvisioningState {
+  Creating = "Creating",
+  Updating = "Updating",
+  Failed = "Failed",
+  Succeeded = "Succeeded",
+  Deleting = "Deleting",
+  Migrating = "Migrating"
+}
+
+/**
+ * Defines values for GalleryPropertiesProvisioningState. \
+ * {@link KnownGalleryPropertiesProvisioningState} can be used interchangeably with GalleryPropertiesProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Updating** \
+ * **Failed** \
+ * **Succeeded** \
+ * **Deleting** \
+ * **Migrating**
+ */
+export type GalleryPropertiesProvisioningState = string;
+
+/**
+ * Known values of {@link GalleryImagePropertiesProvisioningState} that the service accepts.
+ */
+export const enum KnownGalleryImagePropertiesProvisioningState {
+  Creating = "Creating",
+  Updating = "Updating",
+  Failed = "Failed",
+  Succeeded = "Succeeded",
+  Deleting = "Deleting",
+  Migrating = "Migrating"
+}
+
+/**
+ * Defines values for GalleryImagePropertiesProvisioningState. \
+ * {@link KnownGalleryImagePropertiesProvisioningState} can be used interchangeably with GalleryImagePropertiesProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Updating** \
+ * **Failed** \
+ * **Succeeded** \
+ * **Deleting** \
+ * **Migrating**
+ */
+export type GalleryImagePropertiesProvisioningState = string;
+
+/**
+ * Known values of {@link StorageAccountType} that the service accepts.
+ */
+export const enum KnownStorageAccountType {
+  StandardLRS = "Standard_LRS",
+  StandardZRS = "Standard_ZRS",
+  PremiumLRS = "Premium_LRS"
+}
+
+/**
+ * Defines values for StorageAccountType. \
+ * {@link KnownStorageAccountType} can be used interchangeably with StorageAccountType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_LRS** \
+ * **Standard_ZRS** \
+ * **Premium_LRS**
+ */
+export type StorageAccountType = string;
+
+/**
+ * Known values of {@link GalleryImageVersionPropertiesProvisioningState} that the service accepts.
+ */
+export const enum KnownGalleryImageVersionPropertiesProvisioningState {
+  Creating = "Creating",
+  Updating = "Updating",
+  Failed = "Failed",
+  Succeeded = "Succeeded",
+  Deleting = "Deleting",
+  Migrating = "Migrating"
+}
+
+/**
+ * Defines values for GalleryImageVersionPropertiesProvisioningState. \
+ * {@link KnownGalleryImageVersionPropertiesProvisioningState} can be used interchangeably with GalleryImageVersionPropertiesProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Updating** \
+ * **Failed** \
+ * **Succeeded** \
+ * **Deleting** \
+ * **Migrating**
+ */
+export type GalleryImageVersionPropertiesProvisioningState = string;
+
+/**
+ * Known values of {@link AggregatedReplicationState} that the service accepts.
+ */
+export const enum KnownAggregatedReplicationState {
+  Unknown = "Unknown",
+  InProgress = "InProgress",
+  Completed = "Completed",
+  Failed = "Failed"
+}
+
+/**
+ * Defines values for AggregatedReplicationState. \
+ * {@link KnownAggregatedReplicationState} can be used interchangeably with AggregatedReplicationState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **InProgress** \
+ * **Completed** \
+ * **Failed**
+ */
+export type AggregatedReplicationState = string;
+
+/**
+ * Known values of {@link ReplicationState} that the service accepts.
+ */
+export const enum KnownReplicationState {
+  Unknown = "Unknown",
+  Replicating = "Replicating",
+  Completed = "Completed",
+  Failed = "Failed"
+}
+
+/**
+ * Defines values for ReplicationState. \
+ * {@link KnownReplicationState} can be used interchangeably with ReplicationState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Replicating** \
+ * **Completed** \
+ * **Failed**
+ */
+export type ReplicationState = string;
+
+/**
+ * Known values of {@link ReplicationStatusTypes} that the service accepts.
+ */
+export const enum KnownReplicationStatusTypes {
+  ReplicationStatus = "ReplicationStatus"
+}
+
+/**
+ * Defines values for ReplicationStatusTypes. \
+ * {@link KnownReplicationStatusTypes} can be used interchangeably with ReplicationStatusTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ReplicationStatus**
+ */
+export type ReplicationStatusTypes = string;
+
+/**
+ * Known values of {@link GalleryApplicationVersionPropertiesProvisioningState} that the service accepts.
+ */
+export const enum KnownGalleryApplicationVersionPropertiesProvisioningState {
+  Creating = "Creating",
+  Updating = "Updating",
+  Failed = "Failed",
+  Succeeded = "Succeeded",
+  Deleting = "Deleting",
+  Migrating = "Migrating"
+}
+
+/**
+ * Defines values for GalleryApplicationVersionPropertiesProvisioningState. \
+ * {@link KnownGalleryApplicationVersionPropertiesProvisioningState} can be used interchangeably with GalleryApplicationVersionPropertiesProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Updating** \
+ * **Failed** \
+ * **Succeeded** \
+ * **Deleting** \
+ * **Migrating**
+ */
+export type GalleryApplicationVersionPropertiesProvisioningState = string;
+
+/**
+ * Known values of {@link Enum31} that the service accepts.
+ */
+export const enum KnownEnum31 {
+  One = 1,
+  Three = 3,
+  Five = 5
+}
+
+/**
+ * Defines values for Enum31. \
+ * {@link KnownEnum31} can be used interchangeably with Enum31,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **1** \
+ * **3** \
+ * **5**
+ */
+export type Enum31 = number;
+
+/**
+ * Known values of {@link ContainerServiceVMSizeTypes} that the service accepts.
+ */
+export const enum KnownContainerServiceVMSizeTypes {
+  StandardA0 = "Standard_A0",
+  StandardA1 = "Standard_A1",
+  StandardA2 = "Standard_A2",
+  StandardA3 = "Standard_A3",
+  StandardA4 = "Standard_A4",
+  StandardA5 = "Standard_A5",
+  StandardA6 = "Standard_A6",
+  StandardA7 = "Standard_A7",
+  StandardA8 = "Standard_A8",
+  StandardA9 = "Standard_A9",
+  StandardA10 = "Standard_A10",
+  StandardA11 = "Standard_A11",
+  StandardD1 = "Standard_D1",
+  StandardD2 = "Standard_D2",
+  StandardD3 = "Standard_D3",
+  StandardD4 = "Standard_D4",
+  StandardD11 = "Standard_D11",
+  StandardD12 = "Standard_D12",
+  StandardD13 = "Standard_D13",
+  StandardD14 = "Standard_D14",
+  StandardD1V2 = "Standard_D1_v2",
+  StandardD2V2 = "Standard_D2_v2",
+  StandardD3V2 = "Standard_D3_v2",
+  StandardD4V2 = "Standard_D4_v2",
+  StandardD5V2 = "Standard_D5_v2",
+  StandardD11V2 = "Standard_D11_v2",
+  StandardD12V2 = "Standard_D12_v2",
+  StandardD13V2 = "Standard_D13_v2",
+  StandardD14V2 = "Standard_D14_v2",
+  StandardG1 = "Standard_G1",
+  StandardG2 = "Standard_G2",
+  StandardG3 = "Standard_G3",
+  StandardG4 = "Standard_G4",
+  StandardG5 = "Standard_G5",
+  StandardDS1 = "Standard_DS1",
+  StandardDS2 = "Standard_DS2",
+  StandardDS3 = "Standard_DS3",
+  StandardDS4 = "Standard_DS4",
+  StandardDS11 = "Standard_DS11",
+  StandardDS12 = "Standard_DS12",
+  StandardDS13 = "Standard_DS13",
+  StandardDS14 = "Standard_DS14",
+  StandardGS1 = "Standard_GS1",
+  StandardGS2 = "Standard_GS2",
+  StandardGS3 = "Standard_GS3",
+  StandardGS4 = "Standard_GS4",
+  StandardGS5 = "Standard_GS5"
+}
+
+/**
+ * Defines values for ContainerServiceVMSizeTypes. \
+ * {@link KnownContainerServiceVMSizeTypes} can be used interchangeably with ContainerServiceVMSizeTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_A0** \
+ * **Standard_A1** \
+ * **Standard_A2** \
+ * **Standard_A3** \
+ * **Standard_A4** \
+ * **Standard_A5** \
+ * **Standard_A6** \
+ * **Standard_A7** \
+ * **Standard_A8** \
+ * **Standard_A9** \
+ * **Standard_A10** \
+ * **Standard_A11** \
+ * **Standard_D1** \
+ * **Standard_D2** \
+ * **Standard_D3** \
+ * **Standard_D4** \
+ * **Standard_D11** \
+ * **Standard_D12** \
+ * **Standard_D13** \
+ * **Standard_D14** \
+ * **Standard_D1_v2** \
+ * **Standard_D2_v2** \
+ * **Standard_D3_v2** \
+ * **Standard_D4_v2** \
+ * **Standard_D5_v2** \
+ * **Standard_D11_v2** \
+ * **Standard_D12_v2** \
+ * **Standard_D13_v2** \
+ * **Standard_D14_v2** \
+ * **Standard_G1** \
+ * **Standard_G2** \
+ * **Standard_G3** \
+ * **Standard_G4** \
+ * **Standard_G5** \
+ * **Standard_DS1** \
+ * **Standard_DS2** \
+ * **Standard_DS3** \
+ * **Standard_DS4** \
+ * **Standard_DS11** \
+ * **Standard_DS12** \
+ * **Standard_DS13** \
+ * **Standard_DS14** \
+ * **Standard_GS1** \
+ * **Standard_GS2** \
+ * **Standard_GS3** \
+ * **Standard_GS4** \
+ * **Standard_GS5**
+ */
+export type ContainerServiceVMSizeTypes = string;
+
+/**
+ * Known values of {@link AvailabilitySetSkuTypes} that the service accepts.
+ */
+export const enum KnownAvailabilitySetSkuTypes {
+  Classic = "Classic",
+  Aligned = "Aligned"
+}
+
+/**
+ * Defines values for AvailabilitySetSkuTypes. \
+ * {@link KnownAvailabilitySetSkuTypes} can be used interchangeably with AvailabilitySetSkuTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Classic** \
+ * **Aligned**
+ */
+export type AvailabilitySetSkuTypes = string;
 /**
  * Defines values for StatusLevelTypes.
  */

--- a/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.json
+++ b/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.json
@@ -18,7 +18,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!AccessLevel:type",
-          "docComment": "/**\n * Defines values for AccessLevel.\n */\n",
+          "docComment": "/**\n * Defines values for AccessLevel. \\ {@link KnownAccessLevel} can be used interchangeably with AccessLevel, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **Read** \\ **Write**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -26,7 +26,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"Read\" | \"Write\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -242,7 +242,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!AggregatedReplicationState:type",
-          "docComment": "/**\n * Defines values for AggregatedReplicationState.\n */\n",
+          "docComment": "/**\n * Defines values for AggregatedReplicationState. \\ {@link KnownAggregatedReplicationState} can be used interchangeably with AggregatedReplicationState, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **InProgress** \\ **Completed** \\ **Failed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -250,7 +250,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"InProgress\" | \"Completed\" | \"Failed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -952,7 +952,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!AvailabilitySetSkuTypes:type",
-          "docComment": "/**\n * Defines values for AvailabilitySetSkuTypes.\n */\n",
+          "docComment": "/**\n * Defines values for AvailabilitySetSkuTypes. \\ {@link KnownAvailabilitySetSkuTypes} can be used interchangeably with AvailabilitySetSkuTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Classic** \\ **Aligned**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -960,7 +960,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Classic\" | \"Aligned\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4366,7 +4366,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!ContainerServiceVMSizeTypes:type",
-          "docComment": "/**\n * Defines values for ContainerServiceVMSizeTypes.\n */\n",
+          "docComment": "/**\n * Defines values for ContainerServiceVMSizeTypes. \\ {@link KnownContainerServiceVMSizeTypes} can be used interchangeably with ContainerServiceVMSizeTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_A0** \\ **Standard_A1** \\ **Standard_A2** \\ **Standard_A3** \\ **Standard_A4** \\ **Standard_A5** \\ **Standard_A6** \\ **Standard_A7** \\ **Standard_A8** \\ **Standard_A9** \\ **Standard_A10** \\ **Standard_A11** \\ **Standard_D1** \\ **Standard_D2** \\ **Standard_D3** \\ **Standard_D4** \\ **Standard_D11** \\ **Standard_D12** \\ **Standard_D13** \\ **Standard_D14** \\ **Standard_D1_v2** \\ **Standard_D2_v2** \\ **Standard_D3_v2** \\ **Standard_D4_v2** \\ **Standard_D5_v2** \\ **Standard_D11_v2** \\ **Standard_D12_v2** \\ **Standard_D13_v2** \\ **Standard_D14_v2** \\ **Standard_G1** \\ **Standard_G2** \\ **Standard_G3** \\ **Standard_G4** \\ **Standard_G5** \\ **Standard_DS1** \\ **Standard_DS2** \\ **Standard_DS3** \\ **Standard_DS4** \\ **Standard_DS11** \\ **Standard_DS12** \\ **Standard_DS13** \\ **Standard_DS14** \\ **Standard_GS1** \\ **Standard_GS2** \\ **Standard_GS3** \\ **Standard_GS4** \\ **Standard_GS5**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4374,7 +4374,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_A0\" | \"Standard_A1\" | \"Standard_A2\" | \"Standard_A3\" | \"Standard_A4\" | \"Standard_A5\" | \"Standard_A6\" | \"Standard_A7\" | \"Standard_A8\" | \"Standard_A9\" | \"Standard_A10\" | \"Standard_A11\" | \"Standard_D1\" | \"Standard_D2\" | \"Standard_D3\" | \"Standard_D4\" | \"Standard_D11\" | \"Standard_D12\" | \"Standard_D13\" | \"Standard_D14\" | \"Standard_D1_v2\" | \"Standard_D2_v2\" | \"Standard_D3_v2\" | \"Standard_D4_v2\" | \"Standard_D5_v2\" | \"Standard_D11_v2\" | \"Standard_D12_v2\" | \"Standard_D13_v2\" | \"Standard_D14_v2\" | \"Standard_G1\" | \"Standard_G2\" | \"Standard_G3\" | \"Standard_G4\" | \"Standard_G5\" | \"Standard_DS1\" | \"Standard_DS2\" | \"Standard_DS3\" | \"Standard_DS4\" | \"Standard_DS11\" | \"Standard_DS12\" | \"Standard_DS13\" | \"Standard_DS14\" | \"Standard_GS1\" | \"Standard_GS2\" | \"Standard_GS3\" | \"Standard_GS4\" | \"Standard_GS5\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6317,7 +6317,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiffDiskOptions:type",
-          "docComment": "/**\n * Defines values for DiffDiskOptions.\n */\n",
+          "docComment": "/**\n * Defines values for DiffDiskOptions. \\ {@link KnownDiffDiskOptions} can be used interchangeably with DiffDiskOptions, this enum contains the known values that the service supports. ### Know values supported by the service **Local**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6325,7 +6325,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Local\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6342,7 +6342,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiffDiskPlacement:type",
-          "docComment": "/**\n * Defines values for DiffDiskPlacement.\n */\n",
+          "docComment": "/**\n * Defines values for DiffDiskPlacement. \\ {@link KnownDiffDiskPlacement} can be used interchangeably with DiffDiskPlacement, this enum contains the known values that the service supports. ### Know values supported by the service **CacheDisk** \\ **ResourceDisk**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6350,7 +6350,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"CacheDisk\" | \"ResourceDisk\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6587,7 +6587,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiskCreateOption:type",
-          "docComment": "/**\n * Defines values for DiskCreateOption.\n */\n",
+          "docComment": "/**\n * Defines values for DiskCreateOption. \\ {@link KnownDiskCreateOption} can be used interchangeably with DiskCreateOption, this enum contains the known values that the service supports. ### Know values supported by the service **Empty**: Create an empty data disk of a size given by diskSizeGB. \\ **Attach**: Disk will be attached to a VM. \\ **FromImage**: Create a new disk from a platform image specified by the given imageReference or galleryImageReference. \\ **Import**: Create a disk by importing from a blob specified by a sourceUri in a storage account specified by storageAccountId. \\ **Copy**: Create a new disk or snapshot by copying from a disk or snapshot specified by the given sourceResourceId. \\ **Restore**: Create a new disk by copying from a backup recovery point. \\ **Upload**: Create a new disk by obtaining a write token and using it to directly upload the contents of the disk.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6595,7 +6595,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Empty\" | \"Attach\" | \"FromImage\" | \"Import\" | \"Copy\" | \"Restore\" | \"Upload\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6612,7 +6612,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiskCreateOptionTypes:type",
-          "docComment": "/**\n * Defines values for DiskCreateOptionTypes.\n */\n",
+          "docComment": "/**\n * Defines values for DiskCreateOptionTypes. \\ {@link KnownDiskCreateOptionTypes} can be used interchangeably with DiskCreateOptionTypes, this enum contains the known values that the service supports. ### Know values supported by the service **FromImage** \\ **Empty** \\ **Attach**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6620,7 +6620,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"FromImage\" | \"Empty\" | \"Attach\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6694,7 +6694,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiskEncryptionSetIdentityType:type",
-          "docComment": "/**\n * Defines values for DiskEncryptionSetIdentityType.\n */\n",
+          "docComment": "/**\n * Defines values for DiskEncryptionSetIdentityType. \\ {@link KnownDiskEncryptionSetIdentityType} can be used interchangeably with DiskEncryptionSetIdentityType, this enum contains the known values that the service supports. ### Know values supported by the service **SystemAssigned**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6702,7 +6702,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SystemAssigned\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8004,7 +8004,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiskState:type",
-          "docComment": "/**\n * Defines values for DiskState.\n */\n",
+          "docComment": "/**\n * Defines values for DiskState. \\ {@link KnownDiskState} can be used interchangeably with DiskState, this enum contains the known values that the service supports. ### Know values supported by the service **Unattached**: The disk is not being used and can be attached to a VM. \\ **Attached**: The disk is currently mounted to a running VM. \\ **Reserved**: The disk is mounted to a stopped-deallocated VM \\ **ActiveSAS**: The disk currently has an Active SAS Uri associated with it. \\ **ReadyToUpload**: A disk is ready to be created by upload by requesting a write token. \\ **ActiveUpload**: A disk is created for upload and a write token has been issued for uploading to it.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8012,7 +8012,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unattached\" | \"Attached\" | \"Reserved\" | \"ActiveSAS\" | \"ReadyToUpload\" | \"ActiveUpload\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8029,7 +8029,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!DiskStorageAccountTypes:type",
-          "docComment": "/**\n * Defines values for DiskStorageAccountTypes.\n */\n",
+          "docComment": "/**\n * Defines values for DiskStorageAccountTypes. \\ {@link KnownDiskStorageAccountTypes} can be used interchangeably with DiskStorageAccountTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_LRS**: Standard HDD locally redundant storage. Best for backup, non-critical, and infrequent access. \\ **Premium_LRS**: Premium SSD locally redundant storage. Best for production and performance sensitive workloads. \\ **StandardSSD_LRS**: Standard SSD locally redundant storage. Best for web servers, lightly used enterprise applications and dev/test. \\ **UltraSSD_LRS**: Ultra SSD locally redundant storage. Best for IO-intensive workloads such as SAP HANA, top tier databases (for example, SQL, Oracle), and other transaction-heavy workloads.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8037,7 +8037,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_LRS\" | \"Premium_LRS\" | \"StandardSSD_LRS\" | \"UltraSSD_LRS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8810,7 +8810,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!EncryptionType:type",
-          "docComment": "/**\n * Defines values for EncryptionType.\n */\n",
+          "docComment": "/**\n * Defines values for EncryptionType. \\ {@link KnownEncryptionType} can be used interchangeably with EncryptionType, this enum contains the known values that the service supports. ### Know values supported by the service **EncryptionAtRestWithPlatformKey**: Disk is encrypted with XStore managed key at rest. It is the default encryption type. \\ **EncryptionAtRestWithCustomerKey**: Disk is encrypted with Customer managed key at rest.\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8818,7 +8818,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"EncryptionAtRestWithPlatformKey\" | \"EncryptionAtRestWithCustomerKey\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8835,7 +8835,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!Enum31:type",
-          "docComment": "/**\n * Defines values for Enum31.\n */\n",
+          "docComment": "/**\n * Defines values for Enum31. \\ {@link KnownEnum31} can be used interchangeably with Enum31, this enum contains the known values that the service supports. ### Know values supported by the service **1** \\ **3** \\ **5**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8843,7 +8843,7 @@
             },
             {
               "kind": "Content",
-              "text": "1 | 3 | 5 | number"
+              "text": "number"
             },
             {
               "kind": "Content",
@@ -9851,7 +9851,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!GalleryApplicationVersionPropertiesProvisioningState:type",
-          "docComment": "/**\n * Defines values for GalleryApplicationVersionPropertiesProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for GalleryApplicationVersionPropertiesProvisioningState. \\ {@link KnownGalleryApplicationVersionPropertiesProvisioningState} can be used interchangeably with GalleryApplicationVersionPropertiesProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Updating** \\ **Failed** \\ **Succeeded** \\ **Deleting** \\ **Migrating**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9859,7 +9859,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Updating\" | \"Failed\" | \"Succeeded\" | \"Deleting\" | \"Migrating\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11002,7 +11002,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!GalleryImagePropertiesProvisioningState:type",
-          "docComment": "/**\n * Defines values for GalleryImagePropertiesProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for GalleryImagePropertiesProvisioningState. \\ {@link KnownGalleryImagePropertiesProvisioningState} can be used interchangeably with GalleryImagePropertiesProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Updating** \\ **Failed** \\ **Succeeded** \\ **Deleting** \\ **Migrating**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11010,7 +11010,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Updating\" | \"Failed\" | \"Succeeded\" | \"Deleting\" | \"Migrating\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11551,7 +11551,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!GalleryImageVersionPropertiesProvisioningState:type",
-          "docComment": "/**\n * Defines values for GalleryImageVersionPropertiesProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for GalleryImageVersionPropertiesProvisioningState. \\ {@link KnownGalleryImageVersionPropertiesProvisioningState} can be used interchangeably with GalleryImageVersionPropertiesProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Updating** \\ **Failed** \\ **Succeeded** \\ **Deleting** \\ **Migrating**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11559,7 +11559,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Updating\" | \"Failed\" | \"Succeeded\" | \"Deleting\" | \"Migrating\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12207,7 +12207,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!GalleryPropertiesProvisioningState:type",
-          "docComment": "/**\n * Defines values for GalleryPropertiesProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for GalleryPropertiesProvisioningState. \\ {@link KnownGalleryPropertiesProvisioningState} can be used interchangeably with GalleryPropertiesProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Updating** \\ **Failed** \\ **Succeeded** \\ **Deleting** \\ **Migrating**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12215,7 +12215,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Updating\" | \"Failed\" | \"Succeeded\" | \"Deleting\" | \"Migrating\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12414,7 +12414,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!HyperVGeneration:type",
-          "docComment": "/**\n * Defines values for HyperVGeneration.\n */\n",
+          "docComment": "/**\n * Defines values for HyperVGeneration. \\ {@link KnownHyperVGeneration} can be used interchangeably with HyperVGeneration, this enum contains the known values that the service supports. ### Know values supported by the service **V1** \\ **V2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12422,7 +12422,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"V1\" | \"V2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12439,7 +12439,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!HyperVGenerationType:type",
-          "docComment": "/**\n * Defines values for HyperVGenerationType.\n */\n",
+          "docComment": "/**\n * Defines values for HyperVGenerationType. \\ {@link KnownHyperVGenerationType} can be used interchangeably with HyperVGenerationType, this enum contains the known values that the service supports. ### Know values supported by the service **V1** \\ **V2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12447,7 +12447,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"V1\" | \"V2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12464,7 +12464,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!HyperVGenerationTypes:type",
-          "docComment": "/**\n * Defines values for HyperVGenerationTypes.\n */\n",
+          "docComment": "/**\n * Defines values for HyperVGenerationTypes. \\ {@link KnownHyperVGenerationTypes} can be used interchangeably with HyperVGenerationTypes, this enum contains the known values that the service supports. ### Know values supported by the service **V1** \\ **V2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12472,7 +12472,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"V1\" | \"V2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -13897,7 +13897,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!IPVersion:type",
-          "docComment": "/**\n * Defines values for IPVersion.\n */\n",
+          "docComment": "/**\n * Defines values for IPVersion. \\ {@link KnownIPVersion} can be used interchangeably with IPVersion, this enum contains the known values that the service supports. ### Know values supported by the service **IPv4** \\ **IPv6**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -13905,7 +13905,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IPv4\" | \"IPv6\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -14186,6 +14186,7110 @@
             }
           ],
           "extendsTokenRanges": []
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownAccessLevel:enum",
+          "docComment": "/**\n * Known values of {@link AccessLevel} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAccessLevel "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAccessLevel",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAccessLevel.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAccessLevel.Read:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Read = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Read\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Read",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAccessLevel.Write:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Write = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Write\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Write",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownAggregatedReplicationState:enum",
+          "docComment": "/**\n * Known values of {@link AggregatedReplicationState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAggregatedReplicationState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAggregatedReplicationState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAggregatedReplicationState.Completed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Completed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Completed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Completed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAggregatedReplicationState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAggregatedReplicationState.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAggregatedReplicationState.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownAvailabilitySetSkuTypes:enum",
+          "docComment": "/**\n * Known values of {@link AvailabilitySetSkuTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAvailabilitySetSkuTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAvailabilitySetSkuTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAvailabilitySetSkuTypes.Aligned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Aligned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Aligned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Aligned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownAvailabilitySetSkuTypes.Classic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Classic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Classic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Classic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes:enum",
+          "docComment": "/**\n * Known values of {@link ContainerServiceVMSizeTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownContainerServiceVMSizeTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownContainerServiceVMSizeTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA0:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA0 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA0",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA10:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA10 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A10\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA10",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA7:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA7 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A7\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA7",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA8:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA8 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A8\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA8",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardA9:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA9 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A9\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA9",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD11V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD11V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D11_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD11V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD12V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD12V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D12_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD12V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD13:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD13 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D13\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD13",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD13V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD13V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D13_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD13V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD14:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD14 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D14\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD14",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD14V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD14V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D14_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD14V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD1V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD1V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D1_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD1V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD2V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD2V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D2_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD2V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD3V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD3V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D3_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD3V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD4V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD4V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D4_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD4V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardD5V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD5V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D5_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD5V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS13:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS13 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS13\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS13",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS14:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS14 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS14\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS14",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardDS4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardG1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardG2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardG3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardG4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardG5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardGS1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardGS2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardGS3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardGS4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownContainerServiceVMSizeTypes.StandardGS5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiffDiskOptions:enum",
+          "docComment": "/**\n * Known values of {@link DiffDiskOptions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiffDiskOptions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiffDiskOptions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiffDiskOptions.Local:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Local = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Local\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Local",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiffDiskPlacement:enum",
+          "docComment": "/**\n * Known values of {@link DiffDiskPlacement} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiffDiskPlacement "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiffDiskPlacement",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiffDiskPlacement.CacheDisk:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CacheDisk = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CacheDisk\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CacheDisk",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiffDiskPlacement.ResourceDisk:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ResourceDisk = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ResourceDisk\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ResourceDisk",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiskCreateOption:enum",
+          "docComment": "/**\n * Known values of {@link DiskCreateOption} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiskCreateOption "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiskCreateOption",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.Attach:member",
+              "docComment": "/**\n * Disk will be attached to a VM.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Attach = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Attach\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Attach",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.Copy:member",
+              "docComment": "/**\n * Create a new disk or snapshot by copying from a disk or snapshot specified by the given sourceResourceId.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Copy = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Copy\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Copy",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.Empty:member",
+              "docComment": "/**\n * Create an empty data disk of a size given by diskSizeGB.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Empty = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Empty\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Empty",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.FromImage:member",
+              "docComment": "/**\n * Create a new disk from a platform image specified by the given imageReference or galleryImageReference.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FromImage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FromImage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FromImage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.Import:member",
+              "docComment": "/**\n * Create a disk by importing from a blob specified by a sourceUri in a storage account specified by storageAccountId.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Import = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Import\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Import",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.Restore:member",
+              "docComment": "/**\n * Create a new disk by copying from a backup recovery point.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Restore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOption.Upload:member",
+              "docComment": "/**\n * Create a new disk by obtaining a write token and using it to directly upload the contents of the disk.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Upload = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Upload\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Upload",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiskCreateOptionTypes:enum",
+          "docComment": "/**\n * Known values of {@link DiskCreateOptionTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiskCreateOptionTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiskCreateOptionTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOptionTypes.Attach:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Attach = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Attach\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Attach",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOptionTypes.Empty:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Empty = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Empty\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Empty",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskCreateOptionTypes.FromImage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FromImage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FromImage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FromImage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiskEncryptionSetIdentityType:enum",
+          "docComment": "/**\n * Known values of {@link DiskEncryptionSetIdentityType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiskEncryptionSetIdentityType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiskEncryptionSetIdentityType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskEncryptionSetIdentityType.SystemAssigned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SystemAssigned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SystemAssigned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SystemAssigned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiskState:enum",
+          "docComment": "/**\n * Known values of {@link DiskState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiskState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiskState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskState.ActiveSAS:member",
+              "docComment": "/**\n * The disk currently has an Active SAS Uri associated with it.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ActiveSAS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ActiveSAS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ActiveSAS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskState.ActiveUpload:member",
+              "docComment": "/**\n * A disk is created for upload and a write token has been issued for uploading to it.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ActiveUpload = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ActiveUpload\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ActiveUpload",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskState.Attached:member",
+              "docComment": "/**\n * The disk is currently mounted to a running VM.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Attached = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Attached\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Attached",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskState.ReadyToUpload:member",
+              "docComment": "/**\n * A disk is ready to be created by upload by requesting a write token.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ReadyToUpload = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ReadyToUpload\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ReadyToUpload",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskState.Reserved:member",
+              "docComment": "/**\n * The disk is mounted to a stopped-deallocated VM\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Reserved = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Reserved\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Reserved",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskState.Unattached:member",
+              "docComment": "/**\n * The disk is not being used and can be attached to a VM.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unattached = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unattached\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unattached",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownDiskStorageAccountTypes:enum",
+          "docComment": "/**\n * Known values of {@link DiskStorageAccountTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDiskStorageAccountTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDiskStorageAccountTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskStorageAccountTypes.PremiumLRS:member",
+              "docComment": "/**\n * Premium SSD locally redundant storage. Best for production and performance sensitive workloads.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskStorageAccountTypes.StandardLRS:member",
+              "docComment": "/**\n * Standard HDD locally redundant storage. Best for backup, non-critical, and infrequent access.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskStorageAccountTypes.StandardSSDLRS:member",
+              "docComment": "/**\n * Standard SSD locally redundant storage. Best for web servers, lightly used enterprise applications and dev/test.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardSSDLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"StandardSSD_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardSSDLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownDiskStorageAccountTypes.UltraSSDLRS:member",
+              "docComment": "/**\n * Ultra SSD locally redundant storage. Best for IO-intensive workloads such as SAP HANA, top tier databases (for example, SQL, Oracle), and other transaction-heavy workloads.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UltraSSDLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UltraSSD_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UltraSSDLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownEncryptionType:enum",
+          "docComment": "/**\n * Known values of {@link EncryptionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEncryptionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEncryptionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownEncryptionType.EncryptionAtRestWithCustomerKey:member",
+              "docComment": "/**\n * Disk is encrypted with Customer managed key at rest.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EncryptionAtRestWithCustomerKey = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EncryptionAtRestWithCustomerKey\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EncryptionAtRestWithCustomerKey",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownEncryptionType.EncryptionAtRestWithPlatformKey:member",
+              "docComment": "/**\n * Disk is encrypted with XStore managed key at rest. It is the default encryption type.\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EncryptionAtRestWithPlatformKey = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EncryptionAtRestWithPlatformKey\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EncryptionAtRestWithPlatformKey",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownEnum31:enum",
+          "docComment": "/**\n * Known values of {@link Enum31} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEnum31 "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEnum31",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownEnum31.Five:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Five = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "5"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Five",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownEnum31.One:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "One = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "1"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "One",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownEnum31.Three:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Three = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "3"
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Three",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link GalleryApplicationVersionPropertiesProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGalleryApplicationVersionPropertiesProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGalleryApplicationVersionPropertiesProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState.Migrating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Migrating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Migrating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Migrating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryApplicationVersionPropertiesProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link GalleryImagePropertiesProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGalleryImagePropertiesProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGalleryImagePropertiesProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState.Migrating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Migrating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Migrating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Migrating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImagePropertiesProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link GalleryImageVersionPropertiesProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGalleryImageVersionPropertiesProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGalleryImageVersionPropertiesProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState.Migrating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Migrating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Migrating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Migrating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryImageVersionPropertiesProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link GalleryPropertiesProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGalleryPropertiesProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGalleryPropertiesProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState.Migrating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Migrating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Migrating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Migrating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownGalleryPropertiesProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownHyperVGeneration:enum",
+          "docComment": "/**\n * Known values of {@link HyperVGeneration} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownHyperVGeneration "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownHyperVGeneration",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownHyperVGeneration.V1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "V1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"V1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "V1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownHyperVGeneration.V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"V2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownHyperVGenerationType:enum",
+          "docComment": "/**\n * Known values of {@link HyperVGenerationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownHyperVGenerationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownHyperVGenerationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownHyperVGenerationType.V1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "V1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"V1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "V1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownHyperVGenerationType.V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"V2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownHyperVGenerationTypes:enum",
+          "docComment": "/**\n * Known values of {@link HyperVGenerationTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownHyperVGenerationTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownHyperVGenerationTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownHyperVGenerationTypes.V1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "V1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"V1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "V1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownHyperVGenerationTypes.V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"V2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownIPVersion:enum",
+          "docComment": "/**\n * Known values of {@link IPVersion} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIPVersion "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIPVersion",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownIPVersion.IPv4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPv4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPv4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPv4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownIPVersion.IPv6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPv6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPv6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPv6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceNames:enum",
+          "docComment": "/**\n * Known values of {@link OrchestrationServiceNames} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOrchestrationServiceNames "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOrchestrationServiceNames",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceNames.AutomaticRepairs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AutomaticRepairs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AutomaticRepairs\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AutomaticRepairs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceState:enum",
+          "docComment": "/**\n * Known values of {@link OrchestrationServiceState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOrchestrationServiceState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOrchestrationServiceState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceState.NotRunning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotRunning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotRunning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotRunning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceState.Running:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Running = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Running\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Running",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceState.Suspended:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Suspended = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Suspended\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Suspended",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceStateAction:enum",
+          "docComment": "/**\n * Known values of {@link OrchestrationServiceStateAction} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOrchestrationServiceStateAction "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOrchestrationServiceStateAction",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceStateAction.Resume:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Resume = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Resume\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Resume",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownOrchestrationServiceStateAction.Suspend:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Suspend = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Suspend\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Suspend",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownProximityPlacementGroupType:enum",
+          "docComment": "/**\n * Known values of {@link ProximityPlacementGroupType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProximityPlacementGroupType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProximityPlacementGroupType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownProximityPlacementGroupType.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownProximityPlacementGroupType.Ultra:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ultra = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ultra\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ultra",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownReplicationState:enum",
+          "docComment": "/**\n * Known values of {@link ReplicationState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReplicationState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReplicationState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownReplicationState.Completed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Completed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Completed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Completed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownReplicationState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownReplicationState.Replicating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Replicating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Replicating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Replicating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownReplicationState.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownReplicationStatusTypes:enum",
+          "docComment": "/**\n * Known values of {@link ReplicationStatusTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReplicationStatusTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReplicationStatusTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownReplicationStatusTypes.ReplicationStatus:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ReplicationStatus = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ReplicationStatus\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ReplicationStatus",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownSnapshotStorageAccountTypes:enum",
+          "docComment": "/**\n * Known values of {@link SnapshotStorageAccountTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSnapshotStorageAccountTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSnapshotStorageAccountTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownSnapshotStorageAccountTypes.PremiumLRS:member",
+              "docComment": "/**\n * Premium SSD locally redundant storage\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownSnapshotStorageAccountTypes.StandardLRS:member",
+              "docComment": "/**\n * Standard HDD locally redundant storage\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownSnapshotStorageAccountTypes.StandardZRS:member",
+              "docComment": "/**\n * Standard zone redundant storage\n */\n",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardZRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardZRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownStorageAccountType:enum",
+          "docComment": "/**\n * Known values of {@link StorageAccountType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownStorageAccountType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownStorageAccountType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountType.PremiumLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountType.StandardLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountType.StandardZRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardZRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardZRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownStorageAccountTypes:enum",
+          "docComment": "/**\n * Known values of {@link StorageAccountTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownStorageAccountTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownStorageAccountTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountTypes.PremiumLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountTypes.StandardLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountTypes.StandardSSDLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardSSDLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"StandardSSD_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardSSDLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownStorageAccountTypes.UltraSSDLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UltraSSDLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UltraSSD_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UltraSSDLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownVirtualMachineEvictionPolicyTypes:enum",
+          "docComment": "/**\n * Known values of {@link VirtualMachineEvictionPolicyTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualMachineEvictionPolicyTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualMachineEvictionPolicyTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineEvictionPolicyTypes.Deallocate:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deallocate = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deallocate\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deallocate",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineEvictionPolicyTypes.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Delete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownVirtualMachinePriorityTypes:enum",
+          "docComment": "/**\n * Known values of {@link VirtualMachinePriorityTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualMachinePriorityTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualMachinePriorityTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachinePriorityTypes.Low:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Low = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Low\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Low",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachinePriorityTypes.Regular:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Regular = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Regular\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Regular",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachinePriorityTypes.Spot:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Spot = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Spot\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Spot",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownVirtualMachineScaleSetScaleInRules:enum",
+          "docComment": "/**\n * Known values of {@link VirtualMachineScaleSetScaleInRules} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualMachineScaleSetScaleInRules "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualMachineScaleSetScaleInRules",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineScaleSetScaleInRules.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineScaleSetScaleInRules.NewestVM:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NewestVM = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NewestVM\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NewestVM",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineScaleSetScaleInRules.OldestVM:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OldestVM = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OldestVM\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OldestVM",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes:enum",
+          "docComment": "/**\n * Known values of {@link VirtualMachineSizeTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualMachineSizeTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualMachineSizeTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.BasicA0:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasicA0 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic_A0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasicA0",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.BasicA1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasicA1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic_A1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasicA1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.BasicA2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasicA2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic_A2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasicA2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.BasicA3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasicA3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic_A3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasicA3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.BasicA4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasicA4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic_A4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasicA4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA0:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA0 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA0",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA10:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA10 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A10\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA10",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA1V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA1V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A1_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA1V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA2MV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA2MV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A2m_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA2MV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA2V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA2V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A2_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA2V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA4MV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA4MV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A4m_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA4MV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA4V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA4V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A4_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA4V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA7:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA7 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A7\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA7",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA8:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA8 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A8\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA8",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA8MV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA8MV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A8m_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA8MV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA8V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA8V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A8_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA8V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardA9:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardA9 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_A9\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardA9",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardB1Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardB1Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_B1ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardB1Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardB1S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardB1S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_B1s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardB1S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardB2Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardB2Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_B2ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardB2Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardB2S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardB2S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_B2s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardB2S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardB4Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardB4Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_B4ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardB4Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardB8Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardB8Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_B8ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardB8Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD11V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD11V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D11_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD11V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD12V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD12V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D12_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD12V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD13:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD13 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D13\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD13",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD13V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD13V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D13_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD13V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD14:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD14 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D14\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD14",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD14V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD14V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D14_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD14V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD15V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD15V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D15_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD15V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD16SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD16SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D16s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD16SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD16V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD16V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D16_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD16V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD1V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD1V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D1_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD1V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD2SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD2SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D2s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD2SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD2V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD2V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D2_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD2V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD2V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD2V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D2_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD2V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD32SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD32SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D32s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD32SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD32V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD32V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D32_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD32V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD3V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD3V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D3_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD3V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD4SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD4SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D4s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD4SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD4V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD4V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D4_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD4V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD4V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD4V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D4_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD4V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD5V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD5V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D5_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD5V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD64SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD64SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D64s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD64SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD64V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD64V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D64_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD64V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD8SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD8SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D8s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD8SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardD8V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardD8V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_D8_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardD8V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS11V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS11V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS11_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS11V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS12V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS12V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS12_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS12V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS13:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS13 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS13\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS13",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS132V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS132V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS13-2_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS132V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS134V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS134V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS13-4_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS134V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS13V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS13V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS13_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS13V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS14:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS14 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS14\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS14",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS144V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS144V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS14-4_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS144V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS148V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS148V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS14-8_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS148V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS14V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS14V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS14_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS14V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS15V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS15V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS15_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS15V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS1V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS1V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS1_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS1V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS2V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS2V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS2_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS2V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS3V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS3V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS3_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS3V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS4V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS4V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS4_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS4V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardDS5V2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardDS5V2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_DS5_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardDS5V2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE16SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE16SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E16s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE16SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE16V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE16V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E16_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE16V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE2SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE2SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E2s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE2SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE2V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE2V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E2_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE2V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE3216V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE3216V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E32-16_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE3216V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE328SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE328SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E32-8s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE328SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE32SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE32SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E32s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE32SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE32V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE32V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E32_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE32V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE4SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE4SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E4s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE4SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE4V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE4V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E4_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE4V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE6416SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE6416SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E64-16s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE6416SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE6432SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE6432SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E64-32s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE6432SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE64SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE64SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E64s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE64SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE64V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE64V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E64_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE64V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE8SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE8SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E8s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE8SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardE8V3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardE8V3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_E8_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardE8V3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF16:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF16 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F16\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF16",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF16S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF16S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F16s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF16S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF16SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF16SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F16s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF16SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF1S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF1S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F1s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF1S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF2S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF2S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F2s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF2S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF2SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF2SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F2s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF2SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF32SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF32SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F32s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF32SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF4S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF4S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F4s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF4S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF4SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF4SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F4s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF4SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF64SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF64SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F64s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF64SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF72SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF72SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F72s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF72SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF8:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF8 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F8\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF8",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF8S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF8S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F8s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF8S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardF8SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardF8SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_F8s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardF8SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardG1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardG2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardG3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardG4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardG5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardG5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_G5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardG5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS44:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS44 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS4-4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS44",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS48:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS48 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS4-8\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS48",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS516:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS516 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS5-16\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS516",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardGS58:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGS58 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GS5-8\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGS58",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardH16:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardH16 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_H16\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardH16",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardH16M:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardH16M = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_H16m\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardH16M",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardH16Mr:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardH16Mr = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_H16mr\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardH16Mr",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardH16R:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardH16R = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_H16r\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardH16R",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardH8:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardH8 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_H8\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardH8",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardH8M:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardH8M = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_H8m\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardH8M",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardL16S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardL16S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_L16s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardL16S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardL32S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardL32S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_L32s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardL32S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardL4S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardL4S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_L4s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardL4S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardL8S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardL8S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_L8s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardL8S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM12832Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM12832Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M128-32ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM12832Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM12864Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM12864Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M128-64ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM12864Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM128Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM128Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M128ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM128Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM128S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM128S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M128s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM128S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM6416Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM6416Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M64-16ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM6416Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM6432Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM6432Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M64-32ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM6432Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM64Ms:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM64Ms = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M64ms\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM64Ms",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardM64S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardM64S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_M64s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardM64S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC12SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC12SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC12s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC12SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC12SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC12SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC12s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC12SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC24:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC24 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC24\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC24",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC24R:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC24R = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC24r\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC24R",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC24RsV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC24RsV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC24rs_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC24RsV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC24RsV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC24RsV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC24rs_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC24RsV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC24SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC24SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC24s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC24SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC24SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC24SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC24s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC24SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC6SV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC6SV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC6s_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC6SV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNC6SV3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNC6SV3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NC6s_v3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNC6SV3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardND12S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardND12S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ND12s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardND12S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardND24Rs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardND24Rs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ND24rs\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardND24Rs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardND24S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardND24S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ND24s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardND24S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardND6S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardND6S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ND6s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardND6S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNV12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNV12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NV12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNV12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNV24:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNV24 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NV24\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNV24",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "compute-resource-manager!KnownVirtualMachineSizeTypes.StandardNV6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardNV6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_NV6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardNV6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -15220,7 +22324,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!OrchestrationServiceNames:type",
-          "docComment": "/**\n * Defines values for OrchestrationServiceNames.\n */\n",
+          "docComment": "/**\n * Defines values for OrchestrationServiceNames. \\ {@link KnownOrchestrationServiceNames} can be used interchangeably with OrchestrationServiceNames, this enum contains the known values that the service supports. ### Know values supported by the service **AutomaticRepairs**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15228,7 +22332,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AutomaticRepairs\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15245,7 +22349,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!OrchestrationServiceState:type",
-          "docComment": "/**\n * Defines values for OrchestrationServiceState.\n */\n",
+          "docComment": "/**\n * Defines values for OrchestrationServiceState. \\ {@link KnownOrchestrationServiceState} can be used interchangeably with OrchestrationServiceState, this enum contains the known values that the service supports. ### Know values supported by the service **NotRunning** \\ **Running** \\ **Suspended**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15253,7 +22357,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotRunning\" | \"Running\" | \"Suspended\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15270,7 +22374,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!OrchestrationServiceStateAction:type",
-          "docComment": "/**\n * Defines values for OrchestrationServiceStateAction.\n */\n",
+          "docComment": "/**\n * Defines values for OrchestrationServiceStateAction. \\ {@link KnownOrchestrationServiceStateAction} can be used interchangeably with OrchestrationServiceStateAction, this enum contains the known values that the service supports. ### Know values supported by the service **Resume** \\ **Suspend**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15278,7 +22382,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Resume\" | \"Suspend\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -16732,7 +23836,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!ProximityPlacementGroupType:type",
-          "docComment": "/**\n * Defines values for ProximityPlacementGroupType.\n */\n",
+          "docComment": "/**\n * Defines values for ProximityPlacementGroupType. \\ {@link KnownProximityPlacementGroupType} can be used interchangeably with ProximityPlacementGroupType, this enum contains the known values that the service supports. ### Know values supported by the service **Standard** \\ **Ultra**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -16740,7 +23844,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard\" | \"Ultra\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -17129,7 +24233,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!ReplicationState:type",
-          "docComment": "/**\n * Defines values for ReplicationState.\n */\n",
+          "docComment": "/**\n * Defines values for ReplicationState. \\ {@link KnownReplicationState} can be used interchangeably with ReplicationState, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Replicating** \\ **Completed** \\ **Failed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -17137,7 +24241,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Replicating\" | \"Completed\" | \"Failed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -17226,7 +24330,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!ReplicationStatusTypes:type",
-          "docComment": "/**\n * Defines values for ReplicationStatusTypes.\n */\n",
+          "docComment": "/**\n * Defines values for ReplicationStatusTypes. \\ {@link KnownReplicationStatusTypes} can be used interchangeably with ReplicationStatusTypes, this enum contains the known values that the service supports. ### Know values supported by the service **ReplicationStatus**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -17234,7 +24338,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ReplicationStatus\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -20854,7 +27958,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!SnapshotStorageAccountTypes:type",
-          "docComment": "/**\n * Defines values for SnapshotStorageAccountTypes.\n */\n",
+          "docComment": "/**\n * Defines values for SnapshotStorageAccountTypes. \\ {@link KnownSnapshotStorageAccountTypes} can be used interchangeably with SnapshotStorageAccountTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_LRS**: Standard HDD locally redundant storage \\ **Premium_LRS**: Premium SSD locally redundant storage \\ **Standard_ZRS**: Standard zone redundant storage\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -20862,7 +27966,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_LRS\" | \"Premium_LRS\" | \"Standard_ZRS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -21899,7 +29003,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!StorageAccountType:type",
-          "docComment": "/**\n * Defines values for StorageAccountType.\n */\n",
+          "docComment": "/**\n * Defines values for StorageAccountType. \\ {@link KnownStorageAccountType} can be used interchangeably with StorageAccountType, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_LRS** \\ **Standard_ZRS** \\ **Premium_LRS**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21907,7 +29011,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_LRS\" | \"Standard_ZRS\" | \"Premium_LRS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -21924,7 +29028,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!StorageAccountTypes:type",
-          "docComment": "/**\n * Defines values for StorageAccountTypes.\n */\n",
+          "docComment": "/**\n * Defines values for StorageAccountTypes. \\ {@link KnownStorageAccountTypes} can be used interchangeably with StorageAccountTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_LRS** \\ **Premium_LRS** \\ **StandardSSD_LRS** \\ **UltraSSD_LRS**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21932,7 +29036,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_LRS\" | \"Premium_LRS\" | \"StandardSSD_LRS\" | \"UltraSSD_LRS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -23995,7 +31099,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!VirtualMachineEvictionPolicyTypes:type",
-          "docComment": "/**\n * Defines values for VirtualMachineEvictionPolicyTypes.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualMachineEvictionPolicyTypes. \\ {@link KnownVirtualMachineEvictionPolicyTypes} can be used interchangeably with VirtualMachineEvictionPolicyTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Deallocate** \\ **Delete**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -24003,7 +31107,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Deallocate\" | \"Delete\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -26060,7 +33164,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!VirtualMachinePriorityTypes:type",
-          "docComment": "/**\n * Defines values for VirtualMachinePriorityTypes.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualMachinePriorityTypes. \\ {@link KnownVirtualMachinePriorityTypes} can be used interchangeably with VirtualMachinePriorityTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Regular** \\ **Low** \\ **Spot**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -26068,7 +33172,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Regular\" | \"Low\" | \"Spot\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28885,7 +35989,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!VirtualMachineScaleSetScaleInRules:type",
-          "docComment": "/**\n * Defines values for VirtualMachineScaleSetScaleInRules.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualMachineScaleSetScaleInRules. \\ {@link KnownVirtualMachineScaleSetScaleInRules} can be used interchangeably with VirtualMachineScaleSetScaleInRules, this enum contains the known values that the service supports. ### Know values supported by the service **Default** \\ **OldestVM** \\ **NewestVM**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28893,7 +35997,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | \"OldestVM\" | \"NewestVM\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -34039,7 +41143,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "compute-resource-manager!VirtualMachineSizeTypes:type",
-          "docComment": "/**\n * Defines values for VirtualMachineSizeTypes.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualMachineSizeTypes. \\ {@link KnownVirtualMachineSizeTypes} can be used interchangeably with VirtualMachineSizeTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Basic_A0** \\ **Basic_A1** \\ **Basic_A2** \\ **Basic_A3** \\ **Basic_A4** \\ **Standard_A0** \\ **Standard_A1** \\ **Standard_A2** \\ **Standard_A3** \\ **Standard_A4** \\ **Standard_A5** \\ **Standard_A6** \\ **Standard_A7** \\ **Standard_A8** \\ **Standard_A9** \\ **Standard_A10** \\ **Standard_A11** \\ **Standard_A1_v2** \\ **Standard_A2_v2** \\ **Standard_A4_v2** \\ **Standard_A8_v2** \\ **Standard_A2m_v2** \\ **Standard_A4m_v2** \\ **Standard_A8m_v2** \\ **Standard_B1s** \\ **Standard_B1ms** \\ **Standard_B2s** \\ **Standard_B2ms** \\ **Standard_B4ms** \\ **Standard_B8ms** \\ **Standard_D1** \\ **Standard_D2** \\ **Standard_D3** \\ **Standard_D4** \\ **Standard_D11** \\ **Standard_D12** \\ **Standard_D13** \\ **Standard_D14** \\ **Standard_D1_v2** \\ **Standard_D2_v2** \\ **Standard_D3_v2** \\ **Standard_D4_v2** \\ **Standard_D5_v2** \\ **Standard_D2_v3** \\ **Standard_D4_v3** \\ **Standard_D8_v3** \\ **Standard_D16_v3** \\ **Standard_D32_v3** \\ **Standard_D64_v3** \\ **Standard_D2s_v3** \\ **Standard_D4s_v3** \\ **Standard_D8s_v3** \\ **Standard_D16s_v3** \\ **Standard_D32s_v3** \\ **Standard_D64s_v3** \\ **Standard_D11_v2** \\ **Standard_D12_v2** \\ **Standard_D13_v2** \\ **Standard_D14_v2** \\ **Standard_D15_v2** \\ **Standard_DS1** \\ **Standard_DS2** \\ **Standard_DS3** \\ **Standard_DS4** \\ **Standard_DS11** \\ **Standard_DS12** \\ **Standard_DS13** \\ **Standard_DS14** \\ **Standard_DS1_v2** \\ **Standard_DS2_v2** \\ **Standard_DS3_v2** \\ **Standard_DS4_v2** \\ **Standard_DS5_v2** \\ **Standard_DS11_v2** \\ **Standard_DS12_v2** \\ **Standard_DS13_v2** \\ **Standard_DS14_v2** \\ **Standard_DS15_v2** \\ **Standard_DS13-4_v2** \\ **Standard_DS13-2_v2** \\ **Standard_DS14-8_v2** \\ **Standard_DS14-4_v2** \\ **Standard_E2_v3** \\ **Standard_E4_v3** \\ **Standard_E8_v3** \\ **Standard_E16_v3** \\ **Standard_E32_v3** \\ **Standard_E64_v3** \\ **Standard_E2s_v3** \\ **Standard_E4s_v3** \\ **Standard_E8s_v3** \\ **Standard_E16s_v3** \\ **Standard_E32s_v3** \\ **Standard_E64s_v3** \\ **Standard_E32-16_v3** \\ **Standard_E32-8s_v3** \\ **Standard_E64-32s_v3** \\ **Standard_E64-16s_v3** \\ **Standard_F1** \\ **Standard_F2** \\ **Standard_F4** \\ **Standard_F8** \\ **Standard_F16** \\ **Standard_F1s** \\ **Standard_F2s** \\ **Standard_F4s** \\ **Standard_F8s** \\ **Standard_F16s** \\ **Standard_F2s_v2** \\ **Standard_F4s_v2** \\ **Standard_F8s_v2** \\ **Standard_F16s_v2** \\ **Standard_F32s_v2** \\ **Standard_F64s_v2** \\ **Standard_F72s_v2** \\ **Standard_G1** \\ **Standard_G2** \\ **Standard_G3** \\ **Standard_G4** \\ **Standard_G5** \\ **Standard_GS1** \\ **Standard_GS2** \\ **Standard_GS3** \\ **Standard_GS4** \\ **Standard_GS5** \\ **Standard_GS4-8** \\ **Standard_GS4-4** \\ **Standard_GS5-16** \\ **Standard_GS5-8** \\ **Standard_H8** \\ **Standard_H16** \\ **Standard_H8m** \\ **Standard_H16m** \\ **Standard_H16r** \\ **Standard_H16mr** \\ **Standard_L4s** \\ **Standard_L8s** \\ **Standard_L16s** \\ **Standard_L32s** \\ **Standard_M64s** \\ **Standard_M64ms** \\ **Standard_M128s** \\ **Standard_M128ms** \\ **Standard_M64-32ms** \\ **Standard_M64-16ms** \\ **Standard_M128-64ms** \\ **Standard_M128-32ms** \\ **Standard_NC6** \\ **Standard_NC12** \\ **Standard_NC24** \\ **Standard_NC24r** \\ **Standard_NC6s_v2** \\ **Standard_NC12s_v2** \\ **Standard_NC24s_v2** \\ **Standard_NC24rs_v2** \\ **Standard_NC6s_v3** \\ **Standard_NC12s_v3** \\ **Standard_NC24s_v3** \\ **Standard_NC24rs_v3** \\ **Standard_ND6s** \\ **Standard_ND12s** \\ **Standard_ND24s** \\ **Standard_ND24rs** \\ **Standard_NV6** \\ **Standard_NV12** \\ **Standard_NV24**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -34047,7 +41151,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic_A0\" | \"Basic_A1\" | \"Basic_A2\" | \"Basic_A3\" | \"Basic_A4\" | \"Standard_A0\" | \"Standard_A1\" | \"Standard_A2\" | \"Standard_A3\" | \"Standard_A4\" | \"Standard_A5\" | \"Standard_A6\" | \"Standard_A7\" | \"Standard_A8\" | \"Standard_A9\" | \"Standard_A10\" | \"Standard_A11\" | \"Standard_A1_v2\" | \"Standard_A2_v2\" | \"Standard_A4_v2\" | \"Standard_A8_v2\" | \"Standard_A2m_v2\" | \"Standard_A4m_v2\" | \"Standard_A8m_v2\" | \"Standard_B1s\" | \"Standard_B1ms\" | \"Standard_B2s\" | \"Standard_B2ms\" | \"Standard_B4ms\" | \"Standard_B8ms\" | \"Standard_D1\" | \"Standard_D2\" | \"Standard_D3\" | \"Standard_D4\" | \"Standard_D11\" | \"Standard_D12\" | \"Standard_D13\" | \"Standard_D14\" | \"Standard_D1_v2\" | \"Standard_D2_v2\" | \"Standard_D3_v2\" | \"Standard_D4_v2\" | \"Standard_D5_v2\" | \"Standard_D2_v3\" | \"Standard_D4_v3\" | \"Standard_D8_v3\" | \"Standard_D16_v3\" | \"Standard_D32_v3\" | \"Standard_D64_v3\" | \"Standard_D2s_v3\" | \"Standard_D4s_v3\" | \"Standard_D8s_v3\" | \"Standard_D16s_v3\" | \"Standard_D32s_v3\" | \"Standard_D64s_v3\" | \"Standard_D11_v2\" | \"Standard_D12_v2\" | \"Standard_D13_v2\" | \"Standard_D14_v2\" | \"Standard_D15_v2\" | \"Standard_DS1\" | \"Standard_DS2\" | \"Standard_DS3\" | \"Standard_DS4\" | \"Standard_DS11\" | \"Standard_DS12\" | \"Standard_DS13\" | \"Standard_DS14\" | \"Standard_DS1_v2\" | \"Standard_DS2_v2\" | \"Standard_DS3_v2\" | \"Standard_DS4_v2\" | \"Standard_DS5_v2\" | \"Standard_DS11_v2\" | \"Standard_DS12_v2\" | \"Standard_DS13_v2\" | \"Standard_DS14_v2\" | \"Standard_DS15_v2\" | \"Standard_DS13-4_v2\" | \"Standard_DS13-2_v2\" | \"Standard_DS14-8_v2\" | \"Standard_DS14-4_v2\" | \"Standard_E2_v3\" | \"Standard_E4_v3\" | \"Standard_E8_v3\" | \"Standard_E16_v3\" | \"Standard_E32_v3\" | \"Standard_E64_v3\" | \"Standard_E2s_v3\" | \"Standard_E4s_v3\" | \"Standard_E8s_v3\" | \"Standard_E16s_v3\" | \"Standard_E32s_v3\" | \"Standard_E64s_v3\" | \"Standard_E32-16_v3\" | \"Standard_E32-8s_v3\" | \"Standard_E64-32s_v3\" | \"Standard_E64-16s_v3\" | \"Standard_F1\" | \"Standard_F2\" | \"Standard_F4\" | \"Standard_F8\" | \"Standard_F16\" | \"Standard_F1s\" | \"Standard_F2s\" | \"Standard_F4s\" | \"Standard_F8s\" | \"Standard_F16s\" | \"Standard_F2s_v2\" | \"Standard_F4s_v2\" | \"Standard_F8s_v2\" | \"Standard_F16s_v2\" | \"Standard_F32s_v2\" | \"Standard_F64s_v2\" | \"Standard_F72s_v2\" | \"Standard_G1\" | \"Standard_G2\" | \"Standard_G3\" | \"Standard_G4\" | \"Standard_G5\" | \"Standard_GS1\" | \"Standard_GS2\" | \"Standard_GS3\" | \"Standard_GS4\" | \"Standard_GS5\" | \"Standard_GS4-8\" | \"Standard_GS4-4\" | \"Standard_GS5-16\" | \"Standard_GS5-8\" | \"Standard_H8\" | \"Standard_H16\" | \"Standard_H8m\" | \"Standard_H16m\" | \"Standard_H16r\" | \"Standard_H16mr\" | \"Standard_L4s\" | \"Standard_L8s\" | \"Standard_L16s\" | \"Standard_L32s\" | \"Standard_M64s\" | \"Standard_M64ms\" | \"Standard_M128s\" | \"Standard_M128ms\" | \"Standard_M64-32ms\" | \"Standard_M64-16ms\" | \"Standard_M128-64ms\" | \"Standard_M128-32ms\" | \"Standard_NC6\" | \"Standard_NC12\" | \"Standard_NC24\" | \"Standard_NC24r\" | \"Standard_NC6s_v2\" | \"Standard_NC12s_v2\" | \"Standard_NC24s_v2\" | \"Standard_NC24rs_v2\" | \"Standard_NC6s_v3\" | \"Standard_NC12s_v3\" | \"Standard_NC24s_v3\" | \"Standard_NC24rs_v3\" | \"Standard_ND6s\" | \"Standard_ND12s\" | \"Standard_ND24s\" | \"Standard_ND24rs\" | \"Standard_NV6\" | \"Standard_NV12\" | \"Standard_NV24\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.md
+++ b/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.md
@@ -15,7 +15,7 @@ import { PollOperationState } from '@azure/core-lro';
 import { RestResponse } from '@azure/core-http';
 
 // @public
-export type AccessLevel = "None" | "Read" | "Write" | string;
+export type AccessLevel = string;
 
 // @public
 export interface AccessUri {
@@ -36,7 +36,7 @@ export interface AdditionalUnattendContent {
 }
 
 // @public
-export type AggregatedReplicationState = "Unknown" | "InProgress" | "Completed" | "Failed" | string;
+export type AggregatedReplicationState = string;
 
 // @public
 export interface ApiEntityReference {
@@ -109,7 +109,7 @@ export type AvailabilitySetsGetResponse = AvailabilitySet & {
 };
 
 // @public
-export type AvailabilitySetSkuTypes = "Classic" | "Aligned" | string;
+export type AvailabilitySetSkuTypes = string;
 
 // @public
 export type AvailabilitySetsListAvailableSizesResponse = VirtualMachineSizeListResult & {
@@ -503,7 +503,7 @@ export interface ContainerServiceVMDiagnostics {
 }
 
 // @public
-export type ContainerServiceVMSizeTypes = "Standard_A0" | "Standard_A1" | "Standard_A2" | "Standard_A3" | "Standard_A4" | "Standard_A5" | "Standard_A6" | "Standard_A7" | "Standard_A8" | "Standard_A9" | "Standard_A10" | "Standard_A11" | "Standard_D1" | "Standard_D2" | "Standard_D3" | "Standard_D4" | "Standard_D11" | "Standard_D12" | "Standard_D13" | "Standard_D14" | "Standard_D1_v2" | "Standard_D2_v2" | "Standard_D3_v2" | "Standard_D4_v2" | "Standard_D5_v2" | "Standard_D11_v2" | "Standard_D12_v2" | "Standard_D13_v2" | "Standard_D14_v2" | "Standard_G1" | "Standard_G2" | "Standard_G3" | "Standard_G4" | "Standard_G5" | "Standard_DS1" | "Standard_DS2" | "Standard_DS3" | "Standard_DS4" | "Standard_DS11" | "Standard_DS12" | "Standard_DS13" | "Standard_DS14" | "Standard_GS1" | "Standard_GS2" | "Standard_GS3" | "Standard_GS4" | "Standard_GS5" | string;
+export type ContainerServiceVMSizeTypes = string;
 
 // @public
 export interface ContainerServiceWindowsProfile {
@@ -725,10 +725,10 @@ export interface DiagnosticsProfile {
 }
 
 // @public
-export type DiffDiskOptions = "Local" | string;
+export type DiffDiskOptions = string;
 
 // @public
-export type DiffDiskPlacement = "CacheDisk" | "ResourceDisk" | string;
+export type DiffDiskPlacement = string;
 
 // @public
 export interface DiffDiskSettings {
@@ -767,10 +767,10 @@ export type Disk = Resource & {
 };
 
 // @public
-export type DiskCreateOption = "Empty" | "Attach" | "FromImage" | "Import" | "Copy" | "Restore" | "Upload" | string;
+export type DiskCreateOption = string;
 
 // @public
-export type DiskCreateOptionTypes = "FromImage" | "Empty" | "Attach" | string;
+export type DiskCreateOptionTypes = string;
 
 // @public
 export type DiskEncryptionSet = Resource & {
@@ -781,7 +781,7 @@ export type DiskEncryptionSet = Resource & {
 };
 
 // @public
-export type DiskEncryptionSetIdentityType = "SystemAssigned" | string;
+export type DiskEncryptionSetIdentityType = string;
 
 // @public
 export interface DiskEncryptionSetList {
@@ -948,10 +948,10 @@ export type DisksListResponse = DiskList & {
 };
 
 // @public
-export type DiskState = "Unattached" | "Attached" | "Reserved" | "ActiveSAS" | "ReadyToUpload" | "ActiveUpload" | string;
+export type DiskState = string;
 
 // @public
-export type DiskStorageAccountTypes = "Standard_LRS" | "Premium_LRS" | "StandardSSD_LRS" | "UltraSSD_LRS" | string;
+export type DiskStorageAccountTypes = string;
 
 // @public
 export type DisksUpdateResponse = Disk & {
@@ -1012,10 +1012,10 @@ export interface EncryptionSettingsElement {
 }
 
 // @public
-export type EncryptionType = "EncryptionAtRestWithPlatformKey" | "EncryptionAtRestWithCustomerKey" | string;
+export type EncryptionType = string;
 
 // @public
-export type Enum31 = 1 | 3 | 5 | number;
+export type Enum31 = number;
 
 // @public
 export type GalleriesCreateOrUpdateResponse = Gallery & {
@@ -1164,7 +1164,7 @@ export interface GalleryApplicationVersionList {
 }
 
 // @public
-export type GalleryApplicationVersionPropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryApplicationVersionPropertiesProvisioningState = string;
 
 // @public
 export type GalleryApplicationVersionPublishingProfile = GalleryArtifactPublishingProfileBase & {
@@ -1295,7 +1295,7 @@ export interface GalleryImageList {
 }
 
 // @public
-export type GalleryImagePropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryImagePropertiesProvisioningState = string;
 
 // @public
 export type GalleryImagesCreateOrUpdateResponse = GalleryImage & {
@@ -1371,7 +1371,7 @@ export interface GalleryImageVersionList {
 }
 
 // @public
-export type GalleryImageVersionPropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryImageVersionPropertiesProvisioningState = string;
 
 // @public
 export type GalleryImageVersionPublishingProfile = GalleryArtifactPublishingProfileBase & {};
@@ -1448,7 +1448,7 @@ export interface GalleryList {
 export type GalleryOSDiskImage = GalleryDiskImage & {};
 
 // @public
-export type GalleryPropertiesProvisioningState = "Creating" | "Updating" | "Failed" | "Succeeded" | "Deleting" | "Migrating" | string;
+export type GalleryPropertiesProvisioningState = string;
 
 // @public
 export type GalleryUpdate = UpdateResourceDefinition & {
@@ -1473,13 +1473,13 @@ export interface HardwareProfile {
 export type HostCaching = "None" | "ReadOnly" | "ReadWrite";
 
 // @public
-export type HyperVGeneration = "V1" | "V2" | string;
+export type HyperVGeneration = string;
 
 // @public
-export type HyperVGenerationType = "V1" | "V2" | string;
+export type HyperVGenerationType = string;
 
 // @public
-export type HyperVGenerationTypes = "V1" | "V2" | string;
+export type HyperVGenerationTypes = string;
 
 // @public
 type Image_2 = Resource & {
@@ -1638,7 +1638,7 @@ export interface InstanceViewStatus {
 export type IntervalInMins = "ThreeMins" | "FiveMins" | "ThirtyMins" | "SixtyMins";
 
 // @public
-export type IPVersion = "IPv4" | "IPv6" | string;
+export type IPVersion = string;
 
 // @public
 export interface KeyVaultAndKeyReference {
@@ -1662,6 +1662,748 @@ export interface KeyVaultKeyReference {
 export interface KeyVaultSecretReference {
     secretUrl: string;
     sourceVault: SubResource;
+}
+
+// @public
+export const enum KnownAccessLevel {
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Read = "Read",
+    // (undocumented)
+    Write = "Write"
+}
+
+// @public
+export const enum KnownAggregatedReplicationState {
+    // (undocumented)
+    Completed = "Completed",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownAvailabilitySetSkuTypes {
+    // (undocumented)
+    Aligned = "Aligned",
+    // (undocumented)
+    Classic = "Classic"
+}
+
+// @public
+export const enum KnownContainerServiceVMSizeTypes {
+    // (undocumented)
+    StandardA0 = "Standard_A0",
+    // (undocumented)
+    StandardA1 = "Standard_A1",
+    // (undocumented)
+    StandardA10 = "Standard_A10",
+    // (undocumented)
+    StandardA11 = "Standard_A11",
+    // (undocumented)
+    StandardA2 = "Standard_A2",
+    // (undocumented)
+    StandardA3 = "Standard_A3",
+    // (undocumented)
+    StandardA4 = "Standard_A4",
+    // (undocumented)
+    StandardA5 = "Standard_A5",
+    // (undocumented)
+    StandardA6 = "Standard_A6",
+    // (undocumented)
+    StandardA7 = "Standard_A7",
+    // (undocumented)
+    StandardA8 = "Standard_A8",
+    // (undocumented)
+    StandardA9 = "Standard_A9",
+    // (undocumented)
+    StandardD1 = "Standard_D1",
+    // (undocumented)
+    StandardD11 = "Standard_D11",
+    // (undocumented)
+    StandardD11V2 = "Standard_D11_v2",
+    // (undocumented)
+    StandardD12 = "Standard_D12",
+    // (undocumented)
+    StandardD12V2 = "Standard_D12_v2",
+    // (undocumented)
+    StandardD13 = "Standard_D13",
+    // (undocumented)
+    StandardD13V2 = "Standard_D13_v2",
+    // (undocumented)
+    StandardD14 = "Standard_D14",
+    // (undocumented)
+    StandardD14V2 = "Standard_D14_v2",
+    // (undocumented)
+    StandardD1V2 = "Standard_D1_v2",
+    // (undocumented)
+    StandardD2 = "Standard_D2",
+    // (undocumented)
+    StandardD2V2 = "Standard_D2_v2",
+    // (undocumented)
+    StandardD3 = "Standard_D3",
+    // (undocumented)
+    StandardD3V2 = "Standard_D3_v2",
+    // (undocumented)
+    StandardD4 = "Standard_D4",
+    // (undocumented)
+    StandardD4V2 = "Standard_D4_v2",
+    // (undocumented)
+    StandardD5V2 = "Standard_D5_v2",
+    // (undocumented)
+    StandardDS1 = "Standard_DS1",
+    // (undocumented)
+    StandardDS11 = "Standard_DS11",
+    // (undocumented)
+    StandardDS12 = "Standard_DS12",
+    // (undocumented)
+    StandardDS13 = "Standard_DS13",
+    // (undocumented)
+    StandardDS14 = "Standard_DS14",
+    // (undocumented)
+    StandardDS2 = "Standard_DS2",
+    // (undocumented)
+    StandardDS3 = "Standard_DS3",
+    // (undocumented)
+    StandardDS4 = "Standard_DS4",
+    // (undocumented)
+    StandardG1 = "Standard_G1",
+    // (undocumented)
+    StandardG2 = "Standard_G2",
+    // (undocumented)
+    StandardG3 = "Standard_G3",
+    // (undocumented)
+    StandardG4 = "Standard_G4",
+    // (undocumented)
+    StandardG5 = "Standard_G5",
+    // (undocumented)
+    StandardGS1 = "Standard_GS1",
+    // (undocumented)
+    StandardGS2 = "Standard_GS2",
+    // (undocumented)
+    StandardGS3 = "Standard_GS3",
+    // (undocumented)
+    StandardGS4 = "Standard_GS4",
+    // (undocumented)
+    StandardGS5 = "Standard_GS5"
+}
+
+// @public
+export const enum KnownDiffDiskOptions {
+    // (undocumented)
+    Local = "Local"
+}
+
+// @public
+export const enum KnownDiffDiskPlacement {
+    // (undocumented)
+    CacheDisk = "CacheDisk",
+    // (undocumented)
+    ResourceDisk = "ResourceDisk"
+}
+
+// @public
+export const enum KnownDiskCreateOption {
+    Attach = "Attach",
+    Copy = "Copy",
+    Empty = "Empty",
+    FromImage = "FromImage",
+    Import = "Import",
+    Restore = "Restore",
+    Upload = "Upload"
+}
+
+// @public
+export const enum KnownDiskCreateOptionTypes {
+    // (undocumented)
+    Attach = "Attach",
+    // (undocumented)
+    Empty = "Empty",
+    // (undocumented)
+    FromImage = "FromImage"
+}
+
+// @public
+export const enum KnownDiskEncryptionSetIdentityType {
+    // (undocumented)
+    SystemAssigned = "SystemAssigned"
+}
+
+// @public
+export const enum KnownDiskState {
+    ActiveSAS = "ActiveSAS",
+    ActiveUpload = "ActiveUpload",
+    Attached = "Attached",
+    ReadyToUpload = "ReadyToUpload",
+    Reserved = "Reserved",
+    Unattached = "Unattached"
+}
+
+// @public
+export const enum KnownDiskStorageAccountTypes {
+    PremiumLRS = "Premium_LRS",
+    StandardLRS = "Standard_LRS",
+    StandardSSDLRS = "StandardSSD_LRS",
+    UltraSSDLRS = "UltraSSD_LRS"
+}
+
+// @public
+export const enum KnownEncryptionType {
+    EncryptionAtRestWithCustomerKey = "EncryptionAtRestWithCustomerKey",
+    EncryptionAtRestWithPlatformKey = "EncryptionAtRestWithPlatformKey"
+}
+
+// @public
+export const enum KnownEnum31 {
+    // (undocumented)
+    Five = 5,
+    // (undocumented)
+    One = 1,
+    // (undocumented)
+    Three = 3
+}
+
+// @public
+export const enum KnownGalleryApplicationVersionPropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownGalleryImagePropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownGalleryImageVersionPropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownGalleryPropertiesProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Migrating = "Migrating",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownHyperVGeneration {
+    // (undocumented)
+    V1 = "V1",
+    // (undocumented)
+    V2 = "V2"
+}
+
+// @public
+export const enum KnownHyperVGenerationType {
+    // (undocumented)
+    V1 = "V1",
+    // (undocumented)
+    V2 = "V2"
+}
+
+// @public
+export const enum KnownHyperVGenerationTypes {
+    // (undocumented)
+    V1 = "V1",
+    // (undocumented)
+    V2 = "V2"
+}
+
+// @public
+export const enum KnownIPVersion {
+    // (undocumented)
+    IPv4 = "IPv4",
+    // (undocumented)
+    IPv6 = "IPv6"
+}
+
+// @public
+export const enum KnownOrchestrationServiceNames {
+    // (undocumented)
+    AutomaticRepairs = "AutomaticRepairs"
+}
+
+// @public
+export const enum KnownOrchestrationServiceState {
+    // (undocumented)
+    NotRunning = "NotRunning",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Suspended = "Suspended"
+}
+
+// @public
+export const enum KnownOrchestrationServiceStateAction {
+    // (undocumented)
+    Resume = "Resume",
+    // (undocumented)
+    Suspend = "Suspend"
+}
+
+// @public
+export const enum KnownProximityPlacementGroupType {
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    Ultra = "Ultra"
+}
+
+// @public
+export const enum KnownReplicationState {
+    // (undocumented)
+    Completed = "Completed",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Replicating = "Replicating",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownReplicationStatusTypes {
+    // (undocumented)
+    ReplicationStatus = "ReplicationStatus"
+}
+
+// @public
+export const enum KnownSnapshotStorageAccountTypes {
+    PremiumLRS = "Premium_LRS",
+    StandardLRS = "Standard_LRS",
+    StandardZRS = "Standard_ZRS"
+}
+
+// @public
+export const enum KnownStorageAccountType {
+    // (undocumented)
+    PremiumLRS = "Premium_LRS",
+    // (undocumented)
+    StandardLRS = "Standard_LRS",
+    // (undocumented)
+    StandardZRS = "Standard_ZRS"
+}
+
+// @public
+export const enum KnownStorageAccountTypes {
+    // (undocumented)
+    PremiumLRS = "Premium_LRS",
+    // (undocumented)
+    StandardLRS = "Standard_LRS",
+    // (undocumented)
+    StandardSSDLRS = "StandardSSD_LRS",
+    // (undocumented)
+    UltraSSDLRS = "UltraSSD_LRS"
+}
+
+// @public
+export const enum KnownVirtualMachineEvictionPolicyTypes {
+    // (undocumented)
+    Deallocate = "Deallocate",
+    // (undocumented)
+    Delete = "Delete"
+}
+
+// @public
+export const enum KnownVirtualMachinePriorityTypes {
+    // (undocumented)
+    Low = "Low",
+    // (undocumented)
+    Regular = "Regular",
+    // (undocumented)
+    Spot = "Spot"
+}
+
+// @public
+export const enum KnownVirtualMachineScaleSetScaleInRules {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    NewestVM = "NewestVM",
+    // (undocumented)
+    OldestVM = "OldestVM"
+}
+
+// @public
+export const enum KnownVirtualMachineSizeTypes {
+    // (undocumented)
+    BasicA0 = "Basic_A0",
+    // (undocumented)
+    BasicA1 = "Basic_A1",
+    // (undocumented)
+    BasicA2 = "Basic_A2",
+    // (undocumented)
+    BasicA3 = "Basic_A3",
+    // (undocumented)
+    BasicA4 = "Basic_A4",
+    // (undocumented)
+    StandardA0 = "Standard_A0",
+    // (undocumented)
+    StandardA1 = "Standard_A1",
+    // (undocumented)
+    StandardA10 = "Standard_A10",
+    // (undocumented)
+    StandardA11 = "Standard_A11",
+    // (undocumented)
+    StandardA1V2 = "Standard_A1_v2",
+    // (undocumented)
+    StandardA2 = "Standard_A2",
+    // (undocumented)
+    StandardA2MV2 = "Standard_A2m_v2",
+    // (undocumented)
+    StandardA2V2 = "Standard_A2_v2",
+    // (undocumented)
+    StandardA3 = "Standard_A3",
+    // (undocumented)
+    StandardA4 = "Standard_A4",
+    // (undocumented)
+    StandardA4MV2 = "Standard_A4m_v2",
+    // (undocumented)
+    StandardA4V2 = "Standard_A4_v2",
+    // (undocumented)
+    StandardA5 = "Standard_A5",
+    // (undocumented)
+    StandardA6 = "Standard_A6",
+    // (undocumented)
+    StandardA7 = "Standard_A7",
+    // (undocumented)
+    StandardA8 = "Standard_A8",
+    // (undocumented)
+    StandardA8MV2 = "Standard_A8m_v2",
+    // (undocumented)
+    StandardA8V2 = "Standard_A8_v2",
+    // (undocumented)
+    StandardA9 = "Standard_A9",
+    // (undocumented)
+    StandardB1Ms = "Standard_B1ms",
+    // (undocumented)
+    StandardB1S = "Standard_B1s",
+    // (undocumented)
+    StandardB2Ms = "Standard_B2ms",
+    // (undocumented)
+    StandardB2S = "Standard_B2s",
+    // (undocumented)
+    StandardB4Ms = "Standard_B4ms",
+    // (undocumented)
+    StandardB8Ms = "Standard_B8ms",
+    // (undocumented)
+    StandardD1 = "Standard_D1",
+    // (undocumented)
+    StandardD11 = "Standard_D11",
+    // (undocumented)
+    StandardD11V2 = "Standard_D11_v2",
+    // (undocumented)
+    StandardD12 = "Standard_D12",
+    // (undocumented)
+    StandardD12V2 = "Standard_D12_v2",
+    // (undocumented)
+    StandardD13 = "Standard_D13",
+    // (undocumented)
+    StandardD13V2 = "Standard_D13_v2",
+    // (undocumented)
+    StandardD14 = "Standard_D14",
+    // (undocumented)
+    StandardD14V2 = "Standard_D14_v2",
+    // (undocumented)
+    StandardD15V2 = "Standard_D15_v2",
+    // (undocumented)
+    StandardD16SV3 = "Standard_D16s_v3",
+    // (undocumented)
+    StandardD16V3 = "Standard_D16_v3",
+    // (undocumented)
+    StandardD1V2 = "Standard_D1_v2",
+    // (undocumented)
+    StandardD2 = "Standard_D2",
+    // (undocumented)
+    StandardD2SV3 = "Standard_D2s_v3",
+    // (undocumented)
+    StandardD2V2 = "Standard_D2_v2",
+    // (undocumented)
+    StandardD2V3 = "Standard_D2_v3",
+    // (undocumented)
+    StandardD3 = "Standard_D3",
+    // (undocumented)
+    StandardD32SV3 = "Standard_D32s_v3",
+    // (undocumented)
+    StandardD32V3 = "Standard_D32_v3",
+    // (undocumented)
+    StandardD3V2 = "Standard_D3_v2",
+    // (undocumented)
+    StandardD4 = "Standard_D4",
+    // (undocumented)
+    StandardD4SV3 = "Standard_D4s_v3",
+    // (undocumented)
+    StandardD4V2 = "Standard_D4_v2",
+    // (undocumented)
+    StandardD4V3 = "Standard_D4_v3",
+    // (undocumented)
+    StandardD5V2 = "Standard_D5_v2",
+    // (undocumented)
+    StandardD64SV3 = "Standard_D64s_v3",
+    // (undocumented)
+    StandardD64V3 = "Standard_D64_v3",
+    // (undocumented)
+    StandardD8SV3 = "Standard_D8s_v3",
+    // (undocumented)
+    StandardD8V3 = "Standard_D8_v3",
+    // (undocumented)
+    StandardDS1 = "Standard_DS1",
+    // (undocumented)
+    StandardDS11 = "Standard_DS11",
+    // (undocumented)
+    StandardDS11V2 = "Standard_DS11_v2",
+    // (undocumented)
+    StandardDS12 = "Standard_DS12",
+    // (undocumented)
+    StandardDS12V2 = "Standard_DS12_v2",
+    // (undocumented)
+    StandardDS13 = "Standard_DS13",
+    // (undocumented)
+    StandardDS132V2 = "Standard_DS13-2_v2",
+    // (undocumented)
+    StandardDS134V2 = "Standard_DS13-4_v2",
+    // (undocumented)
+    StandardDS13V2 = "Standard_DS13_v2",
+    // (undocumented)
+    StandardDS14 = "Standard_DS14",
+    // (undocumented)
+    StandardDS144V2 = "Standard_DS14-4_v2",
+    // (undocumented)
+    StandardDS148V2 = "Standard_DS14-8_v2",
+    // (undocumented)
+    StandardDS14V2 = "Standard_DS14_v2",
+    // (undocumented)
+    StandardDS15V2 = "Standard_DS15_v2",
+    // (undocumented)
+    StandardDS1V2 = "Standard_DS1_v2",
+    // (undocumented)
+    StandardDS2 = "Standard_DS2",
+    // (undocumented)
+    StandardDS2V2 = "Standard_DS2_v2",
+    // (undocumented)
+    StandardDS3 = "Standard_DS3",
+    // (undocumented)
+    StandardDS3V2 = "Standard_DS3_v2",
+    // (undocumented)
+    StandardDS4 = "Standard_DS4",
+    // (undocumented)
+    StandardDS4V2 = "Standard_DS4_v2",
+    // (undocumented)
+    StandardDS5V2 = "Standard_DS5_v2",
+    // (undocumented)
+    StandardE16SV3 = "Standard_E16s_v3",
+    // (undocumented)
+    StandardE16V3 = "Standard_E16_v3",
+    // (undocumented)
+    StandardE2SV3 = "Standard_E2s_v3",
+    // (undocumented)
+    StandardE2V3 = "Standard_E2_v3",
+    // (undocumented)
+    StandardE3216V3 = "Standard_E32-16_v3",
+    // (undocumented)
+    StandardE328SV3 = "Standard_E32-8s_v3",
+    // (undocumented)
+    StandardE32SV3 = "Standard_E32s_v3",
+    // (undocumented)
+    StandardE32V3 = "Standard_E32_v3",
+    // (undocumented)
+    StandardE4SV3 = "Standard_E4s_v3",
+    // (undocumented)
+    StandardE4V3 = "Standard_E4_v3",
+    // (undocumented)
+    StandardE6416SV3 = "Standard_E64-16s_v3",
+    // (undocumented)
+    StandardE6432SV3 = "Standard_E64-32s_v3",
+    // (undocumented)
+    StandardE64SV3 = "Standard_E64s_v3",
+    // (undocumented)
+    StandardE64V3 = "Standard_E64_v3",
+    // (undocumented)
+    StandardE8SV3 = "Standard_E8s_v3",
+    // (undocumented)
+    StandardE8V3 = "Standard_E8_v3",
+    // (undocumented)
+    StandardF1 = "Standard_F1",
+    // (undocumented)
+    StandardF16 = "Standard_F16",
+    // (undocumented)
+    StandardF16S = "Standard_F16s",
+    // (undocumented)
+    StandardF16SV2 = "Standard_F16s_v2",
+    // (undocumented)
+    StandardF1S = "Standard_F1s",
+    // (undocumented)
+    StandardF2 = "Standard_F2",
+    // (undocumented)
+    StandardF2S = "Standard_F2s",
+    // (undocumented)
+    StandardF2SV2 = "Standard_F2s_v2",
+    // (undocumented)
+    StandardF32SV2 = "Standard_F32s_v2",
+    // (undocumented)
+    StandardF4 = "Standard_F4",
+    // (undocumented)
+    StandardF4S = "Standard_F4s",
+    // (undocumented)
+    StandardF4SV2 = "Standard_F4s_v2",
+    // (undocumented)
+    StandardF64SV2 = "Standard_F64s_v2",
+    // (undocumented)
+    StandardF72SV2 = "Standard_F72s_v2",
+    // (undocumented)
+    StandardF8 = "Standard_F8",
+    // (undocumented)
+    StandardF8S = "Standard_F8s",
+    // (undocumented)
+    StandardF8SV2 = "Standard_F8s_v2",
+    // (undocumented)
+    StandardG1 = "Standard_G1",
+    // (undocumented)
+    StandardG2 = "Standard_G2",
+    // (undocumented)
+    StandardG3 = "Standard_G3",
+    // (undocumented)
+    StandardG4 = "Standard_G4",
+    // (undocumented)
+    StandardG5 = "Standard_G5",
+    // (undocumented)
+    StandardGS1 = "Standard_GS1",
+    // (undocumented)
+    StandardGS2 = "Standard_GS2",
+    // (undocumented)
+    StandardGS3 = "Standard_GS3",
+    // (undocumented)
+    StandardGS4 = "Standard_GS4",
+    // (undocumented)
+    StandardGS44 = "Standard_GS4-4",
+    // (undocumented)
+    StandardGS48 = "Standard_GS4-8",
+    // (undocumented)
+    StandardGS5 = "Standard_GS5",
+    // (undocumented)
+    StandardGS516 = "Standard_GS5-16",
+    // (undocumented)
+    StandardGS58 = "Standard_GS5-8",
+    // (undocumented)
+    StandardH16 = "Standard_H16",
+    // (undocumented)
+    StandardH16M = "Standard_H16m",
+    // (undocumented)
+    StandardH16Mr = "Standard_H16mr",
+    // (undocumented)
+    StandardH16R = "Standard_H16r",
+    // (undocumented)
+    StandardH8 = "Standard_H8",
+    // (undocumented)
+    StandardH8M = "Standard_H8m",
+    // (undocumented)
+    StandardL16S = "Standard_L16s",
+    // (undocumented)
+    StandardL32S = "Standard_L32s",
+    // (undocumented)
+    StandardL4S = "Standard_L4s",
+    // (undocumented)
+    StandardL8S = "Standard_L8s",
+    // (undocumented)
+    StandardM12832Ms = "Standard_M128-32ms",
+    // (undocumented)
+    StandardM12864Ms = "Standard_M128-64ms",
+    // (undocumented)
+    StandardM128Ms = "Standard_M128ms",
+    // (undocumented)
+    StandardM128S = "Standard_M128s",
+    // (undocumented)
+    StandardM6416Ms = "Standard_M64-16ms",
+    // (undocumented)
+    StandardM6432Ms = "Standard_M64-32ms",
+    // (undocumented)
+    StandardM64Ms = "Standard_M64ms",
+    // (undocumented)
+    StandardM64S = "Standard_M64s",
+    // (undocumented)
+    StandardNC12 = "Standard_NC12",
+    // (undocumented)
+    StandardNC12SV2 = "Standard_NC12s_v2",
+    // (undocumented)
+    StandardNC12SV3 = "Standard_NC12s_v3",
+    // (undocumented)
+    StandardNC24 = "Standard_NC24",
+    // (undocumented)
+    StandardNC24R = "Standard_NC24r",
+    // (undocumented)
+    StandardNC24RsV2 = "Standard_NC24rs_v2",
+    // (undocumented)
+    StandardNC24RsV3 = "Standard_NC24rs_v3",
+    // (undocumented)
+    StandardNC24SV2 = "Standard_NC24s_v2",
+    // (undocumented)
+    StandardNC24SV3 = "Standard_NC24s_v3",
+    // (undocumented)
+    StandardNC6 = "Standard_NC6",
+    // (undocumented)
+    StandardNC6SV2 = "Standard_NC6s_v2",
+    // (undocumented)
+    StandardNC6SV3 = "Standard_NC6s_v3",
+    // (undocumented)
+    StandardND12S = "Standard_ND12s",
+    // (undocumented)
+    StandardND24Rs = "Standard_ND24rs",
+    // (undocumented)
+    StandardND24S = "Standard_ND24s",
+    // (undocumented)
+    StandardND6S = "Standard_ND6s",
+    // (undocumented)
+    StandardNV12 = "Standard_NV12",
+    // (undocumented)
+    StandardNV24 = "Standard_NV24",
+    // (undocumented)
+    StandardNV6 = "Standard_NV6"
 }
 
 // @public
@@ -1765,13 +2507,13 @@ export type OperationsListResponse = ComputeOperationListResult & {
 };
 
 // @public
-export type OrchestrationServiceNames = "AutomaticRepairs" | string;
+export type OrchestrationServiceNames = string;
 
 // @public
-export type OrchestrationServiceState = "NotRunning" | "Running" | "Suspended" | string;
+export type OrchestrationServiceState = string;
 
 // @public
-export type OrchestrationServiceStateAction = "Resume" | "Suspend" | string;
+export type OrchestrationServiceStateAction = string;
 
 // @public
 export interface OrchestrationServiceStateInput {
@@ -1909,7 +2651,7 @@ export type ProximityPlacementGroupsUpdateResponse = ProximityPlacementGroup & {
 };
 
 // @public
-export type ProximityPlacementGroupType = "Standard" | "Ultra" | string;
+export type ProximityPlacementGroupType = string;
 
 // @public
 export type ProximityPlacementGroupUpdate = UpdateResource & {};
@@ -1942,7 +2684,7 @@ export interface RegionalReplicationStatus {
 }
 
 // @public
-export type ReplicationState = "Unknown" | "Replicating" | "Completed" | "Failed" | string;
+export type ReplicationState = string;
 
 // @public
 export interface ReplicationStatus {
@@ -1951,7 +2693,7 @@ export interface ReplicationStatus {
 }
 
 // @public
-export type ReplicationStatusTypes = "ReplicationStatus" | string;
+export type ReplicationStatusTypes = string;
 
 // @public
 export type RequestRateByIntervalInput = LogAnalyticsInputBase & {
@@ -2289,7 +3031,7 @@ export type SnapshotsListResponse = SnapshotList & {
 };
 
 // @public
-export type SnapshotStorageAccountTypes = "Standard_LRS" | "Premium_LRS" | "Standard_ZRS" | string;
+export type SnapshotStorageAccountTypes = string;
 
 // @public
 export type SnapshotsUpdateResponse = Snapshot & {
@@ -2419,10 +3161,10 @@ export type SshPublicKeyUpdateResource = UpdateResource & {
 export type StatusLevelTypes = "Info" | "Warning" | "Error";
 
 // @public
-export type StorageAccountType = "Standard_LRS" | "Standard_ZRS" | "Premium_LRS" | string;
+export type StorageAccountType = string;
 
 // @public
-export type StorageAccountTypes = "Standard_LRS" | "Premium_LRS" | "StandardSSD_LRS" | "UltraSSD_LRS" | string;
+export type StorageAccountTypes = string;
 
 // @public
 export interface StorageProfile {
@@ -2621,7 +3363,7 @@ export type VirtualMachineCaptureResult = SubResource & {
 };
 
 // @public
-export type VirtualMachineEvictionPolicyTypes = "Deallocate" | "Delete" | string;
+export type VirtualMachineEvictionPolicyTypes = string;
 
 // @public
 export type VirtualMachineExtension = Resource & {
@@ -2860,7 +3602,7 @@ export interface VirtualMachineListResult {
 }
 
 // @public
-export type VirtualMachinePriorityTypes = "Regular" | "Low" | "Spot" | string;
+export type VirtualMachinePriorityTypes = string;
 
 // @public
 export interface VirtualMachineReimageParameters {
@@ -3161,7 +3903,7 @@ export type VirtualMachineScaleSetRollingUpgradesGetLatestResponse = RollingUpgr
 };
 
 // @public
-export type VirtualMachineScaleSetScaleInRules = "Default" | "OldestVM" | "NewestVM" | string;
+export type VirtualMachineScaleSetScaleInRules = string;
 
 // @public
 export type VirtualMachineScaleSetsCreateOrUpdateResponse = VirtualMachineScaleSet & {
@@ -3690,7 +4432,7 @@ export type VirtualMachineSizesListResponse = VirtualMachineSizeListResult & {
 };
 
 // @public
-export type VirtualMachineSizeTypes = "Basic_A0" | "Basic_A1" | "Basic_A2" | "Basic_A3" | "Basic_A4" | "Standard_A0" | "Standard_A1" | "Standard_A2" | "Standard_A3" | "Standard_A4" | "Standard_A5" | "Standard_A6" | "Standard_A7" | "Standard_A8" | "Standard_A9" | "Standard_A10" | "Standard_A11" | "Standard_A1_v2" | "Standard_A2_v2" | "Standard_A4_v2" | "Standard_A8_v2" | "Standard_A2m_v2" | "Standard_A4m_v2" | "Standard_A8m_v2" | "Standard_B1s" | "Standard_B1ms" | "Standard_B2s" | "Standard_B2ms" | "Standard_B4ms" | "Standard_B8ms" | "Standard_D1" | "Standard_D2" | "Standard_D3" | "Standard_D4" | "Standard_D11" | "Standard_D12" | "Standard_D13" | "Standard_D14" | "Standard_D1_v2" | "Standard_D2_v2" | "Standard_D3_v2" | "Standard_D4_v2" | "Standard_D5_v2" | "Standard_D2_v3" | "Standard_D4_v3" | "Standard_D8_v3" | "Standard_D16_v3" | "Standard_D32_v3" | "Standard_D64_v3" | "Standard_D2s_v3" | "Standard_D4s_v3" | "Standard_D8s_v3" | "Standard_D16s_v3" | "Standard_D32s_v3" | "Standard_D64s_v3" | "Standard_D11_v2" | "Standard_D12_v2" | "Standard_D13_v2" | "Standard_D14_v2" | "Standard_D15_v2" | "Standard_DS1" | "Standard_DS2" | "Standard_DS3" | "Standard_DS4" | "Standard_DS11" | "Standard_DS12" | "Standard_DS13" | "Standard_DS14" | "Standard_DS1_v2" | "Standard_DS2_v2" | "Standard_DS3_v2" | "Standard_DS4_v2" | "Standard_DS5_v2" | "Standard_DS11_v2" | "Standard_DS12_v2" | "Standard_DS13_v2" | "Standard_DS14_v2" | "Standard_DS15_v2" | "Standard_DS13-4_v2" | "Standard_DS13-2_v2" | "Standard_DS14-8_v2" | "Standard_DS14-4_v2" | "Standard_E2_v3" | "Standard_E4_v3" | "Standard_E8_v3" | "Standard_E16_v3" | "Standard_E32_v3" | "Standard_E64_v3" | "Standard_E2s_v3" | "Standard_E4s_v3" | "Standard_E8s_v3" | "Standard_E16s_v3" | "Standard_E32s_v3" | "Standard_E64s_v3" | "Standard_E32-16_v3" | "Standard_E32-8s_v3" | "Standard_E64-32s_v3" | "Standard_E64-16s_v3" | "Standard_F1" | "Standard_F2" | "Standard_F4" | "Standard_F8" | "Standard_F16" | "Standard_F1s" | "Standard_F2s" | "Standard_F4s" | "Standard_F8s" | "Standard_F16s" | "Standard_F2s_v2" | "Standard_F4s_v2" | "Standard_F8s_v2" | "Standard_F16s_v2" | "Standard_F32s_v2" | "Standard_F64s_v2" | "Standard_F72s_v2" | "Standard_G1" | "Standard_G2" | "Standard_G3" | "Standard_G4" | "Standard_G5" | "Standard_GS1" | "Standard_GS2" | "Standard_GS3" | "Standard_GS4" | "Standard_GS5" | "Standard_GS4-8" | "Standard_GS4-4" | "Standard_GS5-16" | "Standard_GS5-8" | "Standard_H8" | "Standard_H16" | "Standard_H8m" | "Standard_H16m" | "Standard_H16r" | "Standard_H16mr" | "Standard_L4s" | "Standard_L8s" | "Standard_L16s" | "Standard_L32s" | "Standard_M64s" | "Standard_M64ms" | "Standard_M128s" | "Standard_M128ms" | "Standard_M64-32ms" | "Standard_M64-16ms" | "Standard_M128-64ms" | "Standard_M128-32ms" | "Standard_NC6" | "Standard_NC12" | "Standard_NC24" | "Standard_NC24r" | "Standard_NC6s_v2" | "Standard_NC12s_v2" | "Standard_NC24s_v2" | "Standard_NC24rs_v2" | "Standard_NC6s_v3" | "Standard_NC12s_v3" | "Standard_NC24s_v3" | "Standard_NC24rs_v3" | "Standard_ND6s" | "Standard_ND12s" | "Standard_ND24s" | "Standard_ND24rs" | "Standard_NV6" | "Standard_NV12" | "Standard_NV24" | string;
+export type VirtualMachineSizeTypes = string;
 
 // @public
 export interface VirtualMachinesListAllNextOptionalParams extends coreHttp.OperationOptions {
@@ -3844,7 +4586,7 @@ export interface WinRMListener {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:9774:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:10508:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/compute-resource-manager/tsconfig.json
+++ b/test/smoke/generated/compute-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/cosmos-db-resource-manager/review/cosmos-db-resource-manager.api.md
+++ b/test/smoke/generated/cosmos-db-resource-manager/review/cosmos-db-resource-manager.api.md
@@ -281,10 +281,10 @@ export interface CompositePath {
 }
 
 // @public
-export type CompositePathSortOrder = "Ascending" | "Descending" | string;
+export type CompositePathSortOrder = string;
 
 // @public
-export type ConflictResolutionMode = "LastWriterWins" | "Custom" | string;
+export type ConflictResolutionMode = string;
 
 // @public
 export interface ConflictResolutionPolicy {
@@ -294,7 +294,7 @@ export interface ConflictResolutionPolicy {
 }
 
 // @public
-export type ConnectorOffer = "Small" | string;
+export type ConnectorOffer = string;
 
 // @public
 export interface ConsistencyPolicy {
@@ -471,7 +471,7 @@ export type DatabaseAccountGetResults = ARMResourceProperties & {
 };
 
 // @public
-export type DatabaseAccountKind = "GlobalDocumentDB" | "MongoDB" | "Parse" | string;
+export type DatabaseAccountKind = string;
 
 // @public
 export interface DatabaseAccountListConnectionStringsResult {
@@ -662,7 +662,7 @@ export type DatabaseListUsagesResponse = UsagesResult & {
 };
 
 // @public
-export type DataType = "String" | "Number" | "Point" | "Polygon" | "LineString" | "MultiPolygon" | string;
+export type DataType = string;
 
 // @public
 export type DefaultConsistencyLevel = "Eventual" | "Session" | "BoundedStaleness" | "Strong" | "ConsistentPrefix";
@@ -856,7 +856,7 @@ export interface Indexes {
 }
 
 // @public
-export type IndexingMode = "Consistent" | "Lazy" | "None" | string;
+export type IndexingMode = string;
 
 // @public
 export interface IndexingPolicy {
@@ -869,10 +869,180 @@ export interface IndexingPolicy {
 }
 
 // @public
-export type IndexKind = "Hash" | "Range" | "Spatial" | string;
+export type IndexKind = string;
 
 // @public
-export type KeyKind = "primary" | "secondary" | "primaryReadonly" | "secondaryReadonly" | string;
+export type KeyKind = string;
+
+// @public
+export const enum KnownCompositePathSortOrder {
+    // (undocumented)
+    Ascending = "Ascending",
+    // (undocumented)
+    Descending = "Descending"
+}
+
+// @public
+export const enum KnownConflictResolutionMode {
+    // (undocumented)
+    Custom = "Custom",
+    // (undocumented)
+    LastWriterWins = "LastWriterWins"
+}
+
+// @public
+export const enum KnownConnectorOffer {
+    // (undocumented)
+    Small = "Small"
+}
+
+// @public
+export const enum KnownDatabaseAccountKind {
+    // (undocumented)
+    GlobalDocumentDB = "GlobalDocumentDB",
+    // (undocumented)
+    MongoDB = "MongoDB",
+    // (undocumented)
+    Parse = "Parse"
+}
+
+// @public
+export const enum KnownDataType {
+    // (undocumented)
+    LineString = "LineString",
+    // (undocumented)
+    MultiPolygon = "MultiPolygon",
+    // (undocumented)
+    Number = "Number",
+    // (undocumented)
+    Point = "Point",
+    // (undocumented)
+    Polygon = "Polygon",
+    // (undocumented)
+    String = "String"
+}
+
+// @public
+export const enum KnownIndexingMode {
+    // (undocumented)
+    Consistent = "Consistent",
+    // (undocumented)
+    Lazy = "Lazy",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownIndexKind {
+    // (undocumented)
+    Hash = "Hash",
+    // (undocumented)
+    Range = "Range",
+    // (undocumented)
+    Spatial = "Spatial"
+}
+
+// @public
+export const enum KnownKeyKind {
+    // (undocumented)
+    Primary = "primary",
+    // (undocumented)
+    PrimaryReadonly = "primaryReadonly",
+    // (undocumented)
+    Secondary = "secondary",
+    // (undocumented)
+    SecondaryReadonly = "secondaryReadonly"
+}
+
+// @public
+export const enum KnownNotebookWorkspaceName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownPartitionKind {
+    // (undocumented)
+    Hash = "Hash",
+    // (undocumented)
+    Range = "Range"
+}
+
+// @public
+export const enum KnownPrimaryAggregationType {
+    // (undocumented)
+    Average = "Average",
+    // (undocumented)
+    Last = "Last",
+    // (undocumented)
+    Maximum = "Maximum",
+    // (undocumented)
+    Minimum = "Minimum",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Total = "Total"
+}
+
+// @public
+export const enum KnownPublicNetworkAccess {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownSpatialType {
+    // (undocumented)
+    LineString = "LineString",
+    // (undocumented)
+    MultiPolygon = "MultiPolygon",
+    // (undocumented)
+    Point = "Point",
+    // (undocumented)
+    Polygon = "Polygon"
+}
+
+// @public
+export const enum KnownTriggerOperation {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Create = "Create",
+    // (undocumented)
+    Delete = "Delete",
+    // (undocumented)
+    Replace = "Replace",
+    // (undocumented)
+    Update = "Update"
+}
+
+// @public
+export const enum KnownTriggerType {
+    // (undocumented)
+    Post = "Post",
+    // (undocumented)
+    Pre = "Pre"
+}
+
+// @public
+export const enum KnownUnitType {
+    // (undocumented)
+    Bytes = "Bytes",
+    // (undocumented)
+    BytesPerSecond = "BytesPerSecond",
+    // (undocumented)
+    Count = "Count",
+    // (undocumented)
+    CountPerSecond = "CountPerSecond",
+    // (undocumented)
+    Milliseconds = "Milliseconds",
+    // (undocumented)
+    Percent = "Percent",
+    // (undocumented)
+    Seconds = "Seconds"
+}
 
 // @public
 interface Location_2 {
@@ -1119,7 +1289,7 @@ export interface NotebookWorkspaceListResult {
 }
 
 // @public
-export type NotebookWorkspaceName = "default" | string;
+export type NotebookWorkspaceName = string;
 
 // @public
 export type NotebookWorkspacesCreateOrUpdateResponse = NotebookWorkspace & {
@@ -1212,7 +1382,7 @@ export type PartitionKeyRangeIdRegionListMetricsResponse = PartitionMetricListRe
 };
 
 // @public
-export type PartitionKind = "Hash" | "Range" | string;
+export type PartitionKind = string;
 
 // @public
 export type PartitionMetric = Metric & {
@@ -1287,7 +1457,7 @@ export type PercentileTargetListMetricsResponse = PercentileMetricListResult & {
 };
 
 // @public
-export type PrimaryAggregationType = "None" | "Average" | "Total" | "Minimum" | "Maximum" | "Last" | string;
+export type PrimaryAggregationType = string;
 
 // @public
 export type PrivateEndpointConnection = Resource & {
@@ -1390,7 +1560,7 @@ export interface ProvisionedThroughputSettingsResource {
 export type ProxyResource = Resource & {};
 
 // @public
-export type PublicNetworkAccess = "Enabled" | "Disabled" | string;
+export type PublicNetworkAccess = string;
 
 // @public
 export interface RegionForOnlineOffline {
@@ -1411,7 +1581,7 @@ export interface SpatialSpec {
 }
 
 // @public
-export type SpatialType = "Point" | "LineString" | "Polygon" | "MultiPolygon" | string;
+export type SpatialType = string;
 
 // @public
 export type SqlContainerCreateUpdateParameters = ARMResourceProperties & {
@@ -1811,10 +1981,10 @@ export type ThroughputSettingsUpdateParameters = ARMResourceProperties & {
 };
 
 // @public
-export type TriggerOperation = "All" | "Create" | "Update" | "Delete" | "Replace" | string;
+export type TriggerOperation = string;
 
 // @public
-export type TriggerType = "Pre" | "Post" | string;
+export type TriggerType = string;
 
 // @public
 export interface UniqueKey {
@@ -1827,7 +1997,7 @@ export interface UniqueKeyPolicy {
 }
 
 // @public
-export type UnitType = "Count" | "Bytes" | "Seconds" | "Percent" | "CountPerSecond" | "BytesPerSecond" | "Milliseconds" | string;
+export type UnitType = string;
 
 // @public
 export interface Usage {
@@ -1852,7 +2022,7 @@ export interface VirtualNetworkRule {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:3695:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:3919:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/cosmos-db-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/models/index.ts
@@ -2132,112 +2132,336 @@ export type PrivateLinkResource = ARMProxyResource & {
  * Parameters to create a notebook workspace resource
  */
 export type NotebookWorkspaceCreateUpdateParameters = ARMProxyResource & {};
+
 /**
- * Defines values for DatabaseAccountKind.
+ * Known values of {@link DatabaseAccountKind} that the service accepts.
  */
-export type DatabaseAccountKind =
-  | "GlobalDocumentDB"
-  | "MongoDB"
-  | "Parse"
-  | string;
+export const enum KnownDatabaseAccountKind {
+  GlobalDocumentDB = "GlobalDocumentDB",
+  MongoDB = "MongoDB",
+  Parse = "Parse"
+}
+
 /**
- * Defines values for ConnectorOffer.
+ * Defines values for DatabaseAccountKind. \
+ * {@link KnownDatabaseAccountKind} can be used interchangeably with DatabaseAccountKind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **GlobalDocumentDB** \
+ * **MongoDB** \
+ * **Parse**
  */
-export type ConnectorOffer = "Small" | string;
+export type DatabaseAccountKind = string;
+
 /**
- * Defines values for PublicNetworkAccess.
+ * Known values of {@link ConnectorOffer} that the service accepts.
  */
-export type PublicNetworkAccess = "Enabled" | "Disabled" | string;
+export const enum KnownConnectorOffer {
+  Small = "Small"
+}
+
 /**
- * Defines values for KeyKind.
+ * Defines values for ConnectorOffer. \
+ * {@link KnownConnectorOffer} can be used interchangeably with ConnectorOffer,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Small**
  */
-export type KeyKind =
-  | "primary"
-  | "secondary"
-  | "primaryReadonly"
-  | "secondaryReadonly"
-  | string;
+export type ConnectorOffer = string;
+
 /**
- * Defines values for UnitType.
+ * Known values of {@link PublicNetworkAccess} that the service accepts.
  */
-export type UnitType =
-  | "Count"
-  | "Bytes"
-  | "Seconds"
-  | "Percent"
-  | "CountPerSecond"
-  | "BytesPerSecond"
-  | "Milliseconds"
-  | string;
+export const enum KnownPublicNetworkAccess {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
 /**
- * Defines values for PrimaryAggregationType.
+ * Defines values for PublicNetworkAccess. \
+ * {@link KnownPublicNetworkAccess} can be used interchangeably with PublicNetworkAccess,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
  */
-export type PrimaryAggregationType =
-  | "None"
-  | "Average"
-  | "Total"
-  | "Minimum"
-  | "Maximum"
-  | "Last"
-  | string;
+export type PublicNetworkAccess = string;
+
 /**
- * Defines values for IndexingMode.
+ * Known values of {@link KeyKind} that the service accepts.
  */
-export type IndexingMode = "Consistent" | "Lazy" | "None" | string;
+export const enum KnownKeyKind {
+  Primary = "primary",
+  Secondary = "secondary",
+  PrimaryReadonly = "primaryReadonly",
+  SecondaryReadonly = "secondaryReadonly"
+}
+
 /**
- * Defines values for DataType.
+ * Defines values for KeyKind. \
+ * {@link KnownKeyKind} can be used interchangeably with KeyKind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **primary** \
+ * **secondary** \
+ * **primaryReadonly** \
+ * **secondaryReadonly**
  */
-export type DataType =
-  | "String"
-  | "Number"
-  | "Point"
-  | "Polygon"
-  | "LineString"
-  | "MultiPolygon"
-  | string;
+export type KeyKind = string;
+
 /**
- * Defines values for IndexKind.
+ * Known values of {@link UnitType} that the service accepts.
  */
-export type IndexKind = "Hash" | "Range" | "Spatial" | string;
+export const enum KnownUnitType {
+  Count = "Count",
+  Bytes = "Bytes",
+  Seconds = "Seconds",
+  Percent = "Percent",
+  CountPerSecond = "CountPerSecond",
+  BytesPerSecond = "BytesPerSecond",
+  Milliseconds = "Milliseconds"
+}
+
 /**
- * Defines values for CompositePathSortOrder.
+ * Defines values for UnitType. \
+ * {@link KnownUnitType} can be used interchangeably with UnitType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Count** \
+ * **Bytes** \
+ * **Seconds** \
+ * **Percent** \
+ * **CountPerSecond** \
+ * **BytesPerSecond** \
+ * **Milliseconds**
  */
-export type CompositePathSortOrder = "Ascending" | "Descending" | string;
+export type UnitType = string;
+
 /**
- * Defines values for SpatialType.
+ * Known values of {@link PrimaryAggregationType} that the service accepts.
  */
-export type SpatialType =
-  | "Point"
-  | "LineString"
-  | "Polygon"
-  | "MultiPolygon"
-  | string;
+export const enum KnownPrimaryAggregationType {
+  None = "None",
+  Average = "Average",
+  Total = "Total",
+  Minimum = "Minimum",
+  Maximum = "Maximum",
+  Last = "Last"
+}
+
 /**
- * Defines values for PartitionKind.
+ * Defines values for PrimaryAggregationType. \
+ * {@link KnownPrimaryAggregationType} can be used interchangeably with PrimaryAggregationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **Average** \
+ * **Total** \
+ * **Minimum** \
+ * **Maximum** \
+ * **Last**
  */
-export type PartitionKind = "Hash" | "Range" | string;
+export type PrimaryAggregationType = string;
+
 /**
- * Defines values for ConflictResolutionMode.
+ * Known values of {@link IndexingMode} that the service accepts.
  */
-export type ConflictResolutionMode = "LastWriterWins" | "Custom" | string;
+export const enum KnownIndexingMode {
+  Consistent = "Consistent",
+  Lazy = "Lazy",
+  None = "None"
+}
+
 /**
- * Defines values for TriggerType.
+ * Defines values for IndexingMode. \
+ * {@link KnownIndexingMode} can be used interchangeably with IndexingMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Consistent** \
+ * **Lazy** \
+ * **None**
  */
-export type TriggerType = "Pre" | "Post" | string;
+export type IndexingMode = string;
+
 /**
- * Defines values for TriggerOperation.
+ * Known values of {@link DataType} that the service accepts.
  */
-export type TriggerOperation =
-  | "All"
-  | "Create"
-  | "Update"
-  | "Delete"
-  | "Replace"
-  | string;
+export const enum KnownDataType {
+  String = "String",
+  Number = "Number",
+  Point = "Point",
+  Polygon = "Polygon",
+  LineString = "LineString",
+  MultiPolygon = "MultiPolygon"
+}
+
 /**
- * Defines values for NotebookWorkspaceName.
+ * Defines values for DataType. \
+ * {@link KnownDataType} can be used interchangeably with DataType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **String** \
+ * **Number** \
+ * **Point** \
+ * **Polygon** \
+ * **LineString** \
+ * **MultiPolygon**
  */
-export type NotebookWorkspaceName = "default" | string;
+export type DataType = string;
+
+/**
+ * Known values of {@link IndexKind} that the service accepts.
+ */
+export const enum KnownIndexKind {
+  Hash = "Hash",
+  Range = "Range",
+  Spatial = "Spatial"
+}
+
+/**
+ * Defines values for IndexKind. \
+ * {@link KnownIndexKind} can be used interchangeably with IndexKind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Hash** \
+ * **Range** \
+ * **Spatial**
+ */
+export type IndexKind = string;
+
+/**
+ * Known values of {@link CompositePathSortOrder} that the service accepts.
+ */
+export const enum KnownCompositePathSortOrder {
+  Ascending = "Ascending",
+  Descending = "Descending"
+}
+
+/**
+ * Defines values for CompositePathSortOrder. \
+ * {@link KnownCompositePathSortOrder} can be used interchangeably with CompositePathSortOrder,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Ascending** \
+ * **Descending**
+ */
+export type CompositePathSortOrder = string;
+
+/**
+ * Known values of {@link SpatialType} that the service accepts.
+ */
+export const enum KnownSpatialType {
+  Point = "Point",
+  LineString = "LineString",
+  Polygon = "Polygon",
+  MultiPolygon = "MultiPolygon"
+}
+
+/**
+ * Defines values for SpatialType. \
+ * {@link KnownSpatialType} can be used interchangeably with SpatialType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Point** \
+ * **LineString** \
+ * **Polygon** \
+ * **MultiPolygon**
+ */
+export type SpatialType = string;
+
+/**
+ * Known values of {@link PartitionKind} that the service accepts.
+ */
+export const enum KnownPartitionKind {
+  Hash = "Hash",
+  Range = "Range"
+}
+
+/**
+ * Defines values for PartitionKind. \
+ * {@link KnownPartitionKind} can be used interchangeably with PartitionKind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Hash** \
+ * **Range**
+ */
+export type PartitionKind = string;
+
+/**
+ * Known values of {@link ConflictResolutionMode} that the service accepts.
+ */
+export const enum KnownConflictResolutionMode {
+  LastWriterWins = "LastWriterWins",
+  Custom = "Custom"
+}
+
+/**
+ * Defines values for ConflictResolutionMode. \
+ * {@link KnownConflictResolutionMode} can be used interchangeably with ConflictResolutionMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **LastWriterWins** \
+ * **Custom**
+ */
+export type ConflictResolutionMode = string;
+
+/**
+ * Known values of {@link TriggerType} that the service accepts.
+ */
+export const enum KnownTriggerType {
+  Pre = "Pre",
+  Post = "Post"
+}
+
+/**
+ * Defines values for TriggerType. \
+ * {@link KnownTriggerType} can be used interchangeably with TriggerType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Pre** \
+ * **Post**
+ */
+export type TriggerType = string;
+
+/**
+ * Known values of {@link TriggerOperation} that the service accepts.
+ */
+export const enum KnownTriggerOperation {
+  All = "All",
+  Create = "Create",
+  Update = "Update",
+  Delete = "Delete",
+  Replace = "Replace"
+}
+
+/**
+ * Defines values for TriggerOperation. \
+ * {@link KnownTriggerOperation} can be used interchangeably with TriggerOperation,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **All** \
+ * **Create** \
+ * **Update** \
+ * **Delete** \
+ * **Replace**
+ */
+export type TriggerOperation = string;
+
+/**
+ * Known values of {@link NotebookWorkspaceName} that the service accepts.
+ */
+export const enum KnownNotebookWorkspaceName {
+  Default = "default"
+}
+
+/**
+ * Defines values for NotebookWorkspaceName. \
+ * {@link KnownNotebookWorkspaceName} can be used interchangeably with NotebookWorkspaceName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type NotebookWorkspaceName = string;
 /**
  * Defines values for DefaultConsistencyLevel.
  */

--- a/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.json
@@ -2240,7 +2240,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!CompositePathSortOrder:type",
-          "docComment": "/**\n * Defines values for CompositePathSortOrder.\n */\n",
+          "docComment": "/**\n * Defines values for CompositePathSortOrder. \\ {@link KnownCompositePathSortOrder} can be used interchangeably with CompositePathSortOrder, this enum contains the known values that the service supports. ### Know values supported by the service **Ascending** \\ **Descending**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2248,7 +2248,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Ascending\" | \"Descending\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2265,7 +2265,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!ConflictResolutionMode:type",
-          "docComment": "/**\n * Defines values for ConflictResolutionMode.\n */\n",
+          "docComment": "/**\n * Defines values for ConflictResolutionMode. \\ {@link KnownConflictResolutionMode} can be used interchangeably with ConflictResolutionMode, this enum contains the known values that the service supports. ### Know values supported by the service **LastWriterWins** \\ **Custom**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2273,7 +2273,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"LastWriterWins\" | \"Custom\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2382,7 +2382,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!ConnectorOffer:type",
-          "docComment": "/**\n * Defines values for ConnectorOffer.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectorOffer. \\ {@link KnownConnectorOffer} can be used interchangeably with ConnectorOffer, this enum contains the known values that the service supports. ### Know values supported by the service **Small**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2390,7 +2390,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Small\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3877,7 +3877,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!DatabaseAccountKind:type",
-          "docComment": "/**\n * Defines values for DatabaseAccountKind.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseAccountKind. \\ {@link KnownDatabaseAccountKind} can be used interchangeably with DatabaseAccountKind, this enum contains the known values that the service supports. ### Know values supported by the service **GlobalDocumentDB** \\ **MongoDB** \\ **Parse**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3885,7 +3885,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"GlobalDocumentDB\" | \"MongoDB\" | \"Parse\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5463,7 +5463,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!DataType:type",
-          "docComment": "/**\n * Defines values for DataType.\n */\n",
+          "docComment": "/**\n * Defines values for DataType. \\ {@link KnownDataType} can be used interchangeably with DataType, this enum contains the known values that the service supports. ### Know values supported by the service **String** \\ **Number** \\ **Point** \\ **Polygon** \\ **LineString** \\ **MultiPolygon**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5471,7 +5471,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"String\" | \"Number\" | \"Point\" | \"Polygon\" | \"LineString\" | \"MultiPolygon\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -7197,7 +7197,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!IndexingMode:type",
-          "docComment": "/**\n * Defines values for IndexingMode.\n */\n",
+          "docComment": "/**\n * Defines values for IndexingMode. \\ {@link KnownIndexingMode} can be used interchangeably with IndexingMode, this enum contains the known values that the service supports. ### Know values supported by the service **Consistent** \\ **Lazy** \\ **None**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7205,7 +7205,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Consistent\" | \"Lazy\" | \"None\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -7409,7 +7409,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!IndexKind:type",
-          "docComment": "/**\n * Defines values for IndexKind.\n */\n",
+          "docComment": "/**\n * Defines values for IndexKind. \\ {@link KnownIndexKind} can be used interchangeably with IndexKind, this enum contains the known values that the service supports. ### Know values supported by the service **Hash** \\ **Range** \\ **Spatial**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7417,7 +7417,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Hash\" | \"Range\" | \"Spatial\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -7434,7 +7434,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!KeyKind:type",
-          "docComment": "/**\n * Defines values for KeyKind.\n */\n",
+          "docComment": "/**\n * Defines values for KeyKind. \\ {@link KnownKeyKind} can be used interchangeably with KeyKind, this enum contains the known values that the service supports. ### Know values supported by the service **primary** \\ **secondary** \\ **primaryReadonly** \\ **secondaryReadonly**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7442,7 +7442,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"primary\" | \"secondary\" | \"primaryReadonly\" | \"secondaryReadonly\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -7455,6 +7455,1359 @@
             "startIndex": 1,
             "endIndex": 2
           }
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownCompositePathSortOrder:enum",
+          "docComment": "/**\n * Known values of {@link CompositePathSortOrder} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCompositePathSortOrder "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCompositePathSortOrder",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownCompositePathSortOrder.Ascending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ascending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ascending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ascending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownCompositePathSortOrder.Descending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Descending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Descending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Descending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownConflictResolutionMode:enum",
+          "docComment": "/**\n * Known values of {@link ConflictResolutionMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConflictResolutionMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConflictResolutionMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownConflictResolutionMode.Custom:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Custom = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Custom\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Custom",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownConflictResolutionMode.LastWriterWins:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LastWriterWins = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LastWriterWins\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LastWriterWins",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownConnectorOffer:enum",
+          "docComment": "/**\n * Known values of {@link ConnectorOffer} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectorOffer "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectorOffer",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownConnectorOffer.Small:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Small = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Small\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Small",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownDatabaseAccountKind:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseAccountKind} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseAccountKind "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseAccountKind",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDatabaseAccountKind.GlobalDocumentDB:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GlobalDocumentDB = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GlobalDocumentDB\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GlobalDocumentDB",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDatabaseAccountKind.MongoDB:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MongoDB = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MongoDB\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MongoDB",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDatabaseAccountKind.Parse:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Parse = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Parse\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Parse",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownDataType:enum",
+          "docComment": "/**\n * Known values of {@link DataType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDataType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDataType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDataType.LineString:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LineString = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LineString\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LineString",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDataType.MultiPolygon:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MultiPolygon = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MultiPolygon\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MultiPolygon",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDataType.Number:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Number = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Number\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Number",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDataType.Point:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Point = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Point\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Point",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDataType.Polygon:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Polygon = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Polygon\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Polygon",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownDataType.String:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "String = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"String\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "String",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownIndexingMode:enum",
+          "docComment": "/**\n * Known values of {@link IndexingMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIndexingMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIndexingMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownIndexingMode.Consistent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Consistent = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Consistent\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Consistent",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownIndexingMode.Lazy:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Lazy = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Lazy\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Lazy",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownIndexingMode.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownIndexKind:enum",
+          "docComment": "/**\n * Known values of {@link IndexKind} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIndexKind "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIndexKind",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownIndexKind.Hash:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Hash = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Hash\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Hash",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownIndexKind.Range:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Range = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Range\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Range",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownIndexKind.Spatial:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Spatial = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Spatial\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Spatial",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownKeyKind:enum",
+          "docComment": "/**\n * Known values of {@link KeyKind} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownKeyKind "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownKeyKind",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownKeyKind.Primary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Primary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"primary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Primary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownKeyKind.PrimaryReadonly:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PrimaryReadonly = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"primaryReadonly\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PrimaryReadonly",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownKeyKind.Secondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Secondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"secondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Secondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownKeyKind.SecondaryReadonly:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SecondaryReadonly = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"secondaryReadonly\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SecondaryReadonly",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownNotebookWorkspaceName:enum",
+          "docComment": "/**\n * Known values of {@link NotebookWorkspaceName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownNotebookWorkspaceName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownNotebookWorkspaceName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownNotebookWorkspaceName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownPartitionKind:enum",
+          "docComment": "/**\n * Known values of {@link PartitionKind} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPartitionKind "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPartitionKind",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPartitionKind.Hash:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Hash = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Hash\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Hash",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPartitionKind.Range:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Range = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Range\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Range",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType:enum",
+          "docComment": "/**\n * Known values of {@link PrimaryAggregationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrimaryAggregationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrimaryAggregationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType.Average:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Average = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Average\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Average",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType.Last:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Last = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Last\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Last",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType.Maximum:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Maximum = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Maximum\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Maximum",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType.Minimum:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Minimum = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Minimum\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Minimum",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPrimaryAggregationType.Total:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Total = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Total\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Total",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownPublicNetworkAccess:enum",
+          "docComment": "/**\n * Known values of {@link PublicNetworkAccess} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPublicNetworkAccess "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPublicNetworkAccess",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPublicNetworkAccess.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownPublicNetworkAccess.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownSpatialType:enum",
+          "docComment": "/**\n * Known values of {@link SpatialType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSpatialType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSpatialType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownSpatialType.LineString:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LineString = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LineString\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LineString",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownSpatialType.MultiPolygon:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MultiPolygon = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MultiPolygon\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MultiPolygon",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownSpatialType.Point:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Point = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Point\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Point",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownSpatialType.Polygon:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Polygon = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Polygon\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Polygon",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownTriggerOperation:enum",
+          "docComment": "/**\n * Known values of {@link TriggerOperation} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTriggerOperation "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTriggerOperation",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerOperation.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerOperation.Create:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Create = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Create\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Create",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerOperation.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Delete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerOperation.Replace:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Replace = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Replace\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Replace",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerOperation.Update:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Update = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Update\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Update",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownTriggerType:enum",
+          "docComment": "/**\n * Known values of {@link TriggerType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTriggerType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTriggerType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerType.Post:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Post = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Post\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Post",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownTriggerType.Pre:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pre = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Pre\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pre",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "cosmos-db-resource-manager!KnownUnitType:enum",
+          "docComment": "/**\n * Known values of {@link UnitType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownUnitType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownUnitType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.Bytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Bytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Bytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Bytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.BytesPerSecond:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BytesPerSecond = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BytesPerSecond\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BytesPerSecond",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.Count:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Count = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Count\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Count",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.CountPerSecond:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CountPerSecond = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CountPerSecond\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CountPerSecond",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.Milliseconds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Milliseconds = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Milliseconds\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Milliseconds",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.Percent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Percent = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Percent\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Percent",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "cosmos-db-resource-manager!KnownUnitType.Seconds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Seconds = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Seconds\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Seconds",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -9798,7 +11151,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!NotebookWorkspaceName:type",
-          "docComment": "/**\n * Defines values for NotebookWorkspaceName.\n */\n",
+          "docComment": "/**\n * Defines values for NotebookWorkspaceName. \\ {@link KnownNotebookWorkspaceName} can be used interchangeably with NotebookWorkspaceName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9806,7 +11159,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10520,7 +11873,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!PartitionKind:type",
-          "docComment": "/**\n * Defines values for PartitionKind.\n */\n",
+          "docComment": "/**\n * Defines values for PartitionKind. \\ {@link KnownPartitionKind} can be used interchangeably with PartitionKind, this enum contains the known values that the service supports. ### Know values supported by the service **Hash** \\ **Range**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10528,7 +11881,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Hash\" | \"Range\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11092,7 +12445,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!PrimaryAggregationType:type",
-          "docComment": "/**\n * Defines values for PrimaryAggregationType.\n */\n",
+          "docComment": "/**\n * Defines values for PrimaryAggregationType. \\ {@link KnownPrimaryAggregationType} can be used interchangeably with PrimaryAggregationType, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **Average** \\ **Total** \\ **Minimum** \\ **Maximum** \\ **Last**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11100,7 +12453,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"Average\" | \"Total\" | \"Minimum\" | \"Maximum\" | \"Last\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11913,7 +13266,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!PublicNetworkAccess:type",
-          "docComment": "/**\n * Defines values for PublicNetworkAccess.\n */\n",
+          "docComment": "/**\n * Defines values for PublicNetworkAccess. \\ {@link KnownPublicNetworkAccess} can be used interchangeably with PublicNetworkAccess, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11921,7 +13274,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12141,7 +13494,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!SpatialType:type",
-          "docComment": "/**\n * Defines values for SpatialType.\n */\n",
+          "docComment": "/**\n * Defines values for SpatialType. \\ {@link KnownSpatialType} can be used interchangeably with SpatialType, this enum contains the known values that the service supports. ### Know values supported by the service **Point** \\ **LineString** \\ **Polygon** \\ **MultiPolygon**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12149,7 +13502,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Point\" | \"LineString\" | \"Polygon\" | \"MultiPolygon\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15431,7 +16784,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!TriggerOperation:type",
-          "docComment": "/**\n * Defines values for TriggerOperation.\n */\n",
+          "docComment": "/**\n * Defines values for TriggerOperation. \\ {@link KnownTriggerOperation} can be used interchangeably with TriggerOperation, this enum contains the known values that the service supports. ### Know values supported by the service **All** \\ **Create** \\ **Update** \\ **Delete** \\ **Replace**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15439,7 +16792,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"All\" | \"Create\" | \"Update\" | \"Delete\" | \"Replace\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15456,7 +16809,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!TriggerType:type",
-          "docComment": "/**\n * Defines values for TriggerType.\n */\n",
+          "docComment": "/**\n * Defines values for TriggerType. \\ {@link KnownTriggerType} can be used interchangeably with TriggerType, this enum contains the known values that the service supports. ### Know values supported by the service **Pre** \\ **Post**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15464,7 +16817,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Pre\" | \"Post\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15568,7 +16921,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "cosmos-db-resource-manager!UnitType:type",
-          "docComment": "/**\n * Defines values for UnitType.\n */\n",
+          "docComment": "/**\n * Defines values for UnitType. \\ {@link KnownUnitType} can be used interchangeably with UnitType, this enum contains the known values that the service supports. ### Know values supported by the service **Count** \\ **Bytes** \\ **Seconds** \\ **Percent** \\ **CountPerSecond** \\ **BytesPerSecond** \\ **Milliseconds**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15576,7 +16929,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Count\" | \"Bytes\" | \"Seconds\" | \"Percent\" | \"CountPerSecond\" | \"BytesPerSecond\" | \"Milliseconds\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.md
+++ b/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.md
@@ -281,10 +281,10 @@ export interface CompositePath {
 }
 
 // @public
-export type CompositePathSortOrder = "Ascending" | "Descending" | string;
+export type CompositePathSortOrder = string;
 
 // @public
-export type ConflictResolutionMode = "LastWriterWins" | "Custom" | string;
+export type ConflictResolutionMode = string;
 
 // @public
 export interface ConflictResolutionPolicy {
@@ -294,7 +294,7 @@ export interface ConflictResolutionPolicy {
 }
 
 // @public
-export type ConnectorOffer = "Small" | string;
+export type ConnectorOffer = string;
 
 // @public
 export interface ConsistencyPolicy {
@@ -471,7 +471,7 @@ export type DatabaseAccountGetResults = ARMResourceProperties & {
 };
 
 // @public
-export type DatabaseAccountKind = "GlobalDocumentDB" | "MongoDB" | "Parse" | string;
+export type DatabaseAccountKind = string;
 
 // @public
 export interface DatabaseAccountListConnectionStringsResult {
@@ -662,7 +662,7 @@ export type DatabaseListUsagesResponse = UsagesResult & {
 };
 
 // @public
-export type DataType = "String" | "Number" | "Point" | "Polygon" | "LineString" | "MultiPolygon" | string;
+export type DataType = string;
 
 // @public
 export type DefaultConsistencyLevel = "Eventual" | "Session" | "BoundedStaleness" | "Strong" | "ConsistentPrefix";
@@ -856,7 +856,7 @@ export interface Indexes {
 }
 
 // @public
-export type IndexingMode = "Consistent" | "Lazy" | "None" | string;
+export type IndexingMode = string;
 
 // @public
 export interface IndexingPolicy {
@@ -869,10 +869,180 @@ export interface IndexingPolicy {
 }
 
 // @public
-export type IndexKind = "Hash" | "Range" | "Spatial" | string;
+export type IndexKind = string;
 
 // @public
-export type KeyKind = "primary" | "secondary" | "primaryReadonly" | "secondaryReadonly" | string;
+export type KeyKind = string;
+
+// @public
+export const enum KnownCompositePathSortOrder {
+    // (undocumented)
+    Ascending = "Ascending",
+    // (undocumented)
+    Descending = "Descending"
+}
+
+// @public
+export const enum KnownConflictResolutionMode {
+    // (undocumented)
+    Custom = "Custom",
+    // (undocumented)
+    LastWriterWins = "LastWriterWins"
+}
+
+// @public
+export const enum KnownConnectorOffer {
+    // (undocumented)
+    Small = "Small"
+}
+
+// @public
+export const enum KnownDatabaseAccountKind {
+    // (undocumented)
+    GlobalDocumentDB = "GlobalDocumentDB",
+    // (undocumented)
+    MongoDB = "MongoDB",
+    // (undocumented)
+    Parse = "Parse"
+}
+
+// @public
+export const enum KnownDataType {
+    // (undocumented)
+    LineString = "LineString",
+    // (undocumented)
+    MultiPolygon = "MultiPolygon",
+    // (undocumented)
+    Number = "Number",
+    // (undocumented)
+    Point = "Point",
+    // (undocumented)
+    Polygon = "Polygon",
+    // (undocumented)
+    String = "String"
+}
+
+// @public
+export const enum KnownIndexingMode {
+    // (undocumented)
+    Consistent = "Consistent",
+    // (undocumented)
+    Lazy = "Lazy",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownIndexKind {
+    // (undocumented)
+    Hash = "Hash",
+    // (undocumented)
+    Range = "Range",
+    // (undocumented)
+    Spatial = "Spatial"
+}
+
+// @public
+export const enum KnownKeyKind {
+    // (undocumented)
+    Primary = "primary",
+    // (undocumented)
+    PrimaryReadonly = "primaryReadonly",
+    // (undocumented)
+    Secondary = "secondary",
+    // (undocumented)
+    SecondaryReadonly = "secondaryReadonly"
+}
+
+// @public
+export const enum KnownNotebookWorkspaceName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownPartitionKind {
+    // (undocumented)
+    Hash = "Hash",
+    // (undocumented)
+    Range = "Range"
+}
+
+// @public
+export const enum KnownPrimaryAggregationType {
+    // (undocumented)
+    Average = "Average",
+    // (undocumented)
+    Last = "Last",
+    // (undocumented)
+    Maximum = "Maximum",
+    // (undocumented)
+    Minimum = "Minimum",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Total = "Total"
+}
+
+// @public
+export const enum KnownPublicNetworkAccess {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownSpatialType {
+    // (undocumented)
+    LineString = "LineString",
+    // (undocumented)
+    MultiPolygon = "MultiPolygon",
+    // (undocumented)
+    Point = "Point",
+    // (undocumented)
+    Polygon = "Polygon"
+}
+
+// @public
+export const enum KnownTriggerOperation {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Create = "Create",
+    // (undocumented)
+    Delete = "Delete",
+    // (undocumented)
+    Replace = "Replace",
+    // (undocumented)
+    Update = "Update"
+}
+
+// @public
+export const enum KnownTriggerType {
+    // (undocumented)
+    Post = "Post",
+    // (undocumented)
+    Pre = "Pre"
+}
+
+// @public
+export const enum KnownUnitType {
+    // (undocumented)
+    Bytes = "Bytes",
+    // (undocumented)
+    BytesPerSecond = "BytesPerSecond",
+    // (undocumented)
+    Count = "Count",
+    // (undocumented)
+    CountPerSecond = "CountPerSecond",
+    // (undocumented)
+    Milliseconds = "Milliseconds",
+    // (undocumented)
+    Percent = "Percent",
+    // (undocumented)
+    Seconds = "Seconds"
+}
 
 // @public
 interface Location_2 {
@@ -1119,7 +1289,7 @@ export interface NotebookWorkspaceListResult {
 }
 
 // @public
-export type NotebookWorkspaceName = "default" | string;
+export type NotebookWorkspaceName = string;
 
 // @public
 export type NotebookWorkspacesCreateOrUpdateResponse = NotebookWorkspace & {
@@ -1212,7 +1382,7 @@ export type PartitionKeyRangeIdRegionListMetricsResponse = PartitionMetricListRe
 };
 
 // @public
-export type PartitionKind = "Hash" | "Range" | string;
+export type PartitionKind = string;
 
 // @public
 export type PartitionMetric = Metric & {
@@ -1287,7 +1457,7 @@ export type PercentileTargetListMetricsResponse = PercentileMetricListResult & {
 };
 
 // @public
-export type PrimaryAggregationType = "None" | "Average" | "Total" | "Minimum" | "Maximum" | "Last" | string;
+export type PrimaryAggregationType = string;
 
 // @public
 export type PrivateEndpointConnection = Resource & {
@@ -1390,7 +1560,7 @@ export interface ProvisionedThroughputSettingsResource {
 export type ProxyResource = Resource & {};
 
 // @public
-export type PublicNetworkAccess = "Enabled" | "Disabled" | string;
+export type PublicNetworkAccess = string;
 
 // @public
 export interface RegionForOnlineOffline {
@@ -1411,7 +1581,7 @@ export interface SpatialSpec {
 }
 
 // @public
-export type SpatialType = "Point" | "LineString" | "Polygon" | "MultiPolygon" | string;
+export type SpatialType = string;
 
 // @public
 export type SqlContainerCreateUpdateParameters = ARMResourceProperties & {
@@ -1811,10 +1981,10 @@ export type ThroughputSettingsUpdateParameters = ARMResourceProperties & {
 };
 
 // @public
-export type TriggerOperation = "All" | "Create" | "Update" | "Delete" | "Replace" | string;
+export type TriggerOperation = string;
 
 // @public
-export type TriggerType = "Pre" | "Post" | string;
+export type TriggerType = string;
 
 // @public
 export interface UniqueKey {
@@ -1827,7 +1997,7 @@ export interface UniqueKeyPolicy {
 }
 
 // @public
-export type UnitType = "Count" | "Bytes" | "Seconds" | "Percent" | "CountPerSecond" | "BytesPerSecond" | "Milliseconds" | string;
+export type UnitType = string;
 
 // @public
 export interface Usage {
@@ -1852,7 +2022,7 @@ export interface VirtualNetworkRule {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:3695:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:3919:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/cosmos-db-resource-manager/tsconfig.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/graphrbac-data-plane/review/graphrbac-data-plane.api.md
+++ b/test/smoke/generated/graphrbac-data-plane/review/graphrbac-data-plane.api.md
@@ -210,7 +210,7 @@ export interface CheckGroupMembershipResult {
 }
 
 // @public
-export type ConsentType = "AllPrincipals" | "Principal" | string;
+export type ConsentType = string;
 
 // @public
 export type DeletedApplicationsListNextResponse = ApplicationListResult & {
@@ -399,7 +399,7 @@ export interface GroupListResult {
 }
 
 // @public
-export type GroupMembershipClaimTypes = "None" | "SecurityGroup" | "All" | string;
+export type GroupMembershipClaimTypes = string;
 
 // @public
 export type GroupsCreateResponse = ADGroup & {
@@ -514,6 +514,32 @@ export interface KeyCredentialListResult {
 // @public
 export interface KeyCredentialsUpdateParameters {
     value: KeyCredential[];
+}
+
+// @public
+export const enum KnownConsentType {
+    // (undocumented)
+    AllPrincipals = "AllPrincipals",
+    // (undocumented)
+    Principal = "Principal"
+}
+
+// @public
+export const enum KnownGroupMembershipClaimTypes {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    SecurityGroup = "SecurityGroup"
+}
+
+// @public
+export const enum KnownUserType {
+    // (undocumented)
+    Guest = "Guest",
+    // (undocumented)
+    Member = "Member"
 }
 
 // @public
@@ -925,7 +951,7 @@ export type UsersListResponse = UserListResult & {
 };
 
 // @public
-export type UserType = "Member" | "Guest" | string;
+export type UserType = string;
 
 // @public
 export type UserUpdateParameters = UserBase & {

--- a/test/smoke/generated/graphrbac-data-plane/src/models/index.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/models/index.ts
@@ -1312,22 +1312,62 @@ export type UserUpdateParameters = UserBase & {
    */
   mailNickname?: string;
 };
+
 /**
- * Defines values for UserType.
+ * Known values of {@link UserType} that the service accepts.
  */
-export type UserType = "Member" | "Guest" | string;
+export const enum KnownUserType {
+  Member = "Member",
+  Guest = "Guest"
+}
+
 /**
- * Defines values for GroupMembershipClaimTypes.
+ * Defines values for UserType. \
+ * {@link KnownUserType} can be used interchangeably with UserType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Member** \
+ * **Guest**
  */
-export type GroupMembershipClaimTypes =
-  | "None"
-  | "SecurityGroup"
-  | "All"
-  | string;
+export type UserType = string;
+
 /**
- * Defines values for ConsentType.
+ * Known values of {@link GroupMembershipClaimTypes} that the service accepts.
  */
-export type ConsentType = "AllPrincipals" | "Principal" | string;
+export const enum KnownGroupMembershipClaimTypes {
+  None = "None",
+  SecurityGroup = "SecurityGroup",
+  All = "All"
+}
+
+/**
+ * Defines values for GroupMembershipClaimTypes. \
+ * {@link KnownGroupMembershipClaimTypes} can be used interchangeably with GroupMembershipClaimTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **SecurityGroup** \
+ * **All**
+ */
+export type GroupMembershipClaimTypes = string;
+
+/**
+ * Known values of {@link ConsentType} that the service accepts.
+ */
+export const enum KnownConsentType {
+  AllPrincipals = "AllPrincipals",
+  Principal = "Principal"
+}
+
+/**
+ * Defines values for ConsentType. \
+ * {@link KnownConsentType} can be used interchangeably with ConsentType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AllPrincipals** \
+ * **Principal**
+ */
+export type ConsentType = string;
 
 /**
  * Contains response data for the get operation.

--- a/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
+++ b/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
@@ -1995,7 +1995,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "graphrbac-data-plane!ConsentType:type",
-          "docComment": "/**\n * Defines values for ConsentType.\n */\n",
+          "docComment": "/**\n * Defines values for ConsentType. \\ {@link KnownConsentType} can be used interchangeably with ConsentType, this enum contains the known values that the service supports. ### Know values supported by the service **AllPrincipals** \\ **Principal**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2003,7 +2003,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AllPrincipals\" | \"Principal\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4117,7 +4117,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "graphrbac-data-plane!GroupMembershipClaimTypes:type",
-          "docComment": "/**\n * Defines values for GroupMembershipClaimTypes.\n */\n",
+          "docComment": "/**\n * Defines values for GroupMembershipClaimTypes. \\ {@link KnownGroupMembershipClaimTypes} can be used interchangeably with GroupMembershipClaimTypes, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **SecurityGroup** \\ **All**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4125,7 +4125,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"SecurityGroup\" | \"All\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5120,6 +5120,198 @@
             }
           ],
           "extendsTokenRanges": []
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "graphrbac-data-plane!KnownConsentType:enum",
+          "docComment": "/**\n * Known values of {@link ConsentType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConsentType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConsentType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownConsentType.AllPrincipals:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AllPrincipals = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AllPrincipals\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AllPrincipals",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownConsentType.Principal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Principal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Principal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Principal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "graphrbac-data-plane!KnownGroupMembershipClaimTypes:enum",
+          "docComment": "/**\n * Known values of {@link GroupMembershipClaimTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGroupMembershipClaimTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGroupMembershipClaimTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownGroupMembershipClaimTypes.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownGroupMembershipClaimTypes.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownGroupMembershipClaimTypes.SecurityGroup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SecurityGroup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SecurityGroup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SecurityGroup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "graphrbac-data-plane!KnownUserType:enum",
+          "docComment": "/**\n * Known values of {@link UserType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownUserType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownUserType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownUserType.Guest:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Guest = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Guest\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Guest",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "graphrbac-data-plane!KnownUserType.Member:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Member = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Member\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Member",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -8973,7 +9165,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "graphrbac-data-plane!UserType:type",
-          "docComment": "/**\n * Defines values for UserType.\n */\n",
+          "docComment": "/**\n * Defines values for UserType. \\ {@link KnownUserType} can be used interchangeably with UserType, this enum contains the known values that the service supports. ### Know values supported by the service **Member** \\ **Guest**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8981,7 +9173,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Member\" | \"Guest\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.md
+++ b/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.md
@@ -210,7 +210,7 @@ export interface CheckGroupMembershipResult {
 }
 
 // @public
-export type ConsentType = "AllPrincipals" | "Principal" | string;
+export type ConsentType = string;
 
 // @public
 export type DeletedApplicationsListNextResponse = ApplicationListResult & {
@@ -399,7 +399,7 @@ export interface GroupListResult {
 }
 
 // @public
-export type GroupMembershipClaimTypes = "None" | "SecurityGroup" | "All" | string;
+export type GroupMembershipClaimTypes = string;
 
 // @public
 export type GroupsCreateResponse = ADGroup & {
@@ -514,6 +514,32 @@ export interface KeyCredentialListResult {
 // @public
 export interface KeyCredentialsUpdateParameters {
     value: KeyCredential[];
+}
+
+// @public
+export const enum KnownConsentType {
+    // (undocumented)
+    AllPrincipals = "AllPrincipals",
+    // (undocumented)
+    Principal = "Principal"
+}
+
+// @public
+export const enum KnownGroupMembershipClaimTypes {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    SecurityGroup = "SecurityGroup"
+}
+
+// @public
+export const enum KnownUserType {
+    // (undocumented)
+    Guest = "Guest",
+    // (undocumented)
+    Member = "Member"
 }
 
 // @public
@@ -925,7 +951,7 @@ export type UsersListResponse = UserListResult & {
 };
 
 // @public
-export type UserType = "Member" | "Guest" | string;
+export type UserType = string;
 
 // @public
 export type UserUpdateParameters = UserBase & {

--- a/test/smoke/generated/graphrbac-data-plane/tsconfig.json
+++ b/test/smoke/generated/graphrbac-data-plane/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/keyvault-resource-manager/review/keyvault-resource-manager.api.md
+++ b/test/smoke/generated/keyvault-resource-manager/review/keyvault-resource-manager.api.md
@@ -26,7 +26,7 @@ export interface AccessPolicyEntry {
 export type AccessPolicyUpdateKind = "add" | "replace" | "remove";
 
 // @public
-export type CertificatePermissions = "get" | "list" | "delete" | "create" | "import" | "update" | "managecontacts" | "getissuers" | "listissuers" | "setissuers" | "deleteissuers" | "manageissuers" | "recover" | "purge" | "backup" | "restore" | string;
+export type CertificatePermissions = string;
 
 // @public
 export interface CheckNameAvailabilityResult {
@@ -80,7 +80,7 @@ export interface IPRule {
 }
 
 // @public
-export type KeyPermissions = "encrypt" | "decrypt" | "wrapKey" | "unwrapKey" | "sign" | "verify" | "get" | "list" | "create" | "update" | "import" | "delete" | "backup" | "restore" | "recover" | "purge" | string;
+export type KeyPermissions = string;
 
 // @public (undocumented)
 export class KeyVaultManagementClient extends KeyVaultManagementClientContext {
@@ -122,6 +122,180 @@ export interface KeyVaultManagementClientOptionalParams extends coreHttp.Service
 }
 
 // @public
+export const enum KnownCertificatePermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Create = "create",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Deleteissuers = "deleteissuers",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    Getissuers = "getissuers",
+    // (undocumented)
+    Import = "import",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Listissuers = "listissuers",
+    // (undocumented)
+    Managecontacts = "managecontacts",
+    // (undocumented)
+    Manageissuers = "manageissuers",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Setissuers = "setissuers",
+    // (undocumented)
+    Update = "update"
+}
+
+// @public
+export const enum KnownKeyPermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Create = "create",
+    // (undocumented)
+    Decrypt = "decrypt",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Encrypt = "encrypt",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    Import = "import",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Sign = "sign",
+    // (undocumented)
+    UnwrapKey = "unwrapKey",
+    // (undocumented)
+    Update = "update",
+    // (undocumented)
+    Verify = "verify",
+    // (undocumented)
+    WrapKey = "wrapKey"
+}
+
+// @public
+export const enum KnownNetworkRuleAction {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownNetworkRuleBypassOptions {
+    // (undocumented)
+    AzureServices = "AzureServices",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownPrivateEndpointConnectionProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownPrivateEndpointServiceConnectionStatus {
+    // (undocumented)
+    Approved = "Approved",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Rejected = "Rejected"
+}
+
+// @public
+export const enum KnownSecretPermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Set = "set"
+}
+
+// @public
+export const enum KnownSkuFamily {
+    // (undocumented)
+    A = "A"
+}
+
+// @public
+export const enum KnownStoragePermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Deletesas = "deletesas",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    Getsas = "getsas",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Listsas = "listsas",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Regeneratekey = "regeneratekey",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Set = "set",
+    // (undocumented)
+    Setsas = "setsas",
+    // (undocumented)
+    Update = "update"
+}
+
+// @public
 export interface LogSpecification {
     blobDuration?: string;
     displayName?: string;
@@ -129,10 +303,10 @@ export interface LogSpecification {
 }
 
 // @public
-export type NetworkRuleAction = "Allow" | "Deny" | string;
+export type NetworkRuleAction = string;
 
 // @public
-export type NetworkRuleBypassOptions = "AzureServices" | "None" | string;
+export type NetworkRuleBypassOptions = string;
 
 // @public
 export interface NetworkRuleSet {
@@ -210,7 +384,7 @@ export interface PrivateEndpointConnectionItem {
 }
 
 // @public
-export type PrivateEndpointConnectionProvisioningState = "Succeeded" | "Creating" | "Updating" | "Deleting" | "Failed" | "Disconnected" | string;
+export type PrivateEndpointConnectionProvisioningState = string;
 
 // @public
 export interface PrivateEndpointConnectionsDeleteHeaders {
@@ -251,7 +425,7 @@ export type PrivateEndpointConnectionsPutResponse = PrivateEndpointConnectionsPu
 };
 
 // @public
-export type PrivateEndpointServiceConnectionStatus = "Pending" | "Approved" | "Rejected" | "Disconnected" | string;
+export type PrivateEndpointServiceConnectionStatus = string;
 
 // @public
 export type PrivateLinkResource = Resource & {
@@ -301,7 +475,7 @@ export interface ResourceListResult {
 }
 
 // @public
-export type SecretPermissions = "get" | "list" | "set" | "delete" | "backup" | "restore" | "recover" | "purge" | string;
+export type SecretPermissions = string;
 
 // @public
 export interface ServiceSpecification {
@@ -315,13 +489,13 @@ export interface Sku {
 }
 
 // @public
-export type SkuFamily = "A" | string;
+export type SkuFamily = string;
 
 // @public
 export type SkuName = "standard" | "premium";
 
 // @public
-export type StoragePermissions = "get" | "list" | "delete" | "set" | "update" | "regeneratekey" | "recover" | "purge" | "backup" | "restore" | "setsas" | "listsas" | "getsas" | "deletesas" | string;
+export type StoragePermissions = string;
 
 // @public
 export interface Vault {
@@ -563,7 +737,7 @@ export interface VirtualNetworkRule {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:1270:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:1427:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/keyvault-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/models/index.ts
@@ -731,111 +731,268 @@ export interface PrivateEndpointConnectionsDeleteHeaders {
 }
 
 /**
- * Defines values for SkuFamily.
+ * Known values of {@link SkuFamily} that the service accepts.
  */
-export type SkuFamily = "A" | string;
+export const enum KnownSkuFamily {
+  A = "A"
+}
+
 /**
- * Defines values for KeyPermissions.
+ * Defines values for SkuFamily. \
+ * {@link KnownSkuFamily} can be used interchangeably with SkuFamily,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **A**
  */
-export type KeyPermissions =
-  | "encrypt"
-  | "decrypt"
-  | "wrapKey"
-  | "unwrapKey"
-  | "sign"
-  | "verify"
-  | "get"
-  | "list"
-  | "create"
-  | "update"
-  | "import"
-  | "delete"
-  | "backup"
-  | "restore"
-  | "recover"
-  | "purge"
-  | string;
+export type SkuFamily = string;
+
 /**
- * Defines values for SecretPermissions.
+ * Known values of {@link KeyPermissions} that the service accepts.
  */
-export type SecretPermissions =
-  | "get"
-  | "list"
-  | "set"
-  | "delete"
-  | "backup"
-  | "restore"
-  | "recover"
-  | "purge"
-  | string;
+export const enum KnownKeyPermissions {
+  Encrypt = "encrypt",
+  Decrypt = "decrypt",
+  WrapKey = "wrapKey",
+  UnwrapKey = "unwrapKey",
+  Sign = "sign",
+  Verify = "verify",
+  Get = "get",
+  List = "list",
+  Create = "create",
+  Update = "update",
+  Import = "import",
+  Delete = "delete",
+  Backup = "backup",
+  Restore = "restore",
+  Recover = "recover",
+  Purge = "purge"
+}
+
 /**
- * Defines values for CertificatePermissions.
+ * Defines values for KeyPermissions. \
+ * {@link KnownKeyPermissions} can be used interchangeably with KeyPermissions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **encrypt** \
+ * **decrypt** \
+ * **wrapKey** \
+ * **unwrapKey** \
+ * **sign** \
+ * **verify** \
+ * **get** \
+ * **list** \
+ * **create** \
+ * **update** \
+ * **import** \
+ * **delete** \
+ * **backup** \
+ * **restore** \
+ * **recover** \
+ * **purge**
  */
-export type CertificatePermissions =
-  | "get"
-  | "list"
-  | "delete"
-  | "create"
-  | "import"
-  | "update"
-  | "managecontacts"
-  | "getissuers"
-  | "listissuers"
-  | "setissuers"
-  | "deleteissuers"
-  | "manageissuers"
-  | "recover"
-  | "purge"
-  | "backup"
-  | "restore"
-  | string;
+export type KeyPermissions = string;
+
 /**
- * Defines values for StoragePermissions.
+ * Known values of {@link SecretPermissions} that the service accepts.
  */
-export type StoragePermissions =
-  | "get"
-  | "list"
-  | "delete"
-  | "set"
-  | "update"
-  | "regeneratekey"
-  | "recover"
-  | "purge"
-  | "backup"
-  | "restore"
-  | "setsas"
-  | "listsas"
-  | "getsas"
-  | "deletesas"
-  | string;
+export const enum KnownSecretPermissions {
+  Get = "get",
+  List = "list",
+  Set = "set",
+  Delete = "delete",
+  Backup = "backup",
+  Restore = "restore",
+  Recover = "recover",
+  Purge = "purge"
+}
+
 /**
- * Defines values for NetworkRuleBypassOptions.
+ * Defines values for SecretPermissions. \
+ * {@link KnownSecretPermissions} can be used interchangeably with SecretPermissions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **get** \
+ * **list** \
+ * **set** \
+ * **delete** \
+ * **backup** \
+ * **restore** \
+ * **recover** \
+ * **purge**
  */
-export type NetworkRuleBypassOptions = "AzureServices" | "None" | string;
+export type SecretPermissions = string;
+
 /**
- * Defines values for NetworkRuleAction.
+ * Known values of {@link CertificatePermissions} that the service accepts.
  */
-export type NetworkRuleAction = "Allow" | "Deny" | string;
+export const enum KnownCertificatePermissions {
+  Get = "get",
+  List = "list",
+  Delete = "delete",
+  Create = "create",
+  Import = "import",
+  Update = "update",
+  Managecontacts = "managecontacts",
+  Getissuers = "getissuers",
+  Listissuers = "listissuers",
+  Setissuers = "setissuers",
+  Deleteissuers = "deleteissuers",
+  Manageissuers = "manageissuers",
+  Recover = "recover",
+  Purge = "purge",
+  Backup = "backup",
+  Restore = "restore"
+}
+
 /**
- * Defines values for PrivateEndpointServiceConnectionStatus.
+ * Defines values for CertificatePermissions. \
+ * {@link KnownCertificatePermissions} can be used interchangeably with CertificatePermissions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **get** \
+ * **list** \
+ * **delete** \
+ * **create** \
+ * **import** \
+ * **update** \
+ * **managecontacts** \
+ * **getissuers** \
+ * **listissuers** \
+ * **setissuers** \
+ * **deleteissuers** \
+ * **manageissuers** \
+ * **recover** \
+ * **purge** \
+ * **backup** \
+ * **restore**
  */
-export type PrivateEndpointServiceConnectionStatus =
-  | "Pending"
-  | "Approved"
-  | "Rejected"
-  | "Disconnected"
-  | string;
+export type CertificatePermissions = string;
+
 /**
- * Defines values for PrivateEndpointConnectionProvisioningState.
+ * Known values of {@link StoragePermissions} that the service accepts.
  */
-export type PrivateEndpointConnectionProvisioningState =
-  | "Succeeded"
-  | "Creating"
-  | "Updating"
-  | "Deleting"
-  | "Failed"
-  | "Disconnected"
-  | string;
+export const enum KnownStoragePermissions {
+  Get = "get",
+  List = "list",
+  Delete = "delete",
+  Set = "set",
+  Update = "update",
+  Regeneratekey = "regeneratekey",
+  Recover = "recover",
+  Purge = "purge",
+  Backup = "backup",
+  Restore = "restore",
+  Setsas = "setsas",
+  Listsas = "listsas",
+  Getsas = "getsas",
+  Deletesas = "deletesas"
+}
+
+/**
+ * Defines values for StoragePermissions. \
+ * {@link KnownStoragePermissions} can be used interchangeably with StoragePermissions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **get** \
+ * **list** \
+ * **delete** \
+ * **set** \
+ * **update** \
+ * **regeneratekey** \
+ * **recover** \
+ * **purge** \
+ * **backup** \
+ * **restore** \
+ * **setsas** \
+ * **listsas** \
+ * **getsas** \
+ * **deletesas**
+ */
+export type StoragePermissions = string;
+
+/**
+ * Known values of {@link NetworkRuleBypassOptions} that the service accepts.
+ */
+export const enum KnownNetworkRuleBypassOptions {
+  AzureServices = "AzureServices",
+  None = "None"
+}
+
+/**
+ * Defines values for NetworkRuleBypassOptions. \
+ * {@link KnownNetworkRuleBypassOptions} can be used interchangeably with NetworkRuleBypassOptions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AzureServices** \
+ * **None**
+ */
+export type NetworkRuleBypassOptions = string;
+
+/**
+ * Known values of {@link NetworkRuleAction} that the service accepts.
+ */
+export const enum KnownNetworkRuleAction {
+  Allow = "Allow",
+  Deny = "Deny"
+}
+
+/**
+ * Defines values for NetworkRuleAction. \
+ * {@link KnownNetworkRuleAction} can be used interchangeably with NetworkRuleAction,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Allow** \
+ * **Deny**
+ */
+export type NetworkRuleAction = string;
+
+/**
+ * Known values of {@link PrivateEndpointServiceConnectionStatus} that the service accepts.
+ */
+export const enum KnownPrivateEndpointServiceConnectionStatus {
+  Pending = "Pending",
+  Approved = "Approved",
+  Rejected = "Rejected",
+  Disconnected = "Disconnected"
+}
+
+/**
+ * Defines values for PrivateEndpointServiceConnectionStatus. \
+ * {@link KnownPrivateEndpointServiceConnectionStatus} can be used interchangeably with PrivateEndpointServiceConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Pending** \
+ * **Approved** \
+ * **Rejected** \
+ * **Disconnected**
+ */
+export type PrivateEndpointServiceConnectionStatus = string;
+
+/**
+ * Known values of {@link PrivateEndpointConnectionProvisioningState} that the service accepts.
+ */
+export const enum KnownPrivateEndpointConnectionProvisioningState {
+  Succeeded = "Succeeded",
+  Creating = "Creating",
+  Updating = "Updating",
+  Deleting = "Deleting",
+  Failed = "Failed",
+  Disconnected = "Disconnected"
+}
+
+/**
+ * Defines values for PrivateEndpointConnectionProvisioningState. \
+ * {@link KnownPrivateEndpointConnectionProvisioningState} can be used interchangeably with PrivateEndpointConnectionProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Creating** \
+ * **Updating** \
+ * **Deleting** \
+ * **Failed** \
+ * **Disconnected**
+ */
+export type PrivateEndpointConnectionProvisioningState = string;
 /**
  * Defines values for SkuName.
  */

--- a/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.json
+++ b/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.json
@@ -160,7 +160,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!CertificatePermissions:type",
-          "docComment": "/**\n * Defines values for CertificatePermissions.\n */\n",
+          "docComment": "/**\n * Defines values for CertificatePermissions. \\ {@link KnownCertificatePermissions} can be used interchangeably with CertificatePermissions, this enum contains the known values that the service supports. ### Know values supported by the service **get** \\ **list** \\ **delete** \\ **create** \\ **import** \\ **update** \\ **managecontacts** \\ **getissuers** \\ **listissuers** \\ **setissuers** \\ **deleteissuers** \\ **manageissuers** \\ **recover** \\ **purge** \\ **backup** \\ **restore**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -168,7 +168,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"get\" | \"list\" | \"delete\" | \"create\" | \"import\" | \"update\" | \"managecontacts\" | \"getissuers\" | \"listissuers\" | \"setissuers\" | \"deleteissuers\" | \"manageissuers\" | \"recover\" | \"purge\" | \"backup\" | \"restore\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -782,7 +782,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!KeyPermissions:type",
-          "docComment": "/**\n * Defines values for KeyPermissions.\n */\n",
+          "docComment": "/**\n * Defines values for KeyPermissions. \\ {@link KnownKeyPermissions} can be used interchangeably with KeyPermissions, this enum contains the known values that the service supports. ### Know values supported by the service **encrypt** \\ **decrypt** \\ **wrapKey** \\ **unwrapKey** \\ **sign** \\ **verify** \\ **get** \\ **list** \\ **create** \\ **update** \\ **import** \\ **delete** \\ **backup** \\ **restore** \\ **recover** \\ **purge**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -790,7 +790,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"encrypt\" | \"decrypt\" | \"wrapKey\" | \"unwrapKey\" | \"sign\" | \"verify\" | \"get\" | \"list\" | \"create\" | \"update\" | \"import\" | \"delete\" | \"backup\" | \"restore\" | \"recover\" | \"purge\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1312,6 +1312,1590 @@
           ]
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions:enum",
+          "docComment": "/**\n * Known values of {@link CertificatePermissions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCertificatePermissions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCertificatePermissions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Backup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Backup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"backup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Backup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Create:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Create = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"create\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Create",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"delete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Deleteissuers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleteissuers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"deleteissuers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleteissuers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Get:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Get = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"get\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Get",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Getissuers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Getissuers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"getissuers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Getissuers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Import:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Import = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"import\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Import",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.List:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "List = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"list\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "List",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Listissuers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Listissuers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"listissuers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Listissuers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Managecontacts:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Managecontacts = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"managecontacts\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Managecontacts",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Manageissuers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Manageissuers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"manageissuers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Manageissuers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Purge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Purge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"purge\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Purge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Recover:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recover = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"recover\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recover",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Restore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"restore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Setissuers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Setissuers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"setissuers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Setissuers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownCertificatePermissions.Update:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Update = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"update\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Update",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions:enum",
+          "docComment": "/**\n * Known values of {@link KeyPermissions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownKeyPermissions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownKeyPermissions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Backup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Backup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"backup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Backup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Create:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Create = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"create\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Create",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Decrypt:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Decrypt = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"decrypt\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Decrypt",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"delete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Encrypt:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Encrypt = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"encrypt\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Encrypt",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Get:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Get = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"get\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Get",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Import:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Import = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"import\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Import",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.List:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "List = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"list\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "List",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Purge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Purge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"purge\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Purge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Recover:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recover = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"recover\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recover",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Restore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"restore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Sign:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Sign = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"sign\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Sign",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.UnwrapKey:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UnwrapKey = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"unwrapKey\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UnwrapKey",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Update:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Update = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"update\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Update",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.Verify:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Verify = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"verify\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Verify",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownKeyPermissions.WrapKey:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WrapKey = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"wrapKey\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WrapKey",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownNetworkRuleAction:enum",
+          "docComment": "/**\n * Known values of {@link NetworkRuleAction} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownNetworkRuleAction "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownNetworkRuleAction",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownNetworkRuleAction.Allow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Allow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Allow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Allow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownNetworkRuleAction.Deny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownNetworkRuleBypassOptions:enum",
+          "docComment": "/**\n * Known values of {@link NetworkRuleBypassOptions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownNetworkRuleBypassOptions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownNetworkRuleBypassOptions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownNetworkRuleBypassOptions.AzureServices:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzureServices = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzureServices\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzureServices",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownNetworkRuleBypassOptions.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link PrivateEndpointConnectionProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateEndpointConnectionProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateEndpointConnectionProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Disconnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disconnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disconnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disconnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointServiceConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link PrivateEndpointServiceConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateEndpointServiceConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateEndpointServiceConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Approved:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Approved = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Approved\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Approved",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Disconnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disconnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disconnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disconnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Pending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Pending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Rejected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Rejected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Rejected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Rejected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions:enum",
+          "docComment": "/**\n * Known values of {@link SecretPermissions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecretPermissions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecretPermissions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Backup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Backup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"backup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Backup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"delete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Get:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Get = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"get\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Get",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.List:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "List = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"list\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "List",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Purge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Purge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"purge\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Purge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Recover:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recover = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"recover\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recover",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Restore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"restore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSecretPermissions.Set:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Set = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"set\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Set",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownSkuFamily:enum",
+          "docComment": "/**\n * Known values of {@link SkuFamily} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSkuFamily "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSkuFamily",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownSkuFamily.A:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "A = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"A\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "A",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions:enum",
+          "docComment": "/**\n * Known values of {@link StoragePermissions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownStoragePermissions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownStoragePermissions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Backup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Backup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"backup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Backup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"delete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Deletesas:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deletesas = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"deletesas\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deletesas",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Get:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Get = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"get\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Get",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Getsas:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Getsas = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"getsas\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Getsas",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.List:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "List = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"list\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "List",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Listsas:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Listsas = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"listsas\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Listsas",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Purge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Purge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"purge\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Purge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Recover:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recover = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"recover\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recover",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Regeneratekey:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Regeneratekey = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"regeneratekey\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Regeneratekey",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Restore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"restore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Set:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Set = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"set\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Set",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Setsas:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Setsas = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"setsas\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Setsas",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "keyvault-resource-manager!KnownStoragePermissions.Update:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Update = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"update\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Update",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "Interface",
           "canonicalReference": "keyvault-resource-manager!LogSpecification:interface",
           "docComment": "/**\n * Log specification of operation.\n */\n",
@@ -1405,7 +2989,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!NetworkRuleAction:type",
-          "docComment": "/**\n * Defines values for NetworkRuleAction.\n */\n",
+          "docComment": "/**\n * Defines values for NetworkRuleAction. \\ {@link KnownNetworkRuleAction} can be used interchangeably with NetworkRuleAction, this enum contains the known values that the service supports. ### Know values supported by the service **Allow** \\ **Deny**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1413,7 +2997,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Allow\" | \"Deny\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1430,7 +3014,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!NetworkRuleBypassOptions:type",
-          "docComment": "/**\n * Defines values for NetworkRuleBypassOptions.\n */\n",
+          "docComment": "/**\n * Defines values for NetworkRuleBypassOptions. \\ {@link KnownNetworkRuleBypassOptions} can be used interchangeably with NetworkRuleBypassOptions, this enum contains the known values that the service supports. ### Know values supported by the service **AzureServices** \\ **None**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1438,7 +3022,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AzureServices\" | \"None\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2312,7 +3896,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!PrivateEndpointConnectionProvisioningState:type",
-          "docComment": "/**\n * Defines values for PrivateEndpointConnectionProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateEndpointConnectionProvisioningState. \\ {@link KnownPrivateEndpointConnectionProvisioningState} can be used interchangeably with PrivateEndpointConnectionProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Succeeded** \\ **Creating** \\ **Updating** \\ **Deleting** \\ **Failed** \\ **Disconnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2320,7 +3904,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Succeeded\" | \"Creating\" | \"Updating\" | \"Deleting\" | \"Failed\" | \"Disconnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2649,7 +4233,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!PrivateEndpointServiceConnectionStatus:type",
-          "docComment": "/**\n * Defines values for PrivateEndpointServiceConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateEndpointServiceConnectionStatus. \\ {@link KnownPrivateEndpointServiceConnectionStatus} can be used interchangeably with PrivateEndpointServiceConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Pending** \\ **Approved** \\ **Rejected** \\ **Disconnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2657,7 +4241,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Pending\" | \"Approved\" | \"Rejected\" | \"Disconnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3127,7 +4711,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!SecretPermissions:type",
-          "docComment": "/**\n * Defines values for SecretPermissions.\n */\n",
+          "docComment": "/**\n * Defines values for SecretPermissions. \\ {@link KnownSecretPermissions} can be used interchangeably with SecretPermissions, this enum contains the known values that the service supports. ### Know values supported by the service **get** \\ **list** \\ **set** \\ **delete** \\ **backup** \\ **restore** \\ **recover** \\ **purge**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3135,7 +4719,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"get\" | \"list\" | \"set\" | \"delete\" | \"backup\" | \"restore\" | \"recover\" | \"purge\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3266,7 +4850,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!SkuFamily:type",
-          "docComment": "/**\n * Defines values for SkuFamily.\n */\n",
+          "docComment": "/**\n * Defines values for SkuFamily. \\ {@link KnownSkuFamily} can be used interchangeably with SkuFamily, this enum contains the known values that the service supports. ### Know values supported by the service **A**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3274,7 +4858,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"A\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3316,7 +4900,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "keyvault-resource-manager!StoragePermissions:type",
-          "docComment": "/**\n * Defines values for StoragePermissions.\n */\n",
+          "docComment": "/**\n * Defines values for StoragePermissions. \\ {@link KnownStoragePermissions} can be used interchangeably with StoragePermissions, this enum contains the known values that the service supports. ### Know values supported by the service **get** \\ **list** \\ **delete** \\ **set** \\ **update** \\ **regeneratekey** \\ **recover** \\ **purge** \\ **backup** \\ **restore** \\ **setsas** \\ **listsas** \\ **getsas** \\ **deletesas**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3324,7 +4908,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"get\" | \"list\" | \"delete\" | \"set\" | \"update\" | \"regeneratekey\" | \"recover\" | \"purge\" | \"backup\" | \"restore\" | \"setsas\" | \"listsas\" | \"getsas\" | \"deletesas\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.md
+++ b/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.md
@@ -26,7 +26,7 @@ export interface AccessPolicyEntry {
 export type AccessPolicyUpdateKind = "add" | "replace" | "remove";
 
 // @public
-export type CertificatePermissions = "get" | "list" | "delete" | "create" | "import" | "update" | "managecontacts" | "getissuers" | "listissuers" | "setissuers" | "deleteissuers" | "manageissuers" | "recover" | "purge" | "backup" | "restore" | string;
+export type CertificatePermissions = string;
 
 // @public
 export interface CheckNameAvailabilityResult {
@@ -80,7 +80,7 @@ export interface IPRule {
 }
 
 // @public
-export type KeyPermissions = "encrypt" | "decrypt" | "wrapKey" | "unwrapKey" | "sign" | "verify" | "get" | "list" | "create" | "update" | "import" | "delete" | "backup" | "restore" | "recover" | "purge" | string;
+export type KeyPermissions = string;
 
 // @public (undocumented)
 export class KeyVaultManagementClient extends KeyVaultManagementClientContext {
@@ -122,6 +122,180 @@ export interface KeyVaultManagementClientOptionalParams extends coreHttp.Service
 }
 
 // @public
+export const enum KnownCertificatePermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Create = "create",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Deleteissuers = "deleteissuers",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    Getissuers = "getissuers",
+    // (undocumented)
+    Import = "import",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Listissuers = "listissuers",
+    // (undocumented)
+    Managecontacts = "managecontacts",
+    // (undocumented)
+    Manageissuers = "manageissuers",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Setissuers = "setissuers",
+    // (undocumented)
+    Update = "update"
+}
+
+// @public
+export const enum KnownKeyPermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Create = "create",
+    // (undocumented)
+    Decrypt = "decrypt",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Encrypt = "encrypt",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    Import = "import",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Sign = "sign",
+    // (undocumented)
+    UnwrapKey = "unwrapKey",
+    // (undocumented)
+    Update = "update",
+    // (undocumented)
+    Verify = "verify",
+    // (undocumented)
+    WrapKey = "wrapKey"
+}
+
+// @public
+export const enum KnownNetworkRuleAction {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownNetworkRuleBypassOptions {
+    // (undocumented)
+    AzureServices = "AzureServices",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownPrivateEndpointConnectionProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownPrivateEndpointServiceConnectionStatus {
+    // (undocumented)
+    Approved = "Approved",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Rejected = "Rejected"
+}
+
+// @public
+export const enum KnownSecretPermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Set = "set"
+}
+
+// @public
+export const enum KnownSkuFamily {
+    // (undocumented)
+    A = "A"
+}
+
+// @public
+export const enum KnownStoragePermissions {
+    // (undocumented)
+    Backup = "backup",
+    // (undocumented)
+    Delete = "delete",
+    // (undocumented)
+    Deletesas = "deletesas",
+    // (undocumented)
+    Get = "get",
+    // (undocumented)
+    Getsas = "getsas",
+    // (undocumented)
+    List = "list",
+    // (undocumented)
+    Listsas = "listsas",
+    // (undocumented)
+    Purge = "purge",
+    // (undocumented)
+    Recover = "recover",
+    // (undocumented)
+    Regeneratekey = "regeneratekey",
+    // (undocumented)
+    Restore = "restore",
+    // (undocumented)
+    Set = "set",
+    // (undocumented)
+    Setsas = "setsas",
+    // (undocumented)
+    Update = "update"
+}
+
+// @public
 export interface LogSpecification {
     blobDuration?: string;
     displayName?: string;
@@ -129,10 +303,10 @@ export interface LogSpecification {
 }
 
 // @public
-export type NetworkRuleAction = "Allow" | "Deny" | string;
+export type NetworkRuleAction = string;
 
 // @public
-export type NetworkRuleBypassOptions = "AzureServices" | "None" | string;
+export type NetworkRuleBypassOptions = string;
 
 // @public
 export interface NetworkRuleSet {
@@ -210,7 +384,7 @@ export interface PrivateEndpointConnectionItem {
 }
 
 // @public
-export type PrivateEndpointConnectionProvisioningState = "Succeeded" | "Creating" | "Updating" | "Deleting" | "Failed" | "Disconnected" | string;
+export type PrivateEndpointConnectionProvisioningState = string;
 
 // @public
 export interface PrivateEndpointConnectionsDeleteHeaders {
@@ -251,7 +425,7 @@ export type PrivateEndpointConnectionsPutResponse = PrivateEndpointConnectionsPu
 };
 
 // @public
-export type PrivateEndpointServiceConnectionStatus = "Pending" | "Approved" | "Rejected" | "Disconnected" | string;
+export type PrivateEndpointServiceConnectionStatus = string;
 
 // @public
 export type PrivateLinkResource = Resource & {
@@ -301,7 +475,7 @@ export interface ResourceListResult {
 }
 
 // @public
-export type SecretPermissions = "get" | "list" | "set" | "delete" | "backup" | "restore" | "recover" | "purge" | string;
+export type SecretPermissions = string;
 
 // @public
 export interface ServiceSpecification {
@@ -315,13 +489,13 @@ export interface Sku {
 }
 
 // @public
-export type SkuFamily = "A" | string;
+export type SkuFamily = string;
 
 // @public
 export type SkuName = "standard" | "premium";
 
 // @public
-export type StoragePermissions = "get" | "list" | "delete" | "set" | "update" | "regeneratekey" | "recover" | "purge" | "backup" | "restore" | "setsas" | "listsas" | "getsas" | "deletesas" | string;
+export type StoragePermissions = string;
 
 // @public
 export interface Vault {
@@ -563,7 +737,7 @@ export interface VirtualNetworkRule {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:1270:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:1427:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/keyvault-resource-manager/tsconfig.json
+++ b/test/smoke/generated/keyvault-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/monitor-data-plane/tsconfig.json
+++ b/test/smoke/generated/monitor-data-plane/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/msi-resource-manager/tsconfig.json
+++ b/test/smoke/generated/msi-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/network-resource-manager/review/network-resource-manager.api.md
+++ b/test/smoke/generated/network-resource-manager/review/network-resource-manager.api.md
@@ -22,7 +22,7 @@ export interface AadAuthenticationParameters {
 }
 
 // @public
-export type Access = "Allow" | "Deny" | string;
+export type Access = string;
 
 // @public
 export interface AddressSpace {
@@ -144,7 +144,7 @@ export interface ApplicationGatewayBackendHealthServer {
 }
 
 // @public
-export type ApplicationGatewayBackendHealthServerHealth = "Unknown" | "Up" | "Down" | "Partial" | "Draining" | string;
+export type ApplicationGatewayBackendHealthServerHealth = string;
 
 // @public
 export type ApplicationGatewayBackendHttpSettings = SubResource & {
@@ -174,7 +174,7 @@ export interface ApplicationGatewayConnectionDraining {
 }
 
 // @public
-export type ApplicationGatewayCookieBasedAffinity = "Enabled" | "Disabled" | string;
+export type ApplicationGatewayCookieBasedAffinity = string;
 
 // @public
 export interface ApplicationGatewayCustomError {
@@ -183,7 +183,7 @@ export interface ApplicationGatewayCustomError {
 }
 
 // @public
-export type ApplicationGatewayCustomErrorStatusCode = "HttpStatus403" | "HttpStatus502" | string;
+export type ApplicationGatewayCustomErrorStatusCode = string;
 
 // @public
 export interface ApplicationGatewayFirewallDisabledRuleGroup {
@@ -199,7 +199,7 @@ export interface ApplicationGatewayFirewallExclusion {
 }
 
 // @public
-export type ApplicationGatewayFirewallMode = "Detection" | "Prevention" | string;
+export type ApplicationGatewayFirewallMode = string;
 
 // @public
 export interface ApplicationGatewayFirewallRule {
@@ -294,7 +294,7 @@ export interface ApplicationGatewayOnDemandProbe {
 }
 
 // @public
-export type ApplicationGatewayOperationalState = "Stopped" | "Starting" | "Running" | "Stopping" | string;
+export type ApplicationGatewayOperationalState = string;
 
 // @public
 export type ApplicationGatewayPathRule = SubResource & {
@@ -335,7 +335,7 @@ export interface ApplicationGatewayProbeHealthResponseMatch {
 }
 
 // @public
-export type ApplicationGatewayProtocol = "Http" | "Https" | string;
+export type ApplicationGatewayProtocol = string;
 
 // @public
 export type ApplicationGatewayRedirectConfiguration = SubResource & {
@@ -353,7 +353,7 @@ export type ApplicationGatewayRedirectConfiguration = SubResource & {
 };
 
 // @public
-export type ApplicationGatewayRedirectType = "Permanent" | "Found" | "SeeOther" | "Temporary" | string;
+export type ApplicationGatewayRedirectType = string;
 
 // @public
 export type ApplicationGatewayRequestRoutingRule = SubResource & {
@@ -372,7 +372,7 @@ export type ApplicationGatewayRequestRoutingRule = SubResource & {
 };
 
 // @public
-export type ApplicationGatewayRequestRoutingRuleType = "Basic" | "PathBasedRouting" | string;
+export type ApplicationGatewayRequestRoutingRuleType = string;
 
 // @public
 export interface ApplicationGatewayRewriteRule {
@@ -466,7 +466,7 @@ export interface ApplicationGatewaySku {
 }
 
 // @public
-export type ApplicationGatewaySkuName = "Standard_Small" | "Standard_Medium" | "Standard_Large" | "WAF_Medium" | "WAF_Large" | "Standard_v2" | "WAF_v2" | string;
+export type ApplicationGatewaySkuName = string;
 
 // @public
 export type ApplicationGatewaysListAllNextResponse = ApplicationGatewayListResult & {
@@ -572,7 +572,7 @@ export type ApplicationGatewaySslCertificate = SubResource & {
 };
 
 // @public
-export type ApplicationGatewaySslCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384" | "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256" | "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" | "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA" | "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384" | "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256" | "TLS_DHE_RSA_WITH_AES_256_CBC_SHA" | "TLS_DHE_RSA_WITH_AES_128_CBC_SHA" | "TLS_RSA_WITH_AES_256_GCM_SHA384" | "TLS_RSA_WITH_AES_128_GCM_SHA256" | "TLS_RSA_WITH_AES_256_CBC_SHA256" | "TLS_RSA_WITH_AES_128_CBC_SHA256" | "TLS_RSA_WITH_AES_256_CBC_SHA" | "TLS_RSA_WITH_AES_128_CBC_SHA" | "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" | "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" | "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384" | "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256" | "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" | "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA" | "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256" | "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256" | "TLS_DHE_DSS_WITH_AES_256_CBC_SHA" | "TLS_DHE_DSS_WITH_AES_128_CBC_SHA" | "TLS_RSA_WITH_3DES_EDE_CBC_SHA" | "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA" | "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" | "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" | string;
+export type ApplicationGatewaySslCipherSuite = string;
 
 // @public
 export interface ApplicationGatewaySslPolicy {
@@ -584,10 +584,10 @@ export interface ApplicationGatewaySslPolicy {
 }
 
 // @public
-export type ApplicationGatewaySslPolicyName = "AppGwSslPolicy20150501" | "AppGwSslPolicy20170401" | "AppGwSslPolicy20170401S" | string;
+export type ApplicationGatewaySslPolicyName = string;
 
 // @public
-export type ApplicationGatewaySslPolicyType = "Predefined" | "Custom" | string;
+export type ApplicationGatewaySslPolicyType = string;
 
 // @public
 export type ApplicationGatewaySslPredefinedPolicy = SubResource & {
@@ -597,7 +597,7 @@ export type ApplicationGatewaySslPredefinedPolicy = SubResource & {
 };
 
 // @public
-export type ApplicationGatewaySslProtocol = "TLSv1_0" | "TLSv1_1" | "TLSv1_2" | string;
+export type ApplicationGatewaySslProtocol = string;
 
 // @public
 export type ApplicationGatewaysUpdateTagsResponse = ApplicationGateway & {
@@ -608,7 +608,7 @@ export type ApplicationGatewaysUpdateTagsResponse = ApplicationGateway & {
 };
 
 // @public
-export type ApplicationGatewayTier = "Standard" | "WAF" | "Standard_v2" | "WAF_v2" | string;
+export type ApplicationGatewayTier = string;
 
 // @public
 export type ApplicationGatewayTrustedRootCertificate = SubResource & {
@@ -736,10 +736,10 @@ export type ApplicationSecurityGroupsUpdateTagsResponse = ApplicationSecurityGro
 };
 
 // @public
-export type AssociationType = "Associated" | "Contains" | string;
+export type AssociationType = string;
 
 // @public
-export type AuthenticationMethod = "EAPTLS" | "EAPMSCHAPv2" | string;
+export type AuthenticationMethod = string;
 
 // @public
 export interface AuthorizationListResult {
@@ -748,7 +748,7 @@ export interface AuthorizationListResult {
 }
 
 // @public
-export type AuthorizationUseStatus = "Available" | "InUse" | string;
+export type AuthorizationUseStatus = string;
 
 // @public
 export interface AutoApprovedPrivateLinkService {
@@ -1011,7 +1011,7 @@ export interface AzureFirewallApplicationRuleProtocol {
 }
 
 // @public
-export type AzureFirewallApplicationRuleProtocolType = "Http" | "Https" | "Mssql" | string;
+export type AzureFirewallApplicationRuleProtocolType = string;
 
 // @public
 export type AzureFirewallFqdnTag = Resource & {
@@ -1071,7 +1071,7 @@ export interface AzureFirewallNatRCAction {
 }
 
 // @public
-export type AzureFirewallNatRCActionType = "Snat" | "Dnat" | string;
+export type AzureFirewallNatRCActionType = string;
 
 // @public
 export interface AzureFirewallNatRule {
@@ -1121,7 +1121,7 @@ export type AzureFirewallNetworkRuleCollection = SubResource & {
 };
 
 // @public
-export type AzureFirewallNetworkRuleProtocol = "TCP" | "UDP" | "Any" | "ICMP" | string;
+export type AzureFirewallNetworkRuleProtocol = string;
 
 // @public
 export interface AzureFirewallPublicIPAddress {
@@ -1134,7 +1134,7 @@ export interface AzureFirewallRCAction {
 }
 
 // @public
-export type AzureFirewallRCActionType = "Allow" | "Deny" | string;
+export type AzureFirewallRCActionType = string;
 
 // @public
 export type AzureFirewallsCreateOrUpdateResponse = AzureFirewall & {
@@ -1160,10 +1160,10 @@ export interface AzureFirewallSku {
 }
 
 // @public
-export type AzureFirewallSkuName = "AZFW_VNet" | "AZFW_Hub" | string;
+export type AzureFirewallSkuName = string;
 
 // @public
-export type AzureFirewallSkuTier = "Standard" | "Premium" | string;
+export type AzureFirewallSkuTier = string;
 
 // @public
 export type AzureFirewallsListAllNextResponse = AzureFirewallListResult & {
@@ -1207,7 +1207,7 @@ export type AzureFirewallsUpdateTagsResponse = AzureFirewall & {
 };
 
 // @public
-export type AzureFirewallThreatIntelMode = "Alert" | "Deny" | "Off" | string;
+export type AzureFirewallThreatIntelMode = string;
 
 // @public
 export interface AzureReachabilityReport {
@@ -1280,7 +1280,7 @@ export interface BastionActiveSessionListResult {
 }
 
 // @public
-export type BastionConnectProtocol = "SSH" | "RDP" | string;
+export type BastionConnectProtocol = string;
 
 // @public
 export type BastionHost = Resource & {
@@ -1399,7 +1399,7 @@ export interface BGPCommunity {
 }
 
 // @public
-export type BgpPeerState = "Unknown" | "Stopped" | "Idle" | "Connecting" | "Connected" | string;
+export type BgpPeerState = string;
 
 // @public
 export interface BgpPeerStatus {
@@ -1460,7 +1460,7 @@ export interface CheckPrivateLinkServiceVisibilityRequest {
 }
 
 // @public
-export type CircuitConnectionStatus = "Connected" | "Connecting" | "Disconnected" | string;
+export type CircuitConnectionStatus = string;
 
 // @public
 export interface CloudError {
@@ -1526,10 +1526,10 @@ export interface ConnectionMonitorEndpointFilterItem {
 }
 
 // @public
-export type ConnectionMonitorEndpointFilterItemType = "AgentAddress" | string;
+export type ConnectionMonitorEndpointFilterItemType = string;
 
 // @public
-export type ConnectionMonitorEndpointFilterType = "Include" | string;
+export type ConnectionMonitorEndpointFilterType = string;
 
 // @public
 export interface ConnectionMonitorHttpConfiguration {
@@ -1641,7 +1641,7 @@ export interface ConnectionMonitorSource {
 }
 
 // @public
-export type ConnectionMonitorSourceStatus = "Unknown" | "Active" | "Inactive" | string;
+export type ConnectionMonitorSourceStatus = string;
 
 // @public
 export type ConnectionMonitorsQueryResponse = ConnectionMonitorQueryResult & {
@@ -1685,7 +1685,7 @@ export interface ConnectionMonitorTestConfiguration {
 }
 
 // @public
-export type ConnectionMonitorTestConfigurationProtocol = "Tcp" | "Http" | "Icmp" | string;
+export type ConnectionMonitorTestConfigurationProtocol = string;
 
 // @public
 export interface ConnectionMonitorTestGroup {
@@ -1697,7 +1697,7 @@ export interface ConnectionMonitorTestGroup {
 }
 
 // @public
-export type ConnectionMonitorType = "MultiEndpoint" | "SingleSourceDestination" | string;
+export type ConnectionMonitorType = string;
 
 // @public
 export interface ConnectionMonitorWorkspaceSettings {
@@ -1715,7 +1715,7 @@ export type ConnectionSharedKey = SubResource & {
 };
 
 // @public
-export type ConnectionState = "Reachable" | "Unreachable" | "Unknown" | string;
+export type ConnectionState = string;
 
 // @public
 export interface ConnectionStateSnapshot {
@@ -1732,7 +1732,7 @@ export interface ConnectionStateSnapshot {
 }
 
 // @public
-export type ConnectionStatus = "Unknown" | "Connected" | "Disconnected" | "Degraded" | string;
+export type ConnectionStatus = string;
 
 // @public
 export interface ConnectivityDestination {
@@ -1860,10 +1860,10 @@ export type DdosCustomPolicy = Resource & {
 };
 
 // @public
-export type DdosCustomPolicyProtocol = "Tcp" | "Udp" | "Syn" | string;
+export type DdosCustomPolicyProtocol = string;
 
 // @public
-export type DdosCustomPolicyTriggerSensitivityOverride = "Relaxed" | "Low" | "Default" | "High" | string;
+export type DdosCustomPolicyTriggerSensitivityOverride = string;
 
 // @public
 export interface DdosProtectionPlan {
@@ -1951,7 +1951,7 @@ export interface DdosSettings {
 }
 
 // @public
-export type DdosSettingsProtectionCoverage = "Basic" | "Standard" | string;
+export type DdosSettingsProtectionCoverage = string;
 
 // @public
 export type DefaultSecurityRulesGetResponse = SecurityRule & {
@@ -1999,7 +1999,7 @@ export interface DhcpOptions {
 }
 
 // @public
-export type DhGroup = "None" | "DHGroup1" | "DHGroup2" | "DHGroup14" | "DHGroup2048" | "ECP256" | "ECP384" | "DHGroup24" | string;
+export type DhGroup = string;
 
 // @public
 export interface Dimension {
@@ -2009,7 +2009,7 @@ export interface Dimension {
 }
 
 // @public
-export type Direction = "Inbound" | "Outbound" | string;
+export type Direction = string;
 
 // @public
 export interface DnsNameAvailabilityResult {
@@ -2073,13 +2073,13 @@ export interface EffectiveRouteListResult {
 }
 
 // @public
-export type EffectiveRouteSource = "Unknown" | "User" | "VirtualNetworkGateway" | "Default" | string;
+export type EffectiveRouteSource = string;
 
 // @public
-export type EffectiveRouteState = "Active" | "Invalid" | string;
+export type EffectiveRouteState = string;
 
 // @public
-export type EffectiveSecurityRuleProtocol = "Tcp" | "Udp" | "All" | string;
+export type EffectiveSecurityRuleProtocol = string;
 
 // @public
 export type EndpointServiceResult = SubResource & {
@@ -2123,7 +2123,7 @@ export interface EvaluatedNetworkSecurityGroup {
 }
 
 // @public
-export type EvaluationState = "NotStarted" | "InProgress" | "Completed" | string;
+export type EvaluationState = string;
 
 // @public
 export type ExpressRouteCircuit = Resource & {
@@ -2283,7 +2283,7 @@ export type ExpressRouteCircuitPeering = SubResource & {
 };
 
 // @public
-export type ExpressRouteCircuitPeeringAdvertisedPublicPrefixState = "NotConfigured" | "Configuring" | "Configured" | "ValidationNeeded" | string;
+export type ExpressRouteCircuitPeeringAdvertisedPublicPrefixState = string;
 
 // @public
 export interface ExpressRouteCircuitPeeringConfig {
@@ -2340,7 +2340,7 @@ export type ExpressRouteCircuitPeeringsListResponse = ExpressRouteCircuitPeering
 };
 
 // @public
-export type ExpressRouteCircuitPeeringState = "Disabled" | "Enabled" | string;
+export type ExpressRouteCircuitPeeringState = string;
 
 // @public
 export interface ExpressRouteCircuitReference {
@@ -2419,10 +2419,10 @@ export interface ExpressRouteCircuitSku {
 }
 
 // @public
-export type ExpressRouteCircuitSkuFamily = "UnlimitedData" | "MeteredData" | string;
+export type ExpressRouteCircuitSkuFamily = string;
 
 // @public
-export type ExpressRouteCircuitSkuTier = "Standard" | "Premium" | "Basic" | "Local" | string;
+export type ExpressRouteCircuitSkuTier = string;
 
 // @public
 export type ExpressRouteCircuitsListAllNextResponse = ExpressRouteCircuitListResult & {
@@ -2809,10 +2809,10 @@ export type ExpressRouteLink = SubResource & {
 };
 
 // @public
-export type ExpressRouteLinkAdminState = "Enabled" | "Disabled" | string;
+export type ExpressRouteLinkAdminState = string;
 
 // @public
-export type ExpressRouteLinkConnectorType = "LC" | "SC" | string;
+export type ExpressRouteLinkConnectorType = string;
 
 // @public
 export interface ExpressRouteLinkListResult {
@@ -2821,7 +2821,7 @@ export interface ExpressRouteLinkListResult {
 }
 
 // @public
-export type ExpressRouteLinkMacSecCipher = "gcm-aes-128" | "gcm-aes-256" | string;
+export type ExpressRouteLinkMacSecCipher = string;
 
 // @public
 export interface ExpressRouteLinkMacSecConfig {
@@ -2855,10 +2855,10 @@ export type ExpressRouteLinksListResponse = ExpressRouteLinkListResult & {
 };
 
 // @public
-export type ExpressRoutePeeringState = "Disabled" | "Enabled" | string;
+export type ExpressRoutePeeringState = string;
 
 // @public
-export type ExpressRoutePeeringType = "AzurePublicPeering" | "AzurePrivatePeering" | "MicrosoftPeering" | string;
+export type ExpressRoutePeeringType = string;
 
 // @public
 export type ExpressRoutePort = Resource & {
@@ -2893,7 +2893,7 @@ export type ExpressRoutePortsCreateOrUpdateResponse = ExpressRoutePort & {
 };
 
 // @public
-export type ExpressRoutePortsEncapsulation = "Dot1Q" | "QinQ" | string;
+export type ExpressRoutePortsEncapsulation = string;
 
 // @public
 export type ExpressRoutePortsGetResponse = ExpressRoutePort & {
@@ -3109,10 +3109,10 @@ export interface FirewallPolicyFilterRuleAction {
 }
 
 // @public
-export type FirewallPolicyFilterRuleActionType = "Allow" | "Deny" | string;
+export type FirewallPolicyFilterRuleActionType = string;
 
 // @public
-export type FirewallPolicyIntrusionSystemMode = "Enabled" | "Disabled" | string;
+export type FirewallPolicyIntrusionSystemMode = string;
 
 // @public
 export interface FirewallPolicyListResult {
@@ -3134,7 +3134,7 @@ export interface FirewallPolicyNatRuleAction {
 }
 
 // @public
-export type FirewallPolicyNatRuleActionType = "DNAT" | string;
+export type FirewallPolicyNatRuleActionType = string;
 
 // @public
 export interface FirewallPolicyRule {
@@ -3157,13 +3157,13 @@ export interface FirewallPolicyRuleConditionApplicationProtocol {
 }
 
 // @public
-export type FirewallPolicyRuleConditionApplicationProtocolType = "Http" | "Https" | string;
+export type FirewallPolicyRuleConditionApplicationProtocolType = string;
 
 // @public
-export type FirewallPolicyRuleConditionNetworkProtocol = "TCP" | "UDP" | "Any" | "ICMP" | string;
+export type FirewallPolicyRuleConditionNetworkProtocol = string;
 
 // @public
-export type FirewallPolicyRuleConditionType = "ApplicationRuleCondition" | "NetworkRuleCondition" | "NatRuleCondition" | string;
+export type FirewallPolicyRuleConditionType = string;
 
 // @public (undocumented)
 export type FirewallPolicyRuleConditionUnion = ApplicationRuleCondition | NatRuleCondition | NetworkRuleCondition;
@@ -3218,7 +3218,7 @@ export type FirewallPolicyRuleGroupsListResponse = FirewallPolicyRuleGroupListRe
 };
 
 // @public
-export type FirewallPolicyRuleType = "FirewallPolicyNatRule" | "FirewallPolicyFilterRule" | string;
+export type FirewallPolicyRuleType = string;
 
 // @public (undocumented)
 export type FirewallPolicyRuleUnion = FirewallPolicyNatRule | FirewallPolicyFilterRule;
@@ -3262,7 +3262,7 @@ export interface FlowLogFormatParameters {
 }
 
 // @public
-export type FlowLogFormatType = "JSON" | string;
+export type FlowLogFormatType = string;
 
 // @public
 export interface FlowLogInformation {
@@ -3367,7 +3367,7 @@ export interface HttpConfiguration {
 }
 
 // @public
-export type HttpConfigurationMethod = "Get" | "Post" | string;
+export type HttpConfigurationMethod = string;
 
 // @public
 export interface HttpHeader {
@@ -3376,7 +3376,7 @@ export interface HttpHeader {
 }
 
 // @public
-export type HttpMethod = "Get" | string;
+export type HttpMethod = string;
 
 // @public
 export interface HubIPAddresses {
@@ -3475,13 +3475,13 @@ export type HubVirtualNetworkConnectionsListResponse = ListHubVirtualNetworkConn
 };
 
 // @public
-export type HubVirtualNetworkConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type HubVirtualNetworkConnectionStatus = string;
 
 // @public
-export type IkeEncryption = "DES" | "DES3" | "AES128" | "AES192" | "AES256" | "GCMAES256" | "GCMAES128" | string;
+export type IkeEncryption = string;
 
 // @public
-export type IkeIntegrity = "MD5" | "SHA1" | "SHA256" | "SHA384" | "GCMAES256" | "GCMAES128" | string;
+export type IkeIntegrity = string;
 
 // @public
 export type InboundNatPool = SubResource & {
@@ -3587,7 +3587,7 @@ export interface IpAllocationListResult {
 }
 
 // @public
-export type IPAllocationMethod = "Static" | "Dynamic" | string;
+export type IPAllocationMethod = string;
 
 // @public
 export type IpAllocationsCreateOrUpdateResponse = IpAllocation & {
@@ -3652,7 +3652,7 @@ export type IpAllocationsUpdateTagsResponse = IpAllocation & {
 };
 
 // @public
-export type IpAllocationType = "Undefined" | "Hypernet" | string;
+export type IpAllocationType = string;
 
 // @public
 export type IPConfiguration = SubResource & {
@@ -3683,7 +3683,7 @@ export type IPConfigurationProfile = SubResource & {
 };
 
 // @public
-export type IpFlowProtocol = "TCP" | "UDP" | string;
+export type IpFlowProtocol = string;
 
 // @public
 export type IpGroup = Resource & {
@@ -3762,10 +3762,10 @@ export type IpGroupsUpdateGroupsResponse = IpGroup & {
 };
 
 // @public
-export type IpsecEncryption = "None" | "DES" | "DES3" | "AES128" | "AES192" | "AES256" | "GCMAES128" | "GCMAES192" | "GCMAES256" | string;
+export type IpsecEncryption = string;
 
 // @public
-export type IpsecIntegrity = "MD5" | "SHA1" | "SHA256" | "GCMAES128" | "GCMAES192" | "GCMAES256" | string;
+export type IpsecIntegrity = string;
 
 // @public
 export interface IpsecPolicy {
@@ -3801,10 +3801,1480 @@ export interface Ipv6ExpressRouteCircuitPeeringConfig {
 }
 
 // @public
-export type IPVersion = "IPv4" | "IPv6" | string;
+export type IPVersion = string;
 
 // @public
-export type IssueType = "Unknown" | "AgentStopped" | "GuestFirewall" | "DnsResolution" | "SocketBind" | "NetworkSecurityRule" | "UserDefinedRoute" | "PortThrottled" | "Platform" | string;
+export type IssueType = string;
+
+// @public
+export const enum KnownAccess {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownApplicationGatewayBackendHealthServerHealth {
+    // (undocumented)
+    Down = "Down",
+    // (undocumented)
+    Draining = "Draining",
+    // (undocumented)
+    Partial = "Partial",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    Up = "Up"
+}
+
+// @public
+export const enum KnownApplicationGatewayCookieBasedAffinity {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownApplicationGatewayCustomErrorStatusCode {
+    // (undocumented)
+    HttpStatus403 = "HttpStatus403",
+    // (undocumented)
+    HttpStatus502 = "HttpStatus502"
+}
+
+// @public
+export const enum KnownApplicationGatewayFirewallMode {
+    // (undocumented)
+    Detection = "Detection",
+    // (undocumented)
+    Prevention = "Prevention"
+}
+
+// @public
+export const enum KnownApplicationGatewayOperationalState {
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Starting = "Starting",
+    // (undocumented)
+    Stopped = "Stopped",
+    // (undocumented)
+    Stopping = "Stopping"
+}
+
+// @public
+export const enum KnownApplicationGatewayProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https"
+}
+
+// @public
+export const enum KnownApplicationGatewayRedirectType {
+    // (undocumented)
+    Found = "Found",
+    // (undocumented)
+    Permanent = "Permanent",
+    // (undocumented)
+    SeeOther = "SeeOther",
+    // (undocumented)
+    Temporary = "Temporary"
+}
+
+// @public
+export const enum KnownApplicationGatewayRequestRoutingRuleType {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    PathBasedRouting = "PathBasedRouting"
+}
+
+// @public
+export const enum KnownApplicationGatewaySkuName {
+    // (undocumented)
+    StandardLarge = "Standard_Large",
+    // (undocumented)
+    StandardMedium = "Standard_Medium",
+    // (undocumented)
+    StandardSmall = "Standard_Small",
+    // (undocumented)
+    StandardV2 = "Standard_v2",
+    // (undocumented)
+    WAFLarge = "WAF_Large",
+    // (undocumented)
+    WAFMedium = "WAF_Medium",
+    // (undocumented)
+    WAFV2 = "WAF_v2"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslCipherSuite {
+    // (undocumented)
+    TLSDHEDSSWith3DESEDECBCSHA = "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+    // (undocumented)
+    TLSDHEDSSWithAES128CBCSHA = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSDHEDSSWithAES128CBCSHA256 = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSDHEDSSWithAES256CBCSHA = "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSDHEDSSWithAES256CBCSHA256 = "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+    // (undocumented)
+    TLSDHERSAWithAES128CBCSHA = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSDHERSAWithAES128GCMSHA256 = "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSDHERSAWithAES256CBCSHA = "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSDHERSAWithAES256GCMSHA384 = "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES128CBCSHA = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES128CBCSHA256 = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES128GCMSHA256 = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES256CBCSHA = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES256CBCSHA384 = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES256GCMSHA384 = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    // (undocumented)
+    TLSEcdheRSAWithAES128CBCSHA = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSEcdheRSAWithAES128CBCSHA256 = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSEcdheRSAWithAES128GCMSHA256 = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSEcdheRSAWithAES256CBCSHA = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSEcdheRSAWithAES256CBCSHA384 = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+    // (undocumented)
+    TLSEcdheRSAWithAES256GCMSHA384 = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    // (undocumented)
+    TLSRSAWith3DESEDECBCSHA = "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+    // (undocumented)
+    TLSRSAWithAES128CBCSHA = "TLS_RSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSRSAWithAES128CBCSHA256 = "TLS_RSA_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSRSAWithAES128GCMSHA256 = "TLS_RSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSRSAWithAES256CBCSHA = "TLS_RSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSRSAWithAES256CBCSHA256 = "TLS_RSA_WITH_AES_256_CBC_SHA256",
+    // (undocumented)
+    TLSRSAWithAES256GCMSHA384 = "TLS_RSA_WITH_AES_256_GCM_SHA384"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslPolicyName {
+    // (undocumented)
+    AppGwSslPolicy20150501 = "AppGwSslPolicy20150501",
+    // (undocumented)
+    AppGwSslPolicy20170401 = "AppGwSslPolicy20170401",
+    // (undocumented)
+    AppGwSslPolicy20170401S = "AppGwSslPolicy20170401S"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslPolicyType {
+    // (undocumented)
+    Custom = "Custom",
+    // (undocumented)
+    Predefined = "Predefined"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslProtocol {
+    // (undocumented)
+    TLSv10 = "TLSv1_0",
+    // (undocumented)
+    TLSv11 = "TLSv1_1",
+    // (undocumented)
+    TLSv12 = "TLSv1_2"
+}
+
+// @public
+export const enum KnownApplicationGatewayTier {
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    StandardV2 = "Standard_v2",
+    // (undocumented)
+    WAF = "WAF",
+    // (undocumented)
+    WAFV2 = "WAF_v2"
+}
+
+// @public
+export const enum KnownAssociationType {
+    // (undocumented)
+    Associated = "Associated",
+    // (undocumented)
+    Contains = "Contains"
+}
+
+// @public
+export const enum KnownAuthenticationMethod {
+    // (undocumented)
+    EapmschaPv2 = "EAPMSCHAPv2",
+    // (undocumented)
+    Eaptls = "EAPTLS"
+}
+
+// @public
+export const enum KnownAuthorizationUseStatus {
+    // (undocumented)
+    Available = "Available",
+    // (undocumented)
+    InUse = "InUse"
+}
+
+// @public
+export const enum KnownAzureFirewallApplicationRuleProtocolType {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https",
+    // (undocumented)
+    Mssql = "Mssql"
+}
+
+// @public
+export const enum KnownAzureFirewallNatRCActionType {
+    // (undocumented)
+    Dnat = "Dnat",
+    // (undocumented)
+    Snat = "Snat"
+}
+
+// @public
+export const enum KnownAzureFirewallNetworkRuleProtocol {
+    // (undocumented)
+    Any = "Any",
+    // (undocumented)
+    Icmp = "ICMP",
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownAzureFirewallRCActionType {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownAzureFirewallSkuName {
+    // (undocumented)
+    AzfwHub = "AZFW_Hub",
+    // (undocumented)
+    AzfwVnet = "AZFW_VNet"
+}
+
+// @public
+export const enum KnownAzureFirewallSkuTier {
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownAzureFirewallThreatIntelMode {
+    // (undocumented)
+    Alert = "Alert",
+    // (undocumented)
+    Deny = "Deny",
+    // (undocumented)
+    Off = "Off"
+}
+
+// @public
+export const enum KnownBastionConnectProtocol {
+    // (undocumented)
+    RDP = "RDP",
+    // (undocumented)
+    SSH = "SSH"
+}
+
+// @public
+export const enum KnownBgpPeerState {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    Idle = "Idle",
+    // (undocumented)
+    Stopped = "Stopped",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownCircuitConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    Disconnected = "Disconnected"
+}
+
+// @public
+export const enum KnownConnectionMonitorEndpointFilterItemType {
+    // (undocumented)
+    AgentAddress = "AgentAddress"
+}
+
+// @public
+export const enum KnownConnectionMonitorEndpointFilterType {
+    // (undocumented)
+    Include = "Include"
+}
+
+// @public
+export const enum KnownConnectionMonitorSourceStatus {
+    // (undocumented)
+    Active = "Active",
+    // (undocumented)
+    Inactive = "Inactive",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownConnectionMonitorTestConfigurationProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Icmp = "Icmp",
+    // (undocumented)
+    Tcp = "Tcp"
+}
+
+// @public
+export const enum KnownConnectionMonitorType {
+    // (undocumented)
+    MultiEndpoint = "MultiEndpoint",
+    // (undocumented)
+    SingleSourceDestination = "SingleSourceDestination"
+}
+
+// @public
+export const enum KnownConnectionState {
+    // (undocumented)
+    Reachable = "Reachable",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    Unreachable = "Unreachable"
+}
+
+// @public
+export const enum KnownConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Degraded = "Degraded",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownDdosCustomPolicyProtocol {
+    // (undocumented)
+    Syn = "Syn",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownDdosCustomPolicyTriggerSensitivityOverride {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    High = "High",
+    // (undocumented)
+    Low = "Low",
+    // (undocumented)
+    Relaxed = "Relaxed"
+}
+
+// @public
+export const enum KnownDdosSettingsProtectionCoverage {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownDhGroup {
+    // (undocumented)
+    DHGroup1 = "DHGroup1",
+    // (undocumented)
+    DHGroup14 = "DHGroup14",
+    // (undocumented)
+    DHGroup2 = "DHGroup2",
+    // (undocumented)
+    DHGroup2048 = "DHGroup2048",
+    // (undocumented)
+    DHGroup24 = "DHGroup24",
+    // (undocumented)
+    ECP256 = "ECP256",
+    // (undocumented)
+    ECP384 = "ECP384",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownDirection {
+    // (undocumented)
+    Inbound = "Inbound",
+    // (undocumented)
+    Outbound = "Outbound"
+}
+
+// @public
+export const enum KnownEffectiveRouteSource {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    User = "User",
+    // (undocumented)
+    VirtualNetworkGateway = "VirtualNetworkGateway"
+}
+
+// @public
+export const enum KnownEffectiveRouteState {
+    // (undocumented)
+    Active = "Active",
+    // (undocumented)
+    Invalid = "Invalid"
+}
+
+// @public
+export const enum KnownEffectiveSecurityRuleProtocol {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownEvaluationState {
+    // (undocumented)
+    Completed = "Completed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    NotStarted = "NotStarted"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState {
+    // (undocumented)
+    Configured = "Configured",
+    // (undocumented)
+    Configuring = "Configuring",
+    // (undocumented)
+    NotConfigured = "NotConfigured",
+    // (undocumented)
+    ValidationNeeded = "ValidationNeeded"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitPeeringState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitSkuFamily {
+    // (undocumented)
+    MeteredData = "MeteredData",
+    // (undocumented)
+    UnlimitedData = "UnlimitedData"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitSkuTier {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Local = "Local",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownExpressRouteLinkAdminState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownExpressRouteLinkConnectorType {
+    // (undocumented)
+    LC = "LC",
+    // (undocumented)
+    SC = "SC"
+}
+
+// @public
+export const enum KnownExpressRouteLinkMacSecCipher {
+    // (undocumented)
+    GcmAes128 = "gcm-aes-128",
+    // (undocumented)
+    GcmAes256 = "gcm-aes-256"
+}
+
+// @public
+export const enum KnownExpressRoutePeeringState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownExpressRoutePeeringType {
+    // (undocumented)
+    AzurePrivatePeering = "AzurePrivatePeering",
+    // (undocumented)
+    AzurePublicPeering = "AzurePublicPeering",
+    // (undocumented)
+    MicrosoftPeering = "MicrosoftPeering"
+}
+
+// @public
+export const enum KnownExpressRoutePortsEncapsulation {
+    // (undocumented)
+    Dot1Q = "Dot1Q",
+    // (undocumented)
+    QinQ = "QinQ"
+}
+
+// @public
+export const enum KnownFirewallPolicyFilterRuleActionType {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownFirewallPolicyIntrusionSystemMode {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownFirewallPolicyNatRuleActionType {
+    // (undocumented)
+    Dnat = "DNAT"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleConditionApplicationProtocolType {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleConditionNetworkProtocol {
+    // (undocumented)
+    Any = "Any",
+    // (undocumented)
+    Icmp = "ICMP",
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleConditionType {
+    // (undocumented)
+    ApplicationRuleCondition = "ApplicationRuleCondition",
+    // (undocumented)
+    NatRuleCondition = "NatRuleCondition",
+    // (undocumented)
+    NetworkRuleCondition = "NetworkRuleCondition"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleType {
+    // (undocumented)
+    FirewallPolicyFilterRule = "FirewallPolicyFilterRule",
+    // (undocumented)
+    FirewallPolicyNatRule = "FirewallPolicyNatRule"
+}
+
+// @public
+export const enum KnownFlowLogFormatType {
+    // (undocumented)
+    Json = "JSON"
+}
+
+// @public
+export const enum KnownHttpConfigurationMethod {
+    // (undocumented)
+    Get = "Get",
+    // (undocumented)
+    Post = "Post"
+}
+
+// @public
+export const enum KnownHttpMethod {
+    // (undocumented)
+    Get = "Get"
+}
+
+// @public
+export const enum KnownHubVirtualNetworkConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownIkeEncryption {
+    // (undocumented)
+    AES128 = "AES128",
+    // (undocumented)
+    AES192 = "AES192",
+    // (undocumented)
+    AES256 = "AES256",
+    // (undocumented)
+    DES = "DES",
+    // (undocumented)
+    DES3 = "DES3",
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256"
+}
+
+// @public
+export const enum KnownIkeIntegrity {
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256",
+    // (undocumented)
+    MD5 = "MD5",
+    // (undocumented)
+    SHA1 = "SHA1",
+    // (undocumented)
+    SHA256 = "SHA256",
+    // (undocumented)
+    SHA384 = "SHA384"
+}
+
+// @public
+export const enum KnownIPAllocationMethod {
+    // (undocumented)
+    Dynamic = "Dynamic",
+    // (undocumented)
+    Static = "Static"
+}
+
+// @public
+export const enum KnownIpAllocationType {
+    // (undocumented)
+    Hypernet = "Hypernet",
+    // (undocumented)
+    Undefined = "Undefined"
+}
+
+// @public
+export const enum KnownIpFlowProtocol {
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownIpsecEncryption {
+    // (undocumented)
+    AES128 = "AES128",
+    // (undocumented)
+    AES192 = "AES192",
+    // (undocumented)
+    AES256 = "AES256",
+    // (undocumented)
+    DES = "DES",
+    // (undocumented)
+    DES3 = "DES3",
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes192 = "GCMAES192",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownIpsecIntegrity {
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes192 = "GCMAES192",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256",
+    // (undocumented)
+    MD5 = "MD5",
+    // (undocumented)
+    SHA1 = "SHA1",
+    // (undocumented)
+    SHA256 = "SHA256"
+}
+
+// @public
+export const enum KnownIPVersion {
+    // (undocumented)
+    IPv4 = "IPv4",
+    // (undocumented)
+    IPv6 = "IPv6"
+}
+
+// @public
+export const enum KnownIssueType {
+    // (undocumented)
+    AgentStopped = "AgentStopped",
+    // (undocumented)
+    DnsResolution = "DnsResolution",
+    // (undocumented)
+    GuestFirewall = "GuestFirewall",
+    // (undocumented)
+    NetworkSecurityRule = "NetworkSecurityRule",
+    // (undocumented)
+    Platform = "Platform",
+    // (undocumented)
+    PortThrottled = "PortThrottled",
+    // (undocumented)
+    SocketBind = "SocketBind",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    UserDefinedRoute = "UserDefinedRoute"
+}
+
+// @public
+export const enum KnownLoadBalancerOutboundRuleProtocol {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownLoadBalancerSkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownLoadDistribution {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    SourceIP = "SourceIP",
+    // (undocumented)
+    SourceIPProtocol = "SourceIPProtocol"
+}
+
+// @public
+export const enum KnownManagedRuleEnabledState {
+    // (undocumented)
+    Disabled = "Disabled"
+}
+
+// @public
+export const enum KnownNatGatewaySkuName {
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownNetworkOperationStatus {
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownNextHopType {
+    // (undocumented)
+    HyperNetGateway = "HyperNetGateway",
+    // (undocumented)
+    Internet = "Internet",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    VirtualAppliance = "VirtualAppliance",
+    // (undocumented)
+    VirtualNetworkGateway = "VirtualNetworkGateway",
+    // (undocumented)
+    VnetLocal = "VnetLocal"
+}
+
+// @public
+export const enum KnownOfficeTrafficCategory {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Optimize = "Optimize",
+    // (undocumented)
+    OptimizeAndAllow = "OptimizeAndAllow"
+}
+
+// @public
+export const enum KnownOrigin {
+    // (undocumented)
+    Inbound = "Inbound",
+    // (undocumented)
+    Local = "Local",
+    // (undocumented)
+    Outbound = "Outbound"
+}
+
+// @public
+export const enum KnownOutputType {
+    // (undocumented)
+    Workspace = "Workspace"
+}
+
+// @public
+export const enum KnownOwaspCrsExclusionEntryMatchVariable {
+    // (undocumented)
+    RequestArgNames = "RequestArgNames",
+    // (undocumented)
+    RequestCookieNames = "RequestCookieNames",
+    // (undocumented)
+    RequestHeaderNames = "RequestHeaderNames"
+}
+
+// @public
+export const enum KnownOwaspCrsExclusionEntrySelectorMatchOperator {
+    // (undocumented)
+    Contains = "Contains",
+    // (undocumented)
+    EndsWith = "EndsWith",
+    // (undocumented)
+    Equals = "Equals",
+    // (undocumented)
+    EqualsAny = "EqualsAny",
+    // (undocumented)
+    StartsWith = "StartsWith"
+}
+
+// @public
+export const enum KnownPcError {
+    // (undocumented)
+    AgentStopped = "AgentStopped",
+    // (undocumented)
+    CaptureFailed = "CaptureFailed",
+    // (undocumented)
+    InternalError = "InternalError",
+    // (undocumented)
+    LocalFileFailed = "LocalFileFailed",
+    // (undocumented)
+    StorageFailed = "StorageFailed"
+}
+
+// @public
+export const enum KnownPcProtocol {
+    // (undocumented)
+    Any = "Any",
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownPcStatus {
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    NotStarted = "NotStarted",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Stopped = "Stopped",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownPfsGroup {
+    // (undocumented)
+    ECP256 = "ECP256",
+    // (undocumented)
+    ECP384 = "ECP384",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    PFS1 = "PFS1",
+    // (undocumented)
+    PFS14 = "PFS14",
+    // (undocumented)
+    PFS2 = "PFS2",
+    // (undocumented)
+    PFS2048 = "PFS2048",
+    // (undocumented)
+    PFS24 = "PFS24",
+    // (undocumented)
+    Pfsmm = "PFSMM"
+}
+
+// @public
+export const enum KnownPreferredIPVersion {
+    // (undocumented)
+    IPv4 = "IPv4",
+    // (undocumented)
+    IPv6 = "IPv6"
+}
+
+// @public
+export const enum KnownProbeProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https",
+    // (undocumented)
+    Tcp = "Tcp"
+}
+
+// @public
+export const enum KnownProcessorArchitecture {
+    // (undocumented)
+    Amd64 = "Amd64",
+    // (undocumented)
+    X86 = "X86"
+}
+
+// @public
+export const enum KnownProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https",
+    // (undocumented)
+    Icmp = "Icmp",
+    // (undocumented)
+    Tcp = "Tcp"
+}
+
+// @public
+export const enum KnownProvisioningState {
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownPublicIPAddressSkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownPublicIPPrefixSkuName {
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownRouteFilterRuleType {
+    // (undocumented)
+    Community = "Community"
+}
+
+// @public
+export const enum KnownRouteNextHopType {
+    // (undocumented)
+    Internet = "Internet",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    VirtualAppliance = "VirtualAppliance",
+    // (undocumented)
+    VirtualNetworkGateway = "VirtualNetworkGateway",
+    // (undocumented)
+    VnetLocal = "VnetLocal"
+}
+
+// @public
+export const enum KnownSecurityPartnerProviderConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    PartiallyConnected = "PartiallyConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownSecurityProviderName {
+    // (undocumented)
+    Checkpoint = "Checkpoint",
+    // (undocumented)
+    IBoss = "IBoss",
+    // (undocumented)
+    ZScaler = "ZScaler"
+}
+
+// @public
+export const enum KnownSecurityRuleAccess {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownSecurityRuleDirection {
+    // (undocumented)
+    Inbound = "Inbound",
+    // (undocumented)
+    Outbound = "Outbound"
+}
+
+// @public
+export const enum KnownSecurityRuleProtocol {
+    // (undocumented)
+    Ah = "Ah",
+    // (undocumented)
+    Asterisk = "*",
+    // (undocumented)
+    Esp = "Esp",
+    // (undocumented)
+    Icmp = "Icmp",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownServiceProviderProvisioningState {
+    // (undocumented)
+    Deprovisioning = "Deprovisioning",
+    // (undocumented)
+    NotProvisioned = "NotProvisioned",
+    // (undocumented)
+    Provisioned = "Provisioned",
+    // (undocumented)
+    Provisioning = "Provisioning"
+}
+
+// @public
+export const enum KnownSeverity {
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownTransportProtocol {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownTunnelConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownUsageUnit {
+    // (undocumented)
+    Count = "Count"
+}
+
+// @public
+export const enum KnownVerbosityLevel {
+    // (undocumented)
+    Full = "Full",
+    // (undocumented)
+    Minimum = "Minimum",
+    // (undocumented)
+    Normal = "Normal"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayConnectionProtocol {
+    // (undocumented)
+    IKEv1 = "IKEv1",
+    // (undocumented)
+    IKEv2 = "IKEv2"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayConnectionType {
+    // (undocumented)
+    ExpressRoute = "ExpressRoute",
+    // (undocumented)
+    IPsec = "IPsec",
+    // (undocumented)
+    Vnet2Vnet = "Vnet2Vnet",
+    // (undocumented)
+    VPNClient = "VPNClient"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewaySkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    ErGw1AZ = "ErGw1AZ",
+    // (undocumented)
+    ErGw2AZ = "ErGw2AZ",
+    // (undocumented)
+    ErGw3AZ = "ErGw3AZ",
+    // (undocumented)
+    HighPerformance = "HighPerformance",
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    UltraPerformance = "UltraPerformance",
+    // (undocumented)
+    VpnGw1 = "VpnGw1",
+    // (undocumented)
+    VpnGw1AZ = "VpnGw1AZ",
+    // (undocumented)
+    VpnGw2 = "VpnGw2",
+    // (undocumented)
+    VpnGw2AZ = "VpnGw2AZ",
+    // (undocumented)
+    VpnGw3 = "VpnGw3",
+    // (undocumented)
+    VpnGw3AZ = "VpnGw3AZ",
+    // (undocumented)
+    VpnGw4 = "VpnGw4",
+    // (undocumented)
+    VpnGw4AZ = "VpnGw4AZ",
+    // (undocumented)
+    VpnGw5 = "VpnGw5",
+    // (undocumented)
+    VpnGw5AZ = "VpnGw5AZ"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewaySkuTier {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    ErGw1AZ = "ErGw1AZ",
+    // (undocumented)
+    ErGw2AZ = "ErGw2AZ",
+    // (undocumented)
+    ErGw3AZ = "ErGw3AZ",
+    // (undocumented)
+    HighPerformance = "HighPerformance",
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    UltraPerformance = "UltraPerformance",
+    // (undocumented)
+    VpnGw1 = "VpnGw1",
+    // (undocumented)
+    VpnGw1AZ = "VpnGw1AZ",
+    // (undocumented)
+    VpnGw2 = "VpnGw2",
+    // (undocumented)
+    VpnGw2AZ = "VpnGw2AZ",
+    // (undocumented)
+    VpnGw3 = "VpnGw3",
+    // (undocumented)
+    VpnGw3AZ = "VpnGw3AZ",
+    // (undocumented)
+    VpnGw4 = "VpnGw4",
+    // (undocumented)
+    VpnGw4AZ = "VpnGw4AZ",
+    // (undocumented)
+    VpnGw5 = "VpnGw5",
+    // (undocumented)
+    VpnGw5AZ = "VpnGw5AZ"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayType {
+    // (undocumented)
+    ExpressRoute = "ExpressRoute",
+    // (undocumented)
+    Vpn = "Vpn"
+}
+
+// @public
+export const enum KnownVirtualNetworkPeeringState {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Initiated = "Initiated"
+}
+
+// @public
+export const enum KnownVirtualWanSecurityProviderType {
+    // (undocumented)
+    External = "External",
+    // (undocumented)
+    Native = "Native"
+}
+
+// @public
+export const enum KnownVpnAuthenticationType {
+    // (undocumented)
+    AAD = "AAD",
+    // (undocumented)
+    Certificate = "Certificate",
+    // (undocumented)
+    Radius = "Radius"
+}
+
+// @public
+export const enum KnownVpnClientProtocol {
+    // (undocumented)
+    IkeV2 = "IkeV2",
+    // (undocumented)
+    OpenVPN = "OpenVPN",
+    // (undocumented)
+    Sstp = "SSTP"
+}
+
+// @public
+export const enum KnownVpnConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownVpnGatewayGeneration {
+    // (undocumented)
+    Generation1 = "Generation1",
+    // (undocumented)
+    Generation2 = "Generation2",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownVpnGatewayTunnelingProtocol {
+    // (undocumented)
+    IkeV2 = "IkeV2",
+    // (undocumented)
+    OpenVPN = "OpenVPN"
+}
+
+// @public
+export const enum KnownVpnType {
+    // (undocumented)
+    PolicyBased = "PolicyBased",
+    // (undocumented)
+    RouteBased = "RouteBased"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallAction {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Block = "Block",
+    // (undocumented)
+    Log = "Log"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallEnabledState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallMatchVariable {
+    // (undocumented)
+    PostArgs = "PostArgs",
+    // (undocumented)
+    QueryString = "QueryString",
+    // (undocumented)
+    RemoteAddr = "RemoteAddr",
+    // (undocumented)
+    RequestBody = "RequestBody",
+    // (undocumented)
+    RequestCookies = "RequestCookies",
+    // (undocumented)
+    RequestHeaders = "RequestHeaders",
+    // (undocumented)
+    RequestMethod = "RequestMethod",
+    // (undocumented)
+    RequestUri = "RequestUri"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallMode {
+    // (undocumented)
+    Detection = "Detection",
+    // (undocumented)
+    Prevention = "Prevention"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallOperator {
+    // (undocumented)
+    BeginsWith = "BeginsWith",
+    // (undocumented)
+    Contains = "Contains",
+    // (undocumented)
+    EndsWith = "EndsWith",
+    // (undocumented)
+    Equal = "Equal",
+    // (undocumented)
+    GeoMatch = "GeoMatch",
+    // (undocumented)
+    GreaterThan = "GreaterThan",
+    // (undocumented)
+    GreaterThanOrEqual = "GreaterThanOrEqual",
+    // (undocumented)
+    IPMatch = "IPMatch",
+    // (undocumented)
+    LessThan = "LessThan",
+    // (undocumented)
+    LessThanOrEqual = "LessThanOrEqual",
+    // (undocumented)
+    Regex = "Regex"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallPolicyResourceState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Disabling = "Disabling",
+    // (undocumented)
+    Enabled = "Enabled",
+    // (undocumented)
+    Enabling = "Enabling"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallRuleType {
+    // (undocumented)
+    Invalid = "Invalid",
+    // (undocumented)
+    MatchRule = "MatchRule"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallTransform {
+    // (undocumented)
+    HtmlEntityDecode = "HtmlEntityDecode",
+    // (undocumented)
+    Lowercase = "Lowercase",
+    // (undocumented)
+    RemoveNulls = "RemoveNulls",
+    // (undocumented)
+    Trim = "Trim",
+    // (undocumented)
+    UrlDecode = "UrlDecode",
+    // (undocumented)
+    UrlEncode = "UrlEncode"
+}
 
 // @public
 export interface ListHubRouteTablesResult {
@@ -4029,7 +5499,7 @@ export interface LoadBalancerOutboundRuleListResult {
 }
 
 // @public
-export type LoadBalancerOutboundRuleProtocol = "Tcp" | "Udp" | "All" | string;
+export type LoadBalancerOutboundRuleProtocol = string;
 
 // @public
 export type LoadBalancerOutboundRulesGetResponse = OutboundRule & {
@@ -4113,7 +5583,7 @@ export interface LoadBalancerSku {
 }
 
 // @public
-export type LoadBalancerSkuName = "Basic" | "Standard" | string;
+export type LoadBalancerSkuName = string;
 
 // @public
 export type LoadBalancersListAllNextResponse = LoadBalancerListResult & {
@@ -4175,7 +5645,7 @@ export type LoadBalancingRule = SubResource & {
 };
 
 // @public
-export type LoadDistribution = "Default" | "SourceIP" | "SourceIPProtocol" | string;
+export type LoadDistribution = string;
 
 // @public
 export type LocalNetworkGateway = Resource & {
@@ -4243,7 +5713,7 @@ export interface LogSpecification {
 }
 
 // @public
-export type ManagedRuleEnabledState = "Disabled" | string;
+export type ManagedRuleEnabledState = string;
 
 // @public
 export interface ManagedRuleGroupOverride {
@@ -4366,7 +5836,7 @@ export interface NatGatewaySku {
 }
 
 // @public
-export type NatGatewaySkuName = "Standard" | string;
+export type NatGatewaySkuName = string;
 
 // @public
 export type NatGatewaysListAllNextResponse = NatGatewayListResult & {
@@ -5282,7 +6752,7 @@ export type NetworkManagementClientSupportedSecurityProvidersResponse = VirtualW
 };
 
 // @public
-export type NetworkOperationStatus = "InProgress" | "Succeeded" | "Failed" | string;
+export type NetworkOperationStatus = string;
 
 // @public
 export type NetworkProfile = Resource & {
@@ -5721,10 +7191,10 @@ export interface NextHopResult {
 }
 
 // @public
-export type NextHopType = "Internet" | "VirtualAppliance" | "VirtualNetworkGateway" | "VnetLocal" | "HyperNetGateway" | "None" | string;
+export type NextHopType = string;
 
 // @public
-export type OfficeTrafficCategory = "Optimize" | "OptimizeAndAllow" | "All" | "None" | string;
+export type OfficeTrafficCategory = string;
 
 // @public
 export interface Operation {
@@ -5771,7 +7241,7 @@ export type OperationsListResponse = OperationListResult & {
 };
 
 // @public
-export type Origin = "Local" | "Inbound" | "Outbound" | string;
+export type Origin = string;
 
 // @public
 export type OutboundRule = SubResource & {
@@ -5788,7 +7258,7 @@ export type OutboundRule = SubResource & {
 };
 
 // @public
-export type OutputType = "Workspace" | string;
+export type OutputType = string;
 
 // @public
 export interface OwaspCrsExclusionEntry {
@@ -5798,10 +7268,10 @@ export interface OwaspCrsExclusionEntry {
 }
 
 // @public
-export type OwaspCrsExclusionEntryMatchVariable = "RequestHeaderNames" | "RequestCookieNames" | "RequestArgNames" | string;
+export type OwaspCrsExclusionEntryMatchVariable = string;
 
 // @public
-export type OwaspCrsExclusionEntrySelectorMatchOperator = "Equals" | "Contains" | "StartsWith" | "EndsWith" | "EqualsAny" | string;
+export type OwaspCrsExclusionEntrySelectorMatchOperator = string;
 
 // @public
 export type P2SConnectionConfiguration = SubResource & {
@@ -6057,13 +7527,13 @@ export type PatchRouteFilterRule = SubResource & {
 };
 
 // @public
-export type PcError = "InternalError" | "AgentStopped" | "CaptureFailed" | "LocalFileFailed" | "StorageFailed" | string;
+export type PcError = string;
 
 // @public
-export type PcProtocol = "TCP" | "UDP" | "Any" | string;
+export type PcProtocol = string;
 
 // @public
-export type PcStatus = "NotStarted" | "Running" | "Stopped" | "Error" | "Unknown" | string;
+export type PcStatus = string;
 
 // @public
 export type PeerExpressRouteCircuitConnection = SubResource & {
@@ -6110,7 +7580,7 @@ export type PeerExpressRouteCircuitConnectionsListResponse = PeerExpressRouteCir
 };
 
 // @public
-export type PfsGroup = "None" | "PFS1" | "PFS2" | "PFS2048" | "ECP256" | "ECP384" | "PFS24" | "PFS14" | "PFSMM" | string;
+export type PfsGroup = string;
 
 // @public
 export interface PolicySettings {
@@ -6122,7 +7592,7 @@ export interface PolicySettings {
 }
 
 // @public
-export type PreferredIPVersion = "IPv4" | "IPv6" | string;
+export type PreferredIPVersion = string;
 
 // @public
 export interface PrepareNetworkPoliciesRequest {
@@ -6490,10 +7960,10 @@ export type Probe = SubResource & {
 };
 
 // @public
-export type ProbeProtocol = "Http" | "Tcp" | "Https" | string;
+export type ProbeProtocol = string;
 
 // @public
-export type ProcessorArchitecture = "Amd64" | "X86" | string;
+export type ProcessorArchitecture = string;
 
 // @public
 export interface PropagatedRouteTable {
@@ -6502,7 +7972,7 @@ export interface PropagatedRouteTable {
 }
 
 // @public
-export type Protocol = "Tcp" | "Http" | "Https" | "Icmp" | string;
+export type Protocol = string;
 
 // @public
 export interface ProtocolConfiguration {
@@ -6518,7 +7988,7 @@ export interface ProtocolCustomSettingsFormat {
 }
 
 // @public
-export type ProvisioningState = "Succeeded" | "Updating" | "Deleting" | "Failed" | string;
+export type ProvisioningState = string;
 
 // @public
 export type PublicIPAddress = Resource & {
@@ -6664,7 +8134,7 @@ export interface PublicIPAddressSku {
 }
 
 // @public
-export type PublicIPAddressSkuName = "Basic" | "Standard" | string;
+export type PublicIPAddressSkuName = string;
 
 // @public
 export type PublicIPPrefix = Resource & {
@@ -6755,7 +8225,7 @@ export interface PublicIPPrefixSku {
 }
 
 // @public
-export type PublicIPPrefixSkuName = "Standard" | string;
+export type PublicIPPrefixSkuName = string;
 
 // @public
 export interface QueryTroubleshootingParameters {
@@ -6909,7 +8379,7 @@ export type RouteFilterRulesListByRouteFilterResponse = RouteFilterRuleListResul
 };
 
 // @public
-export type RouteFilterRuleType = "Community" | string;
+export type RouteFilterRuleType = string;
 
 // @public
 export type RouteFiltersCreateOrUpdateResponse = RouteFilter & {
@@ -6980,7 +8450,7 @@ export interface RouteListResult {
 }
 
 // @public
-export type RouteNextHopType = "VirtualNetworkGateway" | "VnetLocal" | "Internet" | "VirtualAppliance" | "None" | string;
+export type RouteNextHopType = string;
 
 // @public
 export type RoutesCreateOrUpdateResponse = Route & {
@@ -7125,7 +8595,7 @@ export type SecurityPartnerProvider = Resource & {
 };
 
 // @public
-export type SecurityPartnerProviderConnectionStatus = "Unknown" | "PartiallyConnected" | "Connected" | "NotConnected" | string;
+export type SecurityPartnerProviderConnectionStatus = string;
 
 // @public
 export interface SecurityPartnerProviderListResult {
@@ -7191,7 +8661,7 @@ export type SecurityPartnerProvidersUpdateTagsResponse = SecurityPartnerProvider
 };
 
 // @public
-export type SecurityProviderName = "ZScaler" | "IBoss" | "Checkpoint" | string;
+export type SecurityProviderName = string;
 
 // @public
 export type SecurityRule = SubResource & {
@@ -7216,7 +8686,7 @@ export type SecurityRule = SubResource & {
 };
 
 // @public
-export type SecurityRuleAccess = "Allow" | "Deny" | string;
+export type SecurityRuleAccess = string;
 
 // @public
 export interface SecurityRuleAssociations {
@@ -7227,7 +8697,7 @@ export interface SecurityRuleAssociations {
 }
 
 // @public
-export type SecurityRuleDirection = "Inbound" | "Outbound" | string;
+export type SecurityRuleDirection = string;
 
 // @public
 export interface SecurityRuleListResult {
@@ -7236,7 +8706,7 @@ export interface SecurityRuleListResult {
 }
 
 // @public
-export type SecurityRuleProtocol = "Tcp" | "Udp" | "Icmp" | "Esp" | "*" | "Ah" | string;
+export type SecurityRuleProtocol = string;
 
 // @public
 export type SecurityRulesCreateOrUpdateResponse = SecurityRule & {
@@ -7431,7 +8901,7 @@ export interface ServiceEndpointPropertiesFormat {
 }
 
 // @public
-export type ServiceProviderProvisioningState = "NotProvisioned" | "Provisioning" | "Provisioned" | "Deprovisioning" | string;
+export type ServiceProviderProvisioningState = string;
 
 // @public
 export interface ServiceTagInformation {
@@ -7472,7 +8942,7 @@ export interface SessionIds {
 }
 
 // @public
-export type Severity = "Error" | "Warning" | string;
+export type Severity = string;
 
 // @public
 export interface StaticRoute {
@@ -7618,7 +9088,7 @@ export interface TrafficSelectorPolicy {
 }
 
 // @public
-export type TransportProtocol = "Udp" | "Tcp" | "All" | string;
+export type TransportProtocol = string;
 
 // @public
 export interface TroubleshootingDetails {
@@ -7662,7 +9132,7 @@ export interface TunnelConnectionHealth {
 }
 
 // @public
-export type TunnelConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type TunnelConnectionStatus = string;
 
 // @public
 export interface UnprepareNetworkPoliciesRequest {
@@ -7707,10 +9177,10 @@ export interface UsagesListResult {
 }
 
 // @public
-export type UsageUnit = "Count" | string;
+export type UsageUnit = string;
 
 // @public
-export type VerbosityLevel = "Normal" | "Minimum" | "Full" | string;
+export type VerbosityLevel = string;
 
 // @public
 export interface VerificationIPFlowParameters {
@@ -7992,7 +9462,7 @@ export interface VirtualNetworkGatewayConnectionListResult {
 }
 
 // @public
-export type VirtualNetworkGatewayConnectionProtocol = "IKEv2" | "IKEv1" | string;
+export type VirtualNetworkGatewayConnectionProtocol = string;
 
 // @public
 export type VirtualNetworkGatewayConnectionsCreateOrUpdateResponse = VirtualNetworkGatewayConnection & {
@@ -8079,7 +9549,7 @@ export type VirtualNetworkGatewayConnectionsStopPacketCaptureResponse = {
 };
 
 // @public
-export type VirtualNetworkGatewayConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type VirtualNetworkGatewayConnectionStatus = string;
 
 // @public
 export type VirtualNetworkGatewayConnectionsUpdateTagsResponse = VirtualNetworkGatewayConnection & {
@@ -8091,7 +9561,7 @@ export type VirtualNetworkGatewayConnectionsUpdateTagsResponse = VirtualNetworkG
 };
 
 // @public
-export type VirtualNetworkGatewayConnectionType = "IPsec" | "Vnet2Vnet" | "ExpressRoute" | "VPNClient" | string;
+export type VirtualNetworkGatewayConnectionType = string;
 
 // @public
 export type VirtualNetworkGatewayIPConfiguration = SubResource & {
@@ -8221,10 +9691,10 @@ export interface VirtualNetworkGatewaySku {
 }
 
 // @public
-export type VirtualNetworkGatewaySkuName = "Basic" | "HighPerformance" | "Standard" | "UltraPerformance" | "VpnGw1" | "VpnGw2" | "VpnGw3" | "VpnGw4" | "VpnGw5" | "VpnGw1AZ" | "VpnGw2AZ" | "VpnGw3AZ" | "VpnGw4AZ" | "VpnGw5AZ" | "ErGw1AZ" | "ErGw2AZ" | "ErGw3AZ" | string;
+export type VirtualNetworkGatewaySkuName = string;
 
 // @public
-export type VirtualNetworkGatewaySkuTier = "Basic" | "HighPerformance" | "Standard" | "UltraPerformance" | "VpnGw1" | "VpnGw2" | "VpnGw3" | "VpnGw4" | "VpnGw5" | "VpnGw1AZ" | "VpnGw2AZ" | "VpnGw3AZ" | "VpnGw4AZ" | "VpnGw5AZ" | "ErGw1AZ" | "ErGw2AZ" | "ErGw3AZ" | string;
+export type VirtualNetworkGatewaySkuTier = string;
 
 // @public
 export type VirtualNetworkGatewaysListConnectionsNextResponse = VirtualNetworkGatewayListConnectionsResult & {
@@ -8334,7 +9804,7 @@ export type VirtualNetworkGatewaysVpnDeviceConfigurationScriptResponse = {
 };
 
 // @public
-export type VirtualNetworkGatewayType = "Vpn" | "ExpressRoute" | string;
+export type VirtualNetworkGatewayType = string;
 
 // @public
 export interface VirtualNetworkListResult {
@@ -8402,7 +9872,7 @@ export type VirtualNetworkPeeringsListResponse = VirtualNetworkPeeringListResult
 };
 
 // @public
-export type VirtualNetworkPeeringState = "Initiated" | "Connected" | "Disconnected" | string;
+export type VirtualNetworkPeeringState = string;
 
 // @public
 export type VirtualNetworksCheckIPAddressAvailabilityResponse = IPAddressAvailabilityResult & {
@@ -8734,7 +10204,7 @@ export interface VirtualWanSecurityProviders {
 }
 
 // @public
-export type VirtualWanSecurityProviderType = "External" | "Native" | string;
+export type VirtualWanSecurityProviderType = string;
 
 // @public
 export type VirtualWansGetResponse = VirtualWAN & {
@@ -8799,7 +10269,7 @@ export interface VnetRoute {
 }
 
 // @public
-export type VpnAuthenticationType = "Certificate" | "Radius" | "AAD" | string;
+export type VpnAuthenticationType = string;
 
 // @public
 export interface VpnClientConfiguration {
@@ -8866,7 +10336,7 @@ export interface VpnClientParameters {
 }
 
 // @public
-export type VpnClientProtocol = "IkeV2" | "SSTP" | "OpenVPN" | string;
+export type VpnClientProtocol = string;
 
 // @public
 export type VpnClientRevokedCertificate = SubResource & {
@@ -8942,7 +10412,7 @@ export type VpnConnectionsListByVpnGatewayResponse = ListVpnConnectionsResult & 
 };
 
 // @public
-export type VpnConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type VpnConnectionStatus = string;
 
 // @public
 export interface VpnDeviceScriptParameters {
@@ -8962,7 +10432,7 @@ export type VpnGateway = Resource & {
 };
 
 // @public
-export type VpnGatewayGeneration = "None" | "Generation1" | "Generation2" | string;
+export type VpnGatewayGeneration = string;
 
 // @public
 export type VpnGatewaysCreateOrUpdateResponse = VpnGateway & {
@@ -9031,7 +10501,7 @@ export type VpnGatewaysUpdateTagsResponse = VpnGateway & {
 };
 
 // @public
-export type VpnGatewayTunnelingProtocol = "IkeV2" | "OpenVPN" | string;
+export type VpnGatewayTunnelingProtocol = string;
 
 // @public
 export interface VpnLinkBgpSettings {
@@ -9333,10 +10803,10 @@ export type VpnSitesUpdateTagsResponse = VpnSite & {
 };
 
 // @public
-export type VpnType = "PolicyBased" | "RouteBased" | string;
+export type VpnType = string;
 
 // @public
-export type WebApplicationFirewallAction = "Allow" | "Block" | "Log" | string;
+export type WebApplicationFirewallAction = string;
 
 // @public
 export interface WebApplicationFirewallCustomRule {
@@ -9349,16 +10819,16 @@ export interface WebApplicationFirewallCustomRule {
 }
 
 // @public
-export type WebApplicationFirewallEnabledState = "Disabled" | "Enabled" | string;
+export type WebApplicationFirewallEnabledState = string;
 
 // @public
-export type WebApplicationFirewallMatchVariable = "RemoteAddr" | "RequestMethod" | "QueryString" | "PostArgs" | "RequestUri" | "RequestHeaders" | "RequestBody" | "RequestCookies" | string;
+export type WebApplicationFirewallMatchVariable = string;
 
 // @public
-export type WebApplicationFirewallMode = "Prevention" | "Detection" | string;
+export type WebApplicationFirewallMode = string;
 
 // @public
-export type WebApplicationFirewallOperator = "IPMatch" | "Equal" | "Contains" | "LessThan" | "GreaterThan" | "LessThanOrEqual" | "GreaterThanOrEqual" | "BeginsWith" | "EndsWith" | "Regex" | "GeoMatch" | string;
+export type WebApplicationFirewallOperator = string;
 
 // @public
 export type WebApplicationFirewallPoliciesCreateOrUpdateResponse = WebApplicationFirewallPolicy & {
@@ -9428,18 +10898,18 @@ export interface WebApplicationFirewallPolicyListResult {
 }
 
 // @public
-export type WebApplicationFirewallPolicyResourceState = "Creating" | "Enabling" | "Enabled" | "Disabling" | "Disabled" | "Deleting" | string;
+export type WebApplicationFirewallPolicyResourceState = string;
 
 // @public
-export type WebApplicationFirewallRuleType = "MatchRule" | "Invalid" | string;
+export type WebApplicationFirewallRuleType = string;
 
 // @public
-export type WebApplicationFirewallTransform = "Lowercase" | "Trim" | "UrlDecode" | "UrlEncode" | "RemoveNulls" | "HtmlEntityDecode" | string;
+export type WebApplicationFirewallTransform = string;
 
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:13368:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:15227:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/network-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/network-resource-manager/src/models/index.ts
@@ -12255,937 +12255,2796 @@ export type NetworkRuleCondition = FirewallPolicyRuleCondition & {
    */
   destinationIpGroups?: string[];
 };
-/**
- * Defines values for ApplicationGatewaySkuName.
- */
-export type ApplicationGatewaySkuName =
-  | "Standard_Small"
-  | "Standard_Medium"
-  | "Standard_Large"
-  | "WAF_Medium"
-  | "WAF_Large"
-  | "Standard_v2"
-  | "WAF_v2"
-  | string;
-/**
- * Defines values for ApplicationGatewayTier.
- */
-export type ApplicationGatewayTier =
-  | "Standard"
-  | "WAF"
-  | "Standard_v2"
-  | "WAF_v2"
-  | string;
-/**
- * Defines values for ApplicationGatewaySslProtocol.
- */
-export type ApplicationGatewaySslProtocol =
-  | "TLSv1_0"
-  | "TLSv1_1"
-  | "TLSv1_2"
-  | string;
-/**
- * Defines values for ApplicationGatewaySslPolicyType.
- */
-export type ApplicationGatewaySslPolicyType = "Predefined" | "Custom" | string;
-/**
- * Defines values for ApplicationGatewaySslPolicyName.
- */
-export type ApplicationGatewaySslPolicyName =
-  | "AppGwSslPolicy20150501"
-  | "AppGwSslPolicy20170401"
-  | "AppGwSslPolicy20170401S"
-  | string;
-/**
- * Defines values for ApplicationGatewaySslCipherSuite.
- */
-export type ApplicationGatewaySslCipherSuite =
-  | "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384"
-  | "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
-  | "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA"
-  | "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
-  | "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384"
-  | "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256"
-  | "TLS_DHE_RSA_WITH_AES_256_CBC_SHA"
-  | "TLS_DHE_RSA_WITH_AES_128_CBC_SHA"
-  | "TLS_RSA_WITH_AES_256_GCM_SHA384"
-  | "TLS_RSA_WITH_AES_128_GCM_SHA256"
-  | "TLS_RSA_WITH_AES_256_CBC_SHA256"
-  | "TLS_RSA_WITH_AES_128_CBC_SHA256"
-  | "TLS_RSA_WITH_AES_256_CBC_SHA"
-  | "TLS_RSA_WITH_AES_128_CBC_SHA"
-  | "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
-  | "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"
-  | "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384"
-  | "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256"
-  | "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA"
-  | "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"
-  | "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256"
-  | "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256"
-  | "TLS_DHE_DSS_WITH_AES_256_CBC_SHA"
-  | "TLS_DHE_DSS_WITH_AES_128_CBC_SHA"
-  | "TLS_RSA_WITH_3DES_EDE_CBC_SHA"
-  | "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA"
-  | "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-  | "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
-  | string;
-/**
- * Defines values for ApplicationGatewayOperationalState.
- */
-export type ApplicationGatewayOperationalState =
-  | "Stopped"
-  | "Starting"
-  | "Running"
-  | "Stopping"
-  | string;
-/**
- * Defines values for ProvisioningState.
- */
-export type ProvisioningState =
-  | "Succeeded"
-  | "Updating"
-  | "Deleting"
-  | "Failed"
-  | string;
-/**
- * Defines values for IPAllocationMethod.
- */
-export type IPAllocationMethod = "Static" | "Dynamic" | string;
-/**
- * Defines values for ApplicationGatewayProtocol.
- */
-export type ApplicationGatewayProtocol = "Http" | "Https" | string;
-/**
- * Defines values for IPVersion.
- */
-export type IPVersion = "IPv4" | "IPv6" | string;
-/**
- * Defines values for SecurityRuleProtocol.
- */
-export type SecurityRuleProtocol =
-  | "Tcp"
-  | "Udp"
-  | "Icmp"
-  | "Esp"
-  | "*"
-  | "Ah"
-  | string;
-/**
- * Defines values for SecurityRuleAccess.
- */
-export type SecurityRuleAccess = "Allow" | "Deny" | string;
-/**
- * Defines values for SecurityRuleDirection.
- */
-export type SecurityRuleDirection = "Inbound" | "Outbound" | string;
-/**
- * Defines values for FlowLogFormatType.
- */
-export type FlowLogFormatType = "JSON" | string;
-/**
- * Defines values for RouteNextHopType.
- */
-export type RouteNextHopType =
-  | "VirtualNetworkGateway"
-  | "VnetLocal"
-  | "Internet"
-  | "VirtualAppliance"
-  | "None"
-  | string;
-/**
- * Defines values for PublicIPAddressSkuName.
- */
-export type PublicIPAddressSkuName = "Basic" | "Standard" | string;
-/**
- * Defines values for DdosSettingsProtectionCoverage.
- */
-export type DdosSettingsProtectionCoverage = "Basic" | "Standard" | string;
-/**
- * Defines values for VirtualNetworkPeeringState.
- */
-export type VirtualNetworkPeeringState =
-  | "Initiated"
-  | "Connected"
-  | "Disconnected"
-  | string;
-/**
- * Defines values for TransportProtocol.
- */
-export type TransportProtocol = "Udp" | "Tcp" | "All" | string;
-/**
- * Defines values for ApplicationGatewayCookieBasedAffinity.
- */
-export type ApplicationGatewayCookieBasedAffinity =
-  | "Enabled"
-  | "Disabled"
-  | string;
-/**
- * Defines values for ApplicationGatewayCustomErrorStatusCode.
- */
-export type ApplicationGatewayCustomErrorStatusCode =
-  | "HttpStatus403"
-  | "HttpStatus502"
-  | string;
-/**
- * Defines values for ApplicationGatewayRequestRoutingRuleType.
- */
-export type ApplicationGatewayRequestRoutingRuleType =
-  | "Basic"
-  | "PathBasedRouting"
-  | string;
-/**
- * Defines values for ApplicationGatewayRedirectType.
- */
-export type ApplicationGatewayRedirectType =
-  | "Permanent"
-  | "Found"
-  | "SeeOther"
-  | "Temporary"
-  | string;
-/**
- * Defines values for ApplicationGatewayFirewallMode.
- */
-export type ApplicationGatewayFirewallMode =
-  | "Detection"
-  | "Prevention"
-  | string;
-/**
- * Defines values for ApplicationGatewayBackendHealthServerHealth.
- */
-export type ApplicationGatewayBackendHealthServerHealth =
-  | "Unknown"
-  | "Up"
-  | "Down"
-  | "Partial"
-  | "Draining"
-  | string;
-/**
- * Defines values for AzureFirewallRCActionType.
- */
-export type AzureFirewallRCActionType = "Allow" | "Deny" | string;
-/**
- * Defines values for AzureFirewallApplicationRuleProtocolType.
- */
-export type AzureFirewallApplicationRuleProtocolType =
-  | "Http"
-  | "Https"
-  | "Mssql"
-  | string;
-/**
- * Defines values for AzureFirewallNatRCActionType.
- */
-export type AzureFirewallNatRCActionType = "Snat" | "Dnat" | string;
-/**
- * Defines values for AzureFirewallNetworkRuleProtocol.
- */
-export type AzureFirewallNetworkRuleProtocol =
-  | "TCP"
-  | "UDP"
-  | "Any"
-  | "ICMP"
-  | string;
-/**
- * Defines values for AzureFirewallThreatIntelMode.
- */
-export type AzureFirewallThreatIntelMode = "Alert" | "Deny" | "Off" | string;
-/**
- * Defines values for AzureFirewallSkuName.
- */
-export type AzureFirewallSkuName = "AZFW_VNet" | "AZFW_Hub" | string;
-/**
- * Defines values for AzureFirewallSkuTier.
- */
-export type AzureFirewallSkuTier = "Standard" | "Premium" | string;
-/**
- * Defines values for BastionConnectProtocol.
- */
-export type BastionConnectProtocol = "SSH" | "RDP" | string;
-/**
- * Defines values for DdosCustomPolicyProtocol.
- */
-export type DdosCustomPolicyProtocol = "Tcp" | "Udp" | "Syn" | string;
-/**
- * Defines values for DdosCustomPolicyTriggerSensitivityOverride.
- */
-export type DdosCustomPolicyTriggerSensitivityOverride =
-  | "Relaxed"
-  | "Low"
-  | "Default"
-  | "High"
-  | string;
-/**
- * Defines values for AuthorizationUseStatus.
- */
-export type AuthorizationUseStatus = "Available" | "InUse" | string;
-/**
- * Defines values for ExpressRoutePeeringType.
- */
-export type ExpressRoutePeeringType =
-  | "AzurePublicPeering"
-  | "AzurePrivatePeering"
-  | "MicrosoftPeering"
-  | string;
-/**
- * Defines values for ExpressRoutePeeringState.
- */
-export type ExpressRoutePeeringState = "Disabled" | "Enabled" | string;
-/**
- * Defines values for ExpressRouteCircuitPeeringAdvertisedPublicPrefixState.
- */
-export type ExpressRouteCircuitPeeringAdvertisedPublicPrefixState =
-  | "NotConfigured"
-  | "Configuring"
-  | "Configured"
-  | "ValidationNeeded"
-  | string;
-/**
- * Defines values for ExpressRouteCircuitPeeringState.
- */
-export type ExpressRouteCircuitPeeringState = "Disabled" | "Enabled" | string;
-/**
- * Defines values for CircuitConnectionStatus.
- */
-export type CircuitConnectionStatus =
-  | "Connected"
-  | "Connecting"
-  | "Disconnected"
-  | string;
-/**
- * Defines values for ExpressRouteCircuitSkuTier.
- */
-export type ExpressRouteCircuitSkuTier =
-  | "Standard"
-  | "Premium"
-  | "Basic"
-  | "Local"
-  | string;
-/**
- * Defines values for ExpressRouteCircuitSkuFamily.
- */
-export type ExpressRouteCircuitSkuFamily =
-  | "UnlimitedData"
-  | "MeteredData"
-  | string;
-/**
- * Defines values for ServiceProviderProvisioningState.
- */
-export type ServiceProviderProvisioningState =
-  | "NotProvisioned"
-  | "Provisioning"
-  | "Provisioned"
-  | "Deprovisioning"
-  | string;
-/**
- * Defines values for ExpressRoutePortsEncapsulation.
- */
-export type ExpressRoutePortsEncapsulation = "Dot1Q" | "QinQ" | string;
-/**
- * Defines values for ExpressRouteLinkConnectorType.
- */
-export type ExpressRouteLinkConnectorType = "LC" | "SC" | string;
-/**
- * Defines values for ExpressRouteLinkAdminState.
- */
-export type ExpressRouteLinkAdminState = "Enabled" | "Disabled" | string;
-/**
- * Defines values for ExpressRouteLinkMacSecCipher.
- */
-export type ExpressRouteLinkMacSecCipher =
-  | "gcm-aes-128"
-  | "gcm-aes-256"
-  | string;
-/**
- * Defines values for FirewallPolicyIntrusionSystemMode.
- */
-export type FirewallPolicyIntrusionSystemMode = "Enabled" | "Disabled" | string;
-/**
- * Defines values for FirewallPolicyRuleType.
- */
-export type FirewallPolicyRuleType =
-  | "FirewallPolicyNatRule"
-  | "FirewallPolicyFilterRule"
-  | string;
-/**
- * Defines values for IpAllocationType.
- */
-export type IpAllocationType = "Undefined" | "Hypernet" | string;
-/**
- * Defines values for LoadBalancerSkuName.
- */
-export type LoadBalancerSkuName = "Basic" | "Standard" | string;
-/**
- * Defines values for LoadDistribution.
- */
-export type LoadDistribution =
-  | "Default"
-  | "SourceIP"
-  | "SourceIPProtocol"
-  | string;
-/**
- * Defines values for ProbeProtocol.
- */
-export type ProbeProtocol = "Http" | "Tcp" | "Https" | string;
-/**
- * Defines values for LoadBalancerOutboundRuleProtocol.
- */
-export type LoadBalancerOutboundRuleProtocol = "Tcp" | "Udp" | "All" | string;
-/**
- * Defines values for NatGatewaySkuName.
- */
-export type NatGatewaySkuName = "Standard" | string;
-/**
- * Defines values for EffectiveRouteSource.
- */
-export type EffectiveRouteSource =
-  | "Unknown"
-  | "User"
-  | "VirtualNetworkGateway"
-  | "Default"
-  | string;
-/**
- * Defines values for EffectiveRouteState.
- */
-export type EffectiveRouteState = "Active" | "Invalid" | string;
-/**
- * Defines values for EffectiveSecurityRuleProtocol.
- */
-export type EffectiveSecurityRuleProtocol = "Tcp" | "Udp" | "All" | string;
-/**
- * Defines values for AssociationType.
- */
-export type AssociationType = "Associated" | "Contains" | string;
-/**
- * Defines values for Direction.
- */
-export type Direction = "Inbound" | "Outbound" | string;
-/**
- * Defines values for IpFlowProtocol.
- */
-export type IpFlowProtocol = "TCP" | "UDP" | string;
-/**
- * Defines values for Access.
- */
-export type Access = "Allow" | "Deny" | string;
-/**
- * Defines values for NextHopType.
- */
-export type NextHopType =
-  | "Internet"
-  | "VirtualAppliance"
-  | "VirtualNetworkGateway"
-  | "VnetLocal"
-  | "HyperNetGateway"
-  | "None"
-  | string;
-/**
- * Defines values for PcProtocol.
- */
-export type PcProtocol = "TCP" | "UDP" | "Any" | string;
-/**
- * Defines values for PcStatus.
- */
-export type PcStatus =
-  | "NotStarted"
-  | "Running"
-  | "Stopped"
-  | "Error"
-  | "Unknown"
-  | string;
-/**
- * Defines values for PcError.
- */
-export type PcError =
-  | "InternalError"
-  | "AgentStopped"
-  | "CaptureFailed"
-  | "LocalFileFailed"
-  | "StorageFailed"
-  | string;
-/**
- * Defines values for Protocol.
- */
-export type Protocol = "Tcp" | "Http" | "Https" | "Icmp" | string;
-/**
- * Defines values for HttpMethod.
- */
-export type HttpMethod = "Get" | string;
-/**
- * Defines values for Origin.
- */
-export type Origin = "Local" | "Inbound" | "Outbound" | string;
-/**
- * Defines values for Severity.
- */
-export type Severity = "Error" | "Warning" | string;
-/**
- * Defines values for IssueType.
- */
-export type IssueType =
-  | "Unknown"
-  | "AgentStopped"
-  | "GuestFirewall"
-  | "DnsResolution"
-  | "SocketBind"
-  | "NetworkSecurityRule"
-  | "UserDefinedRoute"
-  | "PortThrottled"
-  | "Platform"
-  | string;
-/**
- * Defines values for ConnectionStatus.
- */
-export type ConnectionStatus =
-  | "Unknown"
-  | "Connected"
-  | "Disconnected"
-  | "Degraded"
-  | string;
-/**
- * Defines values for VerbosityLevel.
- */
-export type VerbosityLevel = "Normal" | "Minimum" | "Full" | string;
-/**
- * Defines values for ConnectionMonitorEndpointFilterType.
- */
-export type ConnectionMonitorEndpointFilterType = "Include" | string;
-/**
- * Defines values for ConnectionMonitorEndpointFilterItemType.
- */
-export type ConnectionMonitorEndpointFilterItemType = "AgentAddress" | string;
-/**
- * Defines values for ConnectionMonitorTestConfigurationProtocol.
- */
-export type ConnectionMonitorTestConfigurationProtocol =
-  | "Tcp"
-  | "Http"
-  | "Icmp"
-  | string;
-/**
- * Defines values for PreferredIPVersion.
- */
-export type PreferredIPVersion = "IPv4" | "IPv6" | string;
-/**
- * Defines values for HttpConfigurationMethod.
- */
-export type HttpConfigurationMethod = "Get" | "Post" | string;
-/**
- * Defines values for OutputType.
- */
-export type OutputType = "Workspace" | string;
-/**
- * Defines values for ConnectionMonitorType.
- */
-export type ConnectionMonitorType =
-  | "MultiEndpoint"
-  | "SingleSourceDestination"
-  | string;
-/**
- * Defines values for ConnectionMonitorSourceStatus.
- */
-export type ConnectionMonitorSourceStatus =
-  | "Unknown"
-  | "Active"
-  | "Inactive"
-  | string;
-/**
- * Defines values for ConnectionState.
- */
-export type ConnectionState = "Reachable" | "Unreachable" | "Unknown" | string;
-/**
- * Defines values for EvaluationState.
- */
-export type EvaluationState =
-  | "NotStarted"
-  | "InProgress"
-  | "Completed"
-  | string;
-/**
- * Defines values for PublicIPPrefixSkuName.
- */
-export type PublicIPPrefixSkuName = "Standard" | string;
-/**
- * Defines values for RouteFilterRuleType.
- */
-export type RouteFilterRuleType = "Community" | string;
-/**
- * Defines values for SecurityProviderName.
- */
-export type SecurityProviderName = "ZScaler" | "IBoss" | "Checkpoint" | string;
-/**
- * Defines values for SecurityPartnerProviderConnectionStatus.
- */
-export type SecurityPartnerProviderConnectionStatus =
-  | "Unknown"
-  | "PartiallyConnected"
-  | "Connected"
-  | "NotConnected"
-  | string;
-/**
- * Defines values for UsageUnit.
- */
-export type UsageUnit = "Count" | string;
-/**
- * Defines values for VirtualNetworkGatewayType.
- */
-export type VirtualNetworkGatewayType = "Vpn" | "ExpressRoute" | string;
-/**
- * Defines values for VpnType.
- */
-export type VpnType = "PolicyBased" | "RouteBased" | string;
-/**
- * Defines values for VpnGatewayGeneration.
- */
-export type VpnGatewayGeneration =
-  | "None"
-  | "Generation1"
-  | "Generation2"
-  | string;
-/**
- * Defines values for VirtualNetworkGatewaySkuName.
- */
-export type VirtualNetworkGatewaySkuName =
-  | "Basic"
-  | "HighPerformance"
-  | "Standard"
-  | "UltraPerformance"
-  | "VpnGw1"
-  | "VpnGw2"
-  | "VpnGw3"
-  | "VpnGw4"
-  | "VpnGw5"
-  | "VpnGw1AZ"
-  | "VpnGw2AZ"
-  | "VpnGw3AZ"
-  | "VpnGw4AZ"
-  | "VpnGw5AZ"
-  | "ErGw1AZ"
-  | "ErGw2AZ"
-  | "ErGw3AZ"
-  | string;
-/**
- * Defines values for VirtualNetworkGatewaySkuTier.
- */
-export type VirtualNetworkGatewaySkuTier =
-  | "Basic"
-  | "HighPerformance"
-  | "Standard"
-  | "UltraPerformance"
-  | "VpnGw1"
-  | "VpnGw2"
-  | "VpnGw3"
-  | "VpnGw4"
-  | "VpnGw5"
-  | "VpnGw1AZ"
-  | "VpnGw2AZ"
-  | "VpnGw3AZ"
-  | "VpnGw4AZ"
-  | "VpnGw5AZ"
-  | "ErGw1AZ"
-  | "ErGw2AZ"
-  | "ErGw3AZ"
-  | string;
-/**
- * Defines values for VpnClientProtocol.
- */
-export type VpnClientProtocol = "IkeV2" | "SSTP" | "OpenVPN" | string;
-/**
- * Defines values for IpsecEncryption.
- */
-export type IpsecEncryption =
-  | "None"
-  | "DES"
-  | "DES3"
-  | "AES128"
-  | "AES192"
-  | "AES256"
-  | "GCMAES128"
-  | "GCMAES192"
-  | "GCMAES256"
-  | string;
-/**
- * Defines values for IpsecIntegrity.
- */
-export type IpsecIntegrity =
-  | "MD5"
-  | "SHA1"
-  | "SHA256"
-  | "GCMAES128"
-  | "GCMAES192"
-  | "GCMAES256"
-  | string;
-/**
- * Defines values for IkeEncryption.
- */
-export type IkeEncryption =
-  | "DES"
-  | "DES3"
-  | "AES128"
-  | "AES192"
-  | "AES256"
-  | "GCMAES256"
-  | "GCMAES128"
-  | string;
-/**
- * Defines values for IkeIntegrity.
- */
-export type IkeIntegrity =
-  | "MD5"
-  | "SHA1"
-  | "SHA256"
-  | "SHA384"
-  | "GCMAES256"
-  | "GCMAES128"
-  | string;
-/**
- * Defines values for DhGroup.
- */
-export type DhGroup =
-  | "None"
-  | "DHGroup1"
-  | "DHGroup2"
-  | "DHGroup14"
-  | "DHGroup2048"
-  | "ECP256"
-  | "ECP384"
-  | "DHGroup24"
-  | string;
-/**
- * Defines values for PfsGroup.
- */
-export type PfsGroup =
-  | "None"
-  | "PFS1"
-  | "PFS2"
-  | "PFS2048"
-  | "ECP256"
-  | "ECP384"
-  | "PFS24"
-  | "PFS14"
-  | "PFSMM"
-  | string;
-/**
- * Defines values for VirtualNetworkGatewayConnectionType.
- */
-export type VirtualNetworkGatewayConnectionType =
-  | "IPsec"
-  | "Vnet2Vnet"
-  | "ExpressRoute"
-  | "VPNClient"
-  | string;
-/**
- * Defines values for VirtualNetworkGatewayConnectionProtocol.
- */
-export type VirtualNetworkGatewayConnectionProtocol =
-  | "IKEv2"
-  | "IKEv1"
-  | string;
-/**
- * Defines values for VirtualNetworkGatewayConnectionStatus.
- */
-export type VirtualNetworkGatewayConnectionStatus =
-  | "Unknown"
-  | "Connecting"
-  | "Connected"
-  | "NotConnected"
-  | string;
-/**
- * Defines values for ProcessorArchitecture.
- */
-export type ProcessorArchitecture = "Amd64" | "X86" | string;
-/**
- * Defines values for AuthenticationMethod.
- */
-export type AuthenticationMethod = "EAPTLS" | "EAPMSCHAPv2" | string;
-/**
- * Defines values for BgpPeerState.
- */
-export type BgpPeerState =
-  | "Unknown"
-  | "Stopped"
-  | "Idle"
-  | "Connecting"
-  | "Connected"
-  | string;
-/**
- * Defines values for OfficeTrafficCategory.
- */
-export type OfficeTrafficCategory =
-  | "Optimize"
-  | "OptimizeAndAllow"
-  | "All"
-  | "None"
-  | string;
-/**
- * Defines values for VirtualWanSecurityProviderType.
- */
-export type VirtualWanSecurityProviderType = "External" | "Native" | string;
-/**
- * Defines values for VpnGatewayTunnelingProtocol.
- */
-export type VpnGatewayTunnelingProtocol = "IkeV2" | "OpenVPN" | string;
-/**
- * Defines values for VpnAuthenticationType.
- */
-export type VpnAuthenticationType = "Certificate" | "Radius" | "AAD" | string;
-/**
- * Defines values for VpnConnectionStatus.
- */
-export type VpnConnectionStatus =
-  | "Unknown"
-  | "Connecting"
-  | "Connected"
-  | "NotConnected"
-  | string;
-/**
- * Defines values for WebApplicationFirewallEnabledState.
- */
-export type WebApplicationFirewallEnabledState =
-  | "Disabled"
-  | "Enabled"
-  | string;
-/**
- * Defines values for WebApplicationFirewallMode.
- */
-export type WebApplicationFirewallMode = "Prevention" | "Detection" | string;
-/**
- * Defines values for WebApplicationFirewallRuleType.
- */
-export type WebApplicationFirewallRuleType = "MatchRule" | "Invalid" | string;
-/**
- * Defines values for WebApplicationFirewallMatchVariable.
- */
-export type WebApplicationFirewallMatchVariable =
-  | "RemoteAddr"
-  | "RequestMethod"
-  | "QueryString"
-  | "PostArgs"
-  | "RequestUri"
-  | "RequestHeaders"
-  | "RequestBody"
-  | "RequestCookies"
-  | string;
-/**
- * Defines values for WebApplicationFirewallOperator.
- */
-export type WebApplicationFirewallOperator =
-  | "IPMatch"
-  | "Equal"
-  | "Contains"
-  | "LessThan"
-  | "GreaterThan"
-  | "LessThanOrEqual"
-  | "GreaterThanOrEqual"
-  | "BeginsWith"
-  | "EndsWith"
-  | "Regex"
-  | "GeoMatch"
-  | string;
-/**
- * Defines values for WebApplicationFirewallTransform.
- */
-export type WebApplicationFirewallTransform =
-  | "Lowercase"
-  | "Trim"
-  | "UrlDecode"
-  | "UrlEncode"
-  | "RemoveNulls"
-  | "HtmlEntityDecode"
-  | string;
-/**
- * Defines values for WebApplicationFirewallAction.
- */
-export type WebApplicationFirewallAction = "Allow" | "Block" | "Log" | string;
-/**
- * Defines values for WebApplicationFirewallPolicyResourceState.
- */
-export type WebApplicationFirewallPolicyResourceState =
-  | "Creating"
-  | "Enabling"
-  | "Enabled"
-  | "Disabling"
-  | "Disabled"
-  | "Deleting"
-  | string;
-/**
- * Defines values for OwaspCrsExclusionEntryMatchVariable.
- */
-export type OwaspCrsExclusionEntryMatchVariable =
-  | "RequestHeaderNames"
-  | "RequestCookieNames"
-  | "RequestArgNames"
-  | string;
-/**
- * Defines values for OwaspCrsExclusionEntrySelectorMatchOperator.
- */
-export type OwaspCrsExclusionEntrySelectorMatchOperator =
-  | "Equals"
-  | "Contains"
-  | "StartsWith"
-  | "EndsWith"
-  | "EqualsAny"
-  | string;
-/**
- * Defines values for ManagedRuleEnabledState.
- */
-export type ManagedRuleEnabledState = "Disabled" | string;
-/**
- * Defines values for FirewallPolicyNatRuleActionType.
- */
-export type FirewallPolicyNatRuleActionType = "DNAT" | string;
-/**
- * Defines values for FirewallPolicyRuleConditionType.
- */
-export type FirewallPolicyRuleConditionType =
-  | "ApplicationRuleCondition"
-  | "NetworkRuleCondition"
-  | "NatRuleCondition"
-  | string;
-/**
- * Defines values for FirewallPolicyFilterRuleActionType.
- */
-export type FirewallPolicyFilterRuleActionType = "Allow" | "Deny" | string;
-/**
- * Defines values for FirewallPolicyRuleConditionApplicationProtocolType.
- */
-export type FirewallPolicyRuleConditionApplicationProtocolType =
-  | "Http"
-  | "Https"
-  | string;
-/**
- * Defines values for FirewallPolicyRuleConditionNetworkProtocol.
- */
-export type FirewallPolicyRuleConditionNetworkProtocol =
-  | "TCP"
-  | "UDP"
-  | "Any"
-  | "ICMP"
-  | string;
-/**
- * Defines values for NetworkOperationStatus.
- */
-export type NetworkOperationStatus =
-  | "InProgress"
-  | "Succeeded"
-  | "Failed"
-  | string;
-/**
- * Defines values for TunnelConnectionStatus.
- */
-export type TunnelConnectionStatus =
-  | "Unknown"
-  | "Connecting"
-  | "Connected"
-  | "NotConnected"
-  | string;
-/**
- * Defines values for HubVirtualNetworkConnectionStatus.
- */
-export type HubVirtualNetworkConnectionStatus =
-  | "Unknown"
-  | "Connecting"
-  | "Connected"
-  | "NotConnected"
-  | string;
+
+/**
+ * Known values of {@link ApplicationGatewaySkuName} that the service accepts.
+ */
+export const enum KnownApplicationGatewaySkuName {
+  StandardSmall = "Standard_Small",
+  StandardMedium = "Standard_Medium",
+  StandardLarge = "Standard_Large",
+  WAFMedium = "WAF_Medium",
+  WAFLarge = "WAF_Large",
+  StandardV2 = "Standard_v2",
+  WAFV2 = "WAF_v2"
+}
+
+/**
+ * Defines values for ApplicationGatewaySkuName. \
+ * {@link KnownApplicationGatewaySkuName} can be used interchangeably with ApplicationGatewaySkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_Small** \
+ * **Standard_Medium** \
+ * **Standard_Large** \
+ * **WAF_Medium** \
+ * **WAF_Large** \
+ * **Standard_v2** \
+ * **WAF_v2**
+ */
+export type ApplicationGatewaySkuName = string;
+
+/**
+ * Known values of {@link ApplicationGatewayTier} that the service accepts.
+ */
+export const enum KnownApplicationGatewayTier {
+  Standard = "Standard",
+  WAF = "WAF",
+  StandardV2 = "Standard_v2",
+  WAFV2 = "WAF_v2"
+}
+
+/**
+ * Defines values for ApplicationGatewayTier. \
+ * {@link KnownApplicationGatewayTier} can be used interchangeably with ApplicationGatewayTier,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard** \
+ * **WAF** \
+ * **Standard_v2** \
+ * **WAF_v2**
+ */
+export type ApplicationGatewayTier = string;
+
+/**
+ * Known values of {@link ApplicationGatewaySslProtocol} that the service accepts.
+ */
+export const enum KnownApplicationGatewaySslProtocol {
+  TLSv10 = "TLSv1_0",
+  TLSv11 = "TLSv1_1",
+  TLSv12 = "TLSv1_2"
+}
+
+/**
+ * Defines values for ApplicationGatewaySslProtocol. \
+ * {@link KnownApplicationGatewaySslProtocol} can be used interchangeably with ApplicationGatewaySslProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TLSv1_0** \
+ * **TLSv1_1** \
+ * **TLSv1_2**
+ */
+export type ApplicationGatewaySslProtocol = string;
+
+/**
+ * Known values of {@link ApplicationGatewaySslPolicyType} that the service accepts.
+ */
+export const enum KnownApplicationGatewaySslPolicyType {
+  Predefined = "Predefined",
+  Custom = "Custom"
+}
+
+/**
+ * Defines values for ApplicationGatewaySslPolicyType. \
+ * {@link KnownApplicationGatewaySslPolicyType} can be used interchangeably with ApplicationGatewaySslPolicyType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Predefined** \
+ * **Custom**
+ */
+export type ApplicationGatewaySslPolicyType = string;
+
+/**
+ * Known values of {@link ApplicationGatewaySslPolicyName} that the service accepts.
+ */
+export const enum KnownApplicationGatewaySslPolicyName {
+  AppGwSslPolicy20150501 = "AppGwSslPolicy20150501",
+  AppGwSslPolicy20170401 = "AppGwSslPolicy20170401",
+  AppGwSslPolicy20170401S = "AppGwSslPolicy20170401S"
+}
+
+/**
+ * Defines values for ApplicationGatewaySslPolicyName. \
+ * {@link KnownApplicationGatewaySslPolicyName} can be used interchangeably with ApplicationGatewaySslPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AppGwSslPolicy20150501** \
+ * **AppGwSslPolicy20170401** \
+ * **AppGwSslPolicy20170401S**
+ */
+export type ApplicationGatewaySslPolicyName = string;
+
+/**
+ * Known values of {@link ApplicationGatewaySslCipherSuite} that the service accepts.
+ */
+export const enum KnownApplicationGatewaySslCipherSuite {
+  TLSEcdheRSAWithAES256CBCSHA384 = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+  TLSEcdheRSAWithAES128CBCSHA256 = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+  TLSEcdheRSAWithAES256CBCSHA = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+  TLSEcdheRSAWithAES128CBCSHA = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+  TLSDHERSAWithAES256GCMSHA384 = "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+  TLSDHERSAWithAES128GCMSHA256 = "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+  TLSDHERSAWithAES256CBCSHA = "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+  TLSDHERSAWithAES128CBCSHA = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+  TLSRSAWithAES256GCMSHA384 = "TLS_RSA_WITH_AES_256_GCM_SHA384",
+  TLSRSAWithAES128GCMSHA256 = "TLS_RSA_WITH_AES_128_GCM_SHA256",
+  TLSRSAWithAES256CBCSHA256 = "TLS_RSA_WITH_AES_256_CBC_SHA256",
+  TLSRSAWithAES128CBCSHA256 = "TLS_RSA_WITH_AES_128_CBC_SHA256",
+  TLSRSAWithAES256CBCSHA = "TLS_RSA_WITH_AES_256_CBC_SHA",
+  TLSRSAWithAES128CBCSHA = "TLS_RSA_WITH_AES_128_CBC_SHA",
+  TLSEcdheEcdsaWithAES256GCMSHA384 = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+  TLSEcdheEcdsaWithAES128GCMSHA256 = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+  TLSEcdheEcdsaWithAES256CBCSHA384 = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+  TLSEcdheEcdsaWithAES128CBCSHA256 = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+  TLSEcdheEcdsaWithAES256CBCSHA = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+  TLSEcdheEcdsaWithAES128CBCSHA = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+  TLSDHEDSSWithAES256CBCSHA256 = "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+  TLSDHEDSSWithAES128CBCSHA256 = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+  TLSDHEDSSWithAES256CBCSHA = "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+  TLSDHEDSSWithAES128CBCSHA = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+  TLSRSAWith3DESEDECBCSHA = "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+  TLSDHEDSSWith3DESEDECBCSHA = "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+  TLSEcdheRSAWithAES128GCMSHA256 = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+  TLSEcdheRSAWithAES256GCMSHA384 = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
+}
+
+/**
+ * Defines values for ApplicationGatewaySslCipherSuite. \
+ * {@link KnownApplicationGatewaySslCipherSuite} can be used interchangeably with ApplicationGatewaySslCipherSuite,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384** \
+ * **TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256** \
+ * **TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA** \
+ * **TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA** \
+ * **TLS_DHE_RSA_WITH_AES_256_GCM_SHA384** \
+ * **TLS_DHE_RSA_WITH_AES_128_GCM_SHA256** \
+ * **TLS_DHE_RSA_WITH_AES_256_CBC_SHA** \
+ * **TLS_DHE_RSA_WITH_AES_128_CBC_SHA** \
+ * **TLS_RSA_WITH_AES_256_GCM_SHA384** \
+ * **TLS_RSA_WITH_AES_128_GCM_SHA256** \
+ * **TLS_RSA_WITH_AES_256_CBC_SHA256** \
+ * **TLS_RSA_WITH_AES_128_CBC_SHA256** \
+ * **TLS_RSA_WITH_AES_256_CBC_SHA** \
+ * **TLS_RSA_WITH_AES_128_CBC_SHA** \
+ * **TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384** \
+ * **TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256** \
+ * **TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384** \
+ * **TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256** \
+ * **TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA** \
+ * **TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA** \
+ * **TLS_DHE_DSS_WITH_AES_256_CBC_SHA256** \
+ * **TLS_DHE_DSS_WITH_AES_128_CBC_SHA256** \
+ * **TLS_DHE_DSS_WITH_AES_256_CBC_SHA** \
+ * **TLS_DHE_DSS_WITH_AES_128_CBC_SHA** \
+ * **TLS_RSA_WITH_3DES_EDE_CBC_SHA** \
+ * **TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA** \
+ * **TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256** \
+ * **TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384**
+ */
+export type ApplicationGatewaySslCipherSuite = string;
+
+/**
+ * Known values of {@link ApplicationGatewayOperationalState} that the service accepts.
+ */
+export const enum KnownApplicationGatewayOperationalState {
+  Stopped = "Stopped",
+  Starting = "Starting",
+  Running = "Running",
+  Stopping = "Stopping"
+}
+
+/**
+ * Defines values for ApplicationGatewayOperationalState. \
+ * {@link KnownApplicationGatewayOperationalState} can be used interchangeably with ApplicationGatewayOperationalState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Stopped** \
+ * **Starting** \
+ * **Running** \
+ * **Stopping**
+ */
+export type ApplicationGatewayOperationalState = string;
+
+/**
+ * Known values of {@link ProvisioningState} that the service accepts.
+ */
+export const enum KnownProvisioningState {
+  Succeeded = "Succeeded",
+  Updating = "Updating",
+  Deleting = "Deleting",
+  Failed = "Failed"
+}
+
+/**
+ * Defines values for ProvisioningState. \
+ * {@link KnownProvisioningState} can be used interchangeably with ProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Updating** \
+ * **Deleting** \
+ * **Failed**
+ */
+export type ProvisioningState = string;
+
+/**
+ * Known values of {@link IPAllocationMethod} that the service accepts.
+ */
+export const enum KnownIPAllocationMethod {
+  Static = "Static",
+  Dynamic = "Dynamic"
+}
+
+/**
+ * Defines values for IPAllocationMethod. \
+ * {@link KnownIPAllocationMethod} can be used interchangeably with IPAllocationMethod,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Static** \
+ * **Dynamic**
+ */
+export type IPAllocationMethod = string;
+
+/**
+ * Known values of {@link ApplicationGatewayProtocol} that the service accepts.
+ */
+export const enum KnownApplicationGatewayProtocol {
+  Http = "Http",
+  Https = "Https"
+}
+
+/**
+ * Defines values for ApplicationGatewayProtocol. \
+ * {@link KnownApplicationGatewayProtocol} can be used interchangeably with ApplicationGatewayProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Http** \
+ * **Https**
+ */
+export type ApplicationGatewayProtocol = string;
+
+/**
+ * Known values of {@link IPVersion} that the service accepts.
+ */
+export const enum KnownIPVersion {
+  IPv4 = "IPv4",
+  IPv6 = "IPv6"
+}
+
+/**
+ * Defines values for IPVersion. \
+ * {@link KnownIPVersion} can be used interchangeably with IPVersion,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IPv4** \
+ * **IPv6**
+ */
+export type IPVersion = string;
+
+/**
+ * Known values of {@link SecurityRuleProtocol} that the service accepts.
+ */
+export const enum KnownSecurityRuleProtocol {
+  Tcp = "Tcp",
+  Udp = "Udp",
+  Icmp = "Icmp",
+  Esp = "Esp",
+  Asterisk = "*",
+  Ah = "Ah"
+}
+
+/**
+ * Defines values for SecurityRuleProtocol. \
+ * {@link KnownSecurityRuleProtocol} can be used interchangeably with SecurityRuleProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Tcp** \
+ * **Udp** \
+ * **Icmp** \
+ * **Esp** \
+ * ***** \
+ * **Ah**
+ */
+export type SecurityRuleProtocol = string;
+
+/**
+ * Known values of {@link SecurityRuleAccess} that the service accepts.
+ */
+export const enum KnownSecurityRuleAccess {
+  Allow = "Allow",
+  Deny = "Deny"
+}
+
+/**
+ * Defines values for SecurityRuleAccess. \
+ * {@link KnownSecurityRuleAccess} can be used interchangeably with SecurityRuleAccess,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Allow** \
+ * **Deny**
+ */
+export type SecurityRuleAccess = string;
+
+/**
+ * Known values of {@link SecurityRuleDirection} that the service accepts.
+ */
+export const enum KnownSecurityRuleDirection {
+  Inbound = "Inbound",
+  Outbound = "Outbound"
+}
+
+/**
+ * Defines values for SecurityRuleDirection. \
+ * {@link KnownSecurityRuleDirection} can be used interchangeably with SecurityRuleDirection,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Inbound** \
+ * **Outbound**
+ */
+export type SecurityRuleDirection = string;
+
+/**
+ * Known values of {@link FlowLogFormatType} that the service accepts.
+ */
+export const enum KnownFlowLogFormatType {
+  Json = "JSON"
+}
+
+/**
+ * Defines values for FlowLogFormatType. \
+ * {@link KnownFlowLogFormatType} can be used interchangeably with FlowLogFormatType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **JSON**
+ */
+export type FlowLogFormatType = string;
+
+/**
+ * Known values of {@link RouteNextHopType} that the service accepts.
+ */
+export const enum KnownRouteNextHopType {
+  VirtualNetworkGateway = "VirtualNetworkGateway",
+  VnetLocal = "VnetLocal",
+  Internet = "Internet",
+  VirtualAppliance = "VirtualAppliance",
+  None = "None"
+}
+
+/**
+ * Defines values for RouteNextHopType. \
+ * {@link KnownRouteNextHopType} can be used interchangeably with RouteNextHopType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **VirtualNetworkGateway** \
+ * **VnetLocal** \
+ * **Internet** \
+ * **VirtualAppliance** \
+ * **None**
+ */
+export type RouteNextHopType = string;
+
+/**
+ * Known values of {@link PublicIPAddressSkuName} that the service accepts.
+ */
+export const enum KnownPublicIPAddressSkuName {
+  Basic = "Basic",
+  Standard = "Standard"
+}
+
+/**
+ * Defines values for PublicIPAddressSkuName. \
+ * {@link KnownPublicIPAddressSkuName} can be used interchangeably with PublicIPAddressSkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **Standard**
+ */
+export type PublicIPAddressSkuName = string;
+
+/**
+ * Known values of {@link DdosSettingsProtectionCoverage} that the service accepts.
+ */
+export const enum KnownDdosSettingsProtectionCoverage {
+  Basic = "Basic",
+  Standard = "Standard"
+}
+
+/**
+ * Defines values for DdosSettingsProtectionCoverage. \
+ * {@link KnownDdosSettingsProtectionCoverage} can be used interchangeably with DdosSettingsProtectionCoverage,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **Standard**
+ */
+export type DdosSettingsProtectionCoverage = string;
+
+/**
+ * Known values of {@link VirtualNetworkPeeringState} that the service accepts.
+ */
+export const enum KnownVirtualNetworkPeeringState {
+  Initiated = "Initiated",
+  Connected = "Connected",
+  Disconnected = "Disconnected"
+}
+
+/**
+ * Defines values for VirtualNetworkPeeringState. \
+ * {@link KnownVirtualNetworkPeeringState} can be used interchangeably with VirtualNetworkPeeringState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Initiated** \
+ * **Connected** \
+ * **Disconnected**
+ */
+export type VirtualNetworkPeeringState = string;
+
+/**
+ * Known values of {@link TransportProtocol} that the service accepts.
+ */
+export const enum KnownTransportProtocol {
+  Udp = "Udp",
+  Tcp = "Tcp",
+  All = "All"
+}
+
+/**
+ * Defines values for TransportProtocol. \
+ * {@link KnownTransportProtocol} can be used interchangeably with TransportProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Udp** \
+ * **Tcp** \
+ * **All**
+ */
+export type TransportProtocol = string;
+
+/**
+ * Known values of {@link ApplicationGatewayCookieBasedAffinity} that the service accepts.
+ */
+export const enum KnownApplicationGatewayCookieBasedAffinity {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for ApplicationGatewayCookieBasedAffinity. \
+ * {@link KnownApplicationGatewayCookieBasedAffinity} can be used interchangeably with ApplicationGatewayCookieBasedAffinity,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
+ */
+export type ApplicationGatewayCookieBasedAffinity = string;
+
+/**
+ * Known values of {@link ApplicationGatewayCustomErrorStatusCode} that the service accepts.
+ */
+export const enum KnownApplicationGatewayCustomErrorStatusCode {
+  HttpStatus403 = "HttpStatus403",
+  HttpStatus502 = "HttpStatus502"
+}
+
+/**
+ * Defines values for ApplicationGatewayCustomErrorStatusCode. \
+ * {@link KnownApplicationGatewayCustomErrorStatusCode} can be used interchangeably with ApplicationGatewayCustomErrorStatusCode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **HttpStatus403** \
+ * **HttpStatus502**
+ */
+export type ApplicationGatewayCustomErrorStatusCode = string;
+
+/**
+ * Known values of {@link ApplicationGatewayRequestRoutingRuleType} that the service accepts.
+ */
+export const enum KnownApplicationGatewayRequestRoutingRuleType {
+  Basic = "Basic",
+  PathBasedRouting = "PathBasedRouting"
+}
+
+/**
+ * Defines values for ApplicationGatewayRequestRoutingRuleType. \
+ * {@link KnownApplicationGatewayRequestRoutingRuleType} can be used interchangeably with ApplicationGatewayRequestRoutingRuleType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **PathBasedRouting**
+ */
+export type ApplicationGatewayRequestRoutingRuleType = string;
+
+/**
+ * Known values of {@link ApplicationGatewayRedirectType} that the service accepts.
+ */
+export const enum KnownApplicationGatewayRedirectType {
+  Permanent = "Permanent",
+  Found = "Found",
+  SeeOther = "SeeOther",
+  Temporary = "Temporary"
+}
+
+/**
+ * Defines values for ApplicationGatewayRedirectType. \
+ * {@link KnownApplicationGatewayRedirectType} can be used interchangeably with ApplicationGatewayRedirectType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Permanent** \
+ * **Found** \
+ * **SeeOther** \
+ * **Temporary**
+ */
+export type ApplicationGatewayRedirectType = string;
+
+/**
+ * Known values of {@link ApplicationGatewayFirewallMode} that the service accepts.
+ */
+export const enum KnownApplicationGatewayFirewallMode {
+  Detection = "Detection",
+  Prevention = "Prevention"
+}
+
+/**
+ * Defines values for ApplicationGatewayFirewallMode. \
+ * {@link KnownApplicationGatewayFirewallMode} can be used interchangeably with ApplicationGatewayFirewallMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Detection** \
+ * **Prevention**
+ */
+export type ApplicationGatewayFirewallMode = string;
+
+/**
+ * Known values of {@link ApplicationGatewayBackendHealthServerHealth} that the service accepts.
+ */
+export const enum KnownApplicationGatewayBackendHealthServerHealth {
+  Unknown = "Unknown",
+  Up = "Up",
+  Down = "Down",
+  Partial = "Partial",
+  Draining = "Draining"
+}
+
+/**
+ * Defines values for ApplicationGatewayBackendHealthServerHealth. \
+ * {@link KnownApplicationGatewayBackendHealthServerHealth} can be used interchangeably with ApplicationGatewayBackendHealthServerHealth,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Up** \
+ * **Down** \
+ * **Partial** \
+ * **Draining**
+ */
+export type ApplicationGatewayBackendHealthServerHealth = string;
+
+/**
+ * Known values of {@link AzureFirewallRCActionType} that the service accepts.
+ */
+export const enum KnownAzureFirewallRCActionType {
+  Allow = "Allow",
+  Deny = "Deny"
+}
+
+/**
+ * Defines values for AzureFirewallRCActionType. \
+ * {@link KnownAzureFirewallRCActionType} can be used interchangeably with AzureFirewallRCActionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Allow** \
+ * **Deny**
+ */
+export type AzureFirewallRCActionType = string;
+
+/**
+ * Known values of {@link AzureFirewallApplicationRuleProtocolType} that the service accepts.
+ */
+export const enum KnownAzureFirewallApplicationRuleProtocolType {
+  Http = "Http",
+  Https = "Https",
+  Mssql = "Mssql"
+}
+
+/**
+ * Defines values for AzureFirewallApplicationRuleProtocolType. \
+ * {@link KnownAzureFirewallApplicationRuleProtocolType} can be used interchangeably with AzureFirewallApplicationRuleProtocolType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Http** \
+ * **Https** \
+ * **Mssql**
+ */
+export type AzureFirewallApplicationRuleProtocolType = string;
+
+/**
+ * Known values of {@link AzureFirewallNatRCActionType} that the service accepts.
+ */
+export const enum KnownAzureFirewallNatRCActionType {
+  Snat = "Snat",
+  Dnat = "Dnat"
+}
+
+/**
+ * Defines values for AzureFirewallNatRCActionType. \
+ * {@link KnownAzureFirewallNatRCActionType} can be used interchangeably with AzureFirewallNatRCActionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Snat** \
+ * **Dnat**
+ */
+export type AzureFirewallNatRCActionType = string;
+
+/**
+ * Known values of {@link AzureFirewallNetworkRuleProtocol} that the service accepts.
+ */
+export const enum KnownAzureFirewallNetworkRuleProtocol {
+  TCP = "TCP",
+  UDP = "UDP",
+  Any = "Any",
+  Icmp = "ICMP"
+}
+
+/**
+ * Defines values for AzureFirewallNetworkRuleProtocol. \
+ * {@link KnownAzureFirewallNetworkRuleProtocol} can be used interchangeably with AzureFirewallNetworkRuleProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TCP** \
+ * **UDP** \
+ * **Any** \
+ * **ICMP**
+ */
+export type AzureFirewallNetworkRuleProtocol = string;
+
+/**
+ * Known values of {@link AzureFirewallThreatIntelMode} that the service accepts.
+ */
+export const enum KnownAzureFirewallThreatIntelMode {
+  Alert = "Alert",
+  Deny = "Deny",
+  Off = "Off"
+}
+
+/**
+ * Defines values for AzureFirewallThreatIntelMode. \
+ * {@link KnownAzureFirewallThreatIntelMode} can be used interchangeably with AzureFirewallThreatIntelMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Alert** \
+ * **Deny** \
+ * **Off**
+ */
+export type AzureFirewallThreatIntelMode = string;
+
+/**
+ * Known values of {@link AzureFirewallSkuName} that the service accepts.
+ */
+export const enum KnownAzureFirewallSkuName {
+  AzfwVnet = "AZFW_VNet",
+  AzfwHub = "AZFW_Hub"
+}
+
+/**
+ * Defines values for AzureFirewallSkuName. \
+ * {@link KnownAzureFirewallSkuName} can be used interchangeably with AzureFirewallSkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AZFW_VNet** \
+ * **AZFW_Hub**
+ */
+export type AzureFirewallSkuName = string;
+
+/**
+ * Known values of {@link AzureFirewallSkuTier} that the service accepts.
+ */
+export const enum KnownAzureFirewallSkuTier {
+  Standard = "Standard",
+  Premium = "Premium"
+}
+
+/**
+ * Defines values for AzureFirewallSkuTier. \
+ * {@link KnownAzureFirewallSkuTier} can be used interchangeably with AzureFirewallSkuTier,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard** \
+ * **Premium**
+ */
+export type AzureFirewallSkuTier = string;
+
+/**
+ * Known values of {@link BastionConnectProtocol} that the service accepts.
+ */
+export const enum KnownBastionConnectProtocol {
+  SSH = "SSH",
+  RDP = "RDP"
+}
+
+/**
+ * Defines values for BastionConnectProtocol. \
+ * {@link KnownBastionConnectProtocol} can be used interchangeably with BastionConnectProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SSH** \
+ * **RDP**
+ */
+export type BastionConnectProtocol = string;
+
+/**
+ * Known values of {@link DdosCustomPolicyProtocol} that the service accepts.
+ */
+export const enum KnownDdosCustomPolicyProtocol {
+  Tcp = "Tcp",
+  Udp = "Udp",
+  Syn = "Syn"
+}
+
+/**
+ * Defines values for DdosCustomPolicyProtocol. \
+ * {@link KnownDdosCustomPolicyProtocol} can be used interchangeably with DdosCustomPolicyProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Tcp** \
+ * **Udp** \
+ * **Syn**
+ */
+export type DdosCustomPolicyProtocol = string;
+
+/**
+ * Known values of {@link DdosCustomPolicyTriggerSensitivityOverride} that the service accepts.
+ */
+export const enum KnownDdosCustomPolicyTriggerSensitivityOverride {
+  Relaxed = "Relaxed",
+  Low = "Low",
+  Default = "Default",
+  High = "High"
+}
+
+/**
+ * Defines values for DdosCustomPolicyTriggerSensitivityOverride. \
+ * {@link KnownDdosCustomPolicyTriggerSensitivityOverride} can be used interchangeably with DdosCustomPolicyTriggerSensitivityOverride,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Relaxed** \
+ * **Low** \
+ * **Default** \
+ * **High**
+ */
+export type DdosCustomPolicyTriggerSensitivityOverride = string;
+
+/**
+ * Known values of {@link AuthorizationUseStatus} that the service accepts.
+ */
+export const enum KnownAuthorizationUseStatus {
+  Available = "Available",
+  InUse = "InUse"
+}
+
+/**
+ * Defines values for AuthorizationUseStatus. \
+ * {@link KnownAuthorizationUseStatus} can be used interchangeably with AuthorizationUseStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Available** \
+ * **InUse**
+ */
+export type AuthorizationUseStatus = string;
+
+/**
+ * Known values of {@link ExpressRoutePeeringType} that the service accepts.
+ */
+export const enum KnownExpressRoutePeeringType {
+  AzurePublicPeering = "AzurePublicPeering",
+  AzurePrivatePeering = "AzurePrivatePeering",
+  MicrosoftPeering = "MicrosoftPeering"
+}
+
+/**
+ * Defines values for ExpressRoutePeeringType. \
+ * {@link KnownExpressRoutePeeringType} can be used interchangeably with ExpressRoutePeeringType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AzurePublicPeering** \
+ * **AzurePrivatePeering** \
+ * **MicrosoftPeering**
+ */
+export type ExpressRoutePeeringType = string;
+
+/**
+ * Known values of {@link ExpressRoutePeeringState} that the service accepts.
+ */
+export const enum KnownExpressRoutePeeringState {
+  Disabled = "Disabled",
+  Enabled = "Enabled"
+}
+
+/**
+ * Defines values for ExpressRoutePeeringState. \
+ * {@link KnownExpressRoutePeeringState} can be used interchangeably with ExpressRoutePeeringState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Disabled** \
+ * **Enabled**
+ */
+export type ExpressRoutePeeringState = string;
+
+/**
+ * Known values of {@link ExpressRouteCircuitPeeringAdvertisedPublicPrefixState} that the service accepts.
+ */
+export const enum KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState {
+  NotConfigured = "NotConfigured",
+  Configuring = "Configuring",
+  Configured = "Configured",
+  ValidationNeeded = "ValidationNeeded"
+}
+
+/**
+ * Defines values for ExpressRouteCircuitPeeringAdvertisedPublicPrefixState. \
+ * {@link KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState} can be used interchangeably with ExpressRouteCircuitPeeringAdvertisedPublicPrefixState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotConfigured** \
+ * **Configuring** \
+ * **Configured** \
+ * **ValidationNeeded**
+ */
+export type ExpressRouteCircuitPeeringAdvertisedPublicPrefixState = string;
+
+/**
+ * Known values of {@link ExpressRouteCircuitPeeringState} that the service accepts.
+ */
+export const enum KnownExpressRouteCircuitPeeringState {
+  Disabled = "Disabled",
+  Enabled = "Enabled"
+}
+
+/**
+ * Defines values for ExpressRouteCircuitPeeringState. \
+ * {@link KnownExpressRouteCircuitPeeringState} can be used interchangeably with ExpressRouteCircuitPeeringState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Disabled** \
+ * **Enabled**
+ */
+export type ExpressRouteCircuitPeeringState = string;
+
+/**
+ * Known values of {@link CircuitConnectionStatus} that the service accepts.
+ */
+export const enum KnownCircuitConnectionStatus {
+  Connected = "Connected",
+  Connecting = "Connecting",
+  Disconnected = "Disconnected"
+}
+
+/**
+ * Defines values for CircuitConnectionStatus. \
+ * {@link KnownCircuitConnectionStatus} can be used interchangeably with CircuitConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Connected** \
+ * **Connecting** \
+ * **Disconnected**
+ */
+export type CircuitConnectionStatus = string;
+
+/**
+ * Known values of {@link ExpressRouteCircuitSkuTier} that the service accepts.
+ */
+export const enum KnownExpressRouteCircuitSkuTier {
+  Standard = "Standard",
+  Premium = "Premium",
+  Basic = "Basic",
+  Local = "Local"
+}
+
+/**
+ * Defines values for ExpressRouteCircuitSkuTier. \
+ * {@link KnownExpressRouteCircuitSkuTier} can be used interchangeably with ExpressRouteCircuitSkuTier,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard** \
+ * **Premium** \
+ * **Basic** \
+ * **Local**
+ */
+export type ExpressRouteCircuitSkuTier = string;
+
+/**
+ * Known values of {@link ExpressRouteCircuitSkuFamily} that the service accepts.
+ */
+export const enum KnownExpressRouteCircuitSkuFamily {
+  UnlimitedData = "UnlimitedData",
+  MeteredData = "MeteredData"
+}
+
+/**
+ * Defines values for ExpressRouteCircuitSkuFamily. \
+ * {@link KnownExpressRouteCircuitSkuFamily} can be used interchangeably with ExpressRouteCircuitSkuFamily,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **UnlimitedData** \
+ * **MeteredData**
+ */
+export type ExpressRouteCircuitSkuFamily = string;
+
+/**
+ * Known values of {@link ServiceProviderProvisioningState} that the service accepts.
+ */
+export const enum KnownServiceProviderProvisioningState {
+  NotProvisioned = "NotProvisioned",
+  Provisioning = "Provisioning",
+  Provisioned = "Provisioned",
+  Deprovisioning = "Deprovisioning"
+}
+
+/**
+ * Defines values for ServiceProviderProvisioningState. \
+ * {@link KnownServiceProviderProvisioningState} can be used interchangeably with ServiceProviderProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotProvisioned** \
+ * **Provisioning** \
+ * **Provisioned** \
+ * **Deprovisioning**
+ */
+export type ServiceProviderProvisioningState = string;
+
+/**
+ * Known values of {@link ExpressRoutePortsEncapsulation} that the service accepts.
+ */
+export const enum KnownExpressRoutePortsEncapsulation {
+  Dot1Q = "Dot1Q",
+  QinQ = "QinQ"
+}
+
+/**
+ * Defines values for ExpressRoutePortsEncapsulation. \
+ * {@link KnownExpressRoutePortsEncapsulation} can be used interchangeably with ExpressRoutePortsEncapsulation,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Dot1Q** \
+ * **QinQ**
+ */
+export type ExpressRoutePortsEncapsulation = string;
+
+/**
+ * Known values of {@link ExpressRouteLinkConnectorType} that the service accepts.
+ */
+export const enum KnownExpressRouteLinkConnectorType {
+  LC = "LC",
+  SC = "SC"
+}
+
+/**
+ * Defines values for ExpressRouteLinkConnectorType. \
+ * {@link KnownExpressRouteLinkConnectorType} can be used interchangeably with ExpressRouteLinkConnectorType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **LC** \
+ * **SC**
+ */
+export type ExpressRouteLinkConnectorType = string;
+
+/**
+ * Known values of {@link ExpressRouteLinkAdminState} that the service accepts.
+ */
+export const enum KnownExpressRouteLinkAdminState {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for ExpressRouteLinkAdminState. \
+ * {@link KnownExpressRouteLinkAdminState} can be used interchangeably with ExpressRouteLinkAdminState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
+ */
+export type ExpressRouteLinkAdminState = string;
+
+/**
+ * Known values of {@link ExpressRouteLinkMacSecCipher} that the service accepts.
+ */
+export const enum KnownExpressRouteLinkMacSecCipher {
+  GcmAes128 = "gcm-aes-128",
+  GcmAes256 = "gcm-aes-256"
+}
+
+/**
+ * Defines values for ExpressRouteLinkMacSecCipher. \
+ * {@link KnownExpressRouteLinkMacSecCipher} can be used interchangeably with ExpressRouteLinkMacSecCipher,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **gcm-aes-128** \
+ * **gcm-aes-256**
+ */
+export type ExpressRouteLinkMacSecCipher = string;
+
+/**
+ * Known values of {@link FirewallPolicyIntrusionSystemMode} that the service accepts.
+ */
+export const enum KnownFirewallPolicyIntrusionSystemMode {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for FirewallPolicyIntrusionSystemMode. \
+ * {@link KnownFirewallPolicyIntrusionSystemMode} can be used interchangeably with FirewallPolicyIntrusionSystemMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
+ */
+export type FirewallPolicyIntrusionSystemMode = string;
+
+/**
+ * Known values of {@link FirewallPolicyRuleType} that the service accepts.
+ */
+export const enum KnownFirewallPolicyRuleType {
+  FirewallPolicyNatRule = "FirewallPolicyNatRule",
+  FirewallPolicyFilterRule = "FirewallPolicyFilterRule"
+}
+
+/**
+ * Defines values for FirewallPolicyRuleType. \
+ * {@link KnownFirewallPolicyRuleType} can be used interchangeably with FirewallPolicyRuleType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **FirewallPolicyNatRule** \
+ * **FirewallPolicyFilterRule**
+ */
+export type FirewallPolicyRuleType = string;
+
+/**
+ * Known values of {@link IpAllocationType} that the service accepts.
+ */
+export const enum KnownIpAllocationType {
+  Undefined = "Undefined",
+  Hypernet = "Hypernet"
+}
+
+/**
+ * Defines values for IpAllocationType. \
+ * {@link KnownIpAllocationType} can be used interchangeably with IpAllocationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Undefined** \
+ * **Hypernet**
+ */
+export type IpAllocationType = string;
+
+/**
+ * Known values of {@link LoadBalancerSkuName} that the service accepts.
+ */
+export const enum KnownLoadBalancerSkuName {
+  Basic = "Basic",
+  Standard = "Standard"
+}
+
+/**
+ * Defines values for LoadBalancerSkuName. \
+ * {@link KnownLoadBalancerSkuName} can be used interchangeably with LoadBalancerSkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **Standard**
+ */
+export type LoadBalancerSkuName = string;
+
+/**
+ * Known values of {@link LoadDistribution} that the service accepts.
+ */
+export const enum KnownLoadDistribution {
+  Default = "Default",
+  SourceIP = "SourceIP",
+  SourceIPProtocol = "SourceIPProtocol"
+}
+
+/**
+ * Defines values for LoadDistribution. \
+ * {@link KnownLoadDistribution} can be used interchangeably with LoadDistribution,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default** \
+ * **SourceIP** \
+ * **SourceIPProtocol**
+ */
+export type LoadDistribution = string;
+
+/**
+ * Known values of {@link ProbeProtocol} that the service accepts.
+ */
+export const enum KnownProbeProtocol {
+  Http = "Http",
+  Tcp = "Tcp",
+  Https = "Https"
+}
+
+/**
+ * Defines values for ProbeProtocol. \
+ * {@link KnownProbeProtocol} can be used interchangeably with ProbeProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Http** \
+ * **Tcp** \
+ * **Https**
+ */
+export type ProbeProtocol = string;
+
+/**
+ * Known values of {@link LoadBalancerOutboundRuleProtocol} that the service accepts.
+ */
+export const enum KnownLoadBalancerOutboundRuleProtocol {
+  Tcp = "Tcp",
+  Udp = "Udp",
+  All = "All"
+}
+
+/**
+ * Defines values for LoadBalancerOutboundRuleProtocol. \
+ * {@link KnownLoadBalancerOutboundRuleProtocol} can be used interchangeably with LoadBalancerOutboundRuleProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Tcp** \
+ * **Udp** \
+ * **All**
+ */
+export type LoadBalancerOutboundRuleProtocol = string;
+
+/**
+ * Known values of {@link NatGatewaySkuName} that the service accepts.
+ */
+export const enum KnownNatGatewaySkuName {
+  Standard = "Standard"
+}
+
+/**
+ * Defines values for NatGatewaySkuName. \
+ * {@link KnownNatGatewaySkuName} can be used interchangeably with NatGatewaySkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard**
+ */
+export type NatGatewaySkuName = string;
+
+/**
+ * Known values of {@link EffectiveRouteSource} that the service accepts.
+ */
+export const enum KnownEffectiveRouteSource {
+  Unknown = "Unknown",
+  User = "User",
+  VirtualNetworkGateway = "VirtualNetworkGateway",
+  Default = "Default"
+}
+
+/**
+ * Defines values for EffectiveRouteSource. \
+ * {@link KnownEffectiveRouteSource} can be used interchangeably with EffectiveRouteSource,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **User** \
+ * **VirtualNetworkGateway** \
+ * **Default**
+ */
+export type EffectiveRouteSource = string;
+
+/**
+ * Known values of {@link EffectiveRouteState} that the service accepts.
+ */
+export const enum KnownEffectiveRouteState {
+  Active = "Active",
+  Invalid = "Invalid"
+}
+
+/**
+ * Defines values for EffectiveRouteState. \
+ * {@link KnownEffectiveRouteState} can be used interchangeably with EffectiveRouteState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Active** \
+ * **Invalid**
+ */
+export type EffectiveRouteState = string;
+
+/**
+ * Known values of {@link EffectiveSecurityRuleProtocol} that the service accepts.
+ */
+export const enum KnownEffectiveSecurityRuleProtocol {
+  Tcp = "Tcp",
+  Udp = "Udp",
+  All = "All"
+}
+
+/**
+ * Defines values for EffectiveSecurityRuleProtocol. \
+ * {@link KnownEffectiveSecurityRuleProtocol} can be used interchangeably with EffectiveSecurityRuleProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Tcp** \
+ * **Udp** \
+ * **All**
+ */
+export type EffectiveSecurityRuleProtocol = string;
+
+/**
+ * Known values of {@link AssociationType} that the service accepts.
+ */
+export const enum KnownAssociationType {
+  Associated = "Associated",
+  Contains = "Contains"
+}
+
+/**
+ * Defines values for AssociationType. \
+ * {@link KnownAssociationType} can be used interchangeably with AssociationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Associated** \
+ * **Contains**
+ */
+export type AssociationType = string;
+
+/**
+ * Known values of {@link Direction} that the service accepts.
+ */
+export const enum KnownDirection {
+  Inbound = "Inbound",
+  Outbound = "Outbound"
+}
+
+/**
+ * Defines values for Direction. \
+ * {@link KnownDirection} can be used interchangeably with Direction,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Inbound** \
+ * **Outbound**
+ */
+export type Direction = string;
+
+/**
+ * Known values of {@link IpFlowProtocol} that the service accepts.
+ */
+export const enum KnownIpFlowProtocol {
+  TCP = "TCP",
+  UDP = "UDP"
+}
+
+/**
+ * Defines values for IpFlowProtocol. \
+ * {@link KnownIpFlowProtocol} can be used interchangeably with IpFlowProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TCP** \
+ * **UDP**
+ */
+export type IpFlowProtocol = string;
+
+/**
+ * Known values of {@link Access} that the service accepts.
+ */
+export const enum KnownAccess {
+  Allow = "Allow",
+  Deny = "Deny"
+}
+
+/**
+ * Defines values for Access. \
+ * {@link KnownAccess} can be used interchangeably with Access,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Allow** \
+ * **Deny**
+ */
+export type Access = string;
+
+/**
+ * Known values of {@link NextHopType} that the service accepts.
+ */
+export const enum KnownNextHopType {
+  Internet = "Internet",
+  VirtualAppliance = "VirtualAppliance",
+  VirtualNetworkGateway = "VirtualNetworkGateway",
+  VnetLocal = "VnetLocal",
+  HyperNetGateway = "HyperNetGateway",
+  None = "None"
+}
+
+/**
+ * Defines values for NextHopType. \
+ * {@link KnownNextHopType} can be used interchangeably with NextHopType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Internet** \
+ * **VirtualAppliance** \
+ * **VirtualNetworkGateway** \
+ * **VnetLocal** \
+ * **HyperNetGateway** \
+ * **None**
+ */
+export type NextHopType = string;
+
+/**
+ * Known values of {@link PcProtocol} that the service accepts.
+ */
+export const enum KnownPcProtocol {
+  TCP = "TCP",
+  UDP = "UDP",
+  Any = "Any"
+}
+
+/**
+ * Defines values for PcProtocol. \
+ * {@link KnownPcProtocol} can be used interchangeably with PcProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TCP** \
+ * **UDP** \
+ * **Any**
+ */
+export type PcProtocol = string;
+
+/**
+ * Known values of {@link PcStatus} that the service accepts.
+ */
+export const enum KnownPcStatus {
+  NotStarted = "NotStarted",
+  Running = "Running",
+  Stopped = "Stopped",
+  Error = "Error",
+  Unknown = "Unknown"
+}
+
+/**
+ * Defines values for PcStatus. \
+ * {@link KnownPcStatus} can be used interchangeably with PcStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotStarted** \
+ * **Running** \
+ * **Stopped** \
+ * **Error** \
+ * **Unknown**
+ */
+export type PcStatus = string;
+
+/**
+ * Known values of {@link PcError} that the service accepts.
+ */
+export const enum KnownPcError {
+  InternalError = "InternalError",
+  AgentStopped = "AgentStopped",
+  CaptureFailed = "CaptureFailed",
+  LocalFileFailed = "LocalFileFailed",
+  StorageFailed = "StorageFailed"
+}
+
+/**
+ * Defines values for PcError. \
+ * {@link KnownPcError} can be used interchangeably with PcError,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **InternalError** \
+ * **AgentStopped** \
+ * **CaptureFailed** \
+ * **LocalFileFailed** \
+ * **StorageFailed**
+ */
+export type PcError = string;
+
+/**
+ * Known values of {@link Protocol} that the service accepts.
+ */
+export const enum KnownProtocol {
+  Tcp = "Tcp",
+  Http = "Http",
+  Https = "Https",
+  Icmp = "Icmp"
+}
+
+/**
+ * Defines values for Protocol. \
+ * {@link KnownProtocol} can be used interchangeably with Protocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Tcp** \
+ * **Http** \
+ * **Https** \
+ * **Icmp**
+ */
+export type Protocol = string;
+
+/**
+ * Known values of {@link HttpMethod} that the service accepts.
+ */
+export const enum KnownHttpMethod {
+  Get = "Get"
+}
+
+/**
+ * Defines values for HttpMethod. \
+ * {@link KnownHttpMethod} can be used interchangeably with HttpMethod,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Get**
+ */
+export type HttpMethod = string;
+
+/**
+ * Known values of {@link Origin} that the service accepts.
+ */
+export const enum KnownOrigin {
+  Local = "Local",
+  Inbound = "Inbound",
+  Outbound = "Outbound"
+}
+
+/**
+ * Defines values for Origin. \
+ * {@link KnownOrigin} can be used interchangeably with Origin,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Local** \
+ * **Inbound** \
+ * **Outbound**
+ */
+export type Origin = string;
+
+/**
+ * Known values of {@link Severity} that the service accepts.
+ */
+export const enum KnownSeverity {
+  Error = "Error",
+  Warning = "Warning"
+}
+
+/**
+ * Defines values for Severity. \
+ * {@link KnownSeverity} can be used interchangeably with Severity,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Error** \
+ * **Warning**
+ */
+export type Severity = string;
+
+/**
+ * Known values of {@link IssueType} that the service accepts.
+ */
+export const enum KnownIssueType {
+  Unknown = "Unknown",
+  AgentStopped = "AgentStopped",
+  GuestFirewall = "GuestFirewall",
+  DnsResolution = "DnsResolution",
+  SocketBind = "SocketBind",
+  NetworkSecurityRule = "NetworkSecurityRule",
+  UserDefinedRoute = "UserDefinedRoute",
+  PortThrottled = "PortThrottled",
+  Platform = "Platform"
+}
+
+/**
+ * Defines values for IssueType. \
+ * {@link KnownIssueType} can be used interchangeably with IssueType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **AgentStopped** \
+ * **GuestFirewall** \
+ * **DnsResolution** \
+ * **SocketBind** \
+ * **NetworkSecurityRule** \
+ * **UserDefinedRoute** \
+ * **PortThrottled** \
+ * **Platform**
+ */
+export type IssueType = string;
+
+/**
+ * Known values of {@link ConnectionStatus} that the service accepts.
+ */
+export const enum KnownConnectionStatus {
+  Unknown = "Unknown",
+  Connected = "Connected",
+  Disconnected = "Disconnected",
+  Degraded = "Degraded"
+}
+
+/**
+ * Defines values for ConnectionStatus. \
+ * {@link KnownConnectionStatus} can be used interchangeably with ConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Connected** \
+ * **Disconnected** \
+ * **Degraded**
+ */
+export type ConnectionStatus = string;
+
+/**
+ * Known values of {@link VerbosityLevel} that the service accepts.
+ */
+export const enum KnownVerbosityLevel {
+  Normal = "Normal",
+  Minimum = "Minimum",
+  Full = "Full"
+}
+
+/**
+ * Defines values for VerbosityLevel. \
+ * {@link KnownVerbosityLevel} can be used interchangeably with VerbosityLevel,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Normal** \
+ * **Minimum** \
+ * **Full**
+ */
+export type VerbosityLevel = string;
+
+/**
+ * Known values of {@link ConnectionMonitorEndpointFilterType} that the service accepts.
+ */
+export const enum KnownConnectionMonitorEndpointFilterType {
+  Include = "Include"
+}
+
+/**
+ * Defines values for ConnectionMonitorEndpointFilterType. \
+ * {@link KnownConnectionMonitorEndpointFilterType} can be used interchangeably with ConnectionMonitorEndpointFilterType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Include**
+ */
+export type ConnectionMonitorEndpointFilterType = string;
+
+/**
+ * Known values of {@link ConnectionMonitorEndpointFilterItemType} that the service accepts.
+ */
+export const enum KnownConnectionMonitorEndpointFilterItemType {
+  AgentAddress = "AgentAddress"
+}
+
+/**
+ * Defines values for ConnectionMonitorEndpointFilterItemType. \
+ * {@link KnownConnectionMonitorEndpointFilterItemType} can be used interchangeably with ConnectionMonitorEndpointFilterItemType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AgentAddress**
+ */
+export type ConnectionMonitorEndpointFilterItemType = string;
+
+/**
+ * Known values of {@link ConnectionMonitorTestConfigurationProtocol} that the service accepts.
+ */
+export const enum KnownConnectionMonitorTestConfigurationProtocol {
+  Tcp = "Tcp",
+  Http = "Http",
+  Icmp = "Icmp"
+}
+
+/**
+ * Defines values for ConnectionMonitorTestConfigurationProtocol. \
+ * {@link KnownConnectionMonitorTestConfigurationProtocol} can be used interchangeably with ConnectionMonitorTestConfigurationProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Tcp** \
+ * **Http** \
+ * **Icmp**
+ */
+export type ConnectionMonitorTestConfigurationProtocol = string;
+
+/**
+ * Known values of {@link PreferredIPVersion} that the service accepts.
+ */
+export const enum KnownPreferredIPVersion {
+  IPv4 = "IPv4",
+  IPv6 = "IPv6"
+}
+
+/**
+ * Defines values for PreferredIPVersion. \
+ * {@link KnownPreferredIPVersion} can be used interchangeably with PreferredIPVersion,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IPv4** \
+ * **IPv6**
+ */
+export type PreferredIPVersion = string;
+
+/**
+ * Known values of {@link HttpConfigurationMethod} that the service accepts.
+ */
+export const enum KnownHttpConfigurationMethod {
+  Get = "Get",
+  Post = "Post"
+}
+
+/**
+ * Defines values for HttpConfigurationMethod. \
+ * {@link KnownHttpConfigurationMethod} can be used interchangeably with HttpConfigurationMethod,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Get** \
+ * **Post**
+ */
+export type HttpConfigurationMethod = string;
+
+/**
+ * Known values of {@link OutputType} that the service accepts.
+ */
+export const enum KnownOutputType {
+  Workspace = "Workspace"
+}
+
+/**
+ * Defines values for OutputType. \
+ * {@link KnownOutputType} can be used interchangeably with OutputType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Workspace**
+ */
+export type OutputType = string;
+
+/**
+ * Known values of {@link ConnectionMonitorType} that the service accepts.
+ */
+export const enum KnownConnectionMonitorType {
+  MultiEndpoint = "MultiEndpoint",
+  SingleSourceDestination = "SingleSourceDestination"
+}
+
+/**
+ * Defines values for ConnectionMonitorType. \
+ * {@link KnownConnectionMonitorType} can be used interchangeably with ConnectionMonitorType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **MultiEndpoint** \
+ * **SingleSourceDestination**
+ */
+export type ConnectionMonitorType = string;
+
+/**
+ * Known values of {@link ConnectionMonitorSourceStatus} that the service accepts.
+ */
+export const enum KnownConnectionMonitorSourceStatus {
+  Unknown = "Unknown",
+  Active = "Active",
+  Inactive = "Inactive"
+}
+
+/**
+ * Defines values for ConnectionMonitorSourceStatus. \
+ * {@link KnownConnectionMonitorSourceStatus} can be used interchangeably with ConnectionMonitorSourceStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Active** \
+ * **Inactive**
+ */
+export type ConnectionMonitorSourceStatus = string;
+
+/**
+ * Known values of {@link ConnectionState} that the service accepts.
+ */
+export const enum KnownConnectionState {
+  Reachable = "Reachable",
+  Unreachable = "Unreachable",
+  Unknown = "Unknown"
+}
+
+/**
+ * Defines values for ConnectionState. \
+ * {@link KnownConnectionState} can be used interchangeably with ConnectionState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Reachable** \
+ * **Unreachable** \
+ * **Unknown**
+ */
+export type ConnectionState = string;
+
+/**
+ * Known values of {@link EvaluationState} that the service accepts.
+ */
+export const enum KnownEvaluationState {
+  NotStarted = "NotStarted",
+  InProgress = "InProgress",
+  Completed = "Completed"
+}
+
+/**
+ * Defines values for EvaluationState. \
+ * {@link KnownEvaluationState} can be used interchangeably with EvaluationState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotStarted** \
+ * **InProgress** \
+ * **Completed**
+ */
+export type EvaluationState = string;
+
+/**
+ * Known values of {@link PublicIPPrefixSkuName} that the service accepts.
+ */
+export const enum KnownPublicIPPrefixSkuName {
+  Standard = "Standard"
+}
+
+/**
+ * Defines values for PublicIPPrefixSkuName. \
+ * {@link KnownPublicIPPrefixSkuName} can be used interchangeably with PublicIPPrefixSkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard**
+ */
+export type PublicIPPrefixSkuName = string;
+
+/**
+ * Known values of {@link RouteFilterRuleType} that the service accepts.
+ */
+export const enum KnownRouteFilterRuleType {
+  Community = "Community"
+}
+
+/**
+ * Defines values for RouteFilterRuleType. \
+ * {@link KnownRouteFilterRuleType} can be used interchangeably with RouteFilterRuleType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Community**
+ */
+export type RouteFilterRuleType = string;
+
+/**
+ * Known values of {@link SecurityProviderName} that the service accepts.
+ */
+export const enum KnownSecurityProviderName {
+  ZScaler = "ZScaler",
+  IBoss = "IBoss",
+  Checkpoint = "Checkpoint"
+}
+
+/**
+ * Defines values for SecurityProviderName. \
+ * {@link KnownSecurityProviderName} can be used interchangeably with SecurityProviderName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ZScaler** \
+ * **IBoss** \
+ * **Checkpoint**
+ */
+export type SecurityProviderName = string;
+
+/**
+ * Known values of {@link SecurityPartnerProviderConnectionStatus} that the service accepts.
+ */
+export const enum KnownSecurityPartnerProviderConnectionStatus {
+  Unknown = "Unknown",
+  PartiallyConnected = "PartiallyConnected",
+  Connected = "Connected",
+  NotConnected = "NotConnected"
+}
+
+/**
+ * Defines values for SecurityPartnerProviderConnectionStatus. \
+ * {@link KnownSecurityPartnerProviderConnectionStatus} can be used interchangeably with SecurityPartnerProviderConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **PartiallyConnected** \
+ * **Connected** \
+ * **NotConnected**
+ */
+export type SecurityPartnerProviderConnectionStatus = string;
+
+/**
+ * Known values of {@link UsageUnit} that the service accepts.
+ */
+export const enum KnownUsageUnit {
+  Count = "Count"
+}
+
+/**
+ * Defines values for UsageUnit. \
+ * {@link KnownUsageUnit} can be used interchangeably with UsageUnit,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Count**
+ */
+export type UsageUnit = string;
+
+/**
+ * Known values of {@link VirtualNetworkGatewayType} that the service accepts.
+ */
+export const enum KnownVirtualNetworkGatewayType {
+  Vpn = "Vpn",
+  ExpressRoute = "ExpressRoute"
+}
+
+/**
+ * Defines values for VirtualNetworkGatewayType. \
+ * {@link KnownVirtualNetworkGatewayType} can be used interchangeably with VirtualNetworkGatewayType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Vpn** \
+ * **ExpressRoute**
+ */
+export type VirtualNetworkGatewayType = string;
+
+/**
+ * Known values of {@link VpnType} that the service accepts.
+ */
+export const enum KnownVpnType {
+  PolicyBased = "PolicyBased",
+  RouteBased = "RouteBased"
+}
+
+/**
+ * Defines values for VpnType. \
+ * {@link KnownVpnType} can be used interchangeably with VpnType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **PolicyBased** \
+ * **RouteBased**
+ */
+export type VpnType = string;
+
+/**
+ * Known values of {@link VpnGatewayGeneration} that the service accepts.
+ */
+export const enum KnownVpnGatewayGeneration {
+  None = "None",
+  Generation1 = "Generation1",
+  Generation2 = "Generation2"
+}
+
+/**
+ * Defines values for VpnGatewayGeneration. \
+ * {@link KnownVpnGatewayGeneration} can be used interchangeably with VpnGatewayGeneration,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **Generation1** \
+ * **Generation2**
+ */
+export type VpnGatewayGeneration = string;
+
+/**
+ * Known values of {@link VirtualNetworkGatewaySkuName} that the service accepts.
+ */
+export const enum KnownVirtualNetworkGatewaySkuName {
+  Basic = "Basic",
+  HighPerformance = "HighPerformance",
+  Standard = "Standard",
+  UltraPerformance = "UltraPerformance",
+  VpnGw1 = "VpnGw1",
+  VpnGw2 = "VpnGw2",
+  VpnGw3 = "VpnGw3",
+  VpnGw4 = "VpnGw4",
+  VpnGw5 = "VpnGw5",
+  VpnGw1AZ = "VpnGw1AZ",
+  VpnGw2AZ = "VpnGw2AZ",
+  VpnGw3AZ = "VpnGw3AZ",
+  VpnGw4AZ = "VpnGw4AZ",
+  VpnGw5AZ = "VpnGw5AZ",
+  ErGw1AZ = "ErGw1AZ",
+  ErGw2AZ = "ErGw2AZ",
+  ErGw3AZ = "ErGw3AZ"
+}
+
+/**
+ * Defines values for VirtualNetworkGatewaySkuName. \
+ * {@link KnownVirtualNetworkGatewaySkuName} can be used interchangeably with VirtualNetworkGatewaySkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **HighPerformance** \
+ * **Standard** \
+ * **UltraPerformance** \
+ * **VpnGw1** \
+ * **VpnGw2** \
+ * **VpnGw3** \
+ * **VpnGw4** \
+ * **VpnGw5** \
+ * **VpnGw1AZ** \
+ * **VpnGw2AZ** \
+ * **VpnGw3AZ** \
+ * **VpnGw4AZ** \
+ * **VpnGw5AZ** \
+ * **ErGw1AZ** \
+ * **ErGw2AZ** \
+ * **ErGw3AZ**
+ */
+export type VirtualNetworkGatewaySkuName = string;
+
+/**
+ * Known values of {@link VirtualNetworkGatewaySkuTier} that the service accepts.
+ */
+export const enum KnownVirtualNetworkGatewaySkuTier {
+  Basic = "Basic",
+  HighPerformance = "HighPerformance",
+  Standard = "Standard",
+  UltraPerformance = "UltraPerformance",
+  VpnGw1 = "VpnGw1",
+  VpnGw2 = "VpnGw2",
+  VpnGw3 = "VpnGw3",
+  VpnGw4 = "VpnGw4",
+  VpnGw5 = "VpnGw5",
+  VpnGw1AZ = "VpnGw1AZ",
+  VpnGw2AZ = "VpnGw2AZ",
+  VpnGw3AZ = "VpnGw3AZ",
+  VpnGw4AZ = "VpnGw4AZ",
+  VpnGw5AZ = "VpnGw5AZ",
+  ErGw1AZ = "ErGw1AZ",
+  ErGw2AZ = "ErGw2AZ",
+  ErGw3AZ = "ErGw3AZ"
+}
+
+/**
+ * Defines values for VirtualNetworkGatewaySkuTier. \
+ * {@link KnownVirtualNetworkGatewaySkuTier} can be used interchangeably with VirtualNetworkGatewaySkuTier,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **HighPerformance** \
+ * **Standard** \
+ * **UltraPerformance** \
+ * **VpnGw1** \
+ * **VpnGw2** \
+ * **VpnGw3** \
+ * **VpnGw4** \
+ * **VpnGw5** \
+ * **VpnGw1AZ** \
+ * **VpnGw2AZ** \
+ * **VpnGw3AZ** \
+ * **VpnGw4AZ** \
+ * **VpnGw5AZ** \
+ * **ErGw1AZ** \
+ * **ErGw2AZ** \
+ * **ErGw3AZ**
+ */
+export type VirtualNetworkGatewaySkuTier = string;
+
+/**
+ * Known values of {@link VpnClientProtocol} that the service accepts.
+ */
+export const enum KnownVpnClientProtocol {
+  IkeV2 = "IkeV2",
+  Sstp = "SSTP",
+  OpenVPN = "OpenVPN"
+}
+
+/**
+ * Defines values for VpnClientProtocol. \
+ * {@link KnownVpnClientProtocol} can be used interchangeably with VpnClientProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IkeV2** \
+ * **SSTP** \
+ * **OpenVPN**
+ */
+export type VpnClientProtocol = string;
+
+/**
+ * Known values of {@link IpsecEncryption} that the service accepts.
+ */
+export const enum KnownIpsecEncryption {
+  None = "None",
+  DES = "DES",
+  DES3 = "DES3",
+  AES128 = "AES128",
+  AES192 = "AES192",
+  AES256 = "AES256",
+  Gcmaes128 = "GCMAES128",
+  Gcmaes192 = "GCMAES192",
+  Gcmaes256 = "GCMAES256"
+}
+
+/**
+ * Defines values for IpsecEncryption. \
+ * {@link KnownIpsecEncryption} can be used interchangeably with IpsecEncryption,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **DES** \
+ * **DES3** \
+ * **AES128** \
+ * **AES192** \
+ * **AES256** \
+ * **GCMAES128** \
+ * **GCMAES192** \
+ * **GCMAES256**
+ */
+export type IpsecEncryption = string;
+
+/**
+ * Known values of {@link IpsecIntegrity} that the service accepts.
+ */
+export const enum KnownIpsecIntegrity {
+  MD5 = "MD5",
+  SHA1 = "SHA1",
+  SHA256 = "SHA256",
+  Gcmaes128 = "GCMAES128",
+  Gcmaes192 = "GCMAES192",
+  Gcmaes256 = "GCMAES256"
+}
+
+/**
+ * Defines values for IpsecIntegrity. \
+ * {@link KnownIpsecIntegrity} can be used interchangeably with IpsecIntegrity,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **MD5** \
+ * **SHA1** \
+ * **SHA256** \
+ * **GCMAES128** \
+ * **GCMAES192** \
+ * **GCMAES256**
+ */
+export type IpsecIntegrity = string;
+
+/**
+ * Known values of {@link IkeEncryption} that the service accepts.
+ */
+export const enum KnownIkeEncryption {
+  DES = "DES",
+  DES3 = "DES3",
+  AES128 = "AES128",
+  AES192 = "AES192",
+  AES256 = "AES256",
+  Gcmaes256 = "GCMAES256",
+  Gcmaes128 = "GCMAES128"
+}
+
+/**
+ * Defines values for IkeEncryption. \
+ * {@link KnownIkeEncryption} can be used interchangeably with IkeEncryption,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **DES** \
+ * **DES3** \
+ * **AES128** \
+ * **AES192** \
+ * **AES256** \
+ * **GCMAES256** \
+ * **GCMAES128**
+ */
+export type IkeEncryption = string;
+
+/**
+ * Known values of {@link IkeIntegrity} that the service accepts.
+ */
+export const enum KnownIkeIntegrity {
+  MD5 = "MD5",
+  SHA1 = "SHA1",
+  SHA256 = "SHA256",
+  SHA384 = "SHA384",
+  Gcmaes256 = "GCMAES256",
+  Gcmaes128 = "GCMAES128"
+}
+
+/**
+ * Defines values for IkeIntegrity. \
+ * {@link KnownIkeIntegrity} can be used interchangeably with IkeIntegrity,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **MD5** \
+ * **SHA1** \
+ * **SHA256** \
+ * **SHA384** \
+ * **GCMAES256** \
+ * **GCMAES128**
+ */
+export type IkeIntegrity = string;
+
+/**
+ * Known values of {@link DhGroup} that the service accepts.
+ */
+export const enum KnownDhGroup {
+  None = "None",
+  DHGroup1 = "DHGroup1",
+  DHGroup2 = "DHGroup2",
+  DHGroup14 = "DHGroup14",
+  DHGroup2048 = "DHGroup2048",
+  ECP256 = "ECP256",
+  ECP384 = "ECP384",
+  DHGroup24 = "DHGroup24"
+}
+
+/**
+ * Defines values for DhGroup. \
+ * {@link KnownDhGroup} can be used interchangeably with DhGroup,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **DHGroup1** \
+ * **DHGroup2** \
+ * **DHGroup14** \
+ * **DHGroup2048** \
+ * **ECP256** \
+ * **ECP384** \
+ * **DHGroup24**
+ */
+export type DhGroup = string;
+
+/**
+ * Known values of {@link PfsGroup} that the service accepts.
+ */
+export const enum KnownPfsGroup {
+  None = "None",
+  PFS1 = "PFS1",
+  PFS2 = "PFS2",
+  PFS2048 = "PFS2048",
+  ECP256 = "ECP256",
+  ECP384 = "ECP384",
+  PFS24 = "PFS24",
+  PFS14 = "PFS14",
+  Pfsmm = "PFSMM"
+}
+
+/**
+ * Defines values for PfsGroup. \
+ * {@link KnownPfsGroup} can be used interchangeably with PfsGroup,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **PFS1** \
+ * **PFS2** \
+ * **PFS2048** \
+ * **ECP256** \
+ * **ECP384** \
+ * **PFS24** \
+ * **PFS14** \
+ * **PFSMM**
+ */
+export type PfsGroup = string;
+
+/**
+ * Known values of {@link VirtualNetworkGatewayConnectionType} that the service accepts.
+ */
+export const enum KnownVirtualNetworkGatewayConnectionType {
+  IPsec = "IPsec",
+  Vnet2Vnet = "Vnet2Vnet",
+  ExpressRoute = "ExpressRoute",
+  VPNClient = "VPNClient"
+}
+
+/**
+ * Defines values for VirtualNetworkGatewayConnectionType. \
+ * {@link KnownVirtualNetworkGatewayConnectionType} can be used interchangeably with VirtualNetworkGatewayConnectionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IPsec** \
+ * **Vnet2Vnet** \
+ * **ExpressRoute** \
+ * **VPNClient**
+ */
+export type VirtualNetworkGatewayConnectionType = string;
+
+/**
+ * Known values of {@link VirtualNetworkGatewayConnectionProtocol} that the service accepts.
+ */
+export const enum KnownVirtualNetworkGatewayConnectionProtocol {
+  IKEv2 = "IKEv2",
+  IKEv1 = "IKEv1"
+}
+
+/**
+ * Defines values for VirtualNetworkGatewayConnectionProtocol. \
+ * {@link KnownVirtualNetworkGatewayConnectionProtocol} can be used interchangeably with VirtualNetworkGatewayConnectionProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IKEv2** \
+ * **IKEv1**
+ */
+export type VirtualNetworkGatewayConnectionProtocol = string;
+
+/**
+ * Known values of {@link VirtualNetworkGatewayConnectionStatus} that the service accepts.
+ */
+export const enum KnownVirtualNetworkGatewayConnectionStatus {
+  Unknown = "Unknown",
+  Connecting = "Connecting",
+  Connected = "Connected",
+  NotConnected = "NotConnected"
+}
+
+/**
+ * Defines values for VirtualNetworkGatewayConnectionStatus. \
+ * {@link KnownVirtualNetworkGatewayConnectionStatus} can be used interchangeably with VirtualNetworkGatewayConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Connecting** \
+ * **Connected** \
+ * **NotConnected**
+ */
+export type VirtualNetworkGatewayConnectionStatus = string;
+
+/**
+ * Known values of {@link ProcessorArchitecture} that the service accepts.
+ */
+export const enum KnownProcessorArchitecture {
+  Amd64 = "Amd64",
+  X86 = "X86"
+}
+
+/**
+ * Defines values for ProcessorArchitecture. \
+ * {@link KnownProcessorArchitecture} can be used interchangeably with ProcessorArchitecture,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Amd64** \
+ * **X86**
+ */
+export type ProcessorArchitecture = string;
+
+/**
+ * Known values of {@link AuthenticationMethod} that the service accepts.
+ */
+export const enum KnownAuthenticationMethod {
+  Eaptls = "EAPTLS",
+  EapmschaPv2 = "EAPMSCHAPv2"
+}
+
+/**
+ * Defines values for AuthenticationMethod. \
+ * {@link KnownAuthenticationMethod} can be used interchangeably with AuthenticationMethod,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **EAPTLS** \
+ * **EAPMSCHAPv2**
+ */
+export type AuthenticationMethod = string;
+
+/**
+ * Known values of {@link BgpPeerState} that the service accepts.
+ */
+export const enum KnownBgpPeerState {
+  Unknown = "Unknown",
+  Stopped = "Stopped",
+  Idle = "Idle",
+  Connecting = "Connecting",
+  Connected = "Connected"
+}
+
+/**
+ * Defines values for BgpPeerState. \
+ * {@link KnownBgpPeerState} can be used interchangeably with BgpPeerState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Stopped** \
+ * **Idle** \
+ * **Connecting** \
+ * **Connected**
+ */
+export type BgpPeerState = string;
+
+/**
+ * Known values of {@link OfficeTrafficCategory} that the service accepts.
+ */
+export const enum KnownOfficeTrafficCategory {
+  Optimize = "Optimize",
+  OptimizeAndAllow = "OptimizeAndAllow",
+  All = "All",
+  None = "None"
+}
+
+/**
+ * Defines values for OfficeTrafficCategory. \
+ * {@link KnownOfficeTrafficCategory} can be used interchangeably with OfficeTrafficCategory,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Optimize** \
+ * **OptimizeAndAllow** \
+ * **All** \
+ * **None**
+ */
+export type OfficeTrafficCategory = string;
+
+/**
+ * Known values of {@link VirtualWanSecurityProviderType} that the service accepts.
+ */
+export const enum KnownVirtualWanSecurityProviderType {
+  External = "External",
+  Native = "Native"
+}
+
+/**
+ * Defines values for VirtualWanSecurityProviderType. \
+ * {@link KnownVirtualWanSecurityProviderType} can be used interchangeably with VirtualWanSecurityProviderType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **External** \
+ * **Native**
+ */
+export type VirtualWanSecurityProviderType = string;
+
+/**
+ * Known values of {@link VpnGatewayTunnelingProtocol} that the service accepts.
+ */
+export const enum KnownVpnGatewayTunnelingProtocol {
+  IkeV2 = "IkeV2",
+  OpenVPN = "OpenVPN"
+}
+
+/**
+ * Defines values for VpnGatewayTunnelingProtocol. \
+ * {@link KnownVpnGatewayTunnelingProtocol} can be used interchangeably with VpnGatewayTunnelingProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IkeV2** \
+ * **OpenVPN**
+ */
+export type VpnGatewayTunnelingProtocol = string;
+
+/**
+ * Known values of {@link VpnAuthenticationType} that the service accepts.
+ */
+export const enum KnownVpnAuthenticationType {
+  Certificate = "Certificate",
+  Radius = "Radius",
+  AAD = "AAD"
+}
+
+/**
+ * Defines values for VpnAuthenticationType. \
+ * {@link KnownVpnAuthenticationType} can be used interchangeably with VpnAuthenticationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Certificate** \
+ * **Radius** \
+ * **AAD**
+ */
+export type VpnAuthenticationType = string;
+
+/**
+ * Known values of {@link VpnConnectionStatus} that the service accepts.
+ */
+export const enum KnownVpnConnectionStatus {
+  Unknown = "Unknown",
+  Connecting = "Connecting",
+  Connected = "Connected",
+  NotConnected = "NotConnected"
+}
+
+/**
+ * Defines values for VpnConnectionStatus. \
+ * {@link KnownVpnConnectionStatus} can be used interchangeably with VpnConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Connecting** \
+ * **Connected** \
+ * **NotConnected**
+ */
+export type VpnConnectionStatus = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallEnabledState} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallEnabledState {
+  Disabled = "Disabled",
+  Enabled = "Enabled"
+}
+
+/**
+ * Defines values for WebApplicationFirewallEnabledState. \
+ * {@link KnownWebApplicationFirewallEnabledState} can be used interchangeably with WebApplicationFirewallEnabledState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Disabled** \
+ * **Enabled**
+ */
+export type WebApplicationFirewallEnabledState = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallMode} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallMode {
+  Prevention = "Prevention",
+  Detection = "Detection"
+}
+
+/**
+ * Defines values for WebApplicationFirewallMode. \
+ * {@link KnownWebApplicationFirewallMode} can be used interchangeably with WebApplicationFirewallMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Prevention** \
+ * **Detection**
+ */
+export type WebApplicationFirewallMode = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallRuleType} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallRuleType {
+  MatchRule = "MatchRule",
+  Invalid = "Invalid"
+}
+
+/**
+ * Defines values for WebApplicationFirewallRuleType. \
+ * {@link KnownWebApplicationFirewallRuleType} can be used interchangeably with WebApplicationFirewallRuleType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **MatchRule** \
+ * **Invalid**
+ */
+export type WebApplicationFirewallRuleType = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallMatchVariable} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallMatchVariable {
+  RemoteAddr = "RemoteAddr",
+  RequestMethod = "RequestMethod",
+  QueryString = "QueryString",
+  PostArgs = "PostArgs",
+  RequestUri = "RequestUri",
+  RequestHeaders = "RequestHeaders",
+  RequestBody = "RequestBody",
+  RequestCookies = "RequestCookies"
+}
+
+/**
+ * Defines values for WebApplicationFirewallMatchVariable. \
+ * {@link KnownWebApplicationFirewallMatchVariable} can be used interchangeably with WebApplicationFirewallMatchVariable,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **RemoteAddr** \
+ * **RequestMethod** \
+ * **QueryString** \
+ * **PostArgs** \
+ * **RequestUri** \
+ * **RequestHeaders** \
+ * **RequestBody** \
+ * **RequestCookies**
+ */
+export type WebApplicationFirewallMatchVariable = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallOperator} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallOperator {
+  IPMatch = "IPMatch",
+  Equal = "Equal",
+  Contains = "Contains",
+  LessThan = "LessThan",
+  GreaterThan = "GreaterThan",
+  LessThanOrEqual = "LessThanOrEqual",
+  GreaterThanOrEqual = "GreaterThanOrEqual",
+  BeginsWith = "BeginsWith",
+  EndsWith = "EndsWith",
+  Regex = "Regex",
+  GeoMatch = "GeoMatch"
+}
+
+/**
+ * Defines values for WebApplicationFirewallOperator. \
+ * {@link KnownWebApplicationFirewallOperator} can be used interchangeably with WebApplicationFirewallOperator,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **IPMatch** \
+ * **Equal** \
+ * **Contains** \
+ * **LessThan** \
+ * **GreaterThan** \
+ * **LessThanOrEqual** \
+ * **GreaterThanOrEqual** \
+ * **BeginsWith** \
+ * **EndsWith** \
+ * **Regex** \
+ * **GeoMatch**
+ */
+export type WebApplicationFirewallOperator = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallTransform} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallTransform {
+  Lowercase = "Lowercase",
+  Trim = "Trim",
+  UrlDecode = "UrlDecode",
+  UrlEncode = "UrlEncode",
+  RemoveNulls = "RemoveNulls",
+  HtmlEntityDecode = "HtmlEntityDecode"
+}
+
+/**
+ * Defines values for WebApplicationFirewallTransform. \
+ * {@link KnownWebApplicationFirewallTransform} can be used interchangeably with WebApplicationFirewallTransform,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Lowercase** \
+ * **Trim** \
+ * **UrlDecode** \
+ * **UrlEncode** \
+ * **RemoveNulls** \
+ * **HtmlEntityDecode**
+ */
+export type WebApplicationFirewallTransform = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallAction} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallAction {
+  Allow = "Allow",
+  Block = "Block",
+  Log = "Log"
+}
+
+/**
+ * Defines values for WebApplicationFirewallAction. \
+ * {@link KnownWebApplicationFirewallAction} can be used interchangeably with WebApplicationFirewallAction,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Allow** \
+ * **Block** \
+ * **Log**
+ */
+export type WebApplicationFirewallAction = string;
+
+/**
+ * Known values of {@link WebApplicationFirewallPolicyResourceState} that the service accepts.
+ */
+export const enum KnownWebApplicationFirewallPolicyResourceState {
+  Creating = "Creating",
+  Enabling = "Enabling",
+  Enabled = "Enabled",
+  Disabling = "Disabling",
+  Disabled = "Disabled",
+  Deleting = "Deleting"
+}
+
+/**
+ * Defines values for WebApplicationFirewallPolicyResourceState. \
+ * {@link KnownWebApplicationFirewallPolicyResourceState} can be used interchangeably with WebApplicationFirewallPolicyResourceState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Enabling** \
+ * **Enabled** \
+ * **Disabling** \
+ * **Disabled** \
+ * **Deleting**
+ */
+export type WebApplicationFirewallPolicyResourceState = string;
+
+/**
+ * Known values of {@link OwaspCrsExclusionEntryMatchVariable} that the service accepts.
+ */
+export const enum KnownOwaspCrsExclusionEntryMatchVariable {
+  RequestHeaderNames = "RequestHeaderNames",
+  RequestCookieNames = "RequestCookieNames",
+  RequestArgNames = "RequestArgNames"
+}
+
+/**
+ * Defines values for OwaspCrsExclusionEntryMatchVariable. \
+ * {@link KnownOwaspCrsExclusionEntryMatchVariable} can be used interchangeably with OwaspCrsExclusionEntryMatchVariable,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **RequestHeaderNames** \
+ * **RequestCookieNames** \
+ * **RequestArgNames**
+ */
+export type OwaspCrsExclusionEntryMatchVariable = string;
+
+/**
+ * Known values of {@link OwaspCrsExclusionEntrySelectorMatchOperator} that the service accepts.
+ */
+export const enum KnownOwaspCrsExclusionEntrySelectorMatchOperator {
+  Equals = "Equals",
+  Contains = "Contains",
+  StartsWith = "StartsWith",
+  EndsWith = "EndsWith",
+  EqualsAny = "EqualsAny"
+}
+
+/**
+ * Defines values for OwaspCrsExclusionEntrySelectorMatchOperator. \
+ * {@link KnownOwaspCrsExclusionEntrySelectorMatchOperator} can be used interchangeably with OwaspCrsExclusionEntrySelectorMatchOperator,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Equals** \
+ * **Contains** \
+ * **StartsWith** \
+ * **EndsWith** \
+ * **EqualsAny**
+ */
+export type OwaspCrsExclusionEntrySelectorMatchOperator = string;
+
+/**
+ * Known values of {@link ManagedRuleEnabledState} that the service accepts.
+ */
+export const enum KnownManagedRuleEnabledState {
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for ManagedRuleEnabledState. \
+ * {@link KnownManagedRuleEnabledState} can be used interchangeably with ManagedRuleEnabledState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Disabled**
+ */
+export type ManagedRuleEnabledState = string;
+
+/**
+ * Known values of {@link FirewallPolicyNatRuleActionType} that the service accepts.
+ */
+export const enum KnownFirewallPolicyNatRuleActionType {
+  Dnat = "DNAT"
+}
+
+/**
+ * Defines values for FirewallPolicyNatRuleActionType. \
+ * {@link KnownFirewallPolicyNatRuleActionType} can be used interchangeably with FirewallPolicyNatRuleActionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **DNAT**
+ */
+export type FirewallPolicyNatRuleActionType = string;
+
+/**
+ * Known values of {@link FirewallPolicyRuleConditionType} that the service accepts.
+ */
+export const enum KnownFirewallPolicyRuleConditionType {
+  ApplicationRuleCondition = "ApplicationRuleCondition",
+  NetworkRuleCondition = "NetworkRuleCondition",
+  NatRuleCondition = "NatRuleCondition"
+}
+
+/**
+ * Defines values for FirewallPolicyRuleConditionType. \
+ * {@link KnownFirewallPolicyRuleConditionType} can be used interchangeably with FirewallPolicyRuleConditionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ApplicationRuleCondition** \
+ * **NetworkRuleCondition** \
+ * **NatRuleCondition**
+ */
+export type FirewallPolicyRuleConditionType = string;
+
+/**
+ * Known values of {@link FirewallPolicyFilterRuleActionType} that the service accepts.
+ */
+export const enum KnownFirewallPolicyFilterRuleActionType {
+  Allow = "Allow",
+  Deny = "Deny"
+}
+
+/**
+ * Defines values for FirewallPolicyFilterRuleActionType. \
+ * {@link KnownFirewallPolicyFilterRuleActionType} can be used interchangeably with FirewallPolicyFilterRuleActionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Allow** \
+ * **Deny**
+ */
+export type FirewallPolicyFilterRuleActionType = string;
+
+/**
+ * Known values of {@link FirewallPolicyRuleConditionApplicationProtocolType} that the service accepts.
+ */
+export const enum KnownFirewallPolicyRuleConditionApplicationProtocolType {
+  Http = "Http",
+  Https = "Https"
+}
+
+/**
+ * Defines values for FirewallPolicyRuleConditionApplicationProtocolType. \
+ * {@link KnownFirewallPolicyRuleConditionApplicationProtocolType} can be used interchangeably with FirewallPolicyRuleConditionApplicationProtocolType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Http** \
+ * **Https**
+ */
+export type FirewallPolicyRuleConditionApplicationProtocolType = string;
+
+/**
+ * Known values of {@link FirewallPolicyRuleConditionNetworkProtocol} that the service accepts.
+ */
+export const enum KnownFirewallPolicyRuleConditionNetworkProtocol {
+  TCP = "TCP",
+  UDP = "UDP",
+  Any = "Any",
+  Icmp = "ICMP"
+}
+
+/**
+ * Defines values for FirewallPolicyRuleConditionNetworkProtocol. \
+ * {@link KnownFirewallPolicyRuleConditionNetworkProtocol} can be used interchangeably with FirewallPolicyRuleConditionNetworkProtocol,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TCP** \
+ * **UDP** \
+ * **Any** \
+ * **ICMP**
+ */
+export type FirewallPolicyRuleConditionNetworkProtocol = string;
+
+/**
+ * Known values of {@link NetworkOperationStatus} that the service accepts.
+ */
+export const enum KnownNetworkOperationStatus {
+  InProgress = "InProgress",
+  Succeeded = "Succeeded",
+  Failed = "Failed"
+}
+
+/**
+ * Defines values for NetworkOperationStatus. \
+ * {@link KnownNetworkOperationStatus} can be used interchangeably with NetworkOperationStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **InProgress** \
+ * **Succeeded** \
+ * **Failed**
+ */
+export type NetworkOperationStatus = string;
+
+/**
+ * Known values of {@link TunnelConnectionStatus} that the service accepts.
+ */
+export const enum KnownTunnelConnectionStatus {
+  Unknown = "Unknown",
+  Connecting = "Connecting",
+  Connected = "Connected",
+  NotConnected = "NotConnected"
+}
+
+/**
+ * Defines values for TunnelConnectionStatus. \
+ * {@link KnownTunnelConnectionStatus} can be used interchangeably with TunnelConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Connecting** \
+ * **Connected** \
+ * **NotConnected**
+ */
+export type TunnelConnectionStatus = string;
+
+/**
+ * Known values of {@link HubVirtualNetworkConnectionStatus} that the service accepts.
+ */
+export const enum KnownHubVirtualNetworkConnectionStatus {
+  Unknown = "Unknown",
+  Connecting = "Connecting",
+  Connected = "Connected",
+  NotConnected = "NotConnected"
+}
+
+/**
+ * Defines values for HubVirtualNetworkConnectionStatus. \
+ * {@link KnownHubVirtualNetworkConnectionStatus} can be used interchangeably with HubVirtualNetworkConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Unknown** \
+ * **Connecting** \
+ * **Connected** \
+ * **NotConnected**
+ */
+export type HubVirtualNetworkConnectionStatus = string;
 /**
  * Defines values for ResourceIdentityType.
  */

--- a/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.json
+++ b/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.json
@@ -109,7 +109,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!Access:type",
-          "docComment": "/**\n * Defines values for Access.\n */\n",
+          "docComment": "/**\n * Defines values for Access. \\ {@link KnownAccess} can be used interchangeably with Access, this enum contains the known values that the service supports. ### Know values supported by the service **Allow** \\ **Deny**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -117,7 +117,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Allow\" | \"Deny\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1199,7 +1199,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayBackendHealthServerHealth:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayBackendHealthServerHealth.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayBackendHealthServerHealth. \\ {@link KnownApplicationGatewayBackendHealthServerHealth} can be used interchangeably with ApplicationGatewayBackendHealthServerHealth, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Up** \\ **Down** \\ **Partial** \\ **Draining**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1207,7 +1207,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Up\" | \"Down\" | \"Partial\" | \"Draining\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1383,7 +1383,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayCookieBasedAffinity:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayCookieBasedAffinity.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayCookieBasedAffinity. \\ {@link KnownApplicationGatewayCookieBasedAffinity} can be used interchangeably with ApplicationGatewayCookieBasedAffinity, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1391,7 +1391,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1475,7 +1475,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayCustomErrorStatusCode:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayCustomErrorStatusCode.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayCustomErrorStatusCode. \\ {@link KnownApplicationGatewayCustomErrorStatusCode} can be used interchangeably with ApplicationGatewayCustomErrorStatusCode, this enum contains the known values that the service supports. ### Know values supported by the service **HttpStatus403** \\ **HttpStatus502**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1483,7 +1483,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"HttpStatus403\" | \"HttpStatus502\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1657,7 +1657,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayFirewallMode:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayFirewallMode.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayFirewallMode. \\ {@link KnownApplicationGatewayFirewallMode} can be used interchangeably with ApplicationGatewayFirewallMode, this enum contains the known values that the service supports. ### Know values supported by the service **Detection** \\ **Prevention**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1665,7 +1665,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Detection\" | \"Prevention\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2495,7 +2495,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayOperationalState:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayOperationalState.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayOperationalState. \\ {@link KnownApplicationGatewayOperationalState} can be used interchangeably with ApplicationGatewayOperationalState, this enum contains the known values that the service supports. ### Know values supported by the service **Stopped** \\ **Starting** \\ **Running** \\ **Stopping**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2503,7 +2503,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Stopped\" | \"Starting\" | \"Running\" | \"Stopping\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2727,7 +2727,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayProtocol:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayProtocol. \\ {@link KnownApplicationGatewayProtocol} can be used interchangeably with ApplicationGatewayProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Http** \\ **Https**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2735,7 +2735,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Http\" | \"Https\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2827,7 +2827,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayRedirectType:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayRedirectType.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayRedirectType. \\ {@link KnownApplicationGatewayRedirectType} can be used interchangeably with ApplicationGatewayRedirectType, this enum contains the known values that the service supports. ### Know values supported by the service **Permanent** \\ **Found** \\ **SeeOther** \\ **Temporary**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2835,7 +2835,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Permanent\" | \"Found\" | \"SeeOther\" | \"Temporary\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2954,7 +2954,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayRequestRoutingRuleType:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayRequestRoutingRuleType.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayRequestRoutingRuleType. \\ {@link KnownApplicationGatewayRequestRoutingRuleType} can be used interchangeably with ApplicationGatewayRequestRoutingRuleType, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **PathBasedRouting**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2962,7 +2962,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"PathBasedRouting\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3872,7 +3872,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewaySkuName:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewaySkuName.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewaySkuName. \\ {@link KnownApplicationGatewaySkuName} can be used interchangeably with ApplicationGatewaySkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_Small** \\ **Standard_Medium** \\ **Standard_Large** \\ **WAF_Medium** \\ **WAF_Large** \\ **Standard_v2** \\ **WAF_v2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3880,7 +3880,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_Small\" | \"Standard_Medium\" | \"Standard_Large\" | \"WAF_Medium\" | \"WAF_Large\" | \"Standard_v2\" | \"WAF_v2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4422,7 +4422,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewaySslCipherSuite:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewaySslCipherSuite.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewaySslCipherSuite. \\ {@link KnownApplicationGatewaySslCipherSuite} can be used interchangeably with ApplicationGatewaySslCipherSuite, this enum contains the known values that the service supports. ### Know values supported by the service **TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384** \\ **TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256** \\ **TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA** \\ **TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA** \\ **TLS_DHE_RSA_WITH_AES_256_GCM_SHA384** \\ **TLS_DHE_RSA_WITH_AES_128_GCM_SHA256** \\ **TLS_DHE_RSA_WITH_AES_256_CBC_SHA** \\ **TLS_DHE_RSA_WITH_AES_128_CBC_SHA** \\ **TLS_RSA_WITH_AES_256_GCM_SHA384** \\ **TLS_RSA_WITH_AES_128_GCM_SHA256** \\ **TLS_RSA_WITH_AES_256_CBC_SHA256** \\ **TLS_RSA_WITH_AES_128_CBC_SHA256** \\ **TLS_RSA_WITH_AES_256_CBC_SHA** \\ **TLS_RSA_WITH_AES_128_CBC_SHA** \\ **TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384** \\ **TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256** \\ **TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384** \\ **TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256** \\ **TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA** \\ **TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA** \\ **TLS_DHE_DSS_WITH_AES_256_CBC_SHA256** \\ **TLS_DHE_DSS_WITH_AES_128_CBC_SHA256** \\ **TLS_DHE_DSS_WITH_AES_256_CBC_SHA** \\ **TLS_DHE_DSS_WITH_AES_128_CBC_SHA** \\ **TLS_RSA_WITH_3DES_EDE_CBC_SHA** \\ **TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA** \\ **TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256** \\ **TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4430,7 +4430,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384\" | \"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256\" | \"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\" | \"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\" | \"TLS_DHE_RSA_WITH_AES_256_GCM_SHA384\" | \"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256\" | \"TLS_DHE_RSA_WITH_AES_256_CBC_SHA\" | \"TLS_DHE_RSA_WITH_AES_128_CBC_SHA\" | \"TLS_RSA_WITH_AES_256_GCM_SHA384\" | \"TLS_RSA_WITH_AES_128_GCM_SHA256\" | \"TLS_RSA_WITH_AES_256_CBC_SHA256\" | \"TLS_RSA_WITH_AES_128_CBC_SHA256\" | \"TLS_RSA_WITH_AES_256_CBC_SHA\" | \"TLS_RSA_WITH_AES_128_CBC_SHA\" | \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\" | \"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\" | \"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384\" | \"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256\" | \"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\" | \"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA\" | \"TLS_DHE_DSS_WITH_AES_256_CBC_SHA256\" | \"TLS_DHE_DSS_WITH_AES_128_CBC_SHA256\" | \"TLS_DHE_DSS_WITH_AES_256_CBC_SHA\" | \"TLS_DHE_DSS_WITH_AES_128_CBC_SHA\" | \"TLS_RSA_WITH_3DES_EDE_CBC_SHA\" | \"TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA\" | \"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\" | \"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4601,7 +4601,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewaySslPolicyName:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewaySslPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewaySslPolicyName. \\ {@link KnownApplicationGatewaySslPolicyName} can be used interchangeably with ApplicationGatewaySslPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **AppGwSslPolicy20150501** \\ **AppGwSslPolicy20170401** \\ **AppGwSslPolicy20170401S**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4609,7 +4609,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AppGwSslPolicy20150501\" | \"AppGwSslPolicy20170401\" | \"AppGwSslPolicy20170401S\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4626,7 +4626,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewaySslPolicyType:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewaySslPolicyType.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewaySslPolicyType. \\ {@link KnownApplicationGatewaySslPolicyType} can be used interchangeably with ApplicationGatewaySslPolicyType, this enum contains the known values that the service supports. ### Know values supported by the service **Predefined** \\ **Custom**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4634,7 +4634,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Predefined\" | \"Custom\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4699,7 +4699,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewaySslProtocol:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewaySslProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewaySslProtocol. \\ {@link KnownApplicationGatewaySslProtocol} can be used interchangeably with ApplicationGatewaySslProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **TLSv1_0** \\ **TLSv1_1** \\ **TLSv1_2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4707,7 +4707,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TLSv1_0\" | \"TLSv1_1\" | \"TLSv1_2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4772,7 +4772,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ApplicationGatewayTier:type",
-          "docComment": "/**\n * Defines values for ApplicationGatewayTier.\n */\n",
+          "docComment": "/**\n * Defines values for ApplicationGatewayTier. \\ {@link KnownApplicationGatewayTier} can be used interchangeably with ApplicationGatewayTier, this enum contains the known values that the service supports. ### Know values supported by the service **Standard** \\ **WAF** \\ **Standard_v2** \\ **WAF_v2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4780,7 +4780,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard\" | \"WAF\" | \"Standard_v2\" | \"WAF_v2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5791,7 +5791,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AssociationType:type",
-          "docComment": "/**\n * Defines values for AssociationType.\n */\n",
+          "docComment": "/**\n * Defines values for AssociationType. \\ {@link KnownAssociationType} can be used interchangeably with AssociationType, this enum contains the known values that the service supports. ### Know values supported by the service **Associated** \\ **Contains**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5799,7 +5799,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Associated\" | \"Contains\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5816,7 +5816,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AuthenticationMethod:type",
-          "docComment": "/**\n * Defines values for AuthenticationMethod.\n */\n",
+          "docComment": "/**\n * Defines values for AuthenticationMethod. \\ {@link KnownAuthenticationMethod} can be used interchangeably with AuthenticationMethod, this enum contains the known values that the service supports. ### Know values supported by the service **EAPTLS** \\ **EAPMSCHAPv2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5824,7 +5824,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"EAPTLS\" | \"EAPMSCHAPv2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5912,7 +5912,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AuthorizationUseStatus:type",
-          "docComment": "/**\n * Defines values for AuthorizationUseStatus.\n */\n",
+          "docComment": "/**\n * Defines values for AuthorizationUseStatus. \\ {@link KnownAuthorizationUseStatus} can be used interchangeably with AuthorizationUseStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Available** \\ **InUse**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5920,7 +5920,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Available\" | \"InUse\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8344,7 +8344,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallApplicationRuleProtocolType:type",
-          "docComment": "/**\n * Defines values for AzureFirewallApplicationRuleProtocolType.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallApplicationRuleProtocolType. \\ {@link KnownAzureFirewallApplicationRuleProtocolType} can be used interchangeably with AzureFirewallApplicationRuleProtocolType, this enum contains the known values that the service supports. ### Know values supported by the service **Http** \\ **Https** \\ **Mssql**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8352,7 +8352,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Http\" | \"Https\" | \"Mssql\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8811,7 +8811,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallNatRCActionType:type",
-          "docComment": "/**\n * Defines values for AzureFirewallNatRCActionType.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallNatRCActionType. \\ {@link KnownAzureFirewallNatRCActionType} can be used interchangeably with AzureFirewallNatRCActionType, this enum contains the known values that the service supports. ### Know values supported by the service **Snat** \\ **Dnat**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8819,7 +8819,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Snat\" | \"Dnat\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9467,7 +9467,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallNetworkRuleProtocol:type",
-          "docComment": "/**\n * Defines values for AzureFirewallNetworkRuleProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallNetworkRuleProtocol. \\ {@link KnownAzureFirewallNetworkRuleProtocol} can be used interchangeably with AzureFirewallNetworkRuleProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **TCP** \\ **UDP** \\ **Any** \\ **ICMP**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9475,7 +9475,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TCP\" | \"UDP\" | \"Any\" | \"ICMP\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9575,7 +9575,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallRCActionType:type",
-          "docComment": "/**\n * Defines values for AzureFirewallRCActionType.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallRCActionType. \\ {@link KnownAzureFirewallRCActionType} can be used interchangeably with AzureFirewallRCActionType, this enum contains the known values that the service supports. ### Know values supported by the service **Allow** \\ **Deny**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9583,7 +9583,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Allow\" | \"Deny\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9782,7 +9782,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallSkuName:type",
-          "docComment": "/**\n * Defines values for AzureFirewallSkuName.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallSkuName. \\ {@link KnownAzureFirewallSkuName} can be used interchangeably with AzureFirewallSkuName, this enum contains the known values that the service supports. ### Know values supported by the service **AZFW_VNet** \\ **AZFW_Hub**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9790,7 +9790,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AZFW_VNet\" | \"AZFW_Hub\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9807,7 +9807,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallSkuTier:type",
-          "docComment": "/**\n * Defines values for AzureFirewallSkuTier.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallSkuTier. \\ {@link KnownAzureFirewallSkuTier} can be used interchangeably with AzureFirewallSkuTier, this enum contains the known values that the service supports. ### Know values supported by the service **Standard** \\ **Premium**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9815,7 +9815,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard\" | \"Premium\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10090,7 +10090,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!AzureFirewallThreatIntelMode:type",
-          "docComment": "/**\n * Defines values for AzureFirewallThreatIntelMode.\n */\n",
+          "docComment": "/**\n * Defines values for AzureFirewallThreatIntelMode. \\ {@link KnownAzureFirewallThreatIntelMode} can be used interchangeably with AzureFirewallThreatIntelMode, this enum contains the known values that the service supports. ### Know values supported by the service **Alert** \\ **Deny** \\ **Off**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10098,7 +10098,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Alert\" | \"Deny\" | \"Off\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11057,7 +11057,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!BastionConnectProtocol:type",
-          "docComment": "/**\n * Defines values for BastionConnectProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for BastionConnectProtocol. \\ {@link KnownBastionConnectProtocol} can be used interchangeably with BastionConnectProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **SSH** \\ **RDP**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11065,7 +11065,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SSH\" | \"RDP\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12135,7 +12135,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!BgpPeerState:type",
-          "docComment": "/**\n * Defines values for BgpPeerState.\n */\n",
+          "docComment": "/**\n * Defines values for BgpPeerState. \\ {@link KnownBgpPeerState} can be used interchangeably with BgpPeerState, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Stopped** \\ **Idle** \\ **Connecting** \\ **Connected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12143,7 +12143,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Stopped\" | \"Idle\" | \"Connecting\" | \"Connected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12791,7 +12791,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!CircuitConnectionStatus:type",
-          "docComment": "/**\n * Defines values for CircuitConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for CircuitConnectionStatus. \\ {@link KnownCircuitConnectionStatus} can be used interchangeably with CircuitConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Connected** \\ **Connecting** \\ **Disconnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12799,7 +12799,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Connected\" | \"Connecting\" | \"Disconnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -13705,7 +13705,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionMonitorEndpointFilterItemType:type",
-          "docComment": "/**\n * Defines values for ConnectionMonitorEndpointFilterItemType.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionMonitorEndpointFilterItemType. \\ {@link KnownConnectionMonitorEndpointFilterItemType} can be used interchangeably with ConnectionMonitorEndpointFilterItemType, this enum contains the known values that the service supports. ### Know values supported by the service **AgentAddress**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -13713,7 +13713,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AgentAddress\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -13730,7 +13730,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionMonitorEndpointFilterType:type",
-          "docComment": "/**\n * Defines values for ConnectionMonitorEndpointFilterType.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionMonitorEndpointFilterType. \\ {@link KnownConnectionMonitorEndpointFilterType} can be used interchangeably with ConnectionMonitorEndpointFilterType, this enum contains the known values that the service supports. ### Know values supported by the service **Include**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -13738,7 +13738,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Include\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15218,7 +15218,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionMonitorSourceStatus:type",
-          "docComment": "/**\n * Defines values for ConnectionMonitorSourceStatus.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionMonitorSourceStatus. \\ {@link KnownConnectionMonitorSourceStatus} can be used interchangeably with ConnectionMonitorSourceStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Active** \\ **Inactive**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15226,7 +15226,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Active\" | \"Inactive\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15711,7 +15711,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionMonitorTestConfigurationProtocol:type",
-          "docComment": "/**\n * Defines values for ConnectionMonitorTestConfigurationProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionMonitorTestConfigurationProtocol. \\ {@link KnownConnectionMonitorTestConfigurationProtocol} can be used interchangeably with ConnectionMonitorTestConfigurationProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Tcp** \\ **Http** \\ **Icmp**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15719,7 +15719,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Tcp\" | \"Http\" | \"Icmp\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15877,7 +15877,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionMonitorType:type",
-          "docComment": "/**\n * Defines values for ConnectionMonitorType.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionMonitorType. \\ {@link KnownConnectionMonitorType} can be used interchangeably with ConnectionMonitorType, this enum contains the known values that the service supports. ### Know values supported by the service **MultiEndpoint** \\ **SingleSourceDestination**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15885,7 +15885,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"MultiEndpoint\" | \"SingleSourceDestination\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -16014,7 +16014,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionState:type",
-          "docComment": "/**\n * Defines values for ConnectionState.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionState. \\ {@link KnownConnectionState} can be used interchangeably with ConnectionState, this enum contains the known values that the service supports. ### Know values supported by the service **Reachable** \\ **Unreachable** \\ **Unknown**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -16022,7 +16022,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Reachable\" | \"Unreachable\" | \"Unknown\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -16314,7 +16314,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ConnectionStatus:type",
-          "docComment": "/**\n * Defines values for ConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionStatus. \\ {@link KnownConnectionStatus} can be used interchangeably with ConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Connected** \\ **Disconnected** \\ **Degraded**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -16322,7 +16322,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Connected\" | \"Disconnected\" | \"Degraded\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -17684,7 +17684,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!DdosCustomPolicyProtocol:type",
-          "docComment": "/**\n * Defines values for DdosCustomPolicyProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for DdosCustomPolicyProtocol. \\ {@link KnownDdosCustomPolicyProtocol} can be used interchangeably with DdosCustomPolicyProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Tcp** \\ **Udp** \\ **Syn**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -17692,7 +17692,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Tcp\" | \"Udp\" | \"Syn\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -17709,7 +17709,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!DdosCustomPolicyTriggerSensitivityOverride:type",
-          "docComment": "/**\n * Defines values for DdosCustomPolicyTriggerSensitivityOverride.\n */\n",
+          "docComment": "/**\n * Defines values for DdosCustomPolicyTriggerSensitivityOverride. \\ {@link KnownDdosCustomPolicyTriggerSensitivityOverride} can be used interchangeably with DdosCustomPolicyTriggerSensitivityOverride, this enum contains the known values that the service supports. ### Know values supported by the service **Relaxed** \\ **Low** \\ **Default** \\ **High**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -17717,7 +17717,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Relaxed\" | \"Low\" | \"Default\" | \"High\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -18499,7 +18499,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!DdosSettingsProtectionCoverage:type",
-          "docComment": "/**\n * Defines values for DdosSettingsProtectionCoverage.\n */\n",
+          "docComment": "/**\n * Defines values for DdosSettingsProtectionCoverage. \\ {@link KnownDdosSettingsProtectionCoverage} can be used interchangeably with DdosSettingsProtectionCoverage, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **Standard**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -18507,7 +18507,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"Standard\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -18839,7 +18839,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!DhGroup:type",
-          "docComment": "/**\n * Defines values for DhGroup.\n */\n",
+          "docComment": "/**\n * Defines values for DhGroup. \\ {@link KnownDhGroup} can be used interchangeably with DhGroup, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **DHGroup1** \\ **DHGroup2** \\ **DHGroup14** \\ **DHGroup2048** \\ **ECP256** \\ **ECP384** \\ **DHGroup24**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -18847,7 +18847,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"DHGroup1\" | \"DHGroup2\" | \"DHGroup14\" | \"DHGroup2048\" | \"ECP256\" | \"ECP384\" | \"DHGroup24\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -18955,7 +18955,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!Direction:type",
-          "docComment": "/**\n * Defines values for Direction.\n */\n",
+          "docComment": "/**\n * Defines values for Direction. \\ {@link KnownDirection} can be used interchangeably with Direction, this enum contains the known values that the service supports. ### Know values supported by the service **Inbound** \\ **Outbound**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -18963,7 +18963,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Inbound\" | \"Outbound\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -19942,7 +19942,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!EffectiveRouteSource:type",
-          "docComment": "/**\n * Defines values for EffectiveRouteSource.\n */\n",
+          "docComment": "/**\n * Defines values for EffectiveRouteSource. \\ {@link KnownEffectiveRouteSource} can be used interchangeably with EffectiveRouteSource, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **User** \\ **VirtualNetworkGateway** \\ **Default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -19950,7 +19950,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"User\" | \"VirtualNetworkGateway\" | \"Default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -19967,7 +19967,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!EffectiveRouteState:type",
-          "docComment": "/**\n * Defines values for EffectiveRouteState.\n */\n",
+          "docComment": "/**\n * Defines values for EffectiveRouteState. \\ {@link KnownEffectiveRouteState} can be used interchangeably with EffectiveRouteState, this enum contains the known values that the service supports. ### Know values supported by the service **Active** \\ **Invalid**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -19975,7 +19975,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Active\" | \"Invalid\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -19992,7 +19992,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!EffectiveSecurityRuleProtocol:type",
-          "docComment": "/**\n * Defines values for EffectiveSecurityRuleProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for EffectiveSecurityRuleProtocol. \\ {@link KnownEffectiveSecurityRuleProtocol} can be used interchangeably with EffectiveSecurityRuleProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Tcp** \\ **Udp** \\ **All**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -20000,7 +20000,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Tcp\" | \"Udp\" | \"All\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -20519,7 +20519,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!EvaluationState:type",
-          "docComment": "/**\n * Defines values for EvaluationState.\n */\n",
+          "docComment": "/**\n * Defines values for EvaluationState. \\ {@link KnownEvaluationState} can be used interchangeably with EvaluationState, this enum contains the known values that the service supports. ### Know values supported by the service **NotStarted** \\ **InProgress** \\ **Completed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -20527,7 +20527,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotStarted\" | \"InProgress\" | \"Completed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -21558,7 +21558,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteCircuitPeeringAdvertisedPublicPrefixState:type",
-          "docComment": "/**\n * Defines values for ExpressRouteCircuitPeeringAdvertisedPublicPrefixState.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteCircuitPeeringAdvertisedPublicPrefixState. \\ {@link KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState} can be used interchangeably with ExpressRouteCircuitPeeringAdvertisedPublicPrefixState, this enum contains the known values that the service supports. ### Know values supported by the service **NotConfigured** \\ **Configuring** \\ **Configured** \\ **ValidationNeeded**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21566,7 +21566,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotConfigured\" | \"Configuring\" | \"Configured\" | \"ValidationNeeded\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -22072,7 +22072,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteCircuitPeeringState:type",
-          "docComment": "/**\n * Defines values for ExpressRouteCircuitPeeringState.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteCircuitPeeringState. \\ {@link KnownExpressRouteCircuitPeeringState} can be used interchangeably with ExpressRouteCircuitPeeringState, this enum contains the known values that the service supports. ### Know values supported by the service **Disabled** \\ **Enabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -22080,7 +22080,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Disabled\" | \"Enabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -22885,7 +22885,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteCircuitSkuFamily:type",
-          "docComment": "/**\n * Defines values for ExpressRouteCircuitSkuFamily.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteCircuitSkuFamily. \\ {@link KnownExpressRouteCircuitSkuFamily} can be used interchangeably with ExpressRouteCircuitSkuFamily, this enum contains the known values that the service supports. ### Know values supported by the service **UnlimitedData** \\ **MeteredData**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -22893,7 +22893,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"UnlimitedData\" | \"MeteredData\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -22910,7 +22910,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteCircuitSkuTier:type",
-          "docComment": "/**\n * Defines values for ExpressRouteCircuitSkuTier.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteCircuitSkuTier. \\ {@link KnownExpressRouteCircuitSkuTier} can be used interchangeably with ExpressRouteCircuitSkuTier, this enum contains the known values that the service supports. ### Know values supported by the service **Standard** \\ **Premium** \\ **Basic** \\ **Local**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -22918,7 +22918,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard\" | \"Premium\" | \"Basic\" | \"Local\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -25665,7 +25665,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteLinkAdminState:type",
-          "docComment": "/**\n * Defines values for ExpressRouteLinkAdminState.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteLinkAdminState. \\ {@link KnownExpressRouteLinkAdminState} can be used interchangeably with ExpressRouteLinkAdminState, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -25673,7 +25673,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -25690,7 +25690,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteLinkConnectorType:type",
-          "docComment": "/**\n * Defines values for ExpressRouteLinkConnectorType.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteLinkConnectorType. \\ {@link KnownExpressRouteLinkConnectorType} can be used interchangeably with ExpressRouteLinkConnectorType, this enum contains the known values that the service supports. ### Know values supported by the service **LC** \\ **SC**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -25698,7 +25698,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"LC\" | \"SC\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -25786,7 +25786,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRouteLinkMacSecCipher:type",
-          "docComment": "/**\n * Defines values for ExpressRouteLinkMacSecCipher.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRouteLinkMacSecCipher. \\ {@link KnownExpressRouteLinkMacSecCipher} can be used interchangeably with ExpressRouteLinkMacSecCipher, this enum contains the known values that the service supports. ### Know values supported by the service **gcm-aes-128** \\ **gcm-aes-256**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -25794,7 +25794,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"gcm-aes-128\" | \"gcm-aes-256\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -26047,7 +26047,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRoutePeeringState:type",
-          "docComment": "/**\n * Defines values for ExpressRoutePeeringState.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRoutePeeringState. \\ {@link KnownExpressRoutePeeringState} can be used interchangeably with ExpressRoutePeeringState, this enum contains the known values that the service supports. ### Know values supported by the service **Disabled** \\ **Enabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -26055,7 +26055,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Disabled\" | \"Enabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -26072,7 +26072,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRoutePeeringType:type",
-          "docComment": "/**\n * Defines values for ExpressRoutePeeringType.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRoutePeeringType. \\ {@link KnownExpressRoutePeeringType} can be used interchangeably with ExpressRoutePeeringType, this enum contains the known values that the service supports. ### Know values supported by the service **AzurePublicPeering** \\ **AzurePrivatePeering** \\ **MicrosoftPeering**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -26080,7 +26080,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AzurePublicPeering\" | \"AzurePrivatePeering\" | \"MicrosoftPeering\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -26309,7 +26309,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ExpressRoutePortsEncapsulation:type",
-          "docComment": "/**\n * Defines values for ExpressRoutePortsEncapsulation.\n */\n",
+          "docComment": "/**\n * Defines values for ExpressRoutePortsEncapsulation. \\ {@link KnownExpressRoutePortsEncapsulation} can be used interchangeably with ExpressRoutePortsEncapsulation, this enum contains the known values that the service supports. ### Know values supported by the service **Dot1Q** \\ **QinQ**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -26317,7 +26317,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Dot1Q\" | \"QinQ\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -27873,7 +27873,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyFilterRuleActionType:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyFilterRuleActionType.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyFilterRuleActionType. \\ {@link KnownFirewallPolicyFilterRuleActionType} can be used interchangeably with FirewallPolicyFilterRuleActionType, this enum contains the known values that the service supports. ### Know values supported by the service **Allow** \\ **Deny**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -27881,7 +27881,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Allow\" | \"Deny\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -27898,7 +27898,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyIntrusionSystemMode:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyIntrusionSystemMode.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyIntrusionSystemMode. \\ {@link KnownFirewallPolicyIntrusionSystemMode} can be used interchangeably with FirewallPolicyIntrusionSystemMode, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -27906,7 +27906,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28084,7 +28084,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyNatRuleActionType:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyNatRuleActionType.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyNatRuleActionType. \\ {@link KnownFirewallPolicyNatRuleActionType} can be used interchangeably with FirewallPolicyNatRuleActionType, this enum contains the known values that the service supports. ### Know values supported by the service **DNAT**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28092,7 +28092,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"DNAT\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28358,7 +28358,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyRuleConditionApplicationProtocolType:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyRuleConditionApplicationProtocolType.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyRuleConditionApplicationProtocolType. \\ {@link KnownFirewallPolicyRuleConditionApplicationProtocolType} can be used interchangeably with FirewallPolicyRuleConditionApplicationProtocolType, this enum contains the known values that the service supports. ### Know values supported by the service **Http** \\ **Https**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28366,7 +28366,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Http\" | \"Https\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28383,7 +28383,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyRuleConditionNetworkProtocol:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyRuleConditionNetworkProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyRuleConditionNetworkProtocol. \\ {@link KnownFirewallPolicyRuleConditionNetworkProtocol} can be used interchangeably with FirewallPolicyRuleConditionNetworkProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **TCP** \\ **UDP** \\ **Any** \\ **ICMP**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28391,7 +28391,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TCP\" | \"UDP\" | \"Any\" | \"ICMP\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28408,7 +28408,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyRuleConditionType:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyRuleConditionType.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyRuleConditionType. \\ {@link KnownFirewallPolicyRuleConditionType} can be used interchangeably with FirewallPolicyRuleConditionType, this enum contains the known values that the service supports. ### Know values supported by the service **ApplicationRuleCondition** \\ **NetworkRuleCondition** \\ **NatRuleCondition**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28416,7 +28416,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ApplicationRuleCondition\" | \"NetworkRuleCondition\" | \"NatRuleCondition\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28806,7 +28806,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FirewallPolicyRuleType:type",
-          "docComment": "/**\n * Defines values for FirewallPolicyRuleType.\n */\n",
+          "docComment": "/**\n * Defines values for FirewallPolicyRuleType. \\ {@link KnownFirewallPolicyRuleType} can be used interchangeably with FirewallPolicyRuleType, this enum contains the known values that the service supports. ### Know values supported by the service **FirewallPolicyNatRule** \\ **FirewallPolicyFilterRule**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28814,7 +28814,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"FirewallPolicyNatRule\" | \"FirewallPolicyFilterRule\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -29228,7 +29228,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!FlowLogFormatType:type",
-          "docComment": "/**\n * Defines values for FlowLogFormatType.\n */\n",
+          "docComment": "/**\n * Defines values for FlowLogFormatType. \\ {@link KnownFlowLogFormatType} can be used interchangeably with FlowLogFormatType, this enum contains the known values that the service supports. ### Know values supported by the service **JSON**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -29236,7 +29236,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"JSON\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -30264,7 +30264,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!HttpConfigurationMethod:type",
-          "docComment": "/**\n * Defines values for HttpConfigurationMethod.\n */\n",
+          "docComment": "/**\n * Defines values for HttpConfigurationMethod. \\ {@link KnownHttpConfigurationMethod} can be used interchangeably with HttpConfigurationMethod, this enum contains the known values that the service supports. ### Know values supported by the service **Get** \\ **Post**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -30272,7 +30272,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Get\" | \"Post\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -30355,7 +30355,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!HttpMethod:type",
-          "docComment": "/**\n * Defines values for HttpMethod.\n */\n",
+          "docComment": "/**\n * Defines values for HttpMethod. \\ {@link KnownHttpMethod} can be used interchangeably with HttpMethod, this enum contains the known values that the service supports. ### Know values supported by the service **Get**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -30363,7 +30363,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Get\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -31069,7 +31069,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!HubVirtualNetworkConnectionStatus:type",
-          "docComment": "/**\n * Defines values for HubVirtualNetworkConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for HubVirtualNetworkConnectionStatus. \\ {@link KnownHubVirtualNetworkConnectionStatus} can be used interchangeably with HubVirtualNetworkConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Connecting** \\ **Connected** \\ **NotConnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -31077,7 +31077,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Connecting\" | \"Connected\" | \"NotConnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -31094,7 +31094,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IkeEncryption:type",
-          "docComment": "/**\n * Defines values for IkeEncryption.\n */\n",
+          "docComment": "/**\n * Defines values for IkeEncryption. \\ {@link KnownIkeEncryption} can be used interchangeably with IkeEncryption, this enum contains the known values that the service supports. ### Know values supported by the service **DES** \\ **DES3** \\ **AES128** \\ **AES192** \\ **AES256** \\ **GCMAES256** \\ **GCMAES128**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -31102,7 +31102,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"DES\" | \"DES3\" | \"AES128\" | \"AES192\" | \"AES256\" | \"GCMAES256\" | \"GCMAES128\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -31119,7 +31119,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IkeIntegrity:type",
-          "docComment": "/**\n * Defines values for IkeIntegrity.\n */\n",
+          "docComment": "/**\n * Defines values for IkeIntegrity. \\ {@link KnownIkeIntegrity} can be used interchangeably with IkeIntegrity, this enum contains the known values that the service supports. ### Know values supported by the service **MD5** \\ **SHA1** \\ **SHA256** \\ **SHA384** \\ **GCMAES256** \\ **GCMAES128**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -31127,7 +31127,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"MD5\" | \"SHA1\" | \"SHA256\" | \"SHA384\" | \"GCMAES256\" | \"GCMAES128\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -31810,7 +31810,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IPAllocationMethod:type",
-          "docComment": "/**\n * Defines values for IPAllocationMethod.\n */\n",
+          "docComment": "/**\n * Defines values for IPAllocationMethod. \\ {@link KnownIPAllocationMethod} can be used interchangeably with IPAllocationMethod, this enum contains the known values that the service supports. ### Know values supported by the service **Static** \\ **Dynamic**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -31818,7 +31818,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Static\" | \"Dynamic\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32248,7 +32248,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IpAllocationType:type",
-          "docComment": "/**\n * Defines values for IpAllocationType.\n */\n",
+          "docComment": "/**\n * Defines values for IpAllocationType. \\ {@link KnownIpAllocationType} can be used interchangeably with IpAllocationType, this enum contains the known values that the service supports. ### Know values supported by the service **Undefined** \\ **Hypernet**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32256,7 +32256,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Undefined\" | \"Hypernet\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32503,7 +32503,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IpFlowProtocol:type",
-          "docComment": "/**\n * Defines values for IpFlowProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for IpFlowProtocol. \\ {@link KnownIpFlowProtocol} can be used interchangeably with IpFlowProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **TCP** \\ **UDP**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32511,7 +32511,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TCP\" | \"UDP\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33060,7 +33060,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IpsecEncryption:type",
-          "docComment": "/**\n * Defines values for IpsecEncryption.\n */\n",
+          "docComment": "/**\n * Defines values for IpsecEncryption. \\ {@link KnownIpsecEncryption} can be used interchangeably with IpsecEncryption, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **DES** \\ **DES3** \\ **AES128** \\ **AES192** \\ **AES256** \\ **GCMAES128** \\ **GCMAES192** \\ **GCMAES256**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33068,7 +33068,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"DES\" | \"DES3\" | \"AES128\" | \"AES192\" | \"AES256\" | \"GCMAES128\" | \"GCMAES192\" | \"GCMAES256\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33085,7 +33085,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IpsecIntegrity:type",
-          "docComment": "/**\n * Defines values for IpsecIntegrity.\n */\n",
+          "docComment": "/**\n * Defines values for IpsecIntegrity. \\ {@link KnownIpsecIntegrity} can be used interchangeably with IpsecIntegrity, this enum contains the known values that the service supports. ### Know values supported by the service **MD5** \\ **SHA1** \\ **SHA256** \\ **GCMAES128** \\ **GCMAES192** \\ **GCMAES256**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33093,7 +33093,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"MD5\" | \"SHA1\" | \"SHA256\" | \"GCMAES128\" | \"GCMAES192\" | \"GCMAES256\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33609,7 +33609,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IPVersion:type",
-          "docComment": "/**\n * Defines values for IPVersion.\n */\n",
+          "docComment": "/**\n * Defines values for IPVersion. \\ {@link KnownIPVersion} can be used interchangeably with IPVersion, this enum contains the known values that the service supports. ### Know values supported by the service **IPv4** \\ **IPv6**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33617,7 +33617,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IPv4\" | \"IPv6\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33634,7 +33634,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!IssueType:type",
-          "docComment": "/**\n * Defines values for IssueType.\n */\n",
+          "docComment": "/**\n * Defines values for IssueType. \\ {@link KnownIssueType} can be used interchangeably with IssueType, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **AgentStopped** \\ **GuestFirewall** \\ **DnsResolution** \\ **SocketBind** \\ **NetworkSecurityRule** \\ **UserDefinedRoute** \\ **PortThrottled** \\ **Platform**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33642,7 +33642,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"AgentStopped\" | \"GuestFirewall\" | \"DnsResolution\" | \"SocketBind\" | \"NetworkSecurityRule\" | \"UserDefinedRoute\" | \"PortThrottled\" | \"Platform\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33655,6 +33655,11877 @@
             "startIndex": 1,
             "endIndex": 2
           }
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAccess:enum",
+          "docComment": "/**\n * Known values of {@link Access} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAccess "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAccess",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAccess.Allow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Allow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Allow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Allow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAccess.Deny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayBackendHealthServerHealth:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayBackendHealthServerHealth} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayBackendHealthServerHealth "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayBackendHealthServerHealth",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayBackendHealthServerHealth.Down:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Down = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Down\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Down",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayBackendHealthServerHealth.Draining:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Draining = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Draining\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Draining",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayBackendHealthServerHealth.Partial:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Partial = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Partial\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Partial",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayBackendHealthServerHealth.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayBackendHealthServerHealth.Up:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Up = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Up\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Up",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayCookieBasedAffinity:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayCookieBasedAffinity} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayCookieBasedAffinity "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayCookieBasedAffinity",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayCookieBasedAffinity.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayCookieBasedAffinity.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayCustomErrorStatusCode:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayCustomErrorStatusCode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayCustomErrorStatusCode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayCustomErrorStatusCode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayCustomErrorStatusCode.HttpStatus403:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HttpStatus403 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HttpStatus403\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HttpStatus403",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayCustomErrorStatusCode.HttpStatus502:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HttpStatus502 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HttpStatus502\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HttpStatus502",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayFirewallMode:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayFirewallMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayFirewallMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayFirewallMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayFirewallMode.Detection:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Detection = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Detection\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Detection",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayFirewallMode.Prevention:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Prevention = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Prevention\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Prevention",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayOperationalState:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayOperationalState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayOperationalState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayOperationalState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayOperationalState.Running:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Running = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Running\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Running",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayOperationalState.Starting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Starting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Starting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Starting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayOperationalState.Stopped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Stopped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Stopped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Stopped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayOperationalState.Stopping:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Stopping = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Stopping\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Stopping",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayProtocol:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayProtocol.Http:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Http = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Http\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Http",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayProtocol.Https:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Https = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Https\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Https",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayRedirectType:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayRedirectType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayRedirectType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayRedirectType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayRedirectType.Found:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Found = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Found\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Found",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayRedirectType.Permanent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Permanent = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Permanent\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Permanent",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayRedirectType.SeeOther:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SeeOther = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SeeOther\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SeeOther",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayRedirectType.Temporary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Temporary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Temporary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Temporary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayRequestRoutingRuleType:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayRequestRoutingRuleType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayRequestRoutingRuleType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayRequestRoutingRuleType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayRequestRoutingRuleType.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayRequestRoutingRuleType.PathBasedRouting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PathBasedRouting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PathBasedRouting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PathBasedRouting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewaySkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewaySkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewaySkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.StandardLarge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardLarge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_Large\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardLarge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.StandardMedium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardMedium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_Medium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardMedium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.StandardSmall:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardSmall = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_Small\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardSmall",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.StandardV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.WAFLarge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WAFLarge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WAF_Large\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WAFLarge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.WAFMedium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WAFMedium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WAF_Medium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WAFMedium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySkuName.WAFV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WAFV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WAF_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WAFV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewaySslCipherSuite} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewaySslCipherSuite "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewaySslCipherSuite",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHEDSSWith3DESEDECBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHEDSSWith3DESEDECBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHEDSSWith3DESEDECBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHEDSSWithAES128CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHEDSSWithAES128CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_DSS_WITH_AES_128_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHEDSSWithAES128CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHEDSSWithAES128CBCSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHEDSSWithAES128CBCSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_DSS_WITH_AES_128_CBC_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHEDSSWithAES128CBCSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHEDSSWithAES256CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHEDSSWithAES256CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_DSS_WITH_AES_256_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHEDSSWithAES256CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHEDSSWithAES256CBCSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHEDSSWithAES256CBCSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_DSS_WITH_AES_256_CBC_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHEDSSWithAES256CBCSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHERSAWithAES128CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHERSAWithAES128CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_RSA_WITH_AES_128_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHERSAWithAES128CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHERSAWithAES128GCMSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHERSAWithAES128GCMSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_RSA_WITH_AES_128_GCM_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHERSAWithAES128GCMSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHERSAWithAES256CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHERSAWithAES256CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_RSA_WITH_AES_256_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHERSAWithAES256CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSDHERSAWithAES256GCMSHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSDHERSAWithAES256GCMSHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_DHE_RSA_WITH_AES_256_GCM_SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSDHERSAWithAES256GCMSHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheEcdsaWithAES128CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheEcdsaWithAES128CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheEcdsaWithAES128CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheEcdsaWithAES128CBCSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheEcdsaWithAES128CBCSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheEcdsaWithAES128CBCSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheEcdsaWithAES128GCMSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheEcdsaWithAES128GCMSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheEcdsaWithAES128GCMSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheEcdsaWithAES256CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheEcdsaWithAES256CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheEcdsaWithAES256CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheEcdsaWithAES256CBCSHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheEcdsaWithAES256CBCSHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheEcdsaWithAES256CBCSHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheEcdsaWithAES256GCMSHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheEcdsaWithAES256GCMSHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheEcdsaWithAES256GCMSHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheRSAWithAES128CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheRSAWithAES128CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheRSAWithAES128CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheRSAWithAES128CBCSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheRSAWithAES128CBCSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheRSAWithAES128CBCSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheRSAWithAES128GCMSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheRSAWithAES128GCMSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheRSAWithAES128GCMSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheRSAWithAES256CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheRSAWithAES256CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheRSAWithAES256CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheRSAWithAES256CBCSHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheRSAWithAES256CBCSHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheRSAWithAES256CBCSHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSEcdheRSAWithAES256GCMSHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSEcdheRSAWithAES256GCMSHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSEcdheRSAWithAES256GCMSHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWith3DESEDECBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWith3DESEDECBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_3DES_EDE_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWith3DESEDECBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWithAES128CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWithAES128CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_AES_128_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWithAES128CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWithAES128CBCSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWithAES128CBCSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_AES_128_CBC_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWithAES128CBCSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWithAES128GCMSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWithAES128GCMSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_AES_128_GCM_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWithAES128GCMSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWithAES256CBCSHA:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWithAES256CBCSHA = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_AES_256_CBC_SHA\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWithAES256CBCSHA",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWithAES256CBCSHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWithAES256CBCSHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_AES_256_CBC_SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWithAES256CBCSHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslCipherSuite.TLSRSAWithAES256GCMSHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSRSAWithAES256GCMSHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLS_RSA_WITH_AES_256_GCM_SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSRSAWithAES256GCMSHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewaySslPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewaySslPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewaySslPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyName.AppGwSslPolicy20150501:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AppGwSslPolicy20150501 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AppGwSslPolicy20150501\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AppGwSslPolicy20150501",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyName.AppGwSslPolicy20170401:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AppGwSslPolicy20170401 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AppGwSslPolicy20170401\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AppGwSslPolicy20170401",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyName.AppGwSslPolicy20170401S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AppGwSslPolicy20170401S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AppGwSslPolicy20170401S\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AppGwSslPolicy20170401S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyType:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewaySslPolicyType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewaySslPolicyType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewaySslPolicyType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyType.Custom:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Custom = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Custom\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Custom",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslPolicyType.Predefined:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Predefined = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Predefined\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Predefined",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslProtocol:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewaySslProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewaySslProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewaySslProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslProtocol.TLSv10:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSv10 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLSv1_0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSv10",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslProtocol.TLSv11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSv11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLSv1_1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSv11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewaySslProtocol.TLSv12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TLSv12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TLSv1_2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TLSv12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownApplicationGatewayTier:enum",
+          "docComment": "/**\n * Known values of {@link ApplicationGatewayTier} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownApplicationGatewayTier "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownApplicationGatewayTier",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayTier.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayTier.StandardV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayTier.WAF:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WAF = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WAF\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WAF",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownApplicationGatewayTier.WAFV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WAFV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WAF_v2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WAFV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAssociationType:enum",
+          "docComment": "/**\n * Known values of {@link AssociationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAssociationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAssociationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAssociationType.Associated:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Associated = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Associated\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Associated",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAssociationType.Contains:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Contains = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Contains\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Contains",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAuthenticationMethod:enum",
+          "docComment": "/**\n * Known values of {@link AuthenticationMethod} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAuthenticationMethod "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAuthenticationMethod",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAuthenticationMethod.EapmschaPv2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EapmschaPv2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EAPMSCHAPv2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EapmschaPv2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAuthenticationMethod.Eaptls:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Eaptls = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EAPTLS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Eaptls",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAuthorizationUseStatus:enum",
+          "docComment": "/**\n * Known values of {@link AuthorizationUseStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAuthorizationUseStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAuthorizationUseStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAuthorizationUseStatus.Available:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Available = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Available\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Available",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAuthorizationUseStatus.InUse:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InUse = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InUse\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InUse",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallApplicationRuleProtocolType:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallApplicationRuleProtocolType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallApplicationRuleProtocolType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallApplicationRuleProtocolType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallApplicationRuleProtocolType.Http:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Http = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Http\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Http",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallApplicationRuleProtocolType.Https:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Https = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Https\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Https",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallApplicationRuleProtocolType.Mssql:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Mssql = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Mssql\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Mssql",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallNatRCActionType:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallNatRCActionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallNatRCActionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallNatRCActionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallNatRCActionType.Dnat:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dnat = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Dnat\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dnat",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallNatRCActionType.Snat:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Snat = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Snat\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Snat",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallNetworkRuleProtocol:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallNetworkRuleProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallNetworkRuleProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallNetworkRuleProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallNetworkRuleProtocol.Any:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Any = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Any\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Any",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallNetworkRuleProtocol.Icmp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Icmp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ICMP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Icmp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallNetworkRuleProtocol.TCP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TCP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TCP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TCP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallNetworkRuleProtocol.UDP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UDP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UDP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UDP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallRCActionType:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallRCActionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallRCActionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallRCActionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallRCActionType.Allow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Allow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Allow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Allow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallRCActionType.Deny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallSkuName:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallSkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallSkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallSkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallSkuName.AzfwHub:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzfwHub = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AZFW_Hub\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzfwHub",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallSkuName.AzfwVnet:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzfwVnet = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AZFW_VNet\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzfwVnet",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallSkuTier:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallSkuTier} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallSkuTier "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallSkuTier",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallSkuTier.Premium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Premium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Premium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallSkuTier.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownAzureFirewallThreatIntelMode:enum",
+          "docComment": "/**\n * Known values of {@link AzureFirewallThreatIntelMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAzureFirewallThreatIntelMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAzureFirewallThreatIntelMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallThreatIntelMode.Alert:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Alert = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Alert\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Alert",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallThreatIntelMode.Deny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownAzureFirewallThreatIntelMode.Off:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Off = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Off\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Off",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownBastionConnectProtocol:enum",
+          "docComment": "/**\n * Known values of {@link BastionConnectProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownBastionConnectProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownBastionConnectProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBastionConnectProtocol.RDP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RDP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RDP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RDP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBastionConnectProtocol.SSH:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SSH = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SSH\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SSH",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownBgpPeerState:enum",
+          "docComment": "/**\n * Known values of {@link BgpPeerState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownBgpPeerState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownBgpPeerState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBgpPeerState.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBgpPeerState.Connecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBgpPeerState.Idle:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Idle = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Idle\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Idle",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBgpPeerState.Stopped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Stopped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Stopped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Stopped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownBgpPeerState.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownCircuitConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link CircuitConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCircuitConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCircuitConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownCircuitConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownCircuitConnectionStatus.Connecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownCircuitConnectionStatus.Disconnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disconnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disconnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disconnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionMonitorEndpointFilterItemType:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionMonitorEndpointFilterItemType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionMonitorEndpointFilterItemType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionMonitorEndpointFilterItemType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorEndpointFilterItemType.AgentAddress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AgentAddress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AgentAddress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AgentAddress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionMonitorEndpointFilterType:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionMonitorEndpointFilterType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionMonitorEndpointFilterType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionMonitorEndpointFilterType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorEndpointFilterType.Include:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Include = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Include\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Include",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionMonitorSourceStatus:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionMonitorSourceStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionMonitorSourceStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionMonitorSourceStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorSourceStatus.Active:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Active = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Active\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Active",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorSourceStatus.Inactive:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inactive = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inactive\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inactive",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorSourceStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionMonitorTestConfigurationProtocol:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionMonitorTestConfigurationProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionMonitorTestConfigurationProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionMonitorTestConfigurationProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorTestConfigurationProtocol.Http:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Http = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Http\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Http",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorTestConfigurationProtocol.Icmp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Icmp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Icmp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Icmp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorTestConfigurationProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionMonitorType:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionMonitorType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionMonitorType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionMonitorType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorType.MultiEndpoint:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MultiEndpoint = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MultiEndpoint\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MultiEndpoint",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionMonitorType.SingleSourceDestination:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SingleSourceDestination = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SingleSourceDestination\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SingleSourceDestination",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionState:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionState.Reachable:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Reachable = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Reachable\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Reachable",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionState.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionState.Unreachable:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unreachable = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unreachable\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unreachable",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionStatus.Degraded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Degraded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Degraded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Degraded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionStatus.Disconnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disconnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disconnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disconnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownConnectionStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyProtocol:enum",
+          "docComment": "/**\n * Known values of {@link DdosCustomPolicyProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDdosCustomPolicyProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDdosCustomPolicyProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyProtocol.Syn:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Syn = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Syn\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Syn",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyProtocol.Udp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Udp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Udp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Udp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyTriggerSensitivityOverride:enum",
+          "docComment": "/**\n * Known values of {@link DdosCustomPolicyTriggerSensitivityOverride} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDdosCustomPolicyTriggerSensitivityOverride "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDdosCustomPolicyTriggerSensitivityOverride",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyTriggerSensitivityOverride.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyTriggerSensitivityOverride.High:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "High = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"High\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "High",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyTriggerSensitivityOverride.Low:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Low = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Low\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Low",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosCustomPolicyTriggerSensitivityOverride.Relaxed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Relaxed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Relaxed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Relaxed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownDdosSettingsProtectionCoverage:enum",
+          "docComment": "/**\n * Known values of {@link DdosSettingsProtectionCoverage} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDdosSettingsProtectionCoverage "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDdosSettingsProtectionCoverage",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosSettingsProtectionCoverage.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDdosSettingsProtectionCoverage.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownDhGroup:enum",
+          "docComment": "/**\n * Known values of {@link DhGroup} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDhGroup "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDhGroup",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.DHGroup1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DHGroup1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DHGroup1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DHGroup1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.DHGroup14:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DHGroup14 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DHGroup14\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DHGroup14",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.DHGroup2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DHGroup2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DHGroup2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DHGroup2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.DHGroup2048:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DHGroup2048 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DHGroup2048\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DHGroup2048",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.DHGroup24:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DHGroup24 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DHGroup24\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DHGroup24",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.ECP256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ECP256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ECP256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ECP256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.ECP384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ECP384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ECP384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ECP384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDhGroup.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownDirection:enum",
+          "docComment": "/**\n * Known values of {@link Direction} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDirection "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDirection",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDirection.Inbound:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inbound = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inbound\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inbound",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownDirection.Outbound:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Outbound = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Outbound\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Outbound",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownEffectiveRouteSource:enum",
+          "docComment": "/**\n * Known values of {@link EffectiveRouteSource} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEffectiveRouteSource "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEffectiveRouteSource",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveRouteSource.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveRouteSource.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveRouteSource.User:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "User = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"User\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "User",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveRouteSource.VirtualNetworkGateway:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VirtualNetworkGateway = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VirtualNetworkGateway\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VirtualNetworkGateway",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownEffectiveRouteState:enum",
+          "docComment": "/**\n * Known values of {@link EffectiveRouteState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEffectiveRouteState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEffectiveRouteState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveRouteState.Active:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Active = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Active\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Active",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveRouteState.Invalid:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Invalid = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Invalid\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Invalid",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownEffectiveSecurityRuleProtocol:enum",
+          "docComment": "/**\n * Known values of {@link EffectiveSecurityRuleProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEffectiveSecurityRuleProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEffectiveSecurityRuleProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveSecurityRuleProtocol.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveSecurityRuleProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEffectiveSecurityRuleProtocol.Udp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Udp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Udp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Udp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownEvaluationState:enum",
+          "docComment": "/**\n * Known values of {@link EvaluationState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEvaluationState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEvaluationState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEvaluationState.Completed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Completed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Completed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Completed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEvaluationState.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownEvaluationState.NotStarted:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotStarted = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotStarted\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotStarted",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteCircuitPeeringAdvertisedPublicPrefixState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState.Configured:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Configured = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Configured\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Configured",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState.Configuring:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Configuring = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Configuring\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Configuring",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState.NotConfigured:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotConfigured = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotConfigured\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotConfigured",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState.ValidationNeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ValidationNeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ValidationNeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ValidationNeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringState:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteCircuitPeeringState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteCircuitPeeringState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteCircuitPeeringState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitPeeringState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuFamily:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteCircuitSkuFamily} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteCircuitSkuFamily "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteCircuitSkuFamily",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuFamily.MeteredData:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MeteredData = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MeteredData\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MeteredData",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuFamily.UnlimitedData:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UnlimitedData = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UnlimitedData\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UnlimitedData",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuTier:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteCircuitSkuTier} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteCircuitSkuTier "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteCircuitSkuTier",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuTier.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuTier.Local:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Local = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Local\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Local",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuTier.Premium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Premium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Premium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteCircuitSkuTier.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteLinkAdminState:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteLinkAdminState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteLinkAdminState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteLinkAdminState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteLinkAdminState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteLinkAdminState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteLinkConnectorType:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteLinkConnectorType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteLinkConnectorType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteLinkConnectorType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteLinkConnectorType.LC:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LC = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LC\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LC",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteLinkConnectorType.SC:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SC = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SC\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SC",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRouteLinkMacSecCipher:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRouteLinkMacSecCipher} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRouteLinkMacSecCipher "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRouteLinkMacSecCipher",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteLinkMacSecCipher.GcmAes128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GcmAes128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"gcm-aes-128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GcmAes128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRouteLinkMacSecCipher.GcmAes256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GcmAes256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"gcm-aes-256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GcmAes256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringState:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRoutePeeringState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRoutePeeringState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRoutePeeringState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringType:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRoutePeeringType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRoutePeeringType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRoutePeeringType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringType.AzurePrivatePeering:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzurePrivatePeering = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzurePrivatePeering\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzurePrivatePeering",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringType.AzurePublicPeering:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzurePublicPeering = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzurePublicPeering\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzurePublicPeering",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePeeringType.MicrosoftPeering:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftPeering = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MicrosoftPeering\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftPeering",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownExpressRoutePortsEncapsulation:enum",
+          "docComment": "/**\n * Known values of {@link ExpressRoutePortsEncapsulation} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExpressRoutePortsEncapsulation "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExpressRoutePortsEncapsulation",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePortsEncapsulation.Dot1Q:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dot1Q = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Dot1Q\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dot1Q",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownExpressRoutePortsEncapsulation.QinQ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "QinQ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"QinQ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "QinQ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyFilterRuleActionType:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyFilterRuleActionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyFilterRuleActionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyFilterRuleActionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyFilterRuleActionType.Allow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Allow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Allow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Allow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyFilterRuleActionType.Deny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyIntrusionSystemMode:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyIntrusionSystemMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyIntrusionSystemMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyIntrusionSystemMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyIntrusionSystemMode.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyIntrusionSystemMode.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyNatRuleActionType:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyNatRuleActionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyNatRuleActionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyNatRuleActionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyNatRuleActionType.Dnat:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dnat = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DNAT\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dnat",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionApplicationProtocolType:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyRuleConditionApplicationProtocolType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyRuleConditionApplicationProtocolType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyRuleConditionApplicationProtocolType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionApplicationProtocolType.Http:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Http = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Http\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Http",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionApplicationProtocolType.Https:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Https = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Https\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Https",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionNetworkProtocol:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyRuleConditionNetworkProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyRuleConditionNetworkProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyRuleConditionNetworkProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionNetworkProtocol.Any:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Any = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Any\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Any",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionNetworkProtocol.Icmp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Icmp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ICMP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Icmp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionNetworkProtocol.TCP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TCP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TCP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TCP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionNetworkProtocol.UDP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UDP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UDP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UDP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionType:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyRuleConditionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyRuleConditionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyRuleConditionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionType.ApplicationRuleCondition:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ApplicationRuleCondition = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ApplicationRuleCondition\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ApplicationRuleCondition",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionType.NatRuleCondition:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NatRuleCondition = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NatRuleCondition\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NatRuleCondition",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleConditionType.NetworkRuleCondition:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NetworkRuleCondition = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NetworkRuleCondition\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NetworkRuleCondition",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleType:enum",
+          "docComment": "/**\n * Known values of {@link FirewallPolicyRuleType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFirewallPolicyRuleType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFirewallPolicyRuleType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleType.FirewallPolicyFilterRule:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FirewallPolicyFilterRule = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FirewallPolicyFilterRule\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FirewallPolicyFilterRule",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFirewallPolicyRuleType.FirewallPolicyNatRule:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FirewallPolicyNatRule = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FirewallPolicyNatRule\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FirewallPolicyNatRule",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownFlowLogFormatType:enum",
+          "docComment": "/**\n * Known values of {@link FlowLogFormatType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFlowLogFormatType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFlowLogFormatType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownFlowLogFormatType.Json:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Json = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"JSON\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Json",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownHttpConfigurationMethod:enum",
+          "docComment": "/**\n * Known values of {@link HttpConfigurationMethod} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownHttpConfigurationMethod "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownHttpConfigurationMethod",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHttpConfigurationMethod.Get:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Get = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Get\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Get",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHttpConfigurationMethod.Post:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Post = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Post\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Post",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownHttpMethod:enum",
+          "docComment": "/**\n * Known values of {@link HttpMethod} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownHttpMethod "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownHttpMethod",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHttpMethod.Get:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Get = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Get\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Get",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownHubVirtualNetworkConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link HubVirtualNetworkConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownHubVirtualNetworkConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownHubVirtualNetworkConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHubVirtualNetworkConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHubVirtualNetworkConnectionStatus.Connecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHubVirtualNetworkConnectionStatus.NotConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownHubVirtualNetworkConnectionStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIkeEncryption:enum",
+          "docComment": "/**\n * Known values of {@link IkeEncryption} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIkeEncryption "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIkeEncryption",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.AES128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AES128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AES128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AES128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.AES192:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AES192 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AES192\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AES192",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.AES256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AES256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AES256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AES256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.DES:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DES = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DES\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DES",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.DES3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DES3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DES3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DES3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.Gcmaes128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeEncryption.Gcmaes256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIkeIntegrity:enum",
+          "docComment": "/**\n * Known values of {@link IkeIntegrity} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIkeIntegrity "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIkeIntegrity",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeIntegrity.Gcmaes128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeIntegrity.Gcmaes256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeIntegrity.MD5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MD5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MD5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MD5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeIntegrity.SHA1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SHA1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SHA1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SHA1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeIntegrity.SHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIkeIntegrity.SHA384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SHA384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SHA384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SHA384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIPAllocationMethod:enum",
+          "docComment": "/**\n * Known values of {@link IPAllocationMethod} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIPAllocationMethod "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIPAllocationMethod",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIPAllocationMethod.Dynamic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dynamic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Dynamic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dynamic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIPAllocationMethod.Static:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Static = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Static\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Static",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIpAllocationType:enum",
+          "docComment": "/**\n * Known values of {@link IpAllocationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIpAllocationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIpAllocationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpAllocationType.Hypernet:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Hypernet = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Hypernet\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Hypernet",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpAllocationType.Undefined:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Undefined = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Undefined\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Undefined",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIpFlowProtocol:enum",
+          "docComment": "/**\n * Known values of {@link IpFlowProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIpFlowProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIpFlowProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpFlowProtocol.TCP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TCP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TCP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TCP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpFlowProtocol.UDP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UDP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UDP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UDP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIpsecEncryption:enum",
+          "docComment": "/**\n * Known values of {@link IpsecEncryption} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIpsecEncryption "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIpsecEncryption",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.AES128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AES128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AES128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AES128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.AES192:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AES192 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AES192\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AES192",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.AES256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AES256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AES256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AES256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.DES:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DES = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DES\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DES",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.DES3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DES3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DES3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DES3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.Gcmaes128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.Gcmaes192:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes192 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES192\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes192",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.Gcmaes256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecEncryption.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIpsecIntegrity:enum",
+          "docComment": "/**\n * Known values of {@link IpsecIntegrity} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIpsecIntegrity "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIpsecIntegrity",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecIntegrity.Gcmaes128:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes128 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES128\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes128",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecIntegrity.Gcmaes192:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes192 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES192\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes192",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecIntegrity.Gcmaes256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gcmaes256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GCMAES256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gcmaes256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecIntegrity.MD5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MD5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MD5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MD5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecIntegrity.SHA1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SHA1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SHA1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SHA1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIpsecIntegrity.SHA256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SHA256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SHA256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SHA256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIPVersion:enum",
+          "docComment": "/**\n * Known values of {@link IPVersion} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIPVersion "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIPVersion",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIPVersion.IPv4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPv4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPv4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPv4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIPVersion.IPv6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPv6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPv6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPv6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownIssueType:enum",
+          "docComment": "/**\n * Known values of {@link IssueType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIssueType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIssueType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.AgentStopped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AgentStopped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AgentStopped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AgentStopped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.DnsResolution:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DnsResolution = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DnsResolution\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DnsResolution",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.GuestFirewall:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GuestFirewall = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GuestFirewall\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GuestFirewall",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.NetworkSecurityRule:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NetworkSecurityRule = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NetworkSecurityRule\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NetworkSecurityRule",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.Platform:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Platform = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Platform\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Platform",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.PortThrottled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PortThrottled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PortThrottled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PortThrottled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.SocketBind:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SocketBind = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SocketBind\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SocketBind",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownIssueType.UserDefinedRoute:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UserDefinedRoute = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UserDefinedRoute\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UserDefinedRoute",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownLoadBalancerOutboundRuleProtocol:enum",
+          "docComment": "/**\n * Known values of {@link LoadBalancerOutboundRuleProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLoadBalancerOutboundRuleProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLoadBalancerOutboundRuleProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadBalancerOutboundRuleProtocol.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadBalancerOutboundRuleProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadBalancerOutboundRuleProtocol.Udp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Udp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Udp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Udp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownLoadBalancerSkuName:enum",
+          "docComment": "/**\n * Known values of {@link LoadBalancerSkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLoadBalancerSkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLoadBalancerSkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadBalancerSkuName.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadBalancerSkuName.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownLoadDistribution:enum",
+          "docComment": "/**\n * Known values of {@link LoadDistribution} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLoadDistribution "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLoadDistribution",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadDistribution.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadDistribution.SourceIP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SourceIP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SourceIP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SourceIP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownLoadDistribution.SourceIPProtocol:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SourceIPProtocol = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SourceIPProtocol\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SourceIPProtocol",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownManagedRuleEnabledState:enum",
+          "docComment": "/**\n * Known values of {@link ManagedRuleEnabledState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedRuleEnabledState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedRuleEnabledState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownManagedRuleEnabledState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownNatGatewaySkuName:enum",
+          "docComment": "/**\n * Known values of {@link NatGatewaySkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownNatGatewaySkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownNatGatewaySkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNatGatewaySkuName.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownNetworkOperationStatus:enum",
+          "docComment": "/**\n * Known values of {@link NetworkOperationStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownNetworkOperationStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownNetworkOperationStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNetworkOperationStatus.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNetworkOperationStatus.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNetworkOperationStatus.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownNextHopType:enum",
+          "docComment": "/**\n * Known values of {@link NextHopType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownNextHopType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownNextHopType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNextHopType.HyperNetGateway:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HyperNetGateway = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HyperNetGateway\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HyperNetGateway",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNextHopType.Internet:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Internet = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Internet\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Internet",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNextHopType.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNextHopType.VirtualAppliance:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VirtualAppliance = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VirtualAppliance\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VirtualAppliance",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNextHopType.VirtualNetworkGateway:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VirtualNetworkGateway = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VirtualNetworkGateway\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VirtualNetworkGateway",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownNextHopType.VnetLocal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VnetLocal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VnetLocal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VnetLocal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownOfficeTrafficCategory:enum",
+          "docComment": "/**\n * Known values of {@link OfficeTrafficCategory} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOfficeTrafficCategory "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOfficeTrafficCategory",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOfficeTrafficCategory.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOfficeTrafficCategory.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOfficeTrafficCategory.Optimize:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Optimize = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Optimize\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Optimize",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOfficeTrafficCategory.OptimizeAndAllow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OptimizeAndAllow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OptimizeAndAllow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OptimizeAndAllow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownOrigin:enum",
+          "docComment": "/**\n * Known values of {@link Origin} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOrigin "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOrigin",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOrigin.Inbound:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inbound = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inbound\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inbound",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOrigin.Local:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Local = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Local\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Local",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOrigin.Outbound:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Outbound = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Outbound\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Outbound",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownOutputType:enum",
+          "docComment": "/**\n * Known values of {@link OutputType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOutputType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOutputType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOutputType.Workspace:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Workspace = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Workspace\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Workspace",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntryMatchVariable:enum",
+          "docComment": "/**\n * Known values of {@link OwaspCrsExclusionEntryMatchVariable} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOwaspCrsExclusionEntryMatchVariable "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOwaspCrsExclusionEntryMatchVariable",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntryMatchVariable.RequestArgNames:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestArgNames = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestArgNames\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestArgNames",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntryMatchVariable.RequestCookieNames:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestCookieNames = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestCookieNames\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestCookieNames",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntryMatchVariable.RequestHeaderNames:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestHeaderNames = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestHeaderNames\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestHeaderNames",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntrySelectorMatchOperator:enum",
+          "docComment": "/**\n * Known values of {@link OwaspCrsExclusionEntrySelectorMatchOperator} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOwaspCrsExclusionEntrySelectorMatchOperator "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOwaspCrsExclusionEntrySelectorMatchOperator",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntrySelectorMatchOperator.Contains:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Contains = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Contains\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Contains",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntrySelectorMatchOperator.EndsWith:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EndsWith = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EndsWith\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EndsWith",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntrySelectorMatchOperator.Equals:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Equals = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Equals\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Equals",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntrySelectorMatchOperator.EqualsAny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EqualsAny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EqualsAny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EqualsAny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownOwaspCrsExclusionEntrySelectorMatchOperator.StartsWith:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StartsWith = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"StartsWith\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StartsWith",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPcError:enum",
+          "docComment": "/**\n * Known values of {@link PcError} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPcError "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPcError",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcError.AgentStopped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AgentStopped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AgentStopped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AgentStopped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcError.CaptureFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CaptureFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CaptureFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CaptureFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcError.InternalError:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InternalError = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InternalError\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InternalError",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcError.LocalFileFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LocalFileFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LocalFileFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LocalFileFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcError.StorageFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StorageFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"StorageFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StorageFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPcProtocol:enum",
+          "docComment": "/**\n * Known values of {@link PcProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPcProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPcProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcProtocol.Any:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Any = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Any\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Any",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcProtocol.TCP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TCP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TCP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TCP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcProtocol.UDP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UDP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UDP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UDP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPcStatus:enum",
+          "docComment": "/**\n * Known values of {@link PcStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPcStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPcStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcStatus.Error:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Error = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Error\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Error",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcStatus.NotStarted:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotStarted = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotStarted\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotStarted",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcStatus.Running:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Running = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Running\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Running",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcStatus.Stopped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Stopped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Stopped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Stopped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPcStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPfsGroup:enum",
+          "docComment": "/**\n * Known values of {@link PfsGroup} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPfsGroup "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPfsGroup",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.ECP256:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ECP256 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ECP256\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ECP256",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.ECP384:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ECP384 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ECP384\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ECP384",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.PFS1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PFS1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PFS1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PFS1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.PFS14:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PFS14 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PFS14\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PFS14",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.PFS2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PFS2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PFS2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PFS2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.PFS2048:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PFS2048 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PFS2048\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PFS2048",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.PFS24:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PFS24 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PFS24\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PFS24",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPfsGroup.Pfsmm:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pfsmm = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PFSMM\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pfsmm",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPreferredIPVersion:enum",
+          "docComment": "/**\n * Known values of {@link PreferredIPVersion} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPreferredIPVersion "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPreferredIPVersion",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPreferredIPVersion.IPv4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPv4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPv4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPv4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPreferredIPVersion.IPv6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPv6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPv6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPv6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownProbeProtocol:enum",
+          "docComment": "/**\n * Known values of {@link ProbeProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProbeProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProbeProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProbeProtocol.Http:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Http = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Http\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Http",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProbeProtocol.Https:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Https = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Https\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Https",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProbeProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownProcessorArchitecture:enum",
+          "docComment": "/**\n * Known values of {@link ProcessorArchitecture} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProcessorArchitecture "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProcessorArchitecture",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProcessorArchitecture.Amd64:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Amd64 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Amd64\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Amd64",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProcessorArchitecture.X86:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "X86 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"X86\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "X86",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownProtocol:enum",
+          "docComment": "/**\n * Known values of {@link Protocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProtocol.Http:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Http = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Http\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Http",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProtocol.Https:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Https = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Https\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Https",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProtocol.Icmp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Icmp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Icmp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Icmp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link ProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownProvisioningState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPublicIPAddressSkuName:enum",
+          "docComment": "/**\n * Known values of {@link PublicIPAddressSkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPublicIPAddressSkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPublicIPAddressSkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPublicIPAddressSkuName.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPublicIPAddressSkuName.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownPublicIPPrefixSkuName:enum",
+          "docComment": "/**\n * Known values of {@link PublicIPPrefixSkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPublicIPPrefixSkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPublicIPPrefixSkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownPublicIPPrefixSkuName.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownRouteFilterRuleType:enum",
+          "docComment": "/**\n * Known values of {@link RouteFilterRuleType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRouteFilterRuleType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRouteFilterRuleType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownRouteFilterRuleType.Community:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Community = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Community\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Community",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownRouteNextHopType:enum",
+          "docComment": "/**\n * Known values of {@link RouteNextHopType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRouteNextHopType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRouteNextHopType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownRouteNextHopType.Internet:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Internet = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Internet\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Internet",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownRouteNextHopType.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownRouteNextHopType.VirtualAppliance:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VirtualAppliance = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VirtualAppliance\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VirtualAppliance",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownRouteNextHopType.VirtualNetworkGateway:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VirtualNetworkGateway = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VirtualNetworkGateway\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VirtualNetworkGateway",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownRouteNextHopType.VnetLocal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VnetLocal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VnetLocal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VnetLocal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownSecurityPartnerProviderConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link SecurityPartnerProviderConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityPartnerProviderConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityPartnerProviderConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityPartnerProviderConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityPartnerProviderConnectionStatus.NotConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityPartnerProviderConnectionStatus.PartiallyConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PartiallyConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PartiallyConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PartiallyConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityPartnerProviderConnectionStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownSecurityProviderName:enum",
+          "docComment": "/**\n * Known values of {@link SecurityProviderName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityProviderName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityProviderName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityProviderName.Checkpoint:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Checkpoint = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Checkpoint\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Checkpoint",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityProviderName.IBoss:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IBoss = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IBoss\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IBoss",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityProviderName.ZScaler:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ZScaler = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ZScaler\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ZScaler",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownSecurityRuleAccess:enum",
+          "docComment": "/**\n * Known values of {@link SecurityRuleAccess} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityRuleAccess "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityRuleAccess",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleAccess.Allow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Allow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Allow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Allow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleAccess.Deny:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deny = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deny\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deny",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownSecurityRuleDirection:enum",
+          "docComment": "/**\n * Known values of {@link SecurityRuleDirection} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityRuleDirection "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityRuleDirection",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleDirection.Inbound:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inbound = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inbound\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inbound",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleDirection.Outbound:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Outbound = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Outbound\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Outbound",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol:enum",
+          "docComment": "/**\n * Known values of {@link SecurityRuleProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityRuleProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityRuleProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol.Ah:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ah = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ah\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ah",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol.Asterisk:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Asterisk = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"*\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Asterisk",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol.Esp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Esp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Esp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Esp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol.Icmp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Icmp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Icmp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Icmp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSecurityRuleProtocol.Udp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Udp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Udp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Udp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownServiceProviderProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link ServiceProviderProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownServiceProviderProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownServiceProviderProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownServiceProviderProvisioningState.Deprovisioning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deprovisioning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deprovisioning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deprovisioning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownServiceProviderProvisioningState.NotProvisioned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotProvisioned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotProvisioned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotProvisioned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownServiceProviderProvisioningState.Provisioned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Provisioned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Provisioned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Provisioned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownServiceProviderProvisioningState.Provisioning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Provisioning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Provisioning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Provisioning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownSeverity:enum",
+          "docComment": "/**\n * Known values of {@link Severity} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSeverity "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSeverity",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSeverity.Error:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Error = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Error\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Error",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownSeverity.Warning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Warning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Warning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Warning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownTransportProtocol:enum",
+          "docComment": "/**\n * Known values of {@link TransportProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTransportProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTransportProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTransportProtocol.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTransportProtocol.Tcp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tcp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tcp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tcp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTransportProtocol.Udp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Udp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Udp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Udp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownTunnelConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link TunnelConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTunnelConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTunnelConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTunnelConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTunnelConnectionStatus.Connecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTunnelConnectionStatus.NotConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownTunnelConnectionStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownUsageUnit:enum",
+          "docComment": "/**\n * Known values of {@link UsageUnit} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownUsageUnit "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownUsageUnit",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownUsageUnit.Count:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Count = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Count\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Count",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVerbosityLevel:enum",
+          "docComment": "/**\n * Known values of {@link VerbosityLevel} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVerbosityLevel "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVerbosityLevel",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVerbosityLevel.Full:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Full = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Full\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Full",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVerbosityLevel.Minimum:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Minimum = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Minimum\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Minimum",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVerbosityLevel.Normal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Normal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Normal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Normal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionProtocol:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkGatewayConnectionProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkGatewayConnectionProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkGatewayConnectionProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionProtocol.IKEv1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IKEv1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IKEv1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IKEv1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionProtocol.IKEv2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IKEv2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IKEv2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IKEv2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkGatewayConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkGatewayConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkGatewayConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionStatus.Connecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionStatus.NotConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionType:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkGatewayConnectionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkGatewayConnectionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkGatewayConnectionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionType.ExpressRoute:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExpressRoute = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExpressRoute\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExpressRoute",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionType.IPsec:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPsec = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPsec\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPsec",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionType.Vnet2Vnet:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Vnet2Vnet = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Vnet2Vnet\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Vnet2Vnet",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayConnectionType.VPNClient:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VPNClient = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VPNClient\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VPNClient",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkGatewaySkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkGatewaySkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkGatewaySkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.ErGw1AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ErGw1AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ErGw1AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ErGw1AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.ErGw2AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ErGw2AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ErGw2AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ErGw2AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.ErGw3AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ErGw3AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ErGw3AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ErGw3AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.HighPerformance:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HighPerformance = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HighPerformance\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HighPerformance",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.UltraPerformance:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UltraPerformance = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UltraPerformance\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UltraPerformance",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw1AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw1AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw1AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw1AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw2AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw2AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw2AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw2AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw3AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw3AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw3AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw3AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw4AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw4AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw4AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw4AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuName.VpnGw5AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw5AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw5AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw5AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkGatewaySkuTier} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkGatewaySkuTier "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkGatewaySkuTier",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.ErGw1AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ErGw1AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ErGw1AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ErGw1AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.ErGw2AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ErGw2AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ErGw2AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ErGw2AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.ErGw3AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ErGw3AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ErGw3AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ErGw3AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.HighPerformance:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HighPerformance = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HighPerformance\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HighPerformance",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.UltraPerformance:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UltraPerformance = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UltraPerformance\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UltraPerformance",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw1AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw1AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw1AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw1AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw2AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw2AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw2AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw2AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw3AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw3AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw3AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw3AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw4AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw4AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw4AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw4AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw5:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw5 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw5\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw5",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewaySkuTier.VpnGw5AZ:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VpnGw5AZ = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VpnGw5AZ\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VpnGw5AZ",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayType:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkGatewayType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkGatewayType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkGatewayType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayType.ExpressRoute:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExpressRoute = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExpressRoute\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExpressRoute",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkGatewayType.Vpn:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Vpn = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Vpn\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Vpn",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualNetworkPeeringState:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkPeeringState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkPeeringState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkPeeringState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkPeeringState.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkPeeringState.Disconnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disconnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disconnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disconnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualNetworkPeeringState.Initiated:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Initiated = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Initiated\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Initiated",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVirtualWanSecurityProviderType:enum",
+          "docComment": "/**\n * Known values of {@link VirtualWanSecurityProviderType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualWanSecurityProviderType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualWanSecurityProviderType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualWanSecurityProviderType.External:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "External = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"External\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "External",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVirtualWanSecurityProviderType.Native:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Native = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Native\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Native",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVpnAuthenticationType:enum",
+          "docComment": "/**\n * Known values of {@link VpnAuthenticationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVpnAuthenticationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVpnAuthenticationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnAuthenticationType.AAD:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AAD = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AAD\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AAD",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnAuthenticationType.Certificate:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Certificate = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Certificate\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Certificate",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnAuthenticationType.Radius:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Radius = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Radius\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Radius",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVpnClientProtocol:enum",
+          "docComment": "/**\n * Known values of {@link VpnClientProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVpnClientProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVpnClientProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnClientProtocol.IkeV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IkeV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IkeV2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IkeV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnClientProtocol.OpenVPN:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OpenVPN = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OpenVPN\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OpenVPN",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnClientProtocol.Sstp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Sstp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SSTP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Sstp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVpnConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link VpnConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVpnConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVpnConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnConnectionStatus.Connected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnConnectionStatus.Connecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Connecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Connecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Connecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnConnectionStatus.NotConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnConnectionStatus.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVpnGatewayGeneration:enum",
+          "docComment": "/**\n * Known values of {@link VpnGatewayGeneration} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVpnGatewayGeneration "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVpnGatewayGeneration",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnGatewayGeneration.Generation1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Generation1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Generation1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Generation1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnGatewayGeneration.Generation2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Generation2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Generation2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Generation2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnGatewayGeneration.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVpnGatewayTunnelingProtocol:enum",
+          "docComment": "/**\n * Known values of {@link VpnGatewayTunnelingProtocol} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVpnGatewayTunnelingProtocol "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVpnGatewayTunnelingProtocol",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnGatewayTunnelingProtocol.IkeV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IkeV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IkeV2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IkeV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnGatewayTunnelingProtocol.OpenVPN:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OpenVPN = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OpenVPN\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OpenVPN",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownVpnType:enum",
+          "docComment": "/**\n * Known values of {@link VpnType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVpnType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVpnType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnType.PolicyBased:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PolicyBased = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PolicyBased\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PolicyBased",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownVpnType.RouteBased:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RouteBased = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RouteBased\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RouteBased",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallAction:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallAction} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallAction "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallAction",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallAction.Allow:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Allow = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Allow\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Allow",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallAction.Block:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Block = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Block\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Block",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallAction.Log:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Log = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Log\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Log",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallEnabledState:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallEnabledState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallEnabledState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallEnabledState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallEnabledState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallEnabledState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallMatchVariable} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallMatchVariable "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallMatchVariable",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.PostArgs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PostArgs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PostArgs\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PostArgs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.QueryString:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "QueryString = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"QueryString\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "QueryString",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.RemoteAddr:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RemoteAddr = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RemoteAddr\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RemoteAddr",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.RequestBody:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestBody = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestBody\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestBody",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.RequestCookies:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestCookies = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestCookies\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestCookies",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.RequestHeaders:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestHeaders = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestHeaders\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestHeaders",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.RequestMethod:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestMethod = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestMethod\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestMethod",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMatchVariable.RequestUri:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RequestUri = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RequestUri\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RequestUri",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMode:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMode.Detection:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Detection = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Detection\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Detection",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallMode.Prevention:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Prevention = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Prevention\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Prevention",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallOperator} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallOperator "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallOperator",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.BeginsWith:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BeginsWith = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BeginsWith\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BeginsWith",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.Contains:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Contains = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Contains\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Contains",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.EndsWith:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EndsWith = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EndsWith\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EndsWith",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.Equal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Equal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Equal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Equal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.GeoMatch:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GeoMatch = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GeoMatch\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GeoMatch",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.GreaterThan:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GreaterThan = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GreaterThan\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GreaterThan",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.GreaterThanOrEqual:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GreaterThanOrEqual = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GreaterThanOrEqual\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GreaterThanOrEqual",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.IPMatch:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "IPMatch = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"IPMatch\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "IPMatch",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.LessThan:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LessThan = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LessThan\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LessThan",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.LessThanOrEqual:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LessThanOrEqual = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LessThanOrEqual\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LessThanOrEqual",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallOperator.Regex:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Regex = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Regex\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Regex",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallPolicyResourceState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallPolicyResourceState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallPolicyResourceState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState.Disabling:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabling = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabling\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabling",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallPolicyResourceState.Enabling:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabling = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabling\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabling",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallRuleType:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallRuleType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallRuleType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallRuleType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallRuleType.Invalid:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Invalid = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Invalid\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Invalid",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallRuleType.MatchRule:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MatchRule = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MatchRule\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MatchRule",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform:enum",
+          "docComment": "/**\n * Known values of {@link WebApplicationFirewallTransform} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownWebApplicationFirewallTransform "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownWebApplicationFirewallTransform",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform.HtmlEntityDecode:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HtmlEntityDecode = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HtmlEntityDecode\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HtmlEntityDecode",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform.Lowercase:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Lowercase = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Lowercase\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Lowercase",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform.RemoveNulls:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RemoveNulls = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RemoveNulls\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RemoveNulls",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform.Trim:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Trim = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Trim\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Trim",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform.UrlDecode:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UrlDecode = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UrlDecode\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UrlDecode",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "network-resource-manager!KnownWebApplicationFirewallTransform.UrlEncode:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UrlEncode = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UrlEncode\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UrlEncode",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -35689,7 +47560,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!LoadBalancerOutboundRuleProtocol:type",
-          "docComment": "/**\n * Defines values for LoadBalancerOutboundRuleProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for LoadBalancerOutboundRuleProtocol. \\ {@link KnownLoadBalancerOutboundRuleProtocol} can be used interchangeably with LoadBalancerOutboundRuleProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Tcp** \\ **Udp** \\ **All**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -35697,7 +47568,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Tcp\" | \"Udp\" | \"All\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -36288,7 +48159,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!LoadBalancerSkuName:type",
-          "docComment": "/**\n * Defines values for LoadBalancerSkuName.\n */\n",
+          "docComment": "/**\n * Defines values for LoadBalancerSkuName. \\ {@link KnownLoadBalancerSkuName} can be used interchangeably with LoadBalancerSkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **Standard**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36296,7 +48167,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"Standard\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -36637,7 +48508,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!LoadDistribution:type",
-          "docComment": "/**\n * Defines values for LoadDistribution.\n */\n",
+          "docComment": "/**\n * Defines values for LoadDistribution. \\ {@link KnownLoadDistribution} can be used interchangeably with LoadDistribution, this enum contains the known values that the service supports. ### Know values supported by the service **Default** \\ **SourceIP** \\ **SourceIPProtocol**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36645,7 +48516,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | \"SourceIP\" | \"SourceIPProtocol\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -37139,7 +49010,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ManagedRuleEnabledState:type",
-          "docComment": "/**\n * Defines values for ManagedRuleEnabledState.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedRuleEnabledState. \\ {@link KnownManagedRuleEnabledState} can be used interchangeably with ManagedRuleEnabledState, this enum contains the known values that the service supports. ### Know values supported by the service **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -37147,7 +49018,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -38622,7 +50493,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!NatGatewaySkuName:type",
-          "docComment": "/**\n * Defines values for NatGatewaySkuName.\n */\n",
+          "docComment": "/**\n * Defines values for NatGatewaySkuName. \\ {@link KnownNatGatewaySkuName} can be used interchangeably with NatGatewaySkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Standard**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -38630,7 +50501,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -46158,7 +58029,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!NetworkOperationStatus:type",
-          "docComment": "/**\n * Defines values for NetworkOperationStatus.\n */\n",
+          "docComment": "/**\n * Defines values for NetworkOperationStatus. \\ {@link KnownNetworkOperationStatus} can be used interchangeably with NetworkOperationStatus, this enum contains the known values that the service supports. ### Know values supported by the service **InProgress** \\ **Succeeded** \\ **Failed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -46166,7 +58037,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"InProgress\" | \"Succeeded\" | \"Failed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -49417,7 +61288,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!NextHopType:type",
-          "docComment": "/**\n * Defines values for NextHopType.\n */\n",
+          "docComment": "/**\n * Defines values for NextHopType. \\ {@link KnownNextHopType} can be used interchangeably with NextHopType, this enum contains the known values that the service supports. ### Know values supported by the service **Internet** \\ **VirtualAppliance** \\ **VirtualNetworkGateway** \\ **VnetLocal** \\ **HyperNetGateway** \\ **None**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -49425,7 +61296,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Internet\" | \"VirtualAppliance\" | \"VirtualNetworkGateway\" | \"VnetLocal\" | \"HyperNetGateway\" | \"None\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -49442,7 +61313,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!OfficeTrafficCategory:type",
-          "docComment": "/**\n * Defines values for OfficeTrafficCategory.\n */\n",
+          "docComment": "/**\n * Defines values for OfficeTrafficCategory. \\ {@link KnownOfficeTrafficCategory} can be used interchangeably with OfficeTrafficCategory, this enum contains the known values that the service supports. ### Know values supported by the service **Optimize** \\ **OptimizeAndAllow** \\ **All** \\ **None**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -49450,7 +61321,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Optimize\" | \"OptimizeAndAllow\" | \"All\" | \"None\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -49944,7 +61815,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!Origin:type",
-          "docComment": "/**\n * Defines values for Origin.\n */\n",
+          "docComment": "/**\n * Defines values for Origin. \\ {@link KnownOrigin} can be used interchangeably with Origin, this enum contains the known values that the service supports. ### Know values supported by the service **Local** \\ **Inbound** \\ **Outbound**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -49952,7 +61823,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Local\" | \"Inbound\" | \"Outbound\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50035,7 +61906,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!OutputType:type",
-          "docComment": "/**\n * Defines values for OutputType.\n */\n",
+          "docComment": "/**\n * Defines values for OutputType. \\ {@link KnownOutputType} can be used interchangeably with OutputType, this enum contains the known values that the service supports. ### Know values supported by the service **Workspace**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50043,7 +61914,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Workspace\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50153,7 +62024,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!OwaspCrsExclusionEntryMatchVariable:type",
-          "docComment": "/**\n * Defines values for OwaspCrsExclusionEntryMatchVariable.\n */\n",
+          "docComment": "/**\n * Defines values for OwaspCrsExclusionEntryMatchVariable. \\ {@link KnownOwaspCrsExclusionEntryMatchVariable} can be used interchangeably with OwaspCrsExclusionEntryMatchVariable, this enum contains the known values that the service supports. ### Know values supported by the service **RequestHeaderNames** \\ **RequestCookieNames** \\ **RequestArgNames**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50161,7 +62032,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"RequestHeaderNames\" | \"RequestCookieNames\" | \"RequestArgNames\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50178,7 +62049,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!OwaspCrsExclusionEntrySelectorMatchOperator:type",
-          "docComment": "/**\n * Defines values for OwaspCrsExclusionEntrySelectorMatchOperator.\n */\n",
+          "docComment": "/**\n * Defines values for OwaspCrsExclusionEntrySelectorMatchOperator. \\ {@link KnownOwaspCrsExclusionEntrySelectorMatchOperator} can be used interchangeably with OwaspCrsExclusionEntrySelectorMatchOperator, this enum contains the known values that the service supports. ### Know values supported by the service **Equals** \\ **Contains** \\ **StartsWith** \\ **EndsWith** \\ **EqualsAny**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50186,7 +62057,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Equals\" | \"Contains\" | \"StartsWith\" | \"EndsWith\" | \"EqualsAny\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -52536,7 +64407,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PcError:type",
-          "docComment": "/**\n * Defines values for PcError.\n */\n",
+          "docComment": "/**\n * Defines values for PcError. \\ {@link KnownPcError} can be used interchangeably with PcError, this enum contains the known values that the service supports. ### Know values supported by the service **InternalError** \\ **AgentStopped** \\ **CaptureFailed** \\ **LocalFileFailed** \\ **StorageFailed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -52544,7 +64415,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"InternalError\" | \"AgentStopped\" | \"CaptureFailed\" | \"LocalFileFailed\" | \"StorageFailed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -52561,7 +64432,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PcProtocol:type",
-          "docComment": "/**\n * Defines values for PcProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for PcProtocol. \\ {@link KnownPcProtocol} can be used interchangeably with PcProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **TCP** \\ **UDP** \\ **Any**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -52569,7 +64440,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TCP\" | \"UDP\" | \"Any\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -52586,7 +64457,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PcStatus:type",
-          "docComment": "/**\n * Defines values for PcStatus.\n */\n",
+          "docComment": "/**\n * Defines values for PcStatus. \\ {@link KnownPcStatus} can be used interchangeably with PcStatus, this enum contains the known values that the service supports. ### Know values supported by the service **NotStarted** \\ **Running** \\ **Stopped** \\ **Error** \\ **Unknown**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -52594,7 +64465,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotStarted\" | \"Running\" | \"Stopped\" | \"Error\" | \"Unknown\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -52892,7 +64763,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PfsGroup:type",
-          "docComment": "/**\n * Defines values for PfsGroup.\n */\n",
+          "docComment": "/**\n * Defines values for PfsGroup. \\ {@link KnownPfsGroup} can be used interchangeably with PfsGroup, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **PFS1** \\ **PFS2** \\ **PFS2048** \\ **ECP256** \\ **ECP384** \\ **PFS24** \\ **PFS14** \\ **PFSMM**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -52900,7 +64771,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"PFS1\" | \"PFS2\" | \"PFS2048\" | \"ECP256\" | \"ECP384\" | \"PFS24\" | \"PFS14\" | \"PFSMM\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -53060,7 +64931,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PreferredIPVersion:type",
-          "docComment": "/**\n * Defines values for PreferredIPVersion.\n */\n",
+          "docComment": "/**\n * Defines values for PreferredIPVersion. \\ {@link KnownPreferredIPVersion} can be used interchangeably with PreferredIPVersion, this enum contains the known values that the service supports. ### Know values supported by the service **IPv4** \\ **IPv6**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -53068,7 +64939,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IPv4\" | \"IPv6\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -55660,7 +67531,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ProbeProtocol:type",
-          "docComment": "/**\n * Defines values for ProbeProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for ProbeProtocol. \\ {@link KnownProbeProtocol} can be used interchangeably with ProbeProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Http** \\ **Tcp** \\ **Https**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -55668,7 +67539,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Http\" | \"Tcp\" | \"Https\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -55685,7 +67556,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ProcessorArchitecture:type",
-          "docComment": "/**\n * Defines values for ProcessorArchitecture.\n */\n",
+          "docComment": "/**\n * Defines values for ProcessorArchitecture. \\ {@link KnownProcessorArchitecture} can be used interchangeably with ProcessorArchitecture, this enum contains the known values that the service supports. ### Know values supported by the service **Amd64** \\ **X86**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -55693,7 +67564,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Amd64\" | \"X86\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -55781,7 +67652,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!Protocol:type",
-          "docComment": "/**\n * Defines values for Protocol.\n */\n",
+          "docComment": "/**\n * Defines values for Protocol. \\ {@link KnownProtocol} can be used interchangeably with Protocol, this enum contains the known values that the service supports. ### Know values supported by the service **Tcp** \\ **Http** \\ **Https** \\ **Icmp**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -55789,7 +67660,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Tcp\" | \"Http\" | \"Https\" | \"Icmp\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -55966,7 +67837,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ProvisioningState:type",
-          "docComment": "/**\n * Defines values for ProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for ProvisioningState. \\ {@link KnownProvisioningState} can be used interchangeably with ProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Succeeded** \\ **Updating** \\ **Deleting** \\ **Failed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -55974,7 +67845,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Succeeded\" | \"Updating\" | \"Deleting\" | \"Failed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -57018,7 +68889,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PublicIPAddressSkuName:type",
-          "docComment": "/**\n * Defines values for PublicIPAddressSkuName.\n */\n",
+          "docComment": "/**\n * Defines values for PublicIPAddressSkuName. \\ {@link KnownPublicIPAddressSkuName} can be used interchangeably with PublicIPAddressSkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **Standard**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -57026,7 +68897,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"Standard\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -57653,7 +69524,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!PublicIPPrefixSkuName:type",
-          "docComment": "/**\n * Defines values for PublicIPPrefixSkuName.\n */\n",
+          "docComment": "/**\n * Defines values for PublicIPPrefixSkuName. \\ {@link KnownPublicIPPrefixSkuName} can be used interchangeably with PublicIPPrefixSkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Standard**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -57661,7 +69532,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -58972,7 +70843,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!RouteFilterRuleType:type",
-          "docComment": "/**\n * Defines values for RouteFilterRuleType.\n */\n",
+          "docComment": "/**\n * Defines values for RouteFilterRuleType. \\ {@link KnownRouteFilterRuleType} can be used interchangeably with RouteFilterRuleType, this enum contains the known values that the service supports. ### Know values supported by the service **Community**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -58980,7 +70851,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Community\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -59481,7 +71352,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!RouteNextHopType:type",
-          "docComment": "/**\n * Defines values for RouteNextHopType.\n */\n",
+          "docComment": "/**\n * Defines values for RouteNextHopType. \\ {@link KnownRouteNextHopType} can be used interchangeably with RouteNextHopType, this enum contains the known values that the service supports. ### Know values supported by the service **VirtualNetworkGateway** \\ **VnetLocal** \\ **Internet** \\ **VirtualAppliance** \\ **None**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -59489,7 +71360,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"VirtualNetworkGateway\" | \"VnetLocal\" | \"Internet\" | \"VirtualAppliance\" | \"None\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -60571,7 +72442,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!SecurityPartnerProviderConnectionStatus:type",
-          "docComment": "/**\n * Defines values for SecurityPartnerProviderConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityPartnerProviderConnectionStatus. \\ {@link KnownSecurityPartnerProviderConnectionStatus} can be used interchangeably with SecurityPartnerProviderConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **PartiallyConnected** \\ **Connected** \\ **NotConnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -60579,7 +72450,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"PartiallyConnected\" | \"Connected\" | \"NotConnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -61021,7 +72892,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!SecurityProviderName:type",
-          "docComment": "/**\n * Defines values for SecurityProviderName.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityProviderName. \\ {@link KnownSecurityProviderName} can be used interchangeably with SecurityProviderName, this enum contains the known values that the service supports. ### Know values supported by the service **ZScaler** \\ **IBoss** \\ **Checkpoint**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -61029,7 +72900,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ZScaler\" | \"IBoss\" | \"Checkpoint\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -61130,7 +73001,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!SecurityRuleAccess:type",
-          "docComment": "/**\n * Defines values for SecurityRuleAccess.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityRuleAccess. \\ {@link KnownSecurityRuleAccess} can be used interchangeably with SecurityRuleAccess, this enum contains the known values that the service supports. ### Know values supported by the service **Allow** \\ **Deny**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -61138,7 +73009,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Allow\" | \"Deny\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -61283,7 +73154,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!SecurityRuleDirection:type",
-          "docComment": "/**\n * Defines values for SecurityRuleDirection.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityRuleDirection. \\ {@link KnownSecurityRuleDirection} can be used interchangeably with SecurityRuleDirection, this enum contains the known values that the service supports. ### Know values supported by the service **Inbound** \\ **Outbound**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -61291,7 +73162,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Inbound\" | \"Outbound\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -61379,7 +73250,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!SecurityRuleProtocol:type",
-          "docComment": "/**\n * Defines values for SecurityRuleProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityRuleProtocol. \\ {@link KnownSecurityRuleProtocol} can be used interchangeably with SecurityRuleProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Tcp** \\ **Udp** \\ **Icmp** \\ **Esp** \\ ***** \\ **Ah**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -61387,7 +73258,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Tcp\" | \"Udp\" | \"Icmp\" | \"Esp\" | \"*\" | \"Ah\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -62725,7 +74596,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!ServiceProviderProvisioningState:type",
-          "docComment": "/**\n * Defines values for ServiceProviderProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for ServiceProviderProvisioningState. \\ {@link KnownServiceProviderProvisioningState} can be used interchangeably with ServiceProviderProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **NotProvisioned** \\ **Provisioning** \\ **Provisioned** \\ **Deprovisioning**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -62733,7 +74604,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotProvisioned\" | \"Provisioning\" | \"Provisioned\" | \"Deprovisioning\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -63218,7 +75089,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!Severity:type",
-          "docComment": "/**\n * Defines values for Severity.\n */\n",
+          "docComment": "/**\n * Defines values for Severity. \\ {@link KnownSeverity} can be used interchangeably with Severity, this enum contains the known values that the service supports. ### Know values supported by the service **Error** \\ **Warning**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -63226,7 +75097,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Error\" | \"Warning\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -64652,7 +76523,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!TransportProtocol:type",
-          "docComment": "/**\n * Defines values for TransportProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for TransportProtocol. \\ {@link KnownTransportProtocol} can be used interchangeably with TransportProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **Udp** \\ **Tcp** \\ **All**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -64660,7 +76531,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Udp\" | \"Tcp\" | \"All\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -65295,7 +77166,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!TunnelConnectionStatus:type",
-          "docComment": "/**\n * Defines values for TunnelConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for TunnelConnectionStatus. \\ {@link KnownTunnelConnectionStatus} can be used interchangeably with TunnelConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Connecting** \\ **Connected** \\ **NotConnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -65303,7 +77174,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Connecting\" | \"Connected\" | \"NotConnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -65737,7 +77608,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!UsageUnit:type",
-          "docComment": "/**\n * Defines values for UsageUnit.\n */\n",
+          "docComment": "/**\n * Defines values for UsageUnit. \\ {@link KnownUsageUnit} can be used interchangeably with UsageUnit, this enum contains the known values that the service supports. ### Know values supported by the service **Count**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -65745,7 +77616,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Count\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -65762,7 +77633,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VerbosityLevel:type",
-          "docComment": "/**\n * Defines values for VerbosityLevel.\n */\n",
+          "docComment": "/**\n * Defines values for VerbosityLevel. \\ {@link KnownVerbosityLevel} can be used interchangeably with VerbosityLevel, this enum contains the known values that the service supports. ### Know values supported by the service **Normal** \\ **Minimum** \\ **Full**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -65770,7 +77641,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Normal\" | \"Minimum\" | \"Full\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -67913,7 +79784,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkGatewayConnectionProtocol:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkGatewayConnectionProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkGatewayConnectionProtocol. \\ {@link KnownVirtualNetworkGatewayConnectionProtocol} can be used interchangeably with VirtualNetworkGatewayConnectionProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **IKEv2** \\ **IKEv1**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -67921,7 +79792,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IKEv2\" | \"IKEv1\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -68492,7 +80363,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkGatewayConnectionStatus:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkGatewayConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkGatewayConnectionStatus. \\ {@link KnownVirtualNetworkGatewayConnectionStatus} can be used interchangeably with VirtualNetworkGatewayConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Connecting** \\ **Connected** \\ **NotConnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -68500,7 +80371,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Connecting\" | \"Connected\" | \"NotConnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -68583,7 +80454,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkGatewayConnectionType:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkGatewayConnectionType.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkGatewayConnectionType. \\ {@link KnownVirtualNetworkGatewayConnectionType} can be used interchangeably with VirtualNetworkGatewayConnectionType, this enum contains the known values that the service supports. ### Know values supported by the service **IPsec** \\ **Vnet2Vnet** \\ **ExpressRoute** \\ **VPNClient**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -68591,7 +80462,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IPsec\" | \"Vnet2Vnet\" | \"ExpressRoute\" | \"VPNClient\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -69568,7 +81439,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkGatewaySkuName:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkGatewaySkuName.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkGatewaySkuName. \\ {@link KnownVirtualNetworkGatewaySkuName} can be used interchangeably with VirtualNetworkGatewaySkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **HighPerformance** \\ **Standard** \\ **UltraPerformance** \\ **VpnGw1** \\ **VpnGw2** \\ **VpnGw3** \\ **VpnGw4** \\ **VpnGw5** \\ **VpnGw1AZ** \\ **VpnGw2AZ** \\ **VpnGw3AZ** \\ **VpnGw4AZ** \\ **VpnGw5AZ** \\ **ErGw1AZ** \\ **ErGw2AZ** \\ **ErGw3AZ**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -69576,7 +81447,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"HighPerformance\" | \"Standard\" | \"UltraPerformance\" | \"VpnGw1\" | \"VpnGw2\" | \"VpnGw3\" | \"VpnGw4\" | \"VpnGw5\" | \"VpnGw1AZ\" | \"VpnGw2AZ\" | \"VpnGw3AZ\" | \"VpnGw4AZ\" | \"VpnGw5AZ\" | \"ErGw1AZ\" | \"ErGw2AZ\" | \"ErGw3AZ\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -69593,7 +81464,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkGatewaySkuTier:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkGatewaySkuTier.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkGatewaySkuTier. \\ {@link KnownVirtualNetworkGatewaySkuTier} can be used interchangeably with VirtualNetworkGatewaySkuTier, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **HighPerformance** \\ **Standard** \\ **UltraPerformance** \\ **VpnGw1** \\ **VpnGw2** \\ **VpnGw3** \\ **VpnGw4** \\ **VpnGw5** \\ **VpnGw1AZ** \\ **VpnGw2AZ** \\ **VpnGw3AZ** \\ **VpnGw4AZ** \\ **VpnGw5AZ** \\ **ErGw1AZ** \\ **ErGw2AZ** \\ **ErGw3AZ**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -69601,7 +81472,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"HighPerformance\" | \"Standard\" | \"UltraPerformance\" | \"VpnGw1\" | \"VpnGw2\" | \"VpnGw3\" | \"VpnGw4\" | \"VpnGw5\" | \"VpnGw1AZ\" | \"VpnGw2AZ\" | \"VpnGw3AZ\" | \"VpnGw4AZ\" | \"VpnGw5AZ\" | \"ErGw1AZ\" | \"ErGw2AZ\" | \"ErGw3AZ\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -70299,7 +82170,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkGatewayType:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkGatewayType.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkGatewayType. \\ {@link KnownVirtualNetworkGatewayType} can be used interchangeably with VirtualNetworkGatewayType, this enum contains the known values that the service supports. ### Know values supported by the service **Vpn** \\ **ExpressRoute**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -70307,7 +82178,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Vpn\" | \"ExpressRoute\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -70813,7 +82684,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualNetworkPeeringState:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkPeeringState.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkPeeringState. \\ {@link KnownVirtualNetworkPeeringState} can be used interchangeably with VirtualNetworkPeeringState, this enum contains the known values that the service supports. ### Know values supported by the service **Initiated** \\ **Connected** \\ **Disconnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -70821,7 +82692,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Initiated\" | \"Connected\" | \"Disconnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -73186,7 +85057,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VirtualWanSecurityProviderType:type",
-          "docComment": "/**\n * Defines values for VirtualWanSecurityProviderType.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualWanSecurityProviderType. \\ {@link KnownVirtualWanSecurityProviderType} can be used interchangeably with VirtualWanSecurityProviderType, this enum contains the known values that the service supports. ### Know values supported by the service **External** \\ **Native**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -73194,7 +85065,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"External\" | \"Native\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -73642,7 +85513,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VpnAuthenticationType:type",
-          "docComment": "/**\n * Defines values for VpnAuthenticationType.\n */\n",
+          "docComment": "/**\n * Defines values for VpnAuthenticationType. \\ {@link KnownVpnAuthenticationType} can be used interchangeably with VpnAuthenticationType, this enum contains the known values that the service supports. ### Know values supported by the service **Certificate** \\ **Radius** \\ **AAD**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -73650,7 +85521,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Certificate\" | \"Radius\" | \"AAD\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -74802,7 +86673,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VpnClientProtocol:type",
-          "docComment": "/**\n * Defines values for VpnClientProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for VpnClientProtocol. \\ {@link KnownVpnClientProtocol} can be used interchangeably with VpnClientProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **IkeV2** \\ **SSTP** \\ **OpenVPN**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -74810,7 +86681,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IkeV2\" | \"SSTP\" | \"OpenVPN\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -75208,7 +87079,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VpnConnectionStatus:type",
-          "docComment": "/**\n * Defines values for VpnConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for VpnConnectionStatus. \\ {@link KnownVpnConnectionStatus} can be used interchangeably with VpnConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Unknown** \\ **Connecting** \\ **Connected** \\ **NotConnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -75216,7 +87087,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Unknown\" | \"Connecting\" | \"Connected\" | \"NotConnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -75390,7 +87261,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VpnGatewayGeneration:type",
-          "docComment": "/**\n * Defines values for VpnGatewayGeneration.\n */\n",
+          "docComment": "/**\n * Defines values for VpnGatewayGeneration. \\ {@link KnownVpnGatewayGeneration} can be used interchangeably with VpnGatewayGeneration, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **Generation1** \\ **Generation2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -75398,7 +87269,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"Generation1\" | \"Generation2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -75835,7 +87706,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VpnGatewayTunnelingProtocol:type",
-          "docComment": "/**\n * Defines values for VpnGatewayTunnelingProtocol.\n */\n",
+          "docComment": "/**\n * Defines values for VpnGatewayTunnelingProtocol. \\ {@link KnownVpnGatewayTunnelingProtocol} can be used interchangeably with VpnGatewayTunnelingProtocol, this enum contains the known values that the service supports. ### Know values supported by the service **IkeV2** \\ **OpenVPN**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -75843,7 +87714,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IkeV2\" | \"OpenVPN\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -77859,7 +89730,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!VpnType:type",
-          "docComment": "/**\n * Defines values for VpnType.\n */\n",
+          "docComment": "/**\n * Defines values for VpnType. \\ {@link KnownVpnType} can be used interchangeably with VpnType, this enum contains the known values that the service supports. ### Know values supported by the service **PolicyBased** \\ **RouteBased**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -77867,7 +89738,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"PolicyBased\" | \"RouteBased\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -77884,7 +89755,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallAction:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallAction.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallAction. \\ {@link KnownWebApplicationFirewallAction} can be used interchangeably with WebApplicationFirewallAction, this enum contains the known values that the service supports. ### Know values supported by the service **Allow** \\ **Block** \\ **Log**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -77892,7 +89763,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Allow\" | \"Block\" | \"Log\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78082,7 +89953,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallEnabledState:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallEnabledState.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallEnabledState. \\ {@link KnownWebApplicationFirewallEnabledState} can be used interchangeably with WebApplicationFirewallEnabledState, this enum contains the known values that the service supports. ### Know values supported by the service **Disabled** \\ **Enabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78090,7 +89961,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Disabled\" | \"Enabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78107,7 +89978,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallMatchVariable:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallMatchVariable.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallMatchVariable. \\ {@link KnownWebApplicationFirewallMatchVariable} can be used interchangeably with WebApplicationFirewallMatchVariable, this enum contains the known values that the service supports. ### Know values supported by the service **RemoteAddr** \\ **RequestMethod** \\ **QueryString** \\ **PostArgs** \\ **RequestUri** \\ **RequestHeaders** \\ **RequestBody** \\ **RequestCookies**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78115,7 +89986,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"RemoteAddr\" | \"RequestMethod\" | \"QueryString\" | \"PostArgs\" | \"RequestUri\" | \"RequestHeaders\" | \"RequestBody\" | \"RequestCookies\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78132,7 +90003,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallMode:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallMode.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallMode. \\ {@link KnownWebApplicationFirewallMode} can be used interchangeably with WebApplicationFirewallMode, this enum contains the known values that the service supports. ### Know values supported by the service **Prevention** \\ **Detection**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78140,7 +90011,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Prevention\" | \"Detection\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78157,7 +90028,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallOperator:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallOperator.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallOperator. \\ {@link KnownWebApplicationFirewallOperator} can be used interchangeably with WebApplicationFirewallOperator, this enum contains the known values that the service supports. ### Know values supported by the service **IPMatch** \\ **Equal** \\ **Contains** \\ **LessThan** \\ **GreaterThan** \\ **LessThanOrEqual** \\ **GreaterThanOrEqual** \\ **BeginsWith** \\ **EndsWith** \\ **Regex** \\ **GeoMatch**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78165,7 +90036,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"IPMatch\" | \"Equal\" | \"Contains\" | \"LessThan\" | \"GreaterThan\" | \"LessThanOrEqual\" | \"GreaterThanOrEqual\" | \"BeginsWith\" | \"EndsWith\" | \"Regex\" | \"GeoMatch\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78643,7 +90514,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallPolicyResourceState:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallPolicyResourceState.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallPolicyResourceState. \\ {@link KnownWebApplicationFirewallPolicyResourceState} can be used interchangeably with WebApplicationFirewallPolicyResourceState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Enabling** \\ **Enabled** \\ **Disabling** \\ **Disabled** \\ **Deleting**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78651,7 +90522,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Enabling\" | \"Enabled\" | \"Disabling\" | \"Disabled\" | \"Deleting\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78668,7 +90539,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallRuleType:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallRuleType.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallRuleType. \\ {@link KnownWebApplicationFirewallRuleType} can be used interchangeably with WebApplicationFirewallRuleType, this enum contains the known values that the service supports. ### Know values supported by the service **MatchRule** \\ **Invalid**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78676,7 +90547,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"MatchRule\" | \"Invalid\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -78693,7 +90564,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "network-resource-manager!WebApplicationFirewallTransform:type",
-          "docComment": "/**\n * Defines values for WebApplicationFirewallTransform.\n */\n",
+          "docComment": "/**\n * Defines values for WebApplicationFirewallTransform. \\ {@link KnownWebApplicationFirewallTransform} can be used interchangeably with WebApplicationFirewallTransform, this enum contains the known values that the service supports. ### Know values supported by the service **Lowercase** \\ **Trim** \\ **UrlDecode** \\ **UrlEncode** \\ **RemoveNulls** \\ **HtmlEntityDecode**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -78701,7 +90572,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Lowercase\" | \"Trim\" | \"UrlDecode\" | \"UrlEncode\" | \"RemoveNulls\" | \"HtmlEntityDecode\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.md
+++ b/test/smoke/generated/network-resource-manager/temp/network-resource-manager.api.md
@@ -22,7 +22,7 @@ export interface AadAuthenticationParameters {
 }
 
 // @public
-export type Access = "Allow" | "Deny" | string;
+export type Access = string;
 
 // @public
 export interface AddressSpace {
@@ -144,7 +144,7 @@ export interface ApplicationGatewayBackendHealthServer {
 }
 
 // @public
-export type ApplicationGatewayBackendHealthServerHealth = "Unknown" | "Up" | "Down" | "Partial" | "Draining" | string;
+export type ApplicationGatewayBackendHealthServerHealth = string;
 
 // @public
 export type ApplicationGatewayBackendHttpSettings = SubResource & {
@@ -174,7 +174,7 @@ export interface ApplicationGatewayConnectionDraining {
 }
 
 // @public
-export type ApplicationGatewayCookieBasedAffinity = "Enabled" | "Disabled" | string;
+export type ApplicationGatewayCookieBasedAffinity = string;
 
 // @public
 export interface ApplicationGatewayCustomError {
@@ -183,7 +183,7 @@ export interface ApplicationGatewayCustomError {
 }
 
 // @public
-export type ApplicationGatewayCustomErrorStatusCode = "HttpStatus403" | "HttpStatus502" | string;
+export type ApplicationGatewayCustomErrorStatusCode = string;
 
 // @public
 export interface ApplicationGatewayFirewallDisabledRuleGroup {
@@ -199,7 +199,7 @@ export interface ApplicationGatewayFirewallExclusion {
 }
 
 // @public
-export type ApplicationGatewayFirewallMode = "Detection" | "Prevention" | string;
+export type ApplicationGatewayFirewallMode = string;
 
 // @public
 export interface ApplicationGatewayFirewallRule {
@@ -294,7 +294,7 @@ export interface ApplicationGatewayOnDemandProbe {
 }
 
 // @public
-export type ApplicationGatewayOperationalState = "Stopped" | "Starting" | "Running" | "Stopping" | string;
+export type ApplicationGatewayOperationalState = string;
 
 // @public
 export type ApplicationGatewayPathRule = SubResource & {
@@ -335,7 +335,7 @@ export interface ApplicationGatewayProbeHealthResponseMatch {
 }
 
 // @public
-export type ApplicationGatewayProtocol = "Http" | "Https" | string;
+export type ApplicationGatewayProtocol = string;
 
 // @public
 export type ApplicationGatewayRedirectConfiguration = SubResource & {
@@ -353,7 +353,7 @@ export type ApplicationGatewayRedirectConfiguration = SubResource & {
 };
 
 // @public
-export type ApplicationGatewayRedirectType = "Permanent" | "Found" | "SeeOther" | "Temporary" | string;
+export type ApplicationGatewayRedirectType = string;
 
 // @public
 export type ApplicationGatewayRequestRoutingRule = SubResource & {
@@ -372,7 +372,7 @@ export type ApplicationGatewayRequestRoutingRule = SubResource & {
 };
 
 // @public
-export type ApplicationGatewayRequestRoutingRuleType = "Basic" | "PathBasedRouting" | string;
+export type ApplicationGatewayRequestRoutingRuleType = string;
 
 // @public
 export interface ApplicationGatewayRewriteRule {
@@ -466,7 +466,7 @@ export interface ApplicationGatewaySku {
 }
 
 // @public
-export type ApplicationGatewaySkuName = "Standard_Small" | "Standard_Medium" | "Standard_Large" | "WAF_Medium" | "WAF_Large" | "Standard_v2" | "WAF_v2" | string;
+export type ApplicationGatewaySkuName = string;
 
 // @public
 export type ApplicationGatewaysListAllNextResponse = ApplicationGatewayListResult & {
@@ -572,7 +572,7 @@ export type ApplicationGatewaySslCertificate = SubResource & {
 };
 
 // @public
-export type ApplicationGatewaySslCipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384" | "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256" | "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA" | "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA" | "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384" | "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256" | "TLS_DHE_RSA_WITH_AES_256_CBC_SHA" | "TLS_DHE_RSA_WITH_AES_128_CBC_SHA" | "TLS_RSA_WITH_AES_256_GCM_SHA384" | "TLS_RSA_WITH_AES_128_GCM_SHA256" | "TLS_RSA_WITH_AES_256_CBC_SHA256" | "TLS_RSA_WITH_AES_128_CBC_SHA256" | "TLS_RSA_WITH_AES_256_CBC_SHA" | "TLS_RSA_WITH_AES_128_CBC_SHA" | "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384" | "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256" | "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384" | "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256" | "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA" | "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA" | "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256" | "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256" | "TLS_DHE_DSS_WITH_AES_256_CBC_SHA" | "TLS_DHE_DSS_WITH_AES_128_CBC_SHA" | "TLS_RSA_WITH_3DES_EDE_CBC_SHA" | "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA" | "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" | "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384" | string;
+export type ApplicationGatewaySslCipherSuite = string;
 
 // @public
 export interface ApplicationGatewaySslPolicy {
@@ -584,10 +584,10 @@ export interface ApplicationGatewaySslPolicy {
 }
 
 // @public
-export type ApplicationGatewaySslPolicyName = "AppGwSslPolicy20150501" | "AppGwSslPolicy20170401" | "AppGwSslPolicy20170401S" | string;
+export type ApplicationGatewaySslPolicyName = string;
 
 // @public
-export type ApplicationGatewaySslPolicyType = "Predefined" | "Custom" | string;
+export type ApplicationGatewaySslPolicyType = string;
 
 // @public
 export type ApplicationGatewaySslPredefinedPolicy = SubResource & {
@@ -597,7 +597,7 @@ export type ApplicationGatewaySslPredefinedPolicy = SubResource & {
 };
 
 // @public
-export type ApplicationGatewaySslProtocol = "TLSv1_0" | "TLSv1_1" | "TLSv1_2" | string;
+export type ApplicationGatewaySslProtocol = string;
 
 // @public
 export type ApplicationGatewaysUpdateTagsResponse = ApplicationGateway & {
@@ -608,7 +608,7 @@ export type ApplicationGatewaysUpdateTagsResponse = ApplicationGateway & {
 };
 
 // @public
-export type ApplicationGatewayTier = "Standard" | "WAF" | "Standard_v2" | "WAF_v2" | string;
+export type ApplicationGatewayTier = string;
 
 // @public
 export type ApplicationGatewayTrustedRootCertificate = SubResource & {
@@ -736,10 +736,10 @@ export type ApplicationSecurityGroupsUpdateTagsResponse = ApplicationSecurityGro
 };
 
 // @public
-export type AssociationType = "Associated" | "Contains" | string;
+export type AssociationType = string;
 
 // @public
-export type AuthenticationMethod = "EAPTLS" | "EAPMSCHAPv2" | string;
+export type AuthenticationMethod = string;
 
 // @public
 export interface AuthorizationListResult {
@@ -748,7 +748,7 @@ export interface AuthorizationListResult {
 }
 
 // @public
-export type AuthorizationUseStatus = "Available" | "InUse" | string;
+export type AuthorizationUseStatus = string;
 
 // @public
 export interface AutoApprovedPrivateLinkService {
@@ -1011,7 +1011,7 @@ export interface AzureFirewallApplicationRuleProtocol {
 }
 
 // @public
-export type AzureFirewallApplicationRuleProtocolType = "Http" | "Https" | "Mssql" | string;
+export type AzureFirewallApplicationRuleProtocolType = string;
 
 // @public
 export type AzureFirewallFqdnTag = Resource & {
@@ -1071,7 +1071,7 @@ export interface AzureFirewallNatRCAction {
 }
 
 // @public
-export type AzureFirewallNatRCActionType = "Snat" | "Dnat" | string;
+export type AzureFirewallNatRCActionType = string;
 
 // @public
 export interface AzureFirewallNatRule {
@@ -1121,7 +1121,7 @@ export type AzureFirewallNetworkRuleCollection = SubResource & {
 };
 
 // @public
-export type AzureFirewallNetworkRuleProtocol = "TCP" | "UDP" | "Any" | "ICMP" | string;
+export type AzureFirewallNetworkRuleProtocol = string;
 
 // @public
 export interface AzureFirewallPublicIPAddress {
@@ -1134,7 +1134,7 @@ export interface AzureFirewallRCAction {
 }
 
 // @public
-export type AzureFirewallRCActionType = "Allow" | "Deny" | string;
+export type AzureFirewallRCActionType = string;
 
 // @public
 export type AzureFirewallsCreateOrUpdateResponse = AzureFirewall & {
@@ -1160,10 +1160,10 @@ export interface AzureFirewallSku {
 }
 
 // @public
-export type AzureFirewallSkuName = "AZFW_VNet" | "AZFW_Hub" | string;
+export type AzureFirewallSkuName = string;
 
 // @public
-export type AzureFirewallSkuTier = "Standard" | "Premium" | string;
+export type AzureFirewallSkuTier = string;
 
 // @public
 export type AzureFirewallsListAllNextResponse = AzureFirewallListResult & {
@@ -1207,7 +1207,7 @@ export type AzureFirewallsUpdateTagsResponse = AzureFirewall & {
 };
 
 // @public
-export type AzureFirewallThreatIntelMode = "Alert" | "Deny" | "Off" | string;
+export type AzureFirewallThreatIntelMode = string;
 
 // @public
 export interface AzureReachabilityReport {
@@ -1280,7 +1280,7 @@ export interface BastionActiveSessionListResult {
 }
 
 // @public
-export type BastionConnectProtocol = "SSH" | "RDP" | string;
+export type BastionConnectProtocol = string;
 
 // @public
 export type BastionHost = Resource & {
@@ -1399,7 +1399,7 @@ export interface BGPCommunity {
 }
 
 // @public
-export type BgpPeerState = "Unknown" | "Stopped" | "Idle" | "Connecting" | "Connected" | string;
+export type BgpPeerState = string;
 
 // @public
 export interface BgpPeerStatus {
@@ -1460,7 +1460,7 @@ export interface CheckPrivateLinkServiceVisibilityRequest {
 }
 
 // @public
-export type CircuitConnectionStatus = "Connected" | "Connecting" | "Disconnected" | string;
+export type CircuitConnectionStatus = string;
 
 // @public
 export interface CloudError {
@@ -1526,10 +1526,10 @@ export interface ConnectionMonitorEndpointFilterItem {
 }
 
 // @public
-export type ConnectionMonitorEndpointFilterItemType = "AgentAddress" | string;
+export type ConnectionMonitorEndpointFilterItemType = string;
 
 // @public
-export type ConnectionMonitorEndpointFilterType = "Include" | string;
+export type ConnectionMonitorEndpointFilterType = string;
 
 // @public
 export interface ConnectionMonitorHttpConfiguration {
@@ -1641,7 +1641,7 @@ export interface ConnectionMonitorSource {
 }
 
 // @public
-export type ConnectionMonitorSourceStatus = "Unknown" | "Active" | "Inactive" | string;
+export type ConnectionMonitorSourceStatus = string;
 
 // @public
 export type ConnectionMonitorsQueryResponse = ConnectionMonitorQueryResult & {
@@ -1685,7 +1685,7 @@ export interface ConnectionMonitorTestConfiguration {
 }
 
 // @public
-export type ConnectionMonitorTestConfigurationProtocol = "Tcp" | "Http" | "Icmp" | string;
+export type ConnectionMonitorTestConfigurationProtocol = string;
 
 // @public
 export interface ConnectionMonitorTestGroup {
@@ -1697,7 +1697,7 @@ export interface ConnectionMonitorTestGroup {
 }
 
 // @public
-export type ConnectionMonitorType = "MultiEndpoint" | "SingleSourceDestination" | string;
+export type ConnectionMonitorType = string;
 
 // @public
 export interface ConnectionMonitorWorkspaceSettings {
@@ -1715,7 +1715,7 @@ export type ConnectionSharedKey = SubResource & {
 };
 
 // @public
-export type ConnectionState = "Reachable" | "Unreachable" | "Unknown" | string;
+export type ConnectionState = string;
 
 // @public
 export interface ConnectionStateSnapshot {
@@ -1732,7 +1732,7 @@ export interface ConnectionStateSnapshot {
 }
 
 // @public
-export type ConnectionStatus = "Unknown" | "Connected" | "Disconnected" | "Degraded" | string;
+export type ConnectionStatus = string;
 
 // @public
 export interface ConnectivityDestination {
@@ -1860,10 +1860,10 @@ export type DdosCustomPolicy = Resource & {
 };
 
 // @public
-export type DdosCustomPolicyProtocol = "Tcp" | "Udp" | "Syn" | string;
+export type DdosCustomPolicyProtocol = string;
 
 // @public
-export type DdosCustomPolicyTriggerSensitivityOverride = "Relaxed" | "Low" | "Default" | "High" | string;
+export type DdosCustomPolicyTriggerSensitivityOverride = string;
 
 // @public
 export interface DdosProtectionPlan {
@@ -1951,7 +1951,7 @@ export interface DdosSettings {
 }
 
 // @public
-export type DdosSettingsProtectionCoverage = "Basic" | "Standard" | string;
+export type DdosSettingsProtectionCoverage = string;
 
 // @public
 export type DefaultSecurityRulesGetResponse = SecurityRule & {
@@ -1999,7 +1999,7 @@ export interface DhcpOptions {
 }
 
 // @public
-export type DhGroup = "None" | "DHGroup1" | "DHGroup2" | "DHGroup14" | "DHGroup2048" | "ECP256" | "ECP384" | "DHGroup24" | string;
+export type DhGroup = string;
 
 // @public
 export interface Dimension {
@@ -2009,7 +2009,7 @@ export interface Dimension {
 }
 
 // @public
-export type Direction = "Inbound" | "Outbound" | string;
+export type Direction = string;
 
 // @public
 export interface DnsNameAvailabilityResult {
@@ -2073,13 +2073,13 @@ export interface EffectiveRouteListResult {
 }
 
 // @public
-export type EffectiveRouteSource = "Unknown" | "User" | "VirtualNetworkGateway" | "Default" | string;
+export type EffectiveRouteSource = string;
 
 // @public
-export type EffectiveRouteState = "Active" | "Invalid" | string;
+export type EffectiveRouteState = string;
 
 // @public
-export type EffectiveSecurityRuleProtocol = "Tcp" | "Udp" | "All" | string;
+export type EffectiveSecurityRuleProtocol = string;
 
 // @public
 export type EndpointServiceResult = SubResource & {
@@ -2123,7 +2123,7 @@ export interface EvaluatedNetworkSecurityGroup {
 }
 
 // @public
-export type EvaluationState = "NotStarted" | "InProgress" | "Completed" | string;
+export type EvaluationState = string;
 
 // @public
 export type ExpressRouteCircuit = Resource & {
@@ -2283,7 +2283,7 @@ export type ExpressRouteCircuitPeering = SubResource & {
 };
 
 // @public
-export type ExpressRouteCircuitPeeringAdvertisedPublicPrefixState = "NotConfigured" | "Configuring" | "Configured" | "ValidationNeeded" | string;
+export type ExpressRouteCircuitPeeringAdvertisedPublicPrefixState = string;
 
 // @public
 export interface ExpressRouteCircuitPeeringConfig {
@@ -2340,7 +2340,7 @@ export type ExpressRouteCircuitPeeringsListResponse = ExpressRouteCircuitPeering
 };
 
 // @public
-export type ExpressRouteCircuitPeeringState = "Disabled" | "Enabled" | string;
+export type ExpressRouteCircuitPeeringState = string;
 
 // @public
 export interface ExpressRouteCircuitReference {
@@ -2419,10 +2419,10 @@ export interface ExpressRouteCircuitSku {
 }
 
 // @public
-export type ExpressRouteCircuitSkuFamily = "UnlimitedData" | "MeteredData" | string;
+export type ExpressRouteCircuitSkuFamily = string;
 
 // @public
-export type ExpressRouteCircuitSkuTier = "Standard" | "Premium" | "Basic" | "Local" | string;
+export type ExpressRouteCircuitSkuTier = string;
 
 // @public
 export type ExpressRouteCircuitsListAllNextResponse = ExpressRouteCircuitListResult & {
@@ -2809,10 +2809,10 @@ export type ExpressRouteLink = SubResource & {
 };
 
 // @public
-export type ExpressRouteLinkAdminState = "Enabled" | "Disabled" | string;
+export type ExpressRouteLinkAdminState = string;
 
 // @public
-export type ExpressRouteLinkConnectorType = "LC" | "SC" | string;
+export type ExpressRouteLinkConnectorType = string;
 
 // @public
 export interface ExpressRouteLinkListResult {
@@ -2821,7 +2821,7 @@ export interface ExpressRouteLinkListResult {
 }
 
 // @public
-export type ExpressRouteLinkMacSecCipher = "gcm-aes-128" | "gcm-aes-256" | string;
+export type ExpressRouteLinkMacSecCipher = string;
 
 // @public
 export interface ExpressRouteLinkMacSecConfig {
@@ -2855,10 +2855,10 @@ export type ExpressRouteLinksListResponse = ExpressRouteLinkListResult & {
 };
 
 // @public
-export type ExpressRoutePeeringState = "Disabled" | "Enabled" | string;
+export type ExpressRoutePeeringState = string;
 
 // @public
-export type ExpressRoutePeeringType = "AzurePublicPeering" | "AzurePrivatePeering" | "MicrosoftPeering" | string;
+export type ExpressRoutePeeringType = string;
 
 // @public
 export type ExpressRoutePort = Resource & {
@@ -2893,7 +2893,7 @@ export type ExpressRoutePortsCreateOrUpdateResponse = ExpressRoutePort & {
 };
 
 // @public
-export type ExpressRoutePortsEncapsulation = "Dot1Q" | "QinQ" | string;
+export type ExpressRoutePortsEncapsulation = string;
 
 // @public
 export type ExpressRoutePortsGetResponse = ExpressRoutePort & {
@@ -3109,10 +3109,10 @@ export interface FirewallPolicyFilterRuleAction {
 }
 
 // @public
-export type FirewallPolicyFilterRuleActionType = "Allow" | "Deny" | string;
+export type FirewallPolicyFilterRuleActionType = string;
 
 // @public
-export type FirewallPolicyIntrusionSystemMode = "Enabled" | "Disabled" | string;
+export type FirewallPolicyIntrusionSystemMode = string;
 
 // @public
 export interface FirewallPolicyListResult {
@@ -3134,7 +3134,7 @@ export interface FirewallPolicyNatRuleAction {
 }
 
 // @public
-export type FirewallPolicyNatRuleActionType = "DNAT" | string;
+export type FirewallPolicyNatRuleActionType = string;
 
 // @public
 export interface FirewallPolicyRule {
@@ -3157,13 +3157,13 @@ export interface FirewallPolicyRuleConditionApplicationProtocol {
 }
 
 // @public
-export type FirewallPolicyRuleConditionApplicationProtocolType = "Http" | "Https" | string;
+export type FirewallPolicyRuleConditionApplicationProtocolType = string;
 
 // @public
-export type FirewallPolicyRuleConditionNetworkProtocol = "TCP" | "UDP" | "Any" | "ICMP" | string;
+export type FirewallPolicyRuleConditionNetworkProtocol = string;
 
 // @public
-export type FirewallPolicyRuleConditionType = "ApplicationRuleCondition" | "NetworkRuleCondition" | "NatRuleCondition" | string;
+export type FirewallPolicyRuleConditionType = string;
 
 // @public (undocumented)
 export type FirewallPolicyRuleConditionUnion = ApplicationRuleCondition | NatRuleCondition | NetworkRuleCondition;
@@ -3218,7 +3218,7 @@ export type FirewallPolicyRuleGroupsListResponse = FirewallPolicyRuleGroupListRe
 };
 
 // @public
-export type FirewallPolicyRuleType = "FirewallPolicyNatRule" | "FirewallPolicyFilterRule" | string;
+export type FirewallPolicyRuleType = string;
 
 // @public (undocumented)
 export type FirewallPolicyRuleUnion = FirewallPolicyNatRule | FirewallPolicyFilterRule;
@@ -3262,7 +3262,7 @@ export interface FlowLogFormatParameters {
 }
 
 // @public
-export type FlowLogFormatType = "JSON" | string;
+export type FlowLogFormatType = string;
 
 // @public
 export interface FlowLogInformation {
@@ -3367,7 +3367,7 @@ export interface HttpConfiguration {
 }
 
 // @public
-export type HttpConfigurationMethod = "Get" | "Post" | string;
+export type HttpConfigurationMethod = string;
 
 // @public
 export interface HttpHeader {
@@ -3376,7 +3376,7 @@ export interface HttpHeader {
 }
 
 // @public
-export type HttpMethod = "Get" | string;
+export type HttpMethod = string;
 
 // @public
 export interface HubIPAddresses {
@@ -3475,13 +3475,13 @@ export type HubVirtualNetworkConnectionsListResponse = ListHubVirtualNetworkConn
 };
 
 // @public
-export type HubVirtualNetworkConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type HubVirtualNetworkConnectionStatus = string;
 
 // @public
-export type IkeEncryption = "DES" | "DES3" | "AES128" | "AES192" | "AES256" | "GCMAES256" | "GCMAES128" | string;
+export type IkeEncryption = string;
 
 // @public
-export type IkeIntegrity = "MD5" | "SHA1" | "SHA256" | "SHA384" | "GCMAES256" | "GCMAES128" | string;
+export type IkeIntegrity = string;
 
 // @public
 export type InboundNatPool = SubResource & {
@@ -3587,7 +3587,7 @@ export interface IpAllocationListResult {
 }
 
 // @public
-export type IPAllocationMethod = "Static" | "Dynamic" | string;
+export type IPAllocationMethod = string;
 
 // @public
 export type IpAllocationsCreateOrUpdateResponse = IpAllocation & {
@@ -3652,7 +3652,7 @@ export type IpAllocationsUpdateTagsResponse = IpAllocation & {
 };
 
 // @public
-export type IpAllocationType = "Undefined" | "Hypernet" | string;
+export type IpAllocationType = string;
 
 // @public
 export type IPConfiguration = SubResource & {
@@ -3683,7 +3683,7 @@ export type IPConfigurationProfile = SubResource & {
 };
 
 // @public
-export type IpFlowProtocol = "TCP" | "UDP" | string;
+export type IpFlowProtocol = string;
 
 // @public
 export type IpGroup = Resource & {
@@ -3762,10 +3762,10 @@ export type IpGroupsUpdateGroupsResponse = IpGroup & {
 };
 
 // @public
-export type IpsecEncryption = "None" | "DES" | "DES3" | "AES128" | "AES192" | "AES256" | "GCMAES128" | "GCMAES192" | "GCMAES256" | string;
+export type IpsecEncryption = string;
 
 // @public
-export type IpsecIntegrity = "MD5" | "SHA1" | "SHA256" | "GCMAES128" | "GCMAES192" | "GCMAES256" | string;
+export type IpsecIntegrity = string;
 
 // @public
 export interface IpsecPolicy {
@@ -3801,10 +3801,1480 @@ export interface Ipv6ExpressRouteCircuitPeeringConfig {
 }
 
 // @public
-export type IPVersion = "IPv4" | "IPv6" | string;
+export type IPVersion = string;
 
 // @public
-export type IssueType = "Unknown" | "AgentStopped" | "GuestFirewall" | "DnsResolution" | "SocketBind" | "NetworkSecurityRule" | "UserDefinedRoute" | "PortThrottled" | "Platform" | string;
+export type IssueType = string;
+
+// @public
+export const enum KnownAccess {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownApplicationGatewayBackendHealthServerHealth {
+    // (undocumented)
+    Down = "Down",
+    // (undocumented)
+    Draining = "Draining",
+    // (undocumented)
+    Partial = "Partial",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    Up = "Up"
+}
+
+// @public
+export const enum KnownApplicationGatewayCookieBasedAffinity {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownApplicationGatewayCustomErrorStatusCode {
+    // (undocumented)
+    HttpStatus403 = "HttpStatus403",
+    // (undocumented)
+    HttpStatus502 = "HttpStatus502"
+}
+
+// @public
+export const enum KnownApplicationGatewayFirewallMode {
+    // (undocumented)
+    Detection = "Detection",
+    // (undocumented)
+    Prevention = "Prevention"
+}
+
+// @public
+export const enum KnownApplicationGatewayOperationalState {
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Starting = "Starting",
+    // (undocumented)
+    Stopped = "Stopped",
+    // (undocumented)
+    Stopping = "Stopping"
+}
+
+// @public
+export const enum KnownApplicationGatewayProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https"
+}
+
+// @public
+export const enum KnownApplicationGatewayRedirectType {
+    // (undocumented)
+    Found = "Found",
+    // (undocumented)
+    Permanent = "Permanent",
+    // (undocumented)
+    SeeOther = "SeeOther",
+    // (undocumented)
+    Temporary = "Temporary"
+}
+
+// @public
+export const enum KnownApplicationGatewayRequestRoutingRuleType {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    PathBasedRouting = "PathBasedRouting"
+}
+
+// @public
+export const enum KnownApplicationGatewaySkuName {
+    // (undocumented)
+    StandardLarge = "Standard_Large",
+    // (undocumented)
+    StandardMedium = "Standard_Medium",
+    // (undocumented)
+    StandardSmall = "Standard_Small",
+    // (undocumented)
+    StandardV2 = "Standard_v2",
+    // (undocumented)
+    WAFLarge = "WAF_Large",
+    // (undocumented)
+    WAFMedium = "WAF_Medium",
+    // (undocumented)
+    WAFV2 = "WAF_v2"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslCipherSuite {
+    // (undocumented)
+    TLSDHEDSSWith3DESEDECBCSHA = "TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+    // (undocumented)
+    TLSDHEDSSWithAES128CBCSHA = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSDHEDSSWithAES128CBCSHA256 = "TLS_DHE_DSS_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSDHEDSSWithAES256CBCSHA = "TLS_DHE_DSS_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSDHEDSSWithAES256CBCSHA256 = "TLS_DHE_DSS_WITH_AES_256_CBC_SHA256",
+    // (undocumented)
+    TLSDHERSAWithAES128CBCSHA = "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSDHERSAWithAES128GCMSHA256 = "TLS_DHE_RSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSDHERSAWithAES256CBCSHA = "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSDHERSAWithAES256GCMSHA384 = "TLS_DHE_RSA_WITH_AES_256_GCM_SHA384",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES128CBCSHA = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES128CBCSHA256 = "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES128GCMSHA256 = "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES256CBCSHA = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES256CBCSHA384 = "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+    // (undocumented)
+    TLSEcdheEcdsaWithAES256GCMSHA384 = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    // (undocumented)
+    TLSEcdheRSAWithAES128CBCSHA = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSEcdheRSAWithAES128CBCSHA256 = "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSEcdheRSAWithAES128GCMSHA256 = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSEcdheRSAWithAES256CBCSHA = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSEcdheRSAWithAES256CBCSHA384 = "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384",
+    // (undocumented)
+    TLSEcdheRSAWithAES256GCMSHA384 = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    // (undocumented)
+    TLSRSAWith3DESEDECBCSHA = "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+    // (undocumented)
+    TLSRSAWithAES128CBCSHA = "TLS_RSA_WITH_AES_128_CBC_SHA",
+    // (undocumented)
+    TLSRSAWithAES128CBCSHA256 = "TLS_RSA_WITH_AES_128_CBC_SHA256",
+    // (undocumented)
+    TLSRSAWithAES128GCMSHA256 = "TLS_RSA_WITH_AES_128_GCM_SHA256",
+    // (undocumented)
+    TLSRSAWithAES256CBCSHA = "TLS_RSA_WITH_AES_256_CBC_SHA",
+    // (undocumented)
+    TLSRSAWithAES256CBCSHA256 = "TLS_RSA_WITH_AES_256_CBC_SHA256",
+    // (undocumented)
+    TLSRSAWithAES256GCMSHA384 = "TLS_RSA_WITH_AES_256_GCM_SHA384"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslPolicyName {
+    // (undocumented)
+    AppGwSslPolicy20150501 = "AppGwSslPolicy20150501",
+    // (undocumented)
+    AppGwSslPolicy20170401 = "AppGwSslPolicy20170401",
+    // (undocumented)
+    AppGwSslPolicy20170401S = "AppGwSslPolicy20170401S"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslPolicyType {
+    // (undocumented)
+    Custom = "Custom",
+    // (undocumented)
+    Predefined = "Predefined"
+}
+
+// @public
+export const enum KnownApplicationGatewaySslProtocol {
+    // (undocumented)
+    TLSv10 = "TLSv1_0",
+    // (undocumented)
+    TLSv11 = "TLSv1_1",
+    // (undocumented)
+    TLSv12 = "TLSv1_2"
+}
+
+// @public
+export const enum KnownApplicationGatewayTier {
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    StandardV2 = "Standard_v2",
+    // (undocumented)
+    WAF = "WAF",
+    // (undocumented)
+    WAFV2 = "WAF_v2"
+}
+
+// @public
+export const enum KnownAssociationType {
+    // (undocumented)
+    Associated = "Associated",
+    // (undocumented)
+    Contains = "Contains"
+}
+
+// @public
+export const enum KnownAuthenticationMethod {
+    // (undocumented)
+    EapmschaPv2 = "EAPMSCHAPv2",
+    // (undocumented)
+    Eaptls = "EAPTLS"
+}
+
+// @public
+export const enum KnownAuthorizationUseStatus {
+    // (undocumented)
+    Available = "Available",
+    // (undocumented)
+    InUse = "InUse"
+}
+
+// @public
+export const enum KnownAzureFirewallApplicationRuleProtocolType {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https",
+    // (undocumented)
+    Mssql = "Mssql"
+}
+
+// @public
+export const enum KnownAzureFirewallNatRCActionType {
+    // (undocumented)
+    Dnat = "Dnat",
+    // (undocumented)
+    Snat = "Snat"
+}
+
+// @public
+export const enum KnownAzureFirewallNetworkRuleProtocol {
+    // (undocumented)
+    Any = "Any",
+    // (undocumented)
+    Icmp = "ICMP",
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownAzureFirewallRCActionType {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownAzureFirewallSkuName {
+    // (undocumented)
+    AzfwHub = "AZFW_Hub",
+    // (undocumented)
+    AzfwVnet = "AZFW_VNet"
+}
+
+// @public
+export const enum KnownAzureFirewallSkuTier {
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownAzureFirewallThreatIntelMode {
+    // (undocumented)
+    Alert = "Alert",
+    // (undocumented)
+    Deny = "Deny",
+    // (undocumented)
+    Off = "Off"
+}
+
+// @public
+export const enum KnownBastionConnectProtocol {
+    // (undocumented)
+    RDP = "RDP",
+    // (undocumented)
+    SSH = "SSH"
+}
+
+// @public
+export const enum KnownBgpPeerState {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    Idle = "Idle",
+    // (undocumented)
+    Stopped = "Stopped",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownCircuitConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    Disconnected = "Disconnected"
+}
+
+// @public
+export const enum KnownConnectionMonitorEndpointFilterItemType {
+    // (undocumented)
+    AgentAddress = "AgentAddress"
+}
+
+// @public
+export const enum KnownConnectionMonitorEndpointFilterType {
+    // (undocumented)
+    Include = "Include"
+}
+
+// @public
+export const enum KnownConnectionMonitorSourceStatus {
+    // (undocumented)
+    Active = "Active",
+    // (undocumented)
+    Inactive = "Inactive",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownConnectionMonitorTestConfigurationProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Icmp = "Icmp",
+    // (undocumented)
+    Tcp = "Tcp"
+}
+
+// @public
+export const enum KnownConnectionMonitorType {
+    // (undocumented)
+    MultiEndpoint = "MultiEndpoint",
+    // (undocumented)
+    SingleSourceDestination = "SingleSourceDestination"
+}
+
+// @public
+export const enum KnownConnectionState {
+    // (undocumented)
+    Reachable = "Reachable",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    Unreachable = "Unreachable"
+}
+
+// @public
+export const enum KnownConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Degraded = "Degraded",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownDdosCustomPolicyProtocol {
+    // (undocumented)
+    Syn = "Syn",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownDdosCustomPolicyTriggerSensitivityOverride {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    High = "High",
+    // (undocumented)
+    Low = "Low",
+    // (undocumented)
+    Relaxed = "Relaxed"
+}
+
+// @public
+export const enum KnownDdosSettingsProtectionCoverage {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownDhGroup {
+    // (undocumented)
+    DHGroup1 = "DHGroup1",
+    // (undocumented)
+    DHGroup14 = "DHGroup14",
+    // (undocumented)
+    DHGroup2 = "DHGroup2",
+    // (undocumented)
+    DHGroup2048 = "DHGroup2048",
+    // (undocumented)
+    DHGroup24 = "DHGroup24",
+    // (undocumented)
+    ECP256 = "ECP256",
+    // (undocumented)
+    ECP384 = "ECP384",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownDirection {
+    // (undocumented)
+    Inbound = "Inbound",
+    // (undocumented)
+    Outbound = "Outbound"
+}
+
+// @public
+export const enum KnownEffectiveRouteSource {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    User = "User",
+    // (undocumented)
+    VirtualNetworkGateway = "VirtualNetworkGateway"
+}
+
+// @public
+export const enum KnownEffectiveRouteState {
+    // (undocumented)
+    Active = "Active",
+    // (undocumented)
+    Invalid = "Invalid"
+}
+
+// @public
+export const enum KnownEffectiveSecurityRuleProtocol {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownEvaluationState {
+    // (undocumented)
+    Completed = "Completed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    NotStarted = "NotStarted"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitPeeringAdvertisedPublicPrefixState {
+    // (undocumented)
+    Configured = "Configured",
+    // (undocumented)
+    Configuring = "Configuring",
+    // (undocumented)
+    NotConfigured = "NotConfigured",
+    // (undocumented)
+    ValidationNeeded = "ValidationNeeded"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitPeeringState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitSkuFamily {
+    // (undocumented)
+    MeteredData = "MeteredData",
+    // (undocumented)
+    UnlimitedData = "UnlimitedData"
+}
+
+// @public
+export const enum KnownExpressRouteCircuitSkuTier {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Local = "Local",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownExpressRouteLinkAdminState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownExpressRouteLinkConnectorType {
+    // (undocumented)
+    LC = "LC",
+    // (undocumented)
+    SC = "SC"
+}
+
+// @public
+export const enum KnownExpressRouteLinkMacSecCipher {
+    // (undocumented)
+    GcmAes128 = "gcm-aes-128",
+    // (undocumented)
+    GcmAes256 = "gcm-aes-256"
+}
+
+// @public
+export const enum KnownExpressRoutePeeringState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownExpressRoutePeeringType {
+    // (undocumented)
+    AzurePrivatePeering = "AzurePrivatePeering",
+    // (undocumented)
+    AzurePublicPeering = "AzurePublicPeering",
+    // (undocumented)
+    MicrosoftPeering = "MicrosoftPeering"
+}
+
+// @public
+export const enum KnownExpressRoutePortsEncapsulation {
+    // (undocumented)
+    Dot1Q = "Dot1Q",
+    // (undocumented)
+    QinQ = "QinQ"
+}
+
+// @public
+export const enum KnownFirewallPolicyFilterRuleActionType {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownFirewallPolicyIntrusionSystemMode {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownFirewallPolicyNatRuleActionType {
+    // (undocumented)
+    Dnat = "DNAT"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleConditionApplicationProtocolType {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleConditionNetworkProtocol {
+    // (undocumented)
+    Any = "Any",
+    // (undocumented)
+    Icmp = "ICMP",
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleConditionType {
+    // (undocumented)
+    ApplicationRuleCondition = "ApplicationRuleCondition",
+    // (undocumented)
+    NatRuleCondition = "NatRuleCondition",
+    // (undocumented)
+    NetworkRuleCondition = "NetworkRuleCondition"
+}
+
+// @public
+export const enum KnownFirewallPolicyRuleType {
+    // (undocumented)
+    FirewallPolicyFilterRule = "FirewallPolicyFilterRule",
+    // (undocumented)
+    FirewallPolicyNatRule = "FirewallPolicyNatRule"
+}
+
+// @public
+export const enum KnownFlowLogFormatType {
+    // (undocumented)
+    Json = "JSON"
+}
+
+// @public
+export const enum KnownHttpConfigurationMethod {
+    // (undocumented)
+    Get = "Get",
+    // (undocumented)
+    Post = "Post"
+}
+
+// @public
+export const enum KnownHttpMethod {
+    // (undocumented)
+    Get = "Get"
+}
+
+// @public
+export const enum KnownHubVirtualNetworkConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownIkeEncryption {
+    // (undocumented)
+    AES128 = "AES128",
+    // (undocumented)
+    AES192 = "AES192",
+    // (undocumented)
+    AES256 = "AES256",
+    // (undocumented)
+    DES = "DES",
+    // (undocumented)
+    DES3 = "DES3",
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256"
+}
+
+// @public
+export const enum KnownIkeIntegrity {
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256",
+    // (undocumented)
+    MD5 = "MD5",
+    // (undocumented)
+    SHA1 = "SHA1",
+    // (undocumented)
+    SHA256 = "SHA256",
+    // (undocumented)
+    SHA384 = "SHA384"
+}
+
+// @public
+export const enum KnownIPAllocationMethod {
+    // (undocumented)
+    Dynamic = "Dynamic",
+    // (undocumented)
+    Static = "Static"
+}
+
+// @public
+export const enum KnownIpAllocationType {
+    // (undocumented)
+    Hypernet = "Hypernet",
+    // (undocumented)
+    Undefined = "Undefined"
+}
+
+// @public
+export const enum KnownIpFlowProtocol {
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownIpsecEncryption {
+    // (undocumented)
+    AES128 = "AES128",
+    // (undocumented)
+    AES192 = "AES192",
+    // (undocumented)
+    AES256 = "AES256",
+    // (undocumented)
+    DES = "DES",
+    // (undocumented)
+    DES3 = "DES3",
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes192 = "GCMAES192",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownIpsecIntegrity {
+    // (undocumented)
+    Gcmaes128 = "GCMAES128",
+    // (undocumented)
+    Gcmaes192 = "GCMAES192",
+    // (undocumented)
+    Gcmaes256 = "GCMAES256",
+    // (undocumented)
+    MD5 = "MD5",
+    // (undocumented)
+    SHA1 = "SHA1",
+    // (undocumented)
+    SHA256 = "SHA256"
+}
+
+// @public
+export const enum KnownIPVersion {
+    // (undocumented)
+    IPv4 = "IPv4",
+    // (undocumented)
+    IPv6 = "IPv6"
+}
+
+// @public
+export const enum KnownIssueType {
+    // (undocumented)
+    AgentStopped = "AgentStopped",
+    // (undocumented)
+    DnsResolution = "DnsResolution",
+    // (undocumented)
+    GuestFirewall = "GuestFirewall",
+    // (undocumented)
+    NetworkSecurityRule = "NetworkSecurityRule",
+    // (undocumented)
+    Platform = "Platform",
+    // (undocumented)
+    PortThrottled = "PortThrottled",
+    // (undocumented)
+    SocketBind = "SocketBind",
+    // (undocumented)
+    Unknown = "Unknown",
+    // (undocumented)
+    UserDefinedRoute = "UserDefinedRoute"
+}
+
+// @public
+export const enum KnownLoadBalancerOutboundRuleProtocol {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownLoadBalancerSkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownLoadDistribution {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    SourceIP = "SourceIP",
+    // (undocumented)
+    SourceIPProtocol = "SourceIPProtocol"
+}
+
+// @public
+export const enum KnownManagedRuleEnabledState {
+    // (undocumented)
+    Disabled = "Disabled"
+}
+
+// @public
+export const enum KnownNatGatewaySkuName {
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownNetworkOperationStatus {
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownNextHopType {
+    // (undocumented)
+    HyperNetGateway = "HyperNetGateway",
+    // (undocumented)
+    Internet = "Internet",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    VirtualAppliance = "VirtualAppliance",
+    // (undocumented)
+    VirtualNetworkGateway = "VirtualNetworkGateway",
+    // (undocumented)
+    VnetLocal = "VnetLocal"
+}
+
+// @public
+export const enum KnownOfficeTrafficCategory {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Optimize = "Optimize",
+    // (undocumented)
+    OptimizeAndAllow = "OptimizeAndAllow"
+}
+
+// @public
+export const enum KnownOrigin {
+    // (undocumented)
+    Inbound = "Inbound",
+    // (undocumented)
+    Local = "Local",
+    // (undocumented)
+    Outbound = "Outbound"
+}
+
+// @public
+export const enum KnownOutputType {
+    // (undocumented)
+    Workspace = "Workspace"
+}
+
+// @public
+export const enum KnownOwaspCrsExclusionEntryMatchVariable {
+    // (undocumented)
+    RequestArgNames = "RequestArgNames",
+    // (undocumented)
+    RequestCookieNames = "RequestCookieNames",
+    // (undocumented)
+    RequestHeaderNames = "RequestHeaderNames"
+}
+
+// @public
+export const enum KnownOwaspCrsExclusionEntrySelectorMatchOperator {
+    // (undocumented)
+    Contains = "Contains",
+    // (undocumented)
+    EndsWith = "EndsWith",
+    // (undocumented)
+    Equals = "Equals",
+    // (undocumented)
+    EqualsAny = "EqualsAny",
+    // (undocumented)
+    StartsWith = "StartsWith"
+}
+
+// @public
+export const enum KnownPcError {
+    // (undocumented)
+    AgentStopped = "AgentStopped",
+    // (undocumented)
+    CaptureFailed = "CaptureFailed",
+    // (undocumented)
+    InternalError = "InternalError",
+    // (undocumented)
+    LocalFileFailed = "LocalFileFailed",
+    // (undocumented)
+    StorageFailed = "StorageFailed"
+}
+
+// @public
+export const enum KnownPcProtocol {
+    // (undocumented)
+    Any = "Any",
+    // (undocumented)
+    TCP = "TCP",
+    // (undocumented)
+    UDP = "UDP"
+}
+
+// @public
+export const enum KnownPcStatus {
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    NotStarted = "NotStarted",
+    // (undocumented)
+    Running = "Running",
+    // (undocumented)
+    Stopped = "Stopped",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownPfsGroup {
+    // (undocumented)
+    ECP256 = "ECP256",
+    // (undocumented)
+    ECP384 = "ECP384",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    PFS1 = "PFS1",
+    // (undocumented)
+    PFS14 = "PFS14",
+    // (undocumented)
+    PFS2 = "PFS2",
+    // (undocumented)
+    PFS2048 = "PFS2048",
+    // (undocumented)
+    PFS24 = "PFS24",
+    // (undocumented)
+    Pfsmm = "PFSMM"
+}
+
+// @public
+export const enum KnownPreferredIPVersion {
+    // (undocumented)
+    IPv4 = "IPv4",
+    // (undocumented)
+    IPv6 = "IPv6"
+}
+
+// @public
+export const enum KnownProbeProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https",
+    // (undocumented)
+    Tcp = "Tcp"
+}
+
+// @public
+export const enum KnownProcessorArchitecture {
+    // (undocumented)
+    Amd64 = "Amd64",
+    // (undocumented)
+    X86 = "X86"
+}
+
+// @public
+export const enum KnownProtocol {
+    // (undocumented)
+    Http = "Http",
+    // (undocumented)
+    Https = "Https",
+    // (undocumented)
+    Icmp = "Icmp",
+    // (undocumented)
+    Tcp = "Tcp"
+}
+
+// @public
+export const enum KnownProvisioningState {
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownPublicIPAddressSkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownPublicIPPrefixSkuName {
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownRouteFilterRuleType {
+    // (undocumented)
+    Community = "Community"
+}
+
+// @public
+export const enum KnownRouteNextHopType {
+    // (undocumented)
+    Internet = "Internet",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    VirtualAppliance = "VirtualAppliance",
+    // (undocumented)
+    VirtualNetworkGateway = "VirtualNetworkGateway",
+    // (undocumented)
+    VnetLocal = "VnetLocal"
+}
+
+// @public
+export const enum KnownSecurityPartnerProviderConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    PartiallyConnected = "PartiallyConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownSecurityProviderName {
+    // (undocumented)
+    Checkpoint = "Checkpoint",
+    // (undocumented)
+    IBoss = "IBoss",
+    // (undocumented)
+    ZScaler = "ZScaler"
+}
+
+// @public
+export const enum KnownSecurityRuleAccess {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Deny = "Deny"
+}
+
+// @public
+export const enum KnownSecurityRuleDirection {
+    // (undocumented)
+    Inbound = "Inbound",
+    // (undocumented)
+    Outbound = "Outbound"
+}
+
+// @public
+export const enum KnownSecurityRuleProtocol {
+    // (undocumented)
+    Ah = "Ah",
+    // (undocumented)
+    Asterisk = "*",
+    // (undocumented)
+    Esp = "Esp",
+    // (undocumented)
+    Icmp = "Icmp",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownServiceProviderProvisioningState {
+    // (undocumented)
+    Deprovisioning = "Deprovisioning",
+    // (undocumented)
+    NotProvisioned = "NotProvisioned",
+    // (undocumented)
+    Provisioned = "Provisioned",
+    // (undocumented)
+    Provisioning = "Provisioning"
+}
+
+// @public
+export const enum KnownSeverity {
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownTransportProtocol {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Tcp = "Tcp",
+    // (undocumented)
+    Udp = "Udp"
+}
+
+// @public
+export const enum KnownTunnelConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownUsageUnit {
+    // (undocumented)
+    Count = "Count"
+}
+
+// @public
+export const enum KnownVerbosityLevel {
+    // (undocumented)
+    Full = "Full",
+    // (undocumented)
+    Minimum = "Minimum",
+    // (undocumented)
+    Normal = "Normal"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayConnectionProtocol {
+    // (undocumented)
+    IKEv1 = "IKEv1",
+    // (undocumented)
+    IKEv2 = "IKEv2"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayConnectionType {
+    // (undocumented)
+    ExpressRoute = "ExpressRoute",
+    // (undocumented)
+    IPsec = "IPsec",
+    // (undocumented)
+    Vnet2Vnet = "Vnet2Vnet",
+    // (undocumented)
+    VPNClient = "VPNClient"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewaySkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    ErGw1AZ = "ErGw1AZ",
+    // (undocumented)
+    ErGw2AZ = "ErGw2AZ",
+    // (undocumented)
+    ErGw3AZ = "ErGw3AZ",
+    // (undocumented)
+    HighPerformance = "HighPerformance",
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    UltraPerformance = "UltraPerformance",
+    // (undocumented)
+    VpnGw1 = "VpnGw1",
+    // (undocumented)
+    VpnGw1AZ = "VpnGw1AZ",
+    // (undocumented)
+    VpnGw2 = "VpnGw2",
+    // (undocumented)
+    VpnGw2AZ = "VpnGw2AZ",
+    // (undocumented)
+    VpnGw3 = "VpnGw3",
+    // (undocumented)
+    VpnGw3AZ = "VpnGw3AZ",
+    // (undocumented)
+    VpnGw4 = "VpnGw4",
+    // (undocumented)
+    VpnGw4AZ = "VpnGw4AZ",
+    // (undocumented)
+    VpnGw5 = "VpnGw5",
+    // (undocumented)
+    VpnGw5AZ = "VpnGw5AZ"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewaySkuTier {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    ErGw1AZ = "ErGw1AZ",
+    // (undocumented)
+    ErGw2AZ = "ErGw2AZ",
+    // (undocumented)
+    ErGw3AZ = "ErGw3AZ",
+    // (undocumented)
+    HighPerformance = "HighPerformance",
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    UltraPerformance = "UltraPerformance",
+    // (undocumented)
+    VpnGw1 = "VpnGw1",
+    // (undocumented)
+    VpnGw1AZ = "VpnGw1AZ",
+    // (undocumented)
+    VpnGw2 = "VpnGw2",
+    // (undocumented)
+    VpnGw2AZ = "VpnGw2AZ",
+    // (undocumented)
+    VpnGw3 = "VpnGw3",
+    // (undocumented)
+    VpnGw3AZ = "VpnGw3AZ",
+    // (undocumented)
+    VpnGw4 = "VpnGw4",
+    // (undocumented)
+    VpnGw4AZ = "VpnGw4AZ",
+    // (undocumented)
+    VpnGw5 = "VpnGw5",
+    // (undocumented)
+    VpnGw5AZ = "VpnGw5AZ"
+}
+
+// @public
+export const enum KnownVirtualNetworkGatewayType {
+    // (undocumented)
+    ExpressRoute = "ExpressRoute",
+    // (undocumented)
+    Vpn = "Vpn"
+}
+
+// @public
+export const enum KnownVirtualNetworkPeeringState {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Initiated = "Initiated"
+}
+
+// @public
+export const enum KnownVirtualWanSecurityProviderType {
+    // (undocumented)
+    External = "External",
+    // (undocumented)
+    Native = "Native"
+}
+
+// @public
+export const enum KnownVpnAuthenticationType {
+    // (undocumented)
+    AAD = "AAD",
+    // (undocumented)
+    Certificate = "Certificate",
+    // (undocumented)
+    Radius = "Radius"
+}
+
+// @public
+export const enum KnownVpnClientProtocol {
+    // (undocumented)
+    IkeV2 = "IkeV2",
+    // (undocumented)
+    OpenVPN = "OpenVPN",
+    // (undocumented)
+    Sstp = "SSTP"
+}
+
+// @public
+export const enum KnownVpnConnectionStatus {
+    // (undocumented)
+    Connected = "Connected",
+    // (undocumented)
+    Connecting = "Connecting",
+    // (undocumented)
+    NotConnected = "NotConnected",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownVpnGatewayGeneration {
+    // (undocumented)
+    Generation1 = "Generation1",
+    // (undocumented)
+    Generation2 = "Generation2",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownVpnGatewayTunnelingProtocol {
+    // (undocumented)
+    IkeV2 = "IkeV2",
+    // (undocumented)
+    OpenVPN = "OpenVPN"
+}
+
+// @public
+export const enum KnownVpnType {
+    // (undocumented)
+    PolicyBased = "PolicyBased",
+    // (undocumented)
+    RouteBased = "RouteBased"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallAction {
+    // (undocumented)
+    Allow = "Allow",
+    // (undocumented)
+    Block = "Block",
+    // (undocumented)
+    Log = "Log"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallEnabledState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallMatchVariable {
+    // (undocumented)
+    PostArgs = "PostArgs",
+    // (undocumented)
+    QueryString = "QueryString",
+    // (undocumented)
+    RemoteAddr = "RemoteAddr",
+    // (undocumented)
+    RequestBody = "RequestBody",
+    // (undocumented)
+    RequestCookies = "RequestCookies",
+    // (undocumented)
+    RequestHeaders = "RequestHeaders",
+    // (undocumented)
+    RequestMethod = "RequestMethod",
+    // (undocumented)
+    RequestUri = "RequestUri"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallMode {
+    // (undocumented)
+    Detection = "Detection",
+    // (undocumented)
+    Prevention = "Prevention"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallOperator {
+    // (undocumented)
+    BeginsWith = "BeginsWith",
+    // (undocumented)
+    Contains = "Contains",
+    // (undocumented)
+    EndsWith = "EndsWith",
+    // (undocumented)
+    Equal = "Equal",
+    // (undocumented)
+    GeoMatch = "GeoMatch",
+    // (undocumented)
+    GreaterThan = "GreaterThan",
+    // (undocumented)
+    GreaterThanOrEqual = "GreaterThanOrEqual",
+    // (undocumented)
+    IPMatch = "IPMatch",
+    // (undocumented)
+    LessThan = "LessThan",
+    // (undocumented)
+    LessThanOrEqual = "LessThanOrEqual",
+    // (undocumented)
+    Regex = "Regex"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallPolicyResourceState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Disabling = "Disabling",
+    // (undocumented)
+    Enabled = "Enabled",
+    // (undocumented)
+    Enabling = "Enabling"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallRuleType {
+    // (undocumented)
+    Invalid = "Invalid",
+    // (undocumented)
+    MatchRule = "MatchRule"
+}
+
+// @public
+export const enum KnownWebApplicationFirewallTransform {
+    // (undocumented)
+    HtmlEntityDecode = "HtmlEntityDecode",
+    // (undocumented)
+    Lowercase = "Lowercase",
+    // (undocumented)
+    RemoveNulls = "RemoveNulls",
+    // (undocumented)
+    Trim = "Trim",
+    // (undocumented)
+    UrlDecode = "UrlDecode",
+    // (undocumented)
+    UrlEncode = "UrlEncode"
+}
 
 // @public
 export interface ListHubRouteTablesResult {
@@ -4029,7 +5499,7 @@ export interface LoadBalancerOutboundRuleListResult {
 }
 
 // @public
-export type LoadBalancerOutboundRuleProtocol = "Tcp" | "Udp" | "All" | string;
+export type LoadBalancerOutboundRuleProtocol = string;
 
 // @public
 export type LoadBalancerOutboundRulesGetResponse = OutboundRule & {
@@ -4113,7 +5583,7 @@ export interface LoadBalancerSku {
 }
 
 // @public
-export type LoadBalancerSkuName = "Basic" | "Standard" | string;
+export type LoadBalancerSkuName = string;
 
 // @public
 export type LoadBalancersListAllNextResponse = LoadBalancerListResult & {
@@ -4175,7 +5645,7 @@ export type LoadBalancingRule = SubResource & {
 };
 
 // @public
-export type LoadDistribution = "Default" | "SourceIP" | "SourceIPProtocol" | string;
+export type LoadDistribution = string;
 
 // @public
 export type LocalNetworkGateway = Resource & {
@@ -4243,7 +5713,7 @@ export interface LogSpecification {
 }
 
 // @public
-export type ManagedRuleEnabledState = "Disabled" | string;
+export type ManagedRuleEnabledState = string;
 
 // @public
 export interface ManagedRuleGroupOverride {
@@ -4366,7 +5836,7 @@ export interface NatGatewaySku {
 }
 
 // @public
-export type NatGatewaySkuName = "Standard" | string;
+export type NatGatewaySkuName = string;
 
 // @public
 export type NatGatewaysListAllNextResponse = NatGatewayListResult & {
@@ -5282,7 +6752,7 @@ export type NetworkManagementClientSupportedSecurityProvidersResponse = VirtualW
 };
 
 // @public
-export type NetworkOperationStatus = "InProgress" | "Succeeded" | "Failed" | string;
+export type NetworkOperationStatus = string;
 
 // @public
 export type NetworkProfile = Resource & {
@@ -5721,10 +7191,10 @@ export interface NextHopResult {
 }
 
 // @public
-export type NextHopType = "Internet" | "VirtualAppliance" | "VirtualNetworkGateway" | "VnetLocal" | "HyperNetGateway" | "None" | string;
+export type NextHopType = string;
 
 // @public
-export type OfficeTrafficCategory = "Optimize" | "OptimizeAndAllow" | "All" | "None" | string;
+export type OfficeTrafficCategory = string;
 
 // @public
 export interface Operation {
@@ -5771,7 +7241,7 @@ export type OperationsListResponse = OperationListResult & {
 };
 
 // @public
-export type Origin = "Local" | "Inbound" | "Outbound" | string;
+export type Origin = string;
 
 // @public
 export type OutboundRule = SubResource & {
@@ -5788,7 +7258,7 @@ export type OutboundRule = SubResource & {
 };
 
 // @public
-export type OutputType = "Workspace" | string;
+export type OutputType = string;
 
 // @public
 export interface OwaspCrsExclusionEntry {
@@ -5798,10 +7268,10 @@ export interface OwaspCrsExclusionEntry {
 }
 
 // @public
-export type OwaspCrsExclusionEntryMatchVariable = "RequestHeaderNames" | "RequestCookieNames" | "RequestArgNames" | string;
+export type OwaspCrsExclusionEntryMatchVariable = string;
 
 // @public
-export type OwaspCrsExclusionEntrySelectorMatchOperator = "Equals" | "Contains" | "StartsWith" | "EndsWith" | "EqualsAny" | string;
+export type OwaspCrsExclusionEntrySelectorMatchOperator = string;
 
 // @public
 export type P2SConnectionConfiguration = SubResource & {
@@ -6057,13 +7527,13 @@ export type PatchRouteFilterRule = SubResource & {
 };
 
 // @public
-export type PcError = "InternalError" | "AgentStopped" | "CaptureFailed" | "LocalFileFailed" | "StorageFailed" | string;
+export type PcError = string;
 
 // @public
-export type PcProtocol = "TCP" | "UDP" | "Any" | string;
+export type PcProtocol = string;
 
 // @public
-export type PcStatus = "NotStarted" | "Running" | "Stopped" | "Error" | "Unknown" | string;
+export type PcStatus = string;
 
 // @public
 export type PeerExpressRouteCircuitConnection = SubResource & {
@@ -6110,7 +7580,7 @@ export type PeerExpressRouteCircuitConnectionsListResponse = PeerExpressRouteCir
 };
 
 // @public
-export type PfsGroup = "None" | "PFS1" | "PFS2" | "PFS2048" | "ECP256" | "ECP384" | "PFS24" | "PFS14" | "PFSMM" | string;
+export type PfsGroup = string;
 
 // @public
 export interface PolicySettings {
@@ -6122,7 +7592,7 @@ export interface PolicySettings {
 }
 
 // @public
-export type PreferredIPVersion = "IPv4" | "IPv6" | string;
+export type PreferredIPVersion = string;
 
 // @public
 export interface PrepareNetworkPoliciesRequest {
@@ -6490,10 +7960,10 @@ export type Probe = SubResource & {
 };
 
 // @public
-export type ProbeProtocol = "Http" | "Tcp" | "Https" | string;
+export type ProbeProtocol = string;
 
 // @public
-export type ProcessorArchitecture = "Amd64" | "X86" | string;
+export type ProcessorArchitecture = string;
 
 // @public
 export interface PropagatedRouteTable {
@@ -6502,7 +7972,7 @@ export interface PropagatedRouteTable {
 }
 
 // @public
-export type Protocol = "Tcp" | "Http" | "Https" | "Icmp" | string;
+export type Protocol = string;
 
 // @public
 export interface ProtocolConfiguration {
@@ -6518,7 +7988,7 @@ export interface ProtocolCustomSettingsFormat {
 }
 
 // @public
-export type ProvisioningState = "Succeeded" | "Updating" | "Deleting" | "Failed" | string;
+export type ProvisioningState = string;
 
 // @public
 export type PublicIPAddress = Resource & {
@@ -6664,7 +8134,7 @@ export interface PublicIPAddressSku {
 }
 
 // @public
-export type PublicIPAddressSkuName = "Basic" | "Standard" | string;
+export type PublicIPAddressSkuName = string;
 
 // @public
 export type PublicIPPrefix = Resource & {
@@ -6755,7 +8225,7 @@ export interface PublicIPPrefixSku {
 }
 
 // @public
-export type PublicIPPrefixSkuName = "Standard" | string;
+export type PublicIPPrefixSkuName = string;
 
 // @public
 export interface QueryTroubleshootingParameters {
@@ -6909,7 +8379,7 @@ export type RouteFilterRulesListByRouteFilterResponse = RouteFilterRuleListResul
 };
 
 // @public
-export type RouteFilterRuleType = "Community" | string;
+export type RouteFilterRuleType = string;
 
 // @public
 export type RouteFiltersCreateOrUpdateResponse = RouteFilter & {
@@ -6980,7 +8450,7 @@ export interface RouteListResult {
 }
 
 // @public
-export type RouteNextHopType = "VirtualNetworkGateway" | "VnetLocal" | "Internet" | "VirtualAppliance" | "None" | string;
+export type RouteNextHopType = string;
 
 // @public
 export type RoutesCreateOrUpdateResponse = Route & {
@@ -7125,7 +8595,7 @@ export type SecurityPartnerProvider = Resource & {
 };
 
 // @public
-export type SecurityPartnerProviderConnectionStatus = "Unknown" | "PartiallyConnected" | "Connected" | "NotConnected" | string;
+export type SecurityPartnerProviderConnectionStatus = string;
 
 // @public
 export interface SecurityPartnerProviderListResult {
@@ -7191,7 +8661,7 @@ export type SecurityPartnerProvidersUpdateTagsResponse = SecurityPartnerProvider
 };
 
 // @public
-export type SecurityProviderName = "ZScaler" | "IBoss" | "Checkpoint" | string;
+export type SecurityProviderName = string;
 
 // @public
 export type SecurityRule = SubResource & {
@@ -7216,7 +8686,7 @@ export type SecurityRule = SubResource & {
 };
 
 // @public
-export type SecurityRuleAccess = "Allow" | "Deny" | string;
+export type SecurityRuleAccess = string;
 
 // @public
 export interface SecurityRuleAssociations {
@@ -7227,7 +8697,7 @@ export interface SecurityRuleAssociations {
 }
 
 // @public
-export type SecurityRuleDirection = "Inbound" | "Outbound" | string;
+export type SecurityRuleDirection = string;
 
 // @public
 export interface SecurityRuleListResult {
@@ -7236,7 +8706,7 @@ export interface SecurityRuleListResult {
 }
 
 // @public
-export type SecurityRuleProtocol = "Tcp" | "Udp" | "Icmp" | "Esp" | "*" | "Ah" | string;
+export type SecurityRuleProtocol = string;
 
 // @public
 export type SecurityRulesCreateOrUpdateResponse = SecurityRule & {
@@ -7431,7 +8901,7 @@ export interface ServiceEndpointPropertiesFormat {
 }
 
 // @public
-export type ServiceProviderProvisioningState = "NotProvisioned" | "Provisioning" | "Provisioned" | "Deprovisioning" | string;
+export type ServiceProviderProvisioningState = string;
 
 // @public
 export interface ServiceTagInformation {
@@ -7472,7 +8942,7 @@ export interface SessionIds {
 }
 
 // @public
-export type Severity = "Error" | "Warning" | string;
+export type Severity = string;
 
 // @public
 export interface StaticRoute {
@@ -7618,7 +9088,7 @@ export interface TrafficSelectorPolicy {
 }
 
 // @public
-export type TransportProtocol = "Udp" | "Tcp" | "All" | string;
+export type TransportProtocol = string;
 
 // @public
 export interface TroubleshootingDetails {
@@ -7662,7 +9132,7 @@ export interface TunnelConnectionHealth {
 }
 
 // @public
-export type TunnelConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type TunnelConnectionStatus = string;
 
 // @public
 export interface UnprepareNetworkPoliciesRequest {
@@ -7707,10 +9177,10 @@ export interface UsagesListResult {
 }
 
 // @public
-export type UsageUnit = "Count" | string;
+export type UsageUnit = string;
 
 // @public
-export type VerbosityLevel = "Normal" | "Minimum" | "Full" | string;
+export type VerbosityLevel = string;
 
 // @public
 export interface VerificationIPFlowParameters {
@@ -7992,7 +9462,7 @@ export interface VirtualNetworkGatewayConnectionListResult {
 }
 
 // @public
-export type VirtualNetworkGatewayConnectionProtocol = "IKEv2" | "IKEv1" | string;
+export type VirtualNetworkGatewayConnectionProtocol = string;
 
 // @public
 export type VirtualNetworkGatewayConnectionsCreateOrUpdateResponse = VirtualNetworkGatewayConnection & {
@@ -8079,7 +9549,7 @@ export type VirtualNetworkGatewayConnectionsStopPacketCaptureResponse = {
 };
 
 // @public
-export type VirtualNetworkGatewayConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type VirtualNetworkGatewayConnectionStatus = string;
 
 // @public
 export type VirtualNetworkGatewayConnectionsUpdateTagsResponse = VirtualNetworkGatewayConnection & {
@@ -8091,7 +9561,7 @@ export type VirtualNetworkGatewayConnectionsUpdateTagsResponse = VirtualNetworkG
 };
 
 // @public
-export type VirtualNetworkGatewayConnectionType = "IPsec" | "Vnet2Vnet" | "ExpressRoute" | "VPNClient" | string;
+export type VirtualNetworkGatewayConnectionType = string;
 
 // @public
 export type VirtualNetworkGatewayIPConfiguration = SubResource & {
@@ -8221,10 +9691,10 @@ export interface VirtualNetworkGatewaySku {
 }
 
 // @public
-export type VirtualNetworkGatewaySkuName = "Basic" | "HighPerformance" | "Standard" | "UltraPerformance" | "VpnGw1" | "VpnGw2" | "VpnGw3" | "VpnGw4" | "VpnGw5" | "VpnGw1AZ" | "VpnGw2AZ" | "VpnGw3AZ" | "VpnGw4AZ" | "VpnGw5AZ" | "ErGw1AZ" | "ErGw2AZ" | "ErGw3AZ" | string;
+export type VirtualNetworkGatewaySkuName = string;
 
 // @public
-export type VirtualNetworkGatewaySkuTier = "Basic" | "HighPerformance" | "Standard" | "UltraPerformance" | "VpnGw1" | "VpnGw2" | "VpnGw3" | "VpnGw4" | "VpnGw5" | "VpnGw1AZ" | "VpnGw2AZ" | "VpnGw3AZ" | "VpnGw4AZ" | "VpnGw5AZ" | "ErGw1AZ" | "ErGw2AZ" | "ErGw3AZ" | string;
+export type VirtualNetworkGatewaySkuTier = string;
 
 // @public
 export type VirtualNetworkGatewaysListConnectionsNextResponse = VirtualNetworkGatewayListConnectionsResult & {
@@ -8334,7 +9804,7 @@ export type VirtualNetworkGatewaysVpnDeviceConfigurationScriptResponse = {
 };
 
 // @public
-export type VirtualNetworkGatewayType = "Vpn" | "ExpressRoute" | string;
+export type VirtualNetworkGatewayType = string;
 
 // @public
 export interface VirtualNetworkListResult {
@@ -8402,7 +9872,7 @@ export type VirtualNetworkPeeringsListResponse = VirtualNetworkPeeringListResult
 };
 
 // @public
-export type VirtualNetworkPeeringState = "Initiated" | "Connected" | "Disconnected" | string;
+export type VirtualNetworkPeeringState = string;
 
 // @public
 export type VirtualNetworksCheckIPAddressAvailabilityResponse = IPAddressAvailabilityResult & {
@@ -8734,7 +10204,7 @@ export interface VirtualWanSecurityProviders {
 }
 
 // @public
-export type VirtualWanSecurityProviderType = "External" | "Native" | string;
+export type VirtualWanSecurityProviderType = string;
 
 // @public
 export type VirtualWansGetResponse = VirtualWAN & {
@@ -8799,7 +10269,7 @@ export interface VnetRoute {
 }
 
 // @public
-export type VpnAuthenticationType = "Certificate" | "Radius" | "AAD" | string;
+export type VpnAuthenticationType = string;
 
 // @public
 export interface VpnClientConfiguration {
@@ -8866,7 +10336,7 @@ export interface VpnClientParameters {
 }
 
 // @public
-export type VpnClientProtocol = "IkeV2" | "SSTP" | "OpenVPN" | string;
+export type VpnClientProtocol = string;
 
 // @public
 export type VpnClientRevokedCertificate = SubResource & {
@@ -8942,7 +10412,7 @@ export type VpnConnectionsListByVpnGatewayResponse = ListVpnConnectionsResult & 
 };
 
 // @public
-export type VpnConnectionStatus = "Unknown" | "Connecting" | "Connected" | "NotConnected" | string;
+export type VpnConnectionStatus = string;
 
 // @public
 export interface VpnDeviceScriptParameters {
@@ -8962,7 +10432,7 @@ export type VpnGateway = Resource & {
 };
 
 // @public
-export type VpnGatewayGeneration = "None" | "Generation1" | "Generation2" | string;
+export type VpnGatewayGeneration = string;
 
 // @public
 export type VpnGatewaysCreateOrUpdateResponse = VpnGateway & {
@@ -9031,7 +10501,7 @@ export type VpnGatewaysUpdateTagsResponse = VpnGateway & {
 };
 
 // @public
-export type VpnGatewayTunnelingProtocol = "IkeV2" | "OpenVPN" | string;
+export type VpnGatewayTunnelingProtocol = string;
 
 // @public
 export interface VpnLinkBgpSettings {
@@ -9333,10 +10803,10 @@ export type VpnSitesUpdateTagsResponse = VpnSite & {
 };
 
 // @public
-export type VpnType = "PolicyBased" | "RouteBased" | string;
+export type VpnType = string;
 
 // @public
-export type WebApplicationFirewallAction = "Allow" | "Block" | "Log" | string;
+export type WebApplicationFirewallAction = string;
 
 // @public
 export interface WebApplicationFirewallCustomRule {
@@ -9349,16 +10819,16 @@ export interface WebApplicationFirewallCustomRule {
 }
 
 // @public
-export type WebApplicationFirewallEnabledState = "Disabled" | "Enabled" | string;
+export type WebApplicationFirewallEnabledState = string;
 
 // @public
-export type WebApplicationFirewallMatchVariable = "RemoteAddr" | "RequestMethod" | "QueryString" | "PostArgs" | "RequestUri" | "RequestHeaders" | "RequestBody" | "RequestCookies" | string;
+export type WebApplicationFirewallMatchVariable = string;
 
 // @public
-export type WebApplicationFirewallMode = "Prevention" | "Detection" | string;
+export type WebApplicationFirewallMode = string;
 
 // @public
-export type WebApplicationFirewallOperator = "IPMatch" | "Equal" | "Contains" | "LessThan" | "GreaterThan" | "LessThanOrEqual" | "GreaterThanOrEqual" | "BeginsWith" | "EndsWith" | "Regex" | "GeoMatch" | string;
+export type WebApplicationFirewallOperator = string;
 
 // @public
 export type WebApplicationFirewallPoliciesCreateOrUpdateResponse = WebApplicationFirewallPolicy & {
@@ -9428,18 +10898,18 @@ export interface WebApplicationFirewallPolicyListResult {
 }
 
 // @public
-export type WebApplicationFirewallPolicyResourceState = "Creating" | "Enabling" | "Enabled" | "Disabling" | "Disabled" | "Deleting" | string;
+export type WebApplicationFirewallPolicyResourceState = string;
 
 // @public
-export type WebApplicationFirewallRuleType = "MatchRule" | "Invalid" | string;
+export type WebApplicationFirewallRuleType = string;
 
 // @public
-export type WebApplicationFirewallTransform = "Lowercase" | "Trim" | "UrlDecode" | "UrlEncode" | "RemoveNulls" | "HtmlEntityDecode" | string;
+export type WebApplicationFirewallTransform = string;
 
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:13368:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:15227:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/network-resource-manager/tsconfig.json
+++ b/test/smoke/generated/network-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/sql-resource-manager/review/sql-resource-manager.api.md
+++ b/test/smoke/generated/sql-resource-manager/review/sql-resource-manager.api.md
@@ -21,10 +21,10 @@ export interface AdministratorListResult {
 }
 
 // @public
-export type AdministratorName = "ActiveDirectory" | string;
+export type AdministratorName = string;
 
 // @public
-export type AdministratorType = "ActiveDirectory" | string;
+export type AdministratorType = string;
 
 // @public
 export type AuthenticationType = "SQL" | "ADPassword";
@@ -176,13 +176,13 @@ export type CapabilitiesListByLocationResponse = LocationCapabilities & {
 };
 
 // @public
-export type CapabilityGroup = "supportedEditions" | "supportedElasticPoolEditions" | "supportedManagedInstanceVersions" | "supportedInstancePoolEditions" | "supportedManagedInstanceEditions" | string;
+export type CapabilityGroup = string;
 
 // @public
 export type CapabilityStatus = "Visible" | "Available" | "Default" | "Disabled";
 
 // @public
-export type CatalogCollationType = "DATABASE_DEFAULT" | "SQL_Latin1_General_CP1_CI_AS" | string;
+export type CatalogCollationType = string;
 
 // @public
 export type CheckNameAvailabilityReason = "Invalid" | "AlreadyExists";
@@ -209,7 +209,7 @@ export interface CompleteDatabaseRestoreDefinition {
 }
 
 // @public
-export type ConnectionPolicyName = "default" | string;
+export type ConnectionPolicyName = string;
 
 // @public
 export interface CreateDatabaseRestorePointDefinition {
@@ -217,7 +217,7 @@ export interface CreateDatabaseRestorePointDefinition {
 }
 
 // @public
-export type CreateMode = "Default" | "Copy" | "Secondary" | "PointInTimeRestore" | "Restore" | "Recovery" | "RestoreExternalBackup" | "RestoreExternalBackupSecondary" | "RestoreLongTermRetentionBackup" | "OnlineSecondary" | string;
+export type CreateMode = string;
 
 // @public
 export type Database = TrackedResource & {
@@ -335,10 +335,10 @@ export interface DatabaseBlobAuditingPolicyListResult {
 }
 
 // @public
-export type DatabaseEdition = "Web" | "Business" | "Basic" | "Standard" | "Premium" | "PremiumRS" | "Free" | "Stretch" | "DataWarehouse" | "System" | "System2" | "GeneralPurpose" | "BusinessCritical" | "Hyperscale" | string;
+export type DatabaseEdition = string;
 
 // @public
-export type DatabaseLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type DatabaseLicenseType = string;
 
 // @public
 export interface DatabaseListResult {
@@ -387,7 +387,7 @@ export type DatabaseOperationsListByDatabaseResponse = DatabaseOperationListResu
 };
 
 // @public
-export type DatabaseReadScale = "Enabled" | "Disabled" | string;
+export type DatabaseReadScale = string;
 
 // @public
 export type DatabasesCreateImportOperationResponse = ImportExportResponse & {
@@ -519,10 +519,10 @@ export type DatabasesResumeResponse = Database & {
 };
 
 // @public
-export type DatabaseState = "All" | "Live" | "Deleted" | string;
+export type DatabaseState = string;
 
 // @public
-export type DatabaseStatus = "Online" | "Restoring" | "RecoveryPending" | "Recovering" | "Suspect" | "Offline" | "Standby" | "Shutdown" | "EmergencyMode" | "AutoClosed" | "Copying" | "Creating" | "Inaccessible" | "OfflineSecondary" | "Pausing" | "Paused" | "Resuming" | "Scaling" | "OfflineChangingDwPerformanceTiers" | "OnlineChangingDwPerformanceTiers" | "Disabled" | string;
+export type DatabaseStatus = string;
 
 // @public
 export type DatabasesUpdateResponse = Database & {
@@ -890,7 +890,7 @@ export interface ElasticPoolDatabaseActivityListResult {
 }
 
 // @public
-export type ElasticPoolEdition = "Basic" | "Standard" | "Premium" | "GeneralPurpose" | "BusinessCritical" | string;
+export type ElasticPoolEdition = string;
 
 // @public
 export interface ElasticPoolEditionCapability {
@@ -902,7 +902,7 @@ export interface ElasticPoolEditionCapability {
 }
 
 // @public
-export type ElasticPoolLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type ElasticPoolLicenseType = string;
 
 // @public
 export interface ElasticPoolListResult {
@@ -1048,7 +1048,7 @@ export type ElasticPoolsListMetricsResponse = MetricListResult & {
 };
 
 // @public
-export type ElasticPoolState = "Creating" | "Ready" | "Disabled" | string;
+export type ElasticPoolState = string;
 
 // @public
 export type ElasticPoolsUpdateResponse = ElasticPool & {
@@ -1089,7 +1089,7 @@ export interface EncryptionProtectorListResult {
 }
 
 // @public
-export type EncryptionProtectorName = "current" | string;
+export type EncryptionProtectorName = string;
 
 // @public
 export type EncryptionProtectorsCreateOrUpdateResponse = EncryptionProtector & {
@@ -1125,7 +1125,7 @@ export type EncryptionProtectorsListByServerResponse = EncryptionProtectorListRe
 };
 
 // @public
-export type Enum21 = "All" | "Error" | "Warning" | "Success" | string;
+export type Enum21 = string;
 
 // @public
 export interface ExportRequest {
@@ -1243,7 +1243,7 @@ export interface ExtendedServerBlobAuditingPolicyListResult {
 }
 
 // @public
-export type ExtensionName = "import" | string;
+export type ExtensionName = string;
 
 // @public
 export type FailoverGroup = Resource & {
@@ -1277,7 +1277,7 @@ export interface FailoverGroupReadWriteEndpoint {
 }
 
 // @public
-export type FailoverGroupReplicationRole = "Primary" | "Secondary" | string;
+export type FailoverGroupReplicationRole = string;
 
 // @public
 export type FailoverGroupsCreateOrUpdateResponse = FailoverGroup & {
@@ -1424,13 +1424,13 @@ export interface GeoBackupPolicyListResult {
 }
 
 // @public
-export type GeoBackupPolicyName = "Default" | string;
+export type GeoBackupPolicyName = string;
 
 // @public
 export type GeoBackupPolicyState = "Disabled" | "Enabled";
 
 // @public
-export type IdentityType = "SystemAssigned" | string;
+export type IdentityType = string;
 
 // @public
 export type ImportExportResponse = Resource & {
@@ -1499,7 +1499,7 @@ export interface InstanceFailoverGroupReadWriteEndpoint {
 }
 
 // @public
-export type InstanceFailoverGroupReplicationRole = "Primary" | "Secondary" | string;
+export type InstanceFailoverGroupReplicationRole = string;
 
 // @public
 export type InstanceFailoverGroupsCreateOrUpdateResponse = InstanceFailoverGroup & {
@@ -1578,7 +1578,7 @@ export interface InstancePoolFamilyCapability {
 }
 
 // @public
-export type InstancePoolLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type InstancePoolLicenseType = string;
 
 // @public
 export interface InstancePoolListResult {
@@ -1714,7 +1714,7 @@ export type JobAgentsListByServerResponse = JobAgentListResult & {
 };
 
 // @public
-export type JobAgentState = "Creating" | "Ready" | "Updating" | "Deleting" | "Disabled" | string;
+export type JobAgentState = string;
 
 // @public
 export type JobAgentsUpdateResponse = JobAgent & {
@@ -1794,7 +1794,7 @@ export type JobExecution = Resource & {
 };
 
 // @public
-export type JobExecutionLifecycle = "Created" | "InProgress" | "WaitingForChildJobExecutions" | "WaitingForRetry" | "Succeeded" | "SucceededWithSkipped" | "Failed" | "TimedOut" | "Canceled" | "Skipped" | string;
+export type JobExecutionLifecycle = string;
 
 // @public
 export interface JobExecutionListResult {
@@ -1979,10 +1979,10 @@ export interface JobStepAction {
 }
 
 // @public
-export type JobStepActionSource = "Inline" | string;
+export type JobStepActionSource = string;
 
 // @public
-export type JobStepActionType = "TSql" | string;
+export type JobStepActionType = string;
 
 // @public
 export interface JobStepExecutionOptions {
@@ -2058,7 +2058,7 @@ export interface JobStepOutput {
 }
 
 // @public
-export type JobStepOutputType = "SqlDatabase" | string;
+export type JobStepOutputType = string;
 
 // @public
 export type JobStepsCreateOrUpdateResponse = JobStep & {
@@ -2258,7 +2258,7 @@ export type JobTargetGroupsListByAgentResponse = JobTargetGroupListResult & {
 };
 
 // @public
-export type JobTargetType = "TargetGroup" | "SqlDatabase" | "SqlElasticPool" | "SqlShardMap" | "SqlServer" | string;
+export type JobTargetType = string;
 
 // @public
 export type JobVersion = Resource & {};
@@ -2294,6 +2294,972 @@ export type JobVersionsListByJobResponse = JobVersionListResult & {
 };
 
 // @public
+export const enum KnownAdministratorName {
+    // (undocumented)
+    ActiveDirectory = "ActiveDirectory"
+}
+
+// @public
+export const enum KnownAdministratorType {
+    // (undocumented)
+    ActiveDirectory = "ActiveDirectory"
+}
+
+// @public
+export const enum KnownCapabilityGroup {
+    // (undocumented)
+    SupportedEditions = "supportedEditions",
+    // (undocumented)
+    SupportedElasticPoolEditions = "supportedElasticPoolEditions",
+    // (undocumented)
+    SupportedInstancePoolEditions = "supportedInstancePoolEditions",
+    // (undocumented)
+    SupportedManagedInstanceEditions = "supportedManagedInstanceEditions",
+    // (undocumented)
+    SupportedManagedInstanceVersions = "supportedManagedInstanceVersions"
+}
+
+// @public
+export const enum KnownCatalogCollationType {
+    // (undocumented)
+    DatabaseDefault = "DATABASE_DEFAULT",
+    // (undocumented)
+    SQLLatin1GeneralCP1CIAS = "SQL_Latin1_General_CP1_CI_AS"
+}
+
+// @public
+export const enum KnownConnectionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownCreateMode {
+    // (undocumented)
+    Copy = "Copy",
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    OnlineSecondary = "OnlineSecondary",
+    // (undocumented)
+    PointInTimeRestore = "PointInTimeRestore",
+    // (undocumented)
+    Recovery = "Recovery",
+    // (undocumented)
+    Restore = "Restore",
+    // (undocumented)
+    RestoreExternalBackup = "RestoreExternalBackup",
+    // (undocumented)
+    RestoreExternalBackupSecondary = "RestoreExternalBackupSecondary",
+    // (undocumented)
+    RestoreLongTermRetentionBackup = "RestoreLongTermRetentionBackup",
+    // (undocumented)
+    Secondary = "Secondary"
+}
+
+// @public
+export const enum KnownDatabaseEdition {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Business = "Business",
+    // (undocumented)
+    BusinessCritical = "BusinessCritical",
+    // (undocumented)
+    DataWarehouse = "DataWarehouse",
+    // (undocumented)
+    Free = "Free",
+    // (undocumented)
+    GeneralPurpose = "GeneralPurpose",
+    // (undocumented)
+    Hyperscale = "Hyperscale",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    PremiumRS = "PremiumRS",
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    Stretch = "Stretch",
+    // (undocumented)
+    System = "System",
+    // (undocumented)
+    System2 = "System2",
+    // (undocumented)
+    Web = "Web"
+}
+
+// @public
+export const enum KnownDatabaseLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownDatabaseReadScale {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownDatabaseState {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Deleted = "Deleted",
+    // (undocumented)
+    Live = "Live"
+}
+
+// @public
+export const enum KnownDatabaseStatus {
+    // (undocumented)
+    AutoClosed = "AutoClosed",
+    // (undocumented)
+    Copying = "Copying",
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    EmergencyMode = "EmergencyMode",
+    // (undocumented)
+    Inaccessible = "Inaccessible",
+    // (undocumented)
+    Offline = "Offline",
+    // (undocumented)
+    OfflineChangingDwPerformanceTiers = "OfflineChangingDwPerformanceTiers",
+    // (undocumented)
+    OfflineSecondary = "OfflineSecondary",
+    // (undocumented)
+    Online = "Online",
+    // (undocumented)
+    OnlineChangingDwPerformanceTiers = "OnlineChangingDwPerformanceTiers",
+    // (undocumented)
+    Paused = "Paused",
+    // (undocumented)
+    Pausing = "Pausing",
+    // (undocumented)
+    Recovering = "Recovering",
+    // (undocumented)
+    RecoveryPending = "RecoveryPending",
+    // (undocumented)
+    Restoring = "Restoring",
+    // (undocumented)
+    Resuming = "Resuming",
+    // (undocumented)
+    Scaling = "Scaling",
+    // (undocumented)
+    Shutdown = "Shutdown",
+    // (undocumented)
+    Standby = "Standby",
+    // (undocumented)
+    Suspect = "Suspect"
+}
+
+// @public
+export const enum KnownElasticPoolEdition {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    BusinessCritical = "BusinessCritical",
+    // (undocumented)
+    GeneralPurpose = "GeneralPurpose",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownElasticPoolLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownElasticPoolState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Ready = "Ready"
+}
+
+// @public
+export const enum KnownEncryptionProtectorName {
+    // (undocumented)
+    Current = "current"
+}
+
+// @public
+export const enum KnownEnum21 {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Success = "Success",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownExtensionName {
+    // (undocumented)
+    Import = "import"
+}
+
+// @public
+export const enum KnownFailoverGroupReplicationRole {
+    // (undocumented)
+    Primary = "Primary",
+    // (undocumented)
+    Secondary = "Secondary"
+}
+
+// @public
+export const enum KnownGeoBackupPolicyName {
+    // (undocumented)
+    Default = "Default"
+}
+
+// @public
+export const enum KnownIdentityType {
+    // (undocumented)
+    SystemAssigned = "SystemAssigned"
+}
+
+// @public
+export const enum KnownInstanceFailoverGroupReplicationRole {
+    // (undocumented)
+    Primary = "Primary",
+    // (undocumented)
+    Secondary = "Secondary"
+}
+
+// @public
+export const enum KnownInstancePoolLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownJobAgentState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownJobExecutionLifecycle {
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Created = "Created",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Skipped = "Skipped",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    SucceededWithSkipped = "SucceededWithSkipped",
+    // (undocumented)
+    TimedOut = "TimedOut",
+    // (undocumented)
+    WaitingForChildJobExecutions = "WaitingForChildJobExecutions",
+    // (undocumented)
+    WaitingForRetry = "WaitingForRetry"
+}
+
+// @public
+export const enum KnownJobStepActionSource {
+    // (undocumented)
+    Inline = "Inline"
+}
+
+// @public
+export const enum KnownJobStepActionType {
+    // (undocumented)
+    TSql = "TSql"
+}
+
+// @public
+export const enum KnownJobStepOutputType {
+    // (undocumented)
+    SqlDatabase = "SqlDatabase"
+}
+
+// @public
+export const enum KnownJobTargetType {
+    // (undocumented)
+    SqlDatabase = "SqlDatabase",
+    // (undocumented)
+    SqlElasticPool = "SqlElasticPool",
+    // (undocumented)
+    SqlServer = "SqlServer",
+    // (undocumented)
+    SqlShardMap = "SqlShardMap",
+    // (undocumented)
+    TargetGroup = "TargetGroup"
+}
+
+// @public
+export const enum KnownLogSizeUnit {
+    // (undocumented)
+    Gigabytes = "Gigabytes",
+    // (undocumented)
+    Megabytes = "Megabytes",
+    // (undocumented)
+    Percent = "Percent",
+    // (undocumented)
+    Petabytes = "Petabytes",
+    // (undocumented)
+    Terabytes = "Terabytes"
+}
+
+// @public
+export const enum KnownLongTermRetentionDatabaseState {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Deleted = "Deleted",
+    // (undocumented)
+    Live = "Live"
+}
+
+// @public
+export const enum KnownLongTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownManagedDatabaseCreateMode {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    PointInTimeRestore = "PointInTimeRestore",
+    // (undocumented)
+    Recovery = "Recovery",
+    // (undocumented)
+    RestoreExternalBackup = "RestoreExternalBackup",
+    // (undocumented)
+    RestoreLongTermRetentionBackup = "RestoreLongTermRetentionBackup"
+}
+
+// @public
+export const enum KnownManagedDatabaseStatus {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Inaccessible = "Inaccessible",
+    // (undocumented)
+    Offline = "Offline",
+    // (undocumented)
+    Online = "Online",
+    // (undocumented)
+    Restoring = "Restoring",
+    // (undocumented)
+    Shutdown = "Shutdown",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownManagedInstanceAdministratorType {
+    // (undocumented)
+    ActiveDirectory = "ActiveDirectory"
+}
+
+// @public
+export const enum KnownManagedInstanceLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownManagedInstanceLongTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownManagedInstanceProxyOverride {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    Proxy = "Proxy",
+    // (undocumented)
+    Redirect = "Redirect"
+}
+
+// @public
+export const enum KnownManagedServerCreateMode {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    PointInTimeRestore = "PointInTimeRestore"
+}
+
+// @public
+export const enum KnownManagedShortTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownManagementOperationState {
+    // (undocumented)
+    CancelInProgress = "CancelInProgress",
+    // (undocumented)
+    Cancelled = "Cancelled",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownMaxSizeUnit {
+    // (undocumented)
+    Gigabytes = "Gigabytes",
+    // (undocumented)
+    Megabytes = "Megabytes",
+    // (undocumented)
+    Petabytes = "Petabytes",
+    // (undocumented)
+    Terabytes = "Terabytes"
+}
+
+// @public
+export const enum KnownOperationOrigin {
+    // (undocumented)
+    System = "system",
+    // (undocumented)
+    User = "user"
+}
+
+// @public
+export const enum KnownPauseDelayTimeUnit {
+    // (undocumented)
+    Minutes = "Minutes"
+}
+
+// @public
+export const enum KnownPerformanceLevelUnit {
+    // (undocumented)
+    DTU = "DTU",
+    // (undocumented)
+    VCores = "VCores"
+}
+
+// @public
+export const enum KnownPrimaryAggregationType {
+    // (undocumented)
+    Average = "Average",
+    // (undocumented)
+    Count = "Count",
+    // (undocumented)
+    Maximum = "Maximum",
+    // (undocumented)
+    Minimum = "Minimum",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Total = "Total"
+}
+
+// @public
+export const enum KnownPrivateEndpointProvisioningState {
+    // (undocumented)
+    Approving = "Approving",
+    // (undocumented)
+    Dropping = "Dropping",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Rejecting = "Rejecting"
+}
+
+// @public
+export const enum KnownPrivateLinkServiceConnectionStateActionsRequire {
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownPrivateLinkServiceConnectionStateStatus {
+    // (undocumented)
+    Approved = "Approved",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Rejected = "Rejected"
+}
+
+// @public
+export const enum KnownProvisioningState {
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Created = "Created",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownReadOnlyEndpointFailoverPolicy {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownReadWriteEndpointFailoverPolicy {
+    // (undocumented)
+    Automatic = "Automatic",
+    // (undocumented)
+    Manual = "Manual"
+}
+
+// @public
+export const enum KnownReplicationState {
+    // (undocumented)
+    CatchUP = "CATCH_UP",
+    // (undocumented)
+    Pending = "PENDING",
+    // (undocumented)
+    Seeding = "SEEDING",
+    // (undocumented)
+    Suspended = "SUSPENDED"
+}
+
+// @public
+export const enum KnownReplicaType {
+    // (undocumented)
+    Primary = "Primary",
+    // (undocumented)
+    ReadableSecondary = "ReadableSecondary"
+}
+
+// @public
+export const enum KnownRestoreDetailsName {
+    // (undocumented)
+    Default = "Default"
+}
+
+// @public
+export const enum KnownSampleName {
+    // (undocumented)
+    AdventureWorksLT = "AdventureWorksLT",
+    // (undocumented)
+    WideWorldImportersFull = "WideWorldImportersFull",
+    // (undocumented)
+    WideWorldImportersStd = "WideWorldImportersStd"
+}
+
+// @public
+export const enum KnownSecurityAlertPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownSecurityAlertPolicyNameAutoGenerated {
+    // (undocumented)
+    Default = "Default"
+}
+
+// @public
+export const enum KnownServerKeyType {
+    // (undocumented)
+    AzureKeyVault = "AzureKeyVault",
+    // (undocumented)
+    ServiceManaged = "ServiceManaged"
+}
+
+// @public
+export const enum KnownServerPublicNetworkAccess {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownServiceObjectiveName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    DS100 = "DS100",
+    // (undocumented)
+    DS1000 = "DS1000",
+    // (undocumented)
+    DS1200 = "DS1200",
+    // (undocumented)
+    DS1500 = "DS1500",
+    // (undocumented)
+    DS200 = "DS200",
+    // (undocumented)
+    DS2000 = "DS2000",
+    // (undocumented)
+    DS300 = "DS300",
+    // (undocumented)
+    DS400 = "DS400",
+    // (undocumented)
+    DS500 = "DS500",
+    // (undocumented)
+    DS600 = "DS600",
+    // (undocumented)
+    DW100 = "DW100",
+    // (undocumented)
+    DW1000 = "DW1000",
+    // (undocumented)
+    DW10000C = "DW10000c",
+    // (undocumented)
+    DW1000C = "DW1000c",
+    // (undocumented)
+    DW1200 = "DW1200",
+    // (undocumented)
+    DW1500 = "DW1500",
+    // (undocumented)
+    DW15000C = "DW15000c",
+    // (undocumented)
+    DW1500C = "DW1500c",
+    // (undocumented)
+    DW200 = "DW200",
+    // (undocumented)
+    DW2000 = "DW2000",
+    // (undocumented)
+    DW2000C = "DW2000c",
+    // (undocumented)
+    DW2500C = "DW2500c",
+    // (undocumented)
+    DW300 = "DW300",
+    // (undocumented)
+    DW3000 = "DW3000",
+    // (undocumented)
+    DW30000C = "DW30000c",
+    // (undocumented)
+    DW3000C = "DW3000c",
+    // (undocumented)
+    DW400 = "DW400",
+    // (undocumented)
+    DW500 = "DW500",
+    // (undocumented)
+    DW5000C = "DW5000c",
+    // (undocumented)
+    DW600 = "DW600",
+    // (undocumented)
+    DW6000 = "DW6000",
+    // (undocumented)
+    DW6000C = "DW6000c",
+    // (undocumented)
+    DW7500C = "DW7500c",
+    // (undocumented)
+    ElasticPool = "ElasticPool",
+    // (undocumented)
+    Free = "Free",
+    // (undocumented)
+    P1 = "P1",
+    // (undocumented)
+    P11 = "P11",
+    // (undocumented)
+    P15 = "P15",
+    // (undocumented)
+    P2 = "P2",
+    // (undocumented)
+    P3 = "P3",
+    // (undocumented)
+    P4 = "P4",
+    // (undocumented)
+    P6 = "P6",
+    // (undocumented)
+    PRS1 = "PRS1",
+    // (undocumented)
+    PRS2 = "PRS2",
+    // (undocumented)
+    PRS4 = "PRS4",
+    // (undocumented)
+    PRS6 = "PRS6",
+    // (undocumented)
+    S0 = "S0",
+    // (undocumented)
+    S1 = "S1",
+    // (undocumented)
+    S12 = "S12",
+    // (undocumented)
+    S2 = "S2",
+    // (undocumented)
+    S3 = "S3",
+    // (undocumented)
+    S4 = "S4",
+    // (undocumented)
+    S6 = "S6",
+    // (undocumented)
+    S7 = "S7",
+    // (undocumented)
+    S9 = "S9",
+    // (undocumented)
+    System = "System",
+    // (undocumented)
+    System0 = "System0",
+    // (undocumented)
+    System1 = "System1",
+    // (undocumented)
+    System2 = "System2",
+    // (undocumented)
+    System2L = "System2L",
+    // (undocumented)
+    System3 = "System3",
+    // (undocumented)
+    System3L = "System3L",
+    // (undocumented)
+    System4 = "System4",
+    // (undocumented)
+    System4L = "System4L"
+}
+
+// @public
+export const enum KnownShortTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownStorageCapabilityStorageAccountType {
+    // (undocumented)
+    GRS = "GRS",
+    // (undocumented)
+    LRS = "LRS",
+    // (undocumented)
+    ZRS = "ZRS"
+}
+
+// @public
+export const enum KnownSyncAgentState {
+    // (undocumented)
+    NeverConnected = "NeverConnected",
+    // (undocumented)
+    Offline = "Offline",
+    // (undocumented)
+    Online = "Online"
+}
+
+// @public
+export const enum KnownSyncConflictResolutionPolicy {
+    // (undocumented)
+    HubWin = "HubWin",
+    // (undocumented)
+    MemberWin = "MemberWin"
+}
+
+// @public
+export const enum KnownSyncDirection {
+    // (undocumented)
+    Bidirectional = "Bidirectional",
+    // (undocumented)
+    OneWayHubToMember = "OneWayHubToMember",
+    // (undocumented)
+    OneWayMemberToHub = "OneWayMemberToHub"
+}
+
+// @public
+export const enum KnownSyncGroupLogType {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Success = "Success",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownSyncGroupState {
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Good = "Good",
+    // (undocumented)
+    NotReady = "NotReady",
+    // (undocumented)
+    Progressing = "Progressing",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownSyncMemberDbType {
+    // (undocumented)
+    AzureSqlDatabase = "AzureSqlDatabase",
+    // (undocumented)
+    SqlServerDatabase = "SqlServerDatabase"
+}
+
+// @public
+export const enum KnownSyncMemberState {
+    // (undocumented)
+    DeProvisioned = "DeProvisioned",
+    // (undocumented)
+    DeProvisionFailed = "DeProvisionFailed",
+    // (undocumented)
+    DeProvisioning = "DeProvisioning",
+    // (undocumented)
+    DisabledBackupRestore = "DisabledBackupRestore",
+    // (undocumented)
+    DisabledTombstoneCleanup = "DisabledTombstoneCleanup",
+    // (undocumented)
+    Provisioned = "Provisioned",
+    // (undocumented)
+    ProvisionFailed = "ProvisionFailed",
+    // (undocumented)
+    Provisioning = "Provisioning",
+    // (undocumented)
+    ReprovisionFailed = "ReprovisionFailed",
+    // (undocumented)
+    Reprovisioning = "Reprovisioning",
+    // (undocumented)
+    SyncCancelled = "SyncCancelled",
+    // (undocumented)
+    SyncCancelling = "SyncCancelling",
+    // (undocumented)
+    SyncFailed = "SyncFailed",
+    // (undocumented)
+    SyncInProgress = "SyncInProgress",
+    // (undocumented)
+    SyncSucceeded = "SyncSucceeded",
+    // (undocumented)
+    SyncSucceededWithWarnings = "SyncSucceededWithWarnings",
+    // (undocumented)
+    UnProvisioned = "UnProvisioned",
+    // (undocumented)
+    UnReprovisioned = "UnReprovisioned"
+}
+
+// @public
+export const enum KnownTransparentDataEncryptionActivityStatus {
+    // (undocumented)
+    Decrypting = "Decrypting",
+    // (undocumented)
+    Encrypting = "Encrypting"
+}
+
+// @public
+export const enum KnownTransparentDataEncryptionName {
+    // (undocumented)
+    Current = "current"
+}
+
+// @public
+export const enum KnownUnitDefinitionType {
+    // (undocumented)
+    Bytes = "Bytes",
+    // (undocumented)
+    BytesPerSecond = "BytesPerSecond",
+    // (undocumented)
+    Count = "Count",
+    // (undocumented)
+    CountPerSecond = "CountPerSecond",
+    // (undocumented)
+    Percent = "Percent",
+    // (undocumented)
+    Seconds = "Seconds"
+}
+
+// @public
+export const enum KnownUnitType {
+    // (undocumented)
+    Bytes = "bytes",
+    // (undocumented)
+    BytesPerSecond = "bytesPerSecond",
+    // (undocumented)
+    Count = "count",
+    // (undocumented)
+    CountPerSecond = "countPerSecond",
+    // (undocumented)
+    Percent = "percent",
+    // (undocumented)
+    Seconds = "seconds"
+}
+
+// @public
+export const enum KnownVirtualNetworkRuleState {
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Initializing = "Initializing",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownVulnerabilityAssessmentName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownVulnerabilityAssessmentScanState {
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    FailedToRun = "FailedToRun",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Passed = "Passed"
+}
+
+// @public
+export const enum KnownVulnerabilityAssessmentScanTriggerType {
+    // (undocumented)
+    OnDemand = "OnDemand",
+    // (undocumented)
+    Recurring = "Recurring"
+}
+
+// @public
 export interface LicenseTypeCapability {
     readonly name?: string;
     reason?: string;
@@ -2322,7 +3288,7 @@ export interface LogSizeCapability {
 }
 
 // @public
-export type LogSizeUnit = "Megabytes" | "Gigabytes" | "Terabytes" | "Petabytes" | "Percent" | string;
+export type LogSizeUnit = string;
 
 // @public
 export type LongTermRetentionBackup = Resource & {
@@ -2525,7 +3491,7 @@ export type LongTermRetentionBackupsListByServerResponse = LongTermRetentionBack
 };
 
 // @public
-export type LongTermRetentionDatabaseState = "All" | "Live" | "Deleted" | string;
+export type LongTermRetentionDatabaseState = string;
 
 // @public
 export type LongTermRetentionManagedInstanceBackupsGetByResourceGroupResponse = ManagedInstanceLongTermRetentionBackup & {
@@ -2712,7 +3678,7 @@ export type LongTermRetentionManagedInstanceBackupsListByResourceGroupLocationRe
 };
 
 // @public
-export type LongTermRetentionPolicyName = "default" | string;
+export type LongTermRetentionPolicyName = string;
 
 // @public
 export type ManagedBackupShortTermRetentionPoliciesCreateOrUpdateResponse = ManagedBackupShortTermRetentionPolicy & {
@@ -2787,7 +3753,7 @@ export type ManagedDatabase = TrackedResource & {
 };
 
 // @public
-export type ManagedDatabaseCreateMode = "Default" | "RestoreExternalBackup" | "PointInTimeRestore" | "Recovery" | "RestoreLongTermRetentionBackup" | string;
+export type ManagedDatabaseCreateMode = string;
 
 // @public
 export interface ManagedDatabaseListResult {
@@ -2991,7 +3957,7 @@ export type ManagedDatabasesListInaccessibleByInstanceResponse = ManagedDatabase
 };
 
 // @public
-export type ManagedDatabaseStatus = "Online" | "Offline" | "Shutdown" | "Creating" | "Inaccessible" | "Restoring" | "Updating" | string;
+export type ManagedDatabaseStatus = string;
 
 // @public
 export type ManagedDatabasesUpdateResponse = ManagedDatabase & {
@@ -3177,7 +4143,7 @@ export type ManagedInstanceAdministratorsListByInstanceResponse = ManagedInstanc
 };
 
 // @public
-export type ManagedInstanceAdministratorType = "ActiveDirectory" | string;
+export type ManagedInstanceAdministratorType = string;
 
 // @public
 export interface ManagedInstanceEditionCapability {
@@ -3304,7 +4270,7 @@ export type ManagedInstanceKeysListByInstanceResponse = ManagedInstanceKeyListRe
 };
 
 // @public
-export type ManagedInstanceLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type ManagedInstanceLicenseType = string;
 
 // @public
 export interface ManagedInstanceListResult {
@@ -3376,7 +4342,7 @@ export interface ManagedInstanceLongTermRetentionPolicyListResult {
 }
 
 // @public
-export type ManagedInstanceLongTermRetentionPolicyName = "default" | string;
+export type ManagedInstanceLongTermRetentionPolicyName = string;
 
 // @public
 export type ManagedInstanceOperation = Resource & {
@@ -3432,7 +4398,7 @@ export interface ManagedInstancePairInfo {
 }
 
 // @public
-export type ManagedInstanceProxyOverride = "Proxy" | "Redirect" | "Default" | string;
+export type ManagedInstanceProxyOverride = string;
 
 // @public
 export type ManagedInstancesCreateOrUpdateResponse = ManagedInstance & {
@@ -3645,7 +4611,7 @@ export type ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesUpda
 };
 
 // @public
-export type ManagedServerCreateMode = "Default" | "PointInTimeRestore" | string;
+export type ManagedServerCreateMode = string;
 
 // @public
 export type ManagedServerSecurityAlertPoliciesCreateOrUpdateResponse = ManagedServerSecurityAlertPolicy & {
@@ -3699,10 +4665,10 @@ export interface ManagedServerSecurityAlertPolicyListResult {
 }
 
 // @public
-export type ManagedShortTermRetentionPolicyName = "default" | string;
+export type ManagedShortTermRetentionPolicyName = string;
 
 // @public
-export type ManagementOperationState = "Pending" | "InProgress" | "Succeeded" | "Failed" | "CancelInProgress" | "Cancelled" | string;
+export type ManagementOperationState = string;
 
 // @public
 export interface MaxSizeCapability {
@@ -3721,7 +4687,7 @@ export interface MaxSizeRangeCapability {
 }
 
 // @public
-export type MaxSizeUnit = "Megabytes" | "Gigabytes" | "Terabytes" | "Petabytes" | string;
+export type MaxSizeUnit = string;
 
 // @public
 export interface Metric {
@@ -3820,7 +4786,7 @@ export interface OperationListResult {
 }
 
 // @public
-export type OperationOrigin = "user" | "system" | string;
+export type OperationOrigin = string;
 
 // @public
 export type OperationsListNextResponse = OperationListResult & {
@@ -3852,7 +4818,7 @@ export interface PartnerRegionInfo {
 }
 
 // @public
-export type PauseDelayTimeUnit = "Minutes" | string;
+export type PauseDelayTimeUnit = string;
 
 // @public
 export interface PerformanceLevelCapability {
@@ -3861,10 +4827,10 @@ export interface PerformanceLevelCapability {
 }
 
 // @public
-export type PerformanceLevelUnit = "DTU" | "VCores" | string;
+export type PerformanceLevelUnit = string;
 
 // @public
-export type PrimaryAggregationType = "None" | "Average" | "Count" | "Minimum" | "Maximum" | "Total" | string;
+export type PrimaryAggregationType = string;
 
 // @public
 export type PrivateEndpointConnection = Resource & {
@@ -3925,7 +4891,7 @@ export interface PrivateEndpointProperty {
 }
 
 // @public
-export type PrivateEndpointProvisioningState = "Approving" | "Ready" | "Dropping" | "Failed" | "Rejecting" | string;
+export type PrivateEndpointProvisioningState = string;
 
 // @public
 export type PrivateLinkResource = Resource & {
@@ -3969,7 +4935,7 @@ export type PrivateLinkResourcesListByServerResponse = PrivateLinkResourceListRe
 };
 
 // @public
-export type PrivateLinkServiceConnectionStateActionsRequire = "None" | string;
+export type PrivateLinkServiceConnectionStateActionsRequire = string;
 
 // @public (undocumented)
 export interface PrivateLinkServiceConnectionStateProperty {
@@ -3986,16 +4952,16 @@ export interface PrivateLinkServiceConnectionStatePropertyAutoGenerated {
 }
 
 // @public
-export type PrivateLinkServiceConnectionStateStatus = "Approved" | "Pending" | "Rejected" | "Disconnected" | string;
+export type PrivateLinkServiceConnectionStateStatus = string;
 
 // @public
-export type ProvisioningState = "Created" | "InProgress" | "Succeeded" | "Failed" | "Canceled" | string;
+export type ProvisioningState = string;
 
 // @public
 export type ProxyResource = Resource & {};
 
 // @public
-export type ReadOnlyEndpointFailoverPolicy = "Disabled" | "Enabled" | string;
+export type ReadOnlyEndpointFailoverPolicy = string;
 
 // @public
 export interface ReadScaleCapability {
@@ -4005,7 +4971,7 @@ export interface ReadScaleCapability {
 }
 
 // @public
-export type ReadWriteEndpointFailoverPolicy = "Manual" | "Automatic" | string;
+export type ReadWriteEndpointFailoverPolicy = string;
 
 // @public
 export type RecommendedElasticPool = Resource & {
@@ -4192,10 +5158,10 @@ export type ReplicationLinksListByDatabaseResponse = ReplicationLinkListResult &
 export type ReplicationRole = "Primary" | "Secondary" | "NonReadableSecondary" | "Source" | "Copy";
 
 // @public
-export type ReplicationState = "PENDING" | "SEEDING" | "CATCH_UP" | "SUSPENDED" | string;
+export type ReplicationState = string;
 
 // @public
-export type ReplicaType = "Primary" | "ReadableSecondary" | string;
+export type ReplicaType = string;
 
 // @public
 export interface Resource {
@@ -4289,7 +5255,7 @@ export type RestorableDroppedManagedDatabasesListByInstanceResponse = Restorable
 };
 
 // @public
-export type RestoreDetailsName = "Default" | string;
+export type RestoreDetailsName = string;
 
 // @public
 export type RestorePoint = Resource & {
@@ -4335,16 +5301,16 @@ export type RestorePointsListByDatabaseResponse = RestorePointListResult & {
 export type RestorePointType = "CONTINUOUS" | "DISCRETE";
 
 // @public
-export type SampleName = "AdventureWorksLT" | "WideWorldImportersStd" | "WideWorldImportersFull" | string;
+export type SampleName = string;
 
 // @public
 export type SecurityAlertPolicyEmailAccountAdmins = "Enabled" | "Disabled";
 
 // @public
-export type SecurityAlertPolicyName = "default" | string;
+export type SecurityAlertPolicyName = string;
 
 // @public
-export type SecurityAlertPolicyNameAutoGenerated = "Default" | string;
+export type SecurityAlertPolicyNameAutoGenerated = string;
 
 // @public
 export type SecurityAlertPolicyState = "New" | "Enabled" | "Disabled";
@@ -4754,7 +5720,7 @@ export type ServerKeysListByServerResponse = ServerKeyListResult & {
 };
 
 // @public
-export type ServerKeyType = "ServiceManaged" | "AzureKeyVault" | string;
+export type ServerKeyType = string;
 
 // @public
 export interface ServerListResult {
@@ -4769,7 +5735,7 @@ export interface ServerPrivateEndpointConnection {
 }
 
 // @public
-export type ServerPublicNetworkAccess = "Enabled" | "Disabled" | string;
+export type ServerPublicNetworkAccess = string;
 
 // @public
 export type ServersCheckNameAvailabilityResponse = CheckNameAvailabilityResponse & {
@@ -5008,7 +5974,7 @@ export interface ServiceObjectiveListResult {
 }
 
 // @public
-export type ServiceObjectiveName = "System" | "System0" | "System1" | "System2" | "System3" | "System4" | "System2L" | "System3L" | "System4L" | "Free" | "Basic" | "S0" | "S1" | "S2" | "S3" | "S4" | "S6" | "S7" | "S9" | "S12" | "P1" | "P2" | "P3" | "P4" | "P6" | "P11" | "P15" | "PRS1" | "PRS2" | "PRS4" | "PRS6" | "DW100" | "DW200" | "DW300" | "DW400" | "DW500" | "DW600" | "DW1000" | "DW1200" | "DW1000c" | "DW1500" | "DW1500c" | "DW2000" | "DW2000c" | "DW3000" | "DW2500c" | "DW3000c" | "DW6000" | "DW5000c" | "DW6000c" | "DW7500c" | "DW10000c" | "DW15000c" | "DW30000c" | "DS100" | "DS200" | "DS300" | "DS400" | "DS500" | "DS600" | "DS1000" | "DS1200" | "DS1500" | "DS2000" | "ElasticPool" | string;
+export type ServiceObjectiveName = string;
 
 // @public
 export type ServiceObjectivesGetResponse = ServiceObjective & {
@@ -5071,7 +6037,7 @@ export type ServiceTierAdvisorsListByDatabaseResponse = ServiceTierAdvisorListRe
 };
 
 // @public
-export type ShortTermRetentionPolicyName = "default" | string;
+export type ShortTermRetentionPolicyName = string;
 
 // @public
 export interface Sku {
@@ -5481,7 +6447,7 @@ export interface StorageCapability {
 }
 
 // @public
-export type StorageCapabilityStorageAccountType = "GRS" | "LRS" | "ZRS" | string;
+export type StorageCapabilityStorageAccountType = string;
 
 // @public
 export type StorageKeyType = "StorageAccessKey" | "SharedAccessKey";
@@ -5620,10 +6586,10 @@ export type SyncAgentsListLinkedDatabasesResponse = SyncAgentLinkedDatabaseListR
 };
 
 // @public
-export type SyncAgentState = "Online" | "Offline" | "NeverConnected" | string;
+export type SyncAgentState = string;
 
 // @public
-export type SyncConflictResolutionPolicy = "HubWin" | "MemberWin" | string;
+export type SyncConflictResolutionPolicy = string;
 
 // @public
 export interface SyncDatabaseIdListResult {
@@ -5637,7 +6603,7 @@ export interface SyncDatabaseIdProperties {
 }
 
 // @public
-export type SyncDirection = "Bidirectional" | "OneWayMemberToHub" | "OneWayHubToMember" | string;
+export type SyncDirection = string;
 
 // @public
 export interface SyncFullSchemaProperties {
@@ -5706,7 +6672,7 @@ export interface SyncGroupLogProperties {
 }
 
 // @public
-export type SyncGroupLogType = "All" | "Error" | "Warning" | "Success" | string;
+export type SyncGroupLogType = string;
 
 // @public
 export interface SyncGroupSchema {
@@ -5819,7 +6785,7 @@ export type SyncGroupsListSyncDatabaseIdsResponse = SyncDatabaseIdListResult & {
 };
 
 // @public
-export type SyncGroupState = "NotReady" | "Error" | "Warning" | "Progressing" | "Good" | string;
+export type SyncGroupState = string;
 
 // @public
 export type SyncGroupsUpdateResponse = SyncGroup & {
@@ -5844,7 +6810,7 @@ export type SyncMember = Resource & {
 };
 
 // @public
-export type SyncMemberDbType = "AzureSqlDatabase" | "SqlServerDatabase" | string;
+export type SyncMemberDbType = string;
 
 // @public
 export interface SyncMemberListResult {
@@ -5902,7 +6868,7 @@ export type SyncMembersListMemberSchemasResponse = SyncFullSchemaPropertiesListR
 };
 
 // @public
-export type SyncMemberState = "SyncInProgress" | "SyncSucceeded" | "SyncFailed" | "DisabledTombstoneCleanup" | "DisabledBackupRestore" | "SyncSucceededWithWarnings" | "SyncCancelling" | "SyncCancelled" | "UnProvisioned" | "Provisioning" | "Provisioned" | "ProvisionFailed" | "DeProvisioning" | "DeProvisioned" | "DeProvisionFailed" | "Reprovisioning" | "ReprovisionFailed" | "UnReprovisioned" | string;
+export type SyncMemberState = string;
 
 // @public
 export type SyncMembersUpdateResponse = SyncMember & {
@@ -5954,10 +6920,10 @@ export interface TransparentDataEncryptionActivityListResult {
 }
 
 // @public
-export type TransparentDataEncryptionActivityStatus = "Encrypting" | "Decrypting" | string;
+export type TransparentDataEncryptionActivityStatus = string;
 
 // @public
-export type TransparentDataEncryptionName = "current" | string;
+export type TransparentDataEncryptionName = string;
 
 // @public
 export type TransparentDataEncryptionsCreateOrUpdateResponse = TransparentDataEncryption & {
@@ -5979,10 +6945,10 @@ export type TransparentDataEncryptionsGetResponse = TransparentDataEncryption & 
 export type TransparentDataEncryptionStatus = "Enabled" | "Disabled";
 
 // @public
-export type UnitDefinitionType = "Count" | "Bytes" | "Seconds" | "Percent" | "CountPerSecond" | "BytesPerSecond" | string;
+export type UnitDefinitionType = string;
 
 // @public
-export type UnitType = "count" | "bytes" | "seconds" | "percent" | "countPerSecond" | "bytesPerSecond" | string;
+export type UnitType = string;
 
 // @public
 export interface UnlinkParameters {
@@ -6151,10 +7117,10 @@ export type VirtualNetworkRulesListByServerResponse = VirtualNetworkRuleListResu
 };
 
 // @public
-export type VirtualNetworkRuleState = "Initializing" | "InProgress" | "Ready" | "Deleting" | "Unknown" | string;
+export type VirtualNetworkRuleState = string;
 
 // @public
-export type VulnerabilityAssessmentName = "default" | string;
+export type VulnerabilityAssessmentName = string;
 
 // @public
 export type VulnerabilityAssessmentPolicyBaselineName = "master" | "default";
@@ -6191,10 +7157,10 @@ export interface VulnerabilityAssessmentScanRecordListResult {
 }
 
 // @public
-export type VulnerabilityAssessmentScanState = "Passed" | "Failed" | "FailedToRun" | "InProgress" | string;
+export type VulnerabilityAssessmentScanState = string;
 
 // @public
-export type VulnerabilityAssessmentScanTriggerType = "OnDemand" | "Recurring" | string;
+export type VulnerabilityAssessmentScanTriggerType = string;
 
 // @public
 export type WorkloadClassifier = Resource & {
@@ -6297,7 +7263,7 @@ export type WorkloadGroupsListByDatabaseResponse = WorkloadGroupListResult & {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:12501:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:13631:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/sql-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/sql-resource-manager/src/models/index.ts
@@ -7129,612 +7129,1742 @@ export type ManagedDatabase = TrackedResource & {
    */
   longTermRetentionBackupResourceId?: string;
 };
-/**
- * Defines values for ConnectionPolicyName.
- */
-export type ConnectionPolicyName = "default" | string;
-/**
- * Defines values for SecurityAlertPolicyName.
- */
-export type SecurityAlertPolicyName = "default" | string;
-/**
- * Defines values for GeoBackupPolicyName.
- */
-export type GeoBackupPolicyName = "Default" | string;
-/**
- * Defines values for DatabaseEdition.
- */
-export type DatabaseEdition =
-  | "Web"
-  | "Business"
-  | "Basic"
-  | "Standard"
-  | "Premium"
-  | "PremiumRS"
-  | "Free"
-  | "Stretch"
-  | "DataWarehouse"
-  | "System"
-  | "System2"
-  | "GeneralPurpose"
-  | "BusinessCritical"
-  | "Hyperscale"
-  | string;
-/**
- * Defines values for ServiceObjectiveName.
- */
-export type ServiceObjectiveName =
-  | "System"
-  | "System0"
-  | "System1"
-  | "System2"
-  | "System3"
-  | "System4"
-  | "System2L"
-  | "System3L"
-  | "System4L"
-  | "Free"
-  | "Basic"
-  | "S0"
-  | "S1"
-  | "S2"
-  | "S3"
-  | "S4"
-  | "S6"
-  | "S7"
-  | "S9"
-  | "S12"
-  | "P1"
-  | "P2"
-  | "P3"
-  | "P4"
-  | "P6"
-  | "P11"
-  | "P15"
-  | "PRS1"
-  | "PRS2"
-  | "PRS4"
-  | "PRS6"
-  | "DW100"
-  | "DW200"
-  | "DW300"
-  | "DW400"
-  | "DW500"
-  | "DW600"
-  | "DW1000"
-  | "DW1200"
-  | "DW1000c"
-  | "DW1500"
-  | "DW1500c"
-  | "DW2000"
-  | "DW2000c"
-  | "DW3000"
-  | "DW2500c"
-  | "DW3000c"
-  | "DW6000"
-  | "DW5000c"
-  | "DW6000c"
-  | "DW7500c"
-  | "DW10000c"
-  | "DW15000c"
-  | "DW30000c"
-  | "DS100"
-  | "DS200"
-  | "DS300"
-  | "DS400"
-  | "DS500"
-  | "DS600"
-  | "DS1000"
-  | "DS1200"
-  | "DS1500"
-  | "DS2000"
-  | "ElasticPool"
-  | string;
-/**
- * Defines values for ExtensionName.
- */
-export type ExtensionName = "import" | string;
-/**
- * Defines values for UnitType.
- */
-export type UnitType =
-  | "count"
-  | "bytes"
-  | "seconds"
-  | "percent"
-  | "countPerSecond"
-  | "bytesPerSecond"
-  | string;
-/**
- * Defines values for PrimaryAggregationType.
- */
-export type PrimaryAggregationType =
-  | "None"
-  | "Average"
-  | "Count"
-  | "Minimum"
-  | "Maximum"
-  | "Total"
-  | string;
-/**
- * Defines values for UnitDefinitionType.
- */
-export type UnitDefinitionType =
-  | "Count"
-  | "Bytes"
-  | "Seconds"
-  | "Percent"
-  | "CountPerSecond"
-  | "BytesPerSecond"
-  | string;
-/**
- * Defines values for ElasticPoolEdition.
- */
-export type ElasticPoolEdition =
-  | "Basic"
-  | "Standard"
-  | "Premium"
-  | "GeneralPurpose"
-  | "BusinessCritical"
-  | string;
-/**
- * Defines values for ReplicationState.
- */
-export type ReplicationState =
-  | "PENDING"
-  | "SEEDING"
-  | "CATCH_UP"
-  | "SUSPENDED"
-  | string;
-/**
- * Defines values for TransparentDataEncryptionName.
- */
-export type TransparentDataEncryptionName = "current" | string;
-/**
- * Defines values for TransparentDataEncryptionActivityStatus.
- */
-export type TransparentDataEncryptionActivityStatus =
-  | "Encrypting"
-  | "Decrypting"
-  | string;
-/**
- * Defines values for EncryptionProtectorName.
- */
-export type EncryptionProtectorName = "current" | string;
-/**
- * Defines values for ServerKeyType.
- */
-export type ServerKeyType = "ServiceManaged" | "AzureKeyVault" | string;
-/**
- * Defines values for ReadWriteEndpointFailoverPolicy.
- */
-export type ReadWriteEndpointFailoverPolicy = "Manual" | "Automatic" | string;
-/**
- * Defines values for ReadOnlyEndpointFailoverPolicy.
- */
-export type ReadOnlyEndpointFailoverPolicy = "Disabled" | "Enabled" | string;
-/**
- * Defines values for FailoverGroupReplicationRole.
- */
-export type FailoverGroupReplicationRole = "Primary" | "Secondary" | string;
-/**
- * Defines values for OperationOrigin.
- */
-export type OperationOrigin = "user" | "system" | string;
-/**
- * Defines values for SyncAgentState.
- */
-export type SyncAgentState = "Online" | "Offline" | "NeverConnected" | string;
-/**
- * Defines values for SyncMemberDbType.
- */
-export type SyncMemberDbType =
-  | "AzureSqlDatabase"
-  | "SqlServerDatabase"
-  | string;
-/**
- * Defines values for Enum21.
- */
-export type Enum21 = "All" | "Error" | "Warning" | "Success" | string;
-/**
- * Defines values for SyncGroupLogType.
- */
-export type SyncGroupLogType = "All" | "Error" | "Warning" | "Success" | string;
-/**
- * Defines values for SyncConflictResolutionPolicy.
- */
-export type SyncConflictResolutionPolicy = "HubWin" | "MemberWin" | string;
-/**
- * Defines values for SyncGroupState.
- */
-export type SyncGroupState =
-  | "NotReady"
-  | "Error"
-  | "Warning"
-  | "Progressing"
-  | "Good"
-  | string;
-/**
- * Defines values for SyncDirection.
- */
-export type SyncDirection =
-  | "Bidirectional"
-  | "OneWayMemberToHub"
-  | "OneWayHubToMember"
-  | string;
-/**
- * Defines values for SyncMemberState.
- */
-export type SyncMemberState =
-  | "SyncInProgress"
-  | "SyncSucceeded"
-  | "SyncFailed"
-  | "DisabledTombstoneCleanup"
-  | "DisabledBackupRestore"
-  | "SyncSucceededWithWarnings"
-  | "SyncCancelling"
-  | "SyncCancelled"
-  | "UnProvisioned"
-  | "Provisioning"
-  | "Provisioned"
-  | "ProvisionFailed"
-  | "DeProvisioning"
-  | "DeProvisioned"
-  | "DeProvisionFailed"
-  | "Reprovisioning"
-  | "ReprovisionFailed"
-  | "UnReprovisioned"
-  | string;
-/**
- * Defines values for VirtualNetworkRuleState.
- */
-export type VirtualNetworkRuleState =
-  | "Initializing"
-  | "InProgress"
-  | "Ready"
-  | "Deleting"
-  | "Unknown"
-  | string;
-/**
- * Defines values for VulnerabilityAssessmentName.
- */
-export type VulnerabilityAssessmentName = "default" | string;
-/**
- * Defines values for JobAgentState.
- */
-export type JobAgentState =
-  | "Creating"
-  | "Ready"
-  | "Updating"
-  | "Deleting"
-  | "Disabled"
-  | string;
-/**
- * Defines values for JobExecutionLifecycle.
- */
-export type JobExecutionLifecycle =
-  | "Created"
-  | "InProgress"
-  | "WaitingForChildJobExecutions"
-  | "WaitingForRetry"
-  | "Succeeded"
-  | "SucceededWithSkipped"
-  | "Failed"
-  | "TimedOut"
-  | "Canceled"
-  | "Skipped"
-  | string;
-/**
- * Defines values for ProvisioningState.
- */
-export type ProvisioningState =
-  | "Created"
-  | "InProgress"
-  | "Succeeded"
-  | "Failed"
-  | "Canceled"
-  | string;
-/**
- * Defines values for JobTargetType.
- */
-export type JobTargetType =
-  | "TargetGroup"
-  | "SqlDatabase"
-  | "SqlElasticPool"
-  | "SqlShardMap"
-  | "SqlServer"
-  | string;
-/**
- * Defines values for JobStepActionType.
- */
-export type JobStepActionType = "TSql" | string;
-/**
- * Defines values for JobStepActionSource.
- */
-export type JobStepActionSource = "Inline" | string;
-/**
- * Defines values for JobStepOutputType.
- */
-export type JobStepOutputType = "SqlDatabase" | string;
-/**
- * Defines values for LongTermRetentionDatabaseState.
- */
-export type LongTermRetentionDatabaseState =
-  | "All"
-  | "Live"
-  | "Deleted"
-  | string;
-/**
- * Defines values for LongTermRetentionPolicyName.
- */
-export type LongTermRetentionPolicyName = "default" | string;
-/**
- * Defines values for ManagedShortTermRetentionPolicyName.
- */
-export type ManagedShortTermRetentionPolicyName = "default" | string;
-/**
- * Defines values for SecurityAlertPolicyNameAutoGenerated.
- */
-export type SecurityAlertPolicyNameAutoGenerated = "Default" | string;
-/**
- * Defines values for ManagedInstanceAdministratorType.
- */
-export type ManagedInstanceAdministratorType = "ActiveDirectory" | string;
-/**
- * Defines values for ManagementOperationState.
- */
-export type ManagementOperationState =
-  | "Pending"
-  | "InProgress"
-  | "Succeeded"
-  | "Failed"
-  | "CancelInProgress"
-  | "Cancelled"
-  | string;
-/**
- * Defines values for CreateMode.
- */
-export type CreateMode =
-  | "Default"
-  | "Copy"
-  | "Secondary"
-  | "PointInTimeRestore"
-  | "Restore"
-  | "Recovery"
-  | "RestoreExternalBackup"
-  | "RestoreExternalBackupSecondary"
-  | "RestoreLongTermRetentionBackup"
-  | "OnlineSecondary"
-  | string;
-/**
- * Defines values for SampleName.
- */
-export type SampleName =
-  | "AdventureWorksLT"
-  | "WideWorldImportersStd"
-  | "WideWorldImportersFull"
-  | string;
-/**
- * Defines values for DatabaseStatus.
- */
-export type DatabaseStatus =
-  | "Online"
-  | "Restoring"
-  | "RecoveryPending"
-  | "Recovering"
-  | "Suspect"
-  | "Offline"
-  | "Standby"
-  | "Shutdown"
-  | "EmergencyMode"
-  | "AutoClosed"
-  | "Copying"
-  | "Creating"
-  | "Inaccessible"
-  | "OfflineSecondary"
-  | "Pausing"
-  | "Paused"
-  | "Resuming"
-  | "Scaling"
-  | "OfflineChangingDwPerformanceTiers"
-  | "OnlineChangingDwPerformanceTiers"
-  | "Disabled"
-  | string;
-/**
- * Defines values for CatalogCollationType.
- */
-export type CatalogCollationType =
-  | "DATABASE_DEFAULT"
-  | "SQL_Latin1_General_CP1_CI_AS"
-  | string;
-/**
- * Defines values for DatabaseLicenseType.
- */
-export type DatabaseLicenseType = "LicenseIncluded" | "BasePrice" | string;
-/**
- * Defines values for DatabaseReadScale.
- */
-export type DatabaseReadScale = "Enabled" | "Disabled" | string;
-/**
- * Defines values for ElasticPoolState.
- */
-export type ElasticPoolState = "Creating" | "Ready" | "Disabled" | string;
-/**
- * Defines values for ElasticPoolLicenseType.
- */
-export type ElasticPoolLicenseType = "LicenseIncluded" | "BasePrice" | string;
-/**
- * Defines values for VulnerabilityAssessmentScanTriggerType.
- */
-export type VulnerabilityAssessmentScanTriggerType =
-  | "OnDemand"
-  | "Recurring"
-  | string;
-/**
- * Defines values for VulnerabilityAssessmentScanState.
- */
-export type VulnerabilityAssessmentScanState =
-  | "Passed"
-  | "Failed"
-  | "FailedToRun"
-  | "InProgress"
-  | string;
-/**
- * Defines values for InstanceFailoverGroupReplicationRole.
- */
-export type InstanceFailoverGroupReplicationRole =
-  | "Primary"
-  | "Secondary"
-  | string;
-/**
- * Defines values for ShortTermRetentionPolicyName.
- */
-export type ShortTermRetentionPolicyName = "default" | string;
-/**
- * Defines values for InstancePoolLicenseType.
- */
-export type InstancePoolLicenseType = "LicenseIncluded" | "BasePrice" | string;
-/**
- * Defines values for IdentityType.
- */
-export type IdentityType = "SystemAssigned" | string;
-/**
- * Defines values for ManagedServerCreateMode.
- */
-export type ManagedServerCreateMode = "Default" | "PointInTimeRestore" | string;
-/**
- * Defines values for ManagedInstanceLicenseType.
- */
-export type ManagedInstanceLicenseType =
-  | "LicenseIncluded"
-  | "BasePrice"
-  | string;
-/**
- * Defines values for ManagedInstanceProxyOverride.
- */
-export type ManagedInstanceProxyOverride =
-  | "Proxy"
-  | "Redirect"
-  | "Default"
-  | string;
-/**
- * Defines values for ReplicaType.
- */
-export type ReplicaType = "Primary" | "ReadableSecondary" | string;
-/**
- * Defines values for PrivateLinkServiceConnectionStateStatus.
- */
-export type PrivateLinkServiceConnectionStateStatus =
-  | "Approved"
-  | "Pending"
-  | "Rejected"
-  | "Disconnected"
-  | string;
-/**
- * Defines values for PrivateLinkServiceConnectionStateActionsRequire.
- */
-export type PrivateLinkServiceConnectionStateActionsRequire = "None" | string;
-/**
- * Defines values for PrivateEndpointProvisioningState.
- */
-export type PrivateEndpointProvisioningState =
-  | "Approving"
-  | "Ready"
-  | "Dropping"
-  | "Failed"
-  | "Rejecting"
-  | string;
-/**
- * Defines values for ServerPublicNetworkAccess.
- */
-export type ServerPublicNetworkAccess = "Enabled" | "Disabled" | string;
-/**
- * Defines values for CapabilityGroup.
- */
-export type CapabilityGroup =
-  | "supportedEditions"
-  | "supportedElasticPoolEditions"
-  | "supportedManagedInstanceVersions"
-  | "supportedInstancePoolEditions"
-  | "supportedManagedInstanceEditions"
-  | string;
-/**
- * Defines values for MaxSizeUnit.
- */
-export type MaxSizeUnit =
-  | "Megabytes"
-  | "Gigabytes"
-  | "Terabytes"
-  | "Petabytes"
-  | string;
-/**
- * Defines values for LogSizeUnit.
- */
-export type LogSizeUnit =
-  | "Megabytes"
-  | "Gigabytes"
-  | "Terabytes"
-  | "Petabytes"
-  | "Percent"
-  | string;
-/**
- * Defines values for PerformanceLevelUnit.
- */
-export type PerformanceLevelUnit = "DTU" | "VCores" | string;
-/**
- * Defines values for PauseDelayTimeUnit.
- */
-export type PauseDelayTimeUnit = "Minutes" | string;
-/**
- * Defines values for StorageCapabilityStorageAccountType.
- */
-export type StorageCapabilityStorageAccountType =
-  | "GRS"
-  | "LRS"
-  | "ZRS"
-  | string;
-/**
- * Defines values for DatabaseState.
- */
-export type DatabaseState = "All" | "Live" | "Deleted" | string;
-/**
- * Defines values for ManagedInstanceLongTermRetentionPolicyName.
- */
-export type ManagedInstanceLongTermRetentionPolicyName = "default" | string;
-/**
- * Defines values for RestoreDetailsName.
- */
-export type RestoreDetailsName = "Default" | string;
-/**
- * Defines values for ManagedDatabaseStatus.
- */
-export type ManagedDatabaseStatus =
-  | "Online"
-  | "Offline"
-  | "Shutdown"
-  | "Creating"
-  | "Inaccessible"
-  | "Restoring"
-  | "Updating"
-  | string;
-/**
- * Defines values for ManagedDatabaseCreateMode.
- */
-export type ManagedDatabaseCreateMode =
-  | "Default"
-  | "RestoreExternalBackup"
-  | "PointInTimeRestore"
-  | "Recovery"
-  | "RestoreLongTermRetentionBackup"
-  | string;
-/**
- * Defines values for AdministratorName.
- */
-export type AdministratorName = "ActiveDirectory" | string;
-/**
- * Defines values for AdministratorType.
- */
-export type AdministratorType = "ActiveDirectory" | string;
+
+/**
+ * Known values of {@link ConnectionPolicyName} that the service accepts.
+ */
+export const enum KnownConnectionPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for ConnectionPolicyName. \
+ * {@link KnownConnectionPolicyName} can be used interchangeably with ConnectionPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type ConnectionPolicyName = string;
+
+/**
+ * Known values of {@link SecurityAlertPolicyName} that the service accepts.
+ */
+export const enum KnownSecurityAlertPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for SecurityAlertPolicyName. \
+ * {@link KnownSecurityAlertPolicyName} can be used interchangeably with SecurityAlertPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type SecurityAlertPolicyName = string;
+
+/**
+ * Known values of {@link GeoBackupPolicyName} that the service accepts.
+ */
+export const enum KnownGeoBackupPolicyName {
+  Default = "Default"
+}
+
+/**
+ * Defines values for GeoBackupPolicyName. \
+ * {@link KnownGeoBackupPolicyName} can be used interchangeably with GeoBackupPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default**
+ */
+export type GeoBackupPolicyName = string;
+
+/**
+ * Known values of {@link DatabaseEdition} that the service accepts.
+ */
+export const enum KnownDatabaseEdition {
+  Web = "Web",
+  Business = "Business",
+  Basic = "Basic",
+  Standard = "Standard",
+  Premium = "Premium",
+  PremiumRS = "PremiumRS",
+  Free = "Free",
+  Stretch = "Stretch",
+  DataWarehouse = "DataWarehouse",
+  System = "System",
+  System2 = "System2",
+  GeneralPurpose = "GeneralPurpose",
+  BusinessCritical = "BusinessCritical",
+  Hyperscale = "Hyperscale"
+}
+
+/**
+ * Defines values for DatabaseEdition. \
+ * {@link KnownDatabaseEdition} can be used interchangeably with DatabaseEdition,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Web** \
+ * **Business** \
+ * **Basic** \
+ * **Standard** \
+ * **Premium** \
+ * **PremiumRS** \
+ * **Free** \
+ * **Stretch** \
+ * **DataWarehouse** \
+ * **System** \
+ * **System2** \
+ * **GeneralPurpose** \
+ * **BusinessCritical** \
+ * **Hyperscale**
+ */
+export type DatabaseEdition = string;
+
+/**
+ * Known values of {@link ServiceObjectiveName} that the service accepts.
+ */
+export const enum KnownServiceObjectiveName {
+  System = "System",
+  System0 = "System0",
+  System1 = "System1",
+  System2 = "System2",
+  System3 = "System3",
+  System4 = "System4",
+  System2L = "System2L",
+  System3L = "System3L",
+  System4L = "System4L",
+  Free = "Free",
+  Basic = "Basic",
+  S0 = "S0",
+  S1 = "S1",
+  S2 = "S2",
+  S3 = "S3",
+  S4 = "S4",
+  S6 = "S6",
+  S7 = "S7",
+  S9 = "S9",
+  S12 = "S12",
+  P1 = "P1",
+  P2 = "P2",
+  P3 = "P3",
+  P4 = "P4",
+  P6 = "P6",
+  P11 = "P11",
+  P15 = "P15",
+  PRS1 = "PRS1",
+  PRS2 = "PRS2",
+  PRS4 = "PRS4",
+  PRS6 = "PRS6",
+  DW100 = "DW100",
+  DW200 = "DW200",
+  DW300 = "DW300",
+  DW400 = "DW400",
+  DW500 = "DW500",
+  DW600 = "DW600",
+  DW1000 = "DW1000",
+  DW1200 = "DW1200",
+  DW1000C = "DW1000c",
+  DW1500 = "DW1500",
+  DW1500C = "DW1500c",
+  DW2000 = "DW2000",
+  DW2000C = "DW2000c",
+  DW3000 = "DW3000",
+  DW2500C = "DW2500c",
+  DW3000C = "DW3000c",
+  DW6000 = "DW6000",
+  DW5000C = "DW5000c",
+  DW6000C = "DW6000c",
+  DW7500C = "DW7500c",
+  DW10000C = "DW10000c",
+  DW15000C = "DW15000c",
+  DW30000C = "DW30000c",
+  DS100 = "DS100",
+  DS200 = "DS200",
+  DS300 = "DS300",
+  DS400 = "DS400",
+  DS500 = "DS500",
+  DS600 = "DS600",
+  DS1000 = "DS1000",
+  DS1200 = "DS1200",
+  DS1500 = "DS1500",
+  DS2000 = "DS2000",
+  ElasticPool = "ElasticPool"
+}
+
+/**
+ * Defines values for ServiceObjectiveName. \
+ * {@link KnownServiceObjectiveName} can be used interchangeably with ServiceObjectiveName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **System** \
+ * **System0** \
+ * **System1** \
+ * **System2** \
+ * **System3** \
+ * **System4** \
+ * **System2L** \
+ * **System3L** \
+ * **System4L** \
+ * **Free** \
+ * **Basic** \
+ * **S0** \
+ * **S1** \
+ * **S2** \
+ * **S3** \
+ * **S4** \
+ * **S6** \
+ * **S7** \
+ * **S9** \
+ * **S12** \
+ * **P1** \
+ * **P2** \
+ * **P3** \
+ * **P4** \
+ * **P6** \
+ * **P11** \
+ * **P15** \
+ * **PRS1** \
+ * **PRS2** \
+ * **PRS4** \
+ * **PRS6** \
+ * **DW100** \
+ * **DW200** \
+ * **DW300** \
+ * **DW400** \
+ * **DW500** \
+ * **DW600** \
+ * **DW1000** \
+ * **DW1200** \
+ * **DW1000c** \
+ * **DW1500** \
+ * **DW1500c** \
+ * **DW2000** \
+ * **DW2000c** \
+ * **DW3000** \
+ * **DW2500c** \
+ * **DW3000c** \
+ * **DW6000** \
+ * **DW5000c** \
+ * **DW6000c** \
+ * **DW7500c** \
+ * **DW10000c** \
+ * **DW15000c** \
+ * **DW30000c** \
+ * **DS100** \
+ * **DS200** \
+ * **DS300** \
+ * **DS400** \
+ * **DS500** \
+ * **DS600** \
+ * **DS1000** \
+ * **DS1200** \
+ * **DS1500** \
+ * **DS2000** \
+ * **ElasticPool**
+ */
+export type ServiceObjectiveName = string;
+
+/**
+ * Known values of {@link ExtensionName} that the service accepts.
+ */
+export const enum KnownExtensionName {
+  Import = "import"
+}
+
+/**
+ * Defines values for ExtensionName. \
+ * {@link KnownExtensionName} can be used interchangeably with ExtensionName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **import**
+ */
+export type ExtensionName = string;
+
+/**
+ * Known values of {@link UnitType} that the service accepts.
+ */
+export const enum KnownUnitType {
+  Count = "count",
+  Bytes = "bytes",
+  Seconds = "seconds",
+  Percent = "percent",
+  CountPerSecond = "countPerSecond",
+  BytesPerSecond = "bytesPerSecond"
+}
+
+/**
+ * Defines values for UnitType. \
+ * {@link KnownUnitType} can be used interchangeably with UnitType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **count** \
+ * **bytes** \
+ * **seconds** \
+ * **percent** \
+ * **countPerSecond** \
+ * **bytesPerSecond**
+ */
+export type UnitType = string;
+
+/**
+ * Known values of {@link PrimaryAggregationType} that the service accepts.
+ */
+export const enum KnownPrimaryAggregationType {
+  None = "None",
+  Average = "Average",
+  Count = "Count",
+  Minimum = "Minimum",
+  Maximum = "Maximum",
+  Total = "Total"
+}
+
+/**
+ * Defines values for PrimaryAggregationType. \
+ * {@link KnownPrimaryAggregationType} can be used interchangeably with PrimaryAggregationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **Average** \
+ * **Count** \
+ * **Minimum** \
+ * **Maximum** \
+ * **Total**
+ */
+export type PrimaryAggregationType = string;
+
+/**
+ * Known values of {@link UnitDefinitionType} that the service accepts.
+ */
+export const enum KnownUnitDefinitionType {
+  Count = "Count",
+  Bytes = "Bytes",
+  Seconds = "Seconds",
+  Percent = "Percent",
+  CountPerSecond = "CountPerSecond",
+  BytesPerSecond = "BytesPerSecond"
+}
+
+/**
+ * Defines values for UnitDefinitionType. \
+ * {@link KnownUnitDefinitionType} can be used interchangeably with UnitDefinitionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Count** \
+ * **Bytes** \
+ * **Seconds** \
+ * **Percent** \
+ * **CountPerSecond** \
+ * **BytesPerSecond**
+ */
+export type UnitDefinitionType = string;
+
+/**
+ * Known values of {@link ElasticPoolEdition} that the service accepts.
+ */
+export const enum KnownElasticPoolEdition {
+  Basic = "Basic",
+  Standard = "Standard",
+  Premium = "Premium",
+  GeneralPurpose = "GeneralPurpose",
+  BusinessCritical = "BusinessCritical"
+}
+
+/**
+ * Defines values for ElasticPoolEdition. \
+ * {@link KnownElasticPoolEdition} can be used interchangeably with ElasticPoolEdition,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Basic** \
+ * **Standard** \
+ * **Premium** \
+ * **GeneralPurpose** \
+ * **BusinessCritical**
+ */
+export type ElasticPoolEdition = string;
+
+/**
+ * Known values of {@link ReplicationState} that the service accepts.
+ */
+export const enum KnownReplicationState {
+  Pending = "PENDING",
+  Seeding = "SEEDING",
+  CatchUP = "CATCH_UP",
+  Suspended = "SUSPENDED"
+}
+
+/**
+ * Defines values for ReplicationState. \
+ * {@link KnownReplicationState} can be used interchangeably with ReplicationState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **PENDING** \
+ * **SEEDING** \
+ * **CATCH_UP** \
+ * **SUSPENDED**
+ */
+export type ReplicationState = string;
+
+/**
+ * Known values of {@link TransparentDataEncryptionName} that the service accepts.
+ */
+export const enum KnownTransparentDataEncryptionName {
+  Current = "current"
+}
+
+/**
+ * Defines values for TransparentDataEncryptionName. \
+ * {@link KnownTransparentDataEncryptionName} can be used interchangeably with TransparentDataEncryptionName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **current**
+ */
+export type TransparentDataEncryptionName = string;
+
+/**
+ * Known values of {@link TransparentDataEncryptionActivityStatus} that the service accepts.
+ */
+export const enum KnownTransparentDataEncryptionActivityStatus {
+  Encrypting = "Encrypting",
+  Decrypting = "Decrypting"
+}
+
+/**
+ * Defines values for TransparentDataEncryptionActivityStatus. \
+ * {@link KnownTransparentDataEncryptionActivityStatus} can be used interchangeably with TransparentDataEncryptionActivityStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Encrypting** \
+ * **Decrypting**
+ */
+export type TransparentDataEncryptionActivityStatus = string;
+
+/**
+ * Known values of {@link EncryptionProtectorName} that the service accepts.
+ */
+export const enum KnownEncryptionProtectorName {
+  Current = "current"
+}
+
+/**
+ * Defines values for EncryptionProtectorName. \
+ * {@link KnownEncryptionProtectorName} can be used interchangeably with EncryptionProtectorName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **current**
+ */
+export type EncryptionProtectorName = string;
+
+/**
+ * Known values of {@link ServerKeyType} that the service accepts.
+ */
+export const enum KnownServerKeyType {
+  ServiceManaged = "ServiceManaged",
+  AzureKeyVault = "AzureKeyVault"
+}
+
+/**
+ * Defines values for ServerKeyType. \
+ * {@link KnownServerKeyType} can be used interchangeably with ServerKeyType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ServiceManaged** \
+ * **AzureKeyVault**
+ */
+export type ServerKeyType = string;
+
+/**
+ * Known values of {@link ReadWriteEndpointFailoverPolicy} that the service accepts.
+ */
+export const enum KnownReadWriteEndpointFailoverPolicy {
+  Manual = "Manual",
+  Automatic = "Automatic"
+}
+
+/**
+ * Defines values for ReadWriteEndpointFailoverPolicy. \
+ * {@link KnownReadWriteEndpointFailoverPolicy} can be used interchangeably with ReadWriteEndpointFailoverPolicy,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Manual** \
+ * **Automatic**
+ */
+export type ReadWriteEndpointFailoverPolicy = string;
+
+/**
+ * Known values of {@link ReadOnlyEndpointFailoverPolicy} that the service accepts.
+ */
+export const enum KnownReadOnlyEndpointFailoverPolicy {
+  Disabled = "Disabled",
+  Enabled = "Enabled"
+}
+
+/**
+ * Defines values for ReadOnlyEndpointFailoverPolicy. \
+ * {@link KnownReadOnlyEndpointFailoverPolicy} can be used interchangeably with ReadOnlyEndpointFailoverPolicy,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Disabled** \
+ * **Enabled**
+ */
+export type ReadOnlyEndpointFailoverPolicy = string;
+
+/**
+ * Known values of {@link FailoverGroupReplicationRole} that the service accepts.
+ */
+export const enum KnownFailoverGroupReplicationRole {
+  Primary = "Primary",
+  Secondary = "Secondary"
+}
+
+/**
+ * Defines values for FailoverGroupReplicationRole. \
+ * {@link KnownFailoverGroupReplicationRole} can be used interchangeably with FailoverGroupReplicationRole,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Primary** \
+ * **Secondary**
+ */
+export type FailoverGroupReplicationRole = string;
+
+/**
+ * Known values of {@link OperationOrigin} that the service accepts.
+ */
+export const enum KnownOperationOrigin {
+  User = "user",
+  System = "system"
+}
+
+/**
+ * Defines values for OperationOrigin. \
+ * {@link KnownOperationOrigin} can be used interchangeably with OperationOrigin,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **user** \
+ * **system**
+ */
+export type OperationOrigin = string;
+
+/**
+ * Known values of {@link SyncAgentState} that the service accepts.
+ */
+export const enum KnownSyncAgentState {
+  Online = "Online",
+  Offline = "Offline",
+  NeverConnected = "NeverConnected"
+}
+
+/**
+ * Defines values for SyncAgentState. \
+ * {@link KnownSyncAgentState} can be used interchangeably with SyncAgentState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Online** \
+ * **Offline** \
+ * **NeverConnected**
+ */
+export type SyncAgentState = string;
+
+/**
+ * Known values of {@link SyncMemberDbType} that the service accepts.
+ */
+export const enum KnownSyncMemberDbType {
+  AzureSqlDatabase = "AzureSqlDatabase",
+  SqlServerDatabase = "SqlServerDatabase"
+}
+
+/**
+ * Defines values for SyncMemberDbType. \
+ * {@link KnownSyncMemberDbType} can be used interchangeably with SyncMemberDbType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AzureSqlDatabase** \
+ * **SqlServerDatabase**
+ */
+export type SyncMemberDbType = string;
+
+/**
+ * Known values of {@link Enum21} that the service accepts.
+ */
+export const enum KnownEnum21 {
+  All = "All",
+  Error = "Error",
+  Warning = "Warning",
+  Success = "Success"
+}
+
+/**
+ * Defines values for Enum21. \
+ * {@link KnownEnum21} can be used interchangeably with Enum21,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **All** \
+ * **Error** \
+ * **Warning** \
+ * **Success**
+ */
+export type Enum21 = string;
+
+/**
+ * Known values of {@link SyncGroupLogType} that the service accepts.
+ */
+export const enum KnownSyncGroupLogType {
+  All = "All",
+  Error = "Error",
+  Warning = "Warning",
+  Success = "Success"
+}
+
+/**
+ * Defines values for SyncGroupLogType. \
+ * {@link KnownSyncGroupLogType} can be used interchangeably with SyncGroupLogType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **All** \
+ * **Error** \
+ * **Warning** \
+ * **Success**
+ */
+export type SyncGroupLogType = string;
+
+/**
+ * Known values of {@link SyncConflictResolutionPolicy} that the service accepts.
+ */
+export const enum KnownSyncConflictResolutionPolicy {
+  HubWin = "HubWin",
+  MemberWin = "MemberWin"
+}
+
+/**
+ * Defines values for SyncConflictResolutionPolicy. \
+ * {@link KnownSyncConflictResolutionPolicy} can be used interchangeably with SyncConflictResolutionPolicy,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **HubWin** \
+ * **MemberWin**
+ */
+export type SyncConflictResolutionPolicy = string;
+
+/**
+ * Known values of {@link SyncGroupState} that the service accepts.
+ */
+export const enum KnownSyncGroupState {
+  NotReady = "NotReady",
+  Error = "Error",
+  Warning = "Warning",
+  Progressing = "Progressing",
+  Good = "Good"
+}
+
+/**
+ * Defines values for SyncGroupState. \
+ * {@link KnownSyncGroupState} can be used interchangeably with SyncGroupState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NotReady** \
+ * **Error** \
+ * **Warning** \
+ * **Progressing** \
+ * **Good**
+ */
+export type SyncGroupState = string;
+
+/**
+ * Known values of {@link SyncDirection} that the service accepts.
+ */
+export const enum KnownSyncDirection {
+  Bidirectional = "Bidirectional",
+  OneWayMemberToHub = "OneWayMemberToHub",
+  OneWayHubToMember = "OneWayHubToMember"
+}
+
+/**
+ * Defines values for SyncDirection. \
+ * {@link KnownSyncDirection} can be used interchangeably with SyncDirection,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Bidirectional** \
+ * **OneWayMemberToHub** \
+ * **OneWayHubToMember**
+ */
+export type SyncDirection = string;
+
+/**
+ * Known values of {@link SyncMemberState} that the service accepts.
+ */
+export const enum KnownSyncMemberState {
+  SyncInProgress = "SyncInProgress",
+  SyncSucceeded = "SyncSucceeded",
+  SyncFailed = "SyncFailed",
+  DisabledTombstoneCleanup = "DisabledTombstoneCleanup",
+  DisabledBackupRestore = "DisabledBackupRestore",
+  SyncSucceededWithWarnings = "SyncSucceededWithWarnings",
+  SyncCancelling = "SyncCancelling",
+  SyncCancelled = "SyncCancelled",
+  UnProvisioned = "UnProvisioned",
+  Provisioning = "Provisioning",
+  Provisioned = "Provisioned",
+  ProvisionFailed = "ProvisionFailed",
+  DeProvisioning = "DeProvisioning",
+  DeProvisioned = "DeProvisioned",
+  DeProvisionFailed = "DeProvisionFailed",
+  Reprovisioning = "Reprovisioning",
+  ReprovisionFailed = "ReprovisionFailed",
+  UnReprovisioned = "UnReprovisioned"
+}
+
+/**
+ * Defines values for SyncMemberState. \
+ * {@link KnownSyncMemberState} can be used interchangeably with SyncMemberState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SyncInProgress** \
+ * **SyncSucceeded** \
+ * **SyncFailed** \
+ * **DisabledTombstoneCleanup** \
+ * **DisabledBackupRestore** \
+ * **SyncSucceededWithWarnings** \
+ * **SyncCancelling** \
+ * **SyncCancelled** \
+ * **UnProvisioned** \
+ * **Provisioning** \
+ * **Provisioned** \
+ * **ProvisionFailed** \
+ * **DeProvisioning** \
+ * **DeProvisioned** \
+ * **DeProvisionFailed** \
+ * **Reprovisioning** \
+ * **ReprovisionFailed** \
+ * **UnReprovisioned**
+ */
+export type SyncMemberState = string;
+
+/**
+ * Known values of {@link VirtualNetworkRuleState} that the service accepts.
+ */
+export const enum KnownVirtualNetworkRuleState {
+  Initializing = "Initializing",
+  InProgress = "InProgress",
+  Ready = "Ready",
+  Deleting = "Deleting",
+  Unknown = "Unknown"
+}
+
+/**
+ * Defines values for VirtualNetworkRuleState. \
+ * {@link KnownVirtualNetworkRuleState} can be used interchangeably with VirtualNetworkRuleState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Initializing** \
+ * **InProgress** \
+ * **Ready** \
+ * **Deleting** \
+ * **Unknown**
+ */
+export type VirtualNetworkRuleState = string;
+
+/**
+ * Known values of {@link VulnerabilityAssessmentName} that the service accepts.
+ */
+export const enum KnownVulnerabilityAssessmentName {
+  Default = "default"
+}
+
+/**
+ * Defines values for VulnerabilityAssessmentName. \
+ * {@link KnownVulnerabilityAssessmentName} can be used interchangeably with VulnerabilityAssessmentName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type VulnerabilityAssessmentName = string;
+
+/**
+ * Known values of {@link JobAgentState} that the service accepts.
+ */
+export const enum KnownJobAgentState {
+  Creating = "Creating",
+  Ready = "Ready",
+  Updating = "Updating",
+  Deleting = "Deleting",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for JobAgentState. \
+ * {@link KnownJobAgentState} can be used interchangeably with JobAgentState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Ready** \
+ * **Updating** \
+ * **Deleting** \
+ * **Disabled**
+ */
+export type JobAgentState = string;
+
+/**
+ * Known values of {@link JobExecutionLifecycle} that the service accepts.
+ */
+export const enum KnownJobExecutionLifecycle {
+  Created = "Created",
+  InProgress = "InProgress",
+  WaitingForChildJobExecutions = "WaitingForChildJobExecutions",
+  WaitingForRetry = "WaitingForRetry",
+  Succeeded = "Succeeded",
+  SucceededWithSkipped = "SucceededWithSkipped",
+  Failed = "Failed",
+  TimedOut = "TimedOut",
+  Canceled = "Canceled",
+  Skipped = "Skipped"
+}
+
+/**
+ * Defines values for JobExecutionLifecycle. \
+ * {@link KnownJobExecutionLifecycle} can be used interchangeably with JobExecutionLifecycle,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Created** \
+ * **InProgress** \
+ * **WaitingForChildJobExecutions** \
+ * **WaitingForRetry** \
+ * **Succeeded** \
+ * **SucceededWithSkipped** \
+ * **Failed** \
+ * **TimedOut** \
+ * **Canceled** \
+ * **Skipped**
+ */
+export type JobExecutionLifecycle = string;
+
+/**
+ * Known values of {@link ProvisioningState} that the service accepts.
+ */
+export const enum KnownProvisioningState {
+  Created = "Created",
+  InProgress = "InProgress",
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  Canceled = "Canceled"
+}
+
+/**
+ * Defines values for ProvisioningState. \
+ * {@link KnownProvisioningState} can be used interchangeably with ProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Created** \
+ * **InProgress** \
+ * **Succeeded** \
+ * **Failed** \
+ * **Canceled**
+ */
+export type ProvisioningState = string;
+
+/**
+ * Known values of {@link JobTargetType} that the service accepts.
+ */
+export const enum KnownJobTargetType {
+  TargetGroup = "TargetGroup",
+  SqlDatabase = "SqlDatabase",
+  SqlElasticPool = "SqlElasticPool",
+  SqlShardMap = "SqlShardMap",
+  SqlServer = "SqlServer"
+}
+
+/**
+ * Defines values for JobTargetType. \
+ * {@link KnownJobTargetType} can be used interchangeably with JobTargetType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TargetGroup** \
+ * **SqlDatabase** \
+ * **SqlElasticPool** \
+ * **SqlShardMap** \
+ * **SqlServer**
+ */
+export type JobTargetType = string;
+
+/**
+ * Known values of {@link JobStepActionType} that the service accepts.
+ */
+export const enum KnownJobStepActionType {
+  TSql = "TSql"
+}
+
+/**
+ * Defines values for JobStepActionType. \
+ * {@link KnownJobStepActionType} can be used interchangeably with JobStepActionType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TSql**
+ */
+export type JobStepActionType = string;
+
+/**
+ * Known values of {@link JobStepActionSource} that the service accepts.
+ */
+export const enum KnownJobStepActionSource {
+  Inline = "Inline"
+}
+
+/**
+ * Defines values for JobStepActionSource. \
+ * {@link KnownJobStepActionSource} can be used interchangeably with JobStepActionSource,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Inline**
+ */
+export type JobStepActionSource = string;
+
+/**
+ * Known values of {@link JobStepOutputType} that the service accepts.
+ */
+export const enum KnownJobStepOutputType {
+  SqlDatabase = "SqlDatabase"
+}
+
+/**
+ * Defines values for JobStepOutputType. \
+ * {@link KnownJobStepOutputType} can be used interchangeably with JobStepOutputType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SqlDatabase**
+ */
+export type JobStepOutputType = string;
+
+/**
+ * Known values of {@link LongTermRetentionDatabaseState} that the service accepts.
+ */
+export const enum KnownLongTermRetentionDatabaseState {
+  All = "All",
+  Live = "Live",
+  Deleted = "Deleted"
+}
+
+/**
+ * Defines values for LongTermRetentionDatabaseState. \
+ * {@link KnownLongTermRetentionDatabaseState} can be used interchangeably with LongTermRetentionDatabaseState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **All** \
+ * **Live** \
+ * **Deleted**
+ */
+export type LongTermRetentionDatabaseState = string;
+
+/**
+ * Known values of {@link LongTermRetentionPolicyName} that the service accepts.
+ */
+export const enum KnownLongTermRetentionPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for LongTermRetentionPolicyName. \
+ * {@link KnownLongTermRetentionPolicyName} can be used interchangeably with LongTermRetentionPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type LongTermRetentionPolicyName = string;
+
+/**
+ * Known values of {@link ManagedShortTermRetentionPolicyName} that the service accepts.
+ */
+export const enum KnownManagedShortTermRetentionPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for ManagedShortTermRetentionPolicyName. \
+ * {@link KnownManagedShortTermRetentionPolicyName} can be used interchangeably with ManagedShortTermRetentionPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type ManagedShortTermRetentionPolicyName = string;
+
+/**
+ * Known values of {@link SecurityAlertPolicyNameAutoGenerated} that the service accepts.
+ */
+export const enum KnownSecurityAlertPolicyNameAutoGenerated {
+  Default = "Default"
+}
+
+/**
+ * Defines values for SecurityAlertPolicyNameAutoGenerated. \
+ * {@link KnownSecurityAlertPolicyNameAutoGenerated} can be used interchangeably with SecurityAlertPolicyNameAutoGenerated,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default**
+ */
+export type SecurityAlertPolicyNameAutoGenerated = string;
+
+/**
+ * Known values of {@link ManagedInstanceAdministratorType} that the service accepts.
+ */
+export const enum KnownManagedInstanceAdministratorType {
+  ActiveDirectory = "ActiveDirectory"
+}
+
+/**
+ * Defines values for ManagedInstanceAdministratorType. \
+ * {@link KnownManagedInstanceAdministratorType} can be used interchangeably with ManagedInstanceAdministratorType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ActiveDirectory**
+ */
+export type ManagedInstanceAdministratorType = string;
+
+/**
+ * Known values of {@link ManagementOperationState} that the service accepts.
+ */
+export const enum KnownManagementOperationState {
+  Pending = "Pending",
+  InProgress = "InProgress",
+  Succeeded = "Succeeded",
+  Failed = "Failed",
+  CancelInProgress = "CancelInProgress",
+  Cancelled = "Cancelled"
+}
+
+/**
+ * Defines values for ManagementOperationState. \
+ * {@link KnownManagementOperationState} can be used interchangeably with ManagementOperationState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Pending** \
+ * **InProgress** \
+ * **Succeeded** \
+ * **Failed** \
+ * **CancelInProgress** \
+ * **Cancelled**
+ */
+export type ManagementOperationState = string;
+
+/**
+ * Known values of {@link CreateMode} that the service accepts.
+ */
+export const enum KnownCreateMode {
+  Default = "Default",
+  Copy = "Copy",
+  Secondary = "Secondary",
+  PointInTimeRestore = "PointInTimeRestore",
+  Restore = "Restore",
+  Recovery = "Recovery",
+  RestoreExternalBackup = "RestoreExternalBackup",
+  RestoreExternalBackupSecondary = "RestoreExternalBackupSecondary",
+  RestoreLongTermRetentionBackup = "RestoreLongTermRetentionBackup",
+  OnlineSecondary = "OnlineSecondary"
+}
+
+/**
+ * Defines values for CreateMode. \
+ * {@link KnownCreateMode} can be used interchangeably with CreateMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default** \
+ * **Copy** \
+ * **Secondary** \
+ * **PointInTimeRestore** \
+ * **Restore** \
+ * **Recovery** \
+ * **RestoreExternalBackup** \
+ * **RestoreExternalBackupSecondary** \
+ * **RestoreLongTermRetentionBackup** \
+ * **OnlineSecondary**
+ */
+export type CreateMode = string;
+
+/**
+ * Known values of {@link SampleName} that the service accepts.
+ */
+export const enum KnownSampleName {
+  AdventureWorksLT = "AdventureWorksLT",
+  WideWorldImportersStd = "WideWorldImportersStd",
+  WideWorldImportersFull = "WideWorldImportersFull"
+}
+
+/**
+ * Defines values for SampleName. \
+ * {@link KnownSampleName} can be used interchangeably with SampleName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AdventureWorksLT** \
+ * **WideWorldImportersStd** \
+ * **WideWorldImportersFull**
+ */
+export type SampleName = string;
+
+/**
+ * Known values of {@link DatabaseStatus} that the service accepts.
+ */
+export const enum KnownDatabaseStatus {
+  Online = "Online",
+  Restoring = "Restoring",
+  RecoveryPending = "RecoveryPending",
+  Recovering = "Recovering",
+  Suspect = "Suspect",
+  Offline = "Offline",
+  Standby = "Standby",
+  Shutdown = "Shutdown",
+  EmergencyMode = "EmergencyMode",
+  AutoClosed = "AutoClosed",
+  Copying = "Copying",
+  Creating = "Creating",
+  Inaccessible = "Inaccessible",
+  OfflineSecondary = "OfflineSecondary",
+  Pausing = "Pausing",
+  Paused = "Paused",
+  Resuming = "Resuming",
+  Scaling = "Scaling",
+  OfflineChangingDwPerformanceTiers = "OfflineChangingDwPerformanceTiers",
+  OnlineChangingDwPerformanceTiers = "OnlineChangingDwPerformanceTiers",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for DatabaseStatus. \
+ * {@link KnownDatabaseStatus} can be used interchangeably with DatabaseStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Online** \
+ * **Restoring** \
+ * **RecoveryPending** \
+ * **Recovering** \
+ * **Suspect** \
+ * **Offline** \
+ * **Standby** \
+ * **Shutdown** \
+ * **EmergencyMode** \
+ * **AutoClosed** \
+ * **Copying** \
+ * **Creating** \
+ * **Inaccessible** \
+ * **OfflineSecondary** \
+ * **Pausing** \
+ * **Paused** \
+ * **Resuming** \
+ * **Scaling** \
+ * **OfflineChangingDwPerformanceTiers** \
+ * **OnlineChangingDwPerformanceTiers** \
+ * **Disabled**
+ */
+export type DatabaseStatus = string;
+
+/**
+ * Known values of {@link CatalogCollationType} that the service accepts.
+ */
+export const enum KnownCatalogCollationType {
+  DatabaseDefault = "DATABASE_DEFAULT",
+  SQLLatin1GeneralCP1CIAS = "SQL_Latin1_General_CP1_CI_AS"
+}
+
+/**
+ * Defines values for CatalogCollationType. \
+ * {@link KnownCatalogCollationType} can be used interchangeably with CatalogCollationType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **DATABASE_DEFAULT** \
+ * **SQL_Latin1_General_CP1_CI_AS**
+ */
+export type CatalogCollationType = string;
+
+/**
+ * Known values of {@link DatabaseLicenseType} that the service accepts.
+ */
+export const enum KnownDatabaseLicenseType {
+  LicenseIncluded = "LicenseIncluded",
+  BasePrice = "BasePrice"
+}
+
+/**
+ * Defines values for DatabaseLicenseType. \
+ * {@link KnownDatabaseLicenseType} can be used interchangeably with DatabaseLicenseType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **LicenseIncluded** \
+ * **BasePrice**
+ */
+export type DatabaseLicenseType = string;
+
+/**
+ * Known values of {@link DatabaseReadScale} that the service accepts.
+ */
+export const enum KnownDatabaseReadScale {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for DatabaseReadScale. \
+ * {@link KnownDatabaseReadScale} can be used interchangeably with DatabaseReadScale,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
+ */
+export type DatabaseReadScale = string;
+
+/**
+ * Known values of {@link ElasticPoolState} that the service accepts.
+ */
+export const enum KnownElasticPoolState {
+  Creating = "Creating",
+  Ready = "Ready",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for ElasticPoolState. \
+ * {@link KnownElasticPoolState} can be used interchangeably with ElasticPoolState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Creating** \
+ * **Ready** \
+ * **Disabled**
+ */
+export type ElasticPoolState = string;
+
+/**
+ * Known values of {@link ElasticPoolLicenseType} that the service accepts.
+ */
+export const enum KnownElasticPoolLicenseType {
+  LicenseIncluded = "LicenseIncluded",
+  BasePrice = "BasePrice"
+}
+
+/**
+ * Defines values for ElasticPoolLicenseType. \
+ * {@link KnownElasticPoolLicenseType} can be used interchangeably with ElasticPoolLicenseType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **LicenseIncluded** \
+ * **BasePrice**
+ */
+export type ElasticPoolLicenseType = string;
+
+/**
+ * Known values of {@link VulnerabilityAssessmentScanTriggerType} that the service accepts.
+ */
+export const enum KnownVulnerabilityAssessmentScanTriggerType {
+  OnDemand = "OnDemand",
+  Recurring = "Recurring"
+}
+
+/**
+ * Defines values for VulnerabilityAssessmentScanTriggerType. \
+ * {@link KnownVulnerabilityAssessmentScanTriggerType} can be used interchangeably with VulnerabilityAssessmentScanTriggerType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **OnDemand** \
+ * **Recurring**
+ */
+export type VulnerabilityAssessmentScanTriggerType = string;
+
+/**
+ * Known values of {@link VulnerabilityAssessmentScanState} that the service accepts.
+ */
+export const enum KnownVulnerabilityAssessmentScanState {
+  Passed = "Passed",
+  Failed = "Failed",
+  FailedToRun = "FailedToRun",
+  InProgress = "InProgress"
+}
+
+/**
+ * Defines values for VulnerabilityAssessmentScanState. \
+ * {@link KnownVulnerabilityAssessmentScanState} can be used interchangeably with VulnerabilityAssessmentScanState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Passed** \
+ * **Failed** \
+ * **FailedToRun** \
+ * **InProgress**
+ */
+export type VulnerabilityAssessmentScanState = string;
+
+/**
+ * Known values of {@link InstanceFailoverGroupReplicationRole} that the service accepts.
+ */
+export const enum KnownInstanceFailoverGroupReplicationRole {
+  Primary = "Primary",
+  Secondary = "Secondary"
+}
+
+/**
+ * Defines values for InstanceFailoverGroupReplicationRole. \
+ * {@link KnownInstanceFailoverGroupReplicationRole} can be used interchangeably with InstanceFailoverGroupReplicationRole,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Primary** \
+ * **Secondary**
+ */
+export type InstanceFailoverGroupReplicationRole = string;
+
+/**
+ * Known values of {@link ShortTermRetentionPolicyName} that the service accepts.
+ */
+export const enum KnownShortTermRetentionPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for ShortTermRetentionPolicyName. \
+ * {@link KnownShortTermRetentionPolicyName} can be used interchangeably with ShortTermRetentionPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type ShortTermRetentionPolicyName = string;
+
+/**
+ * Known values of {@link InstancePoolLicenseType} that the service accepts.
+ */
+export const enum KnownInstancePoolLicenseType {
+  LicenseIncluded = "LicenseIncluded",
+  BasePrice = "BasePrice"
+}
+
+/**
+ * Defines values for InstancePoolLicenseType. \
+ * {@link KnownInstancePoolLicenseType} can be used interchangeably with InstancePoolLicenseType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **LicenseIncluded** \
+ * **BasePrice**
+ */
+export type InstancePoolLicenseType = string;
+
+/**
+ * Known values of {@link IdentityType} that the service accepts.
+ */
+export const enum KnownIdentityType {
+  SystemAssigned = "SystemAssigned"
+}
+
+/**
+ * Defines values for IdentityType. \
+ * {@link KnownIdentityType} can be used interchangeably with IdentityType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SystemAssigned**
+ */
+export type IdentityType = string;
+
+/**
+ * Known values of {@link ManagedServerCreateMode} that the service accepts.
+ */
+export const enum KnownManagedServerCreateMode {
+  Default = "Default",
+  PointInTimeRestore = "PointInTimeRestore"
+}
+
+/**
+ * Defines values for ManagedServerCreateMode. \
+ * {@link KnownManagedServerCreateMode} can be used interchangeably with ManagedServerCreateMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default** \
+ * **PointInTimeRestore**
+ */
+export type ManagedServerCreateMode = string;
+
+/**
+ * Known values of {@link ManagedInstanceLicenseType} that the service accepts.
+ */
+export const enum KnownManagedInstanceLicenseType {
+  LicenseIncluded = "LicenseIncluded",
+  BasePrice = "BasePrice"
+}
+
+/**
+ * Defines values for ManagedInstanceLicenseType. \
+ * {@link KnownManagedInstanceLicenseType} can be used interchangeably with ManagedInstanceLicenseType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **LicenseIncluded** \
+ * **BasePrice**
+ */
+export type ManagedInstanceLicenseType = string;
+
+/**
+ * Known values of {@link ManagedInstanceProxyOverride} that the service accepts.
+ */
+export const enum KnownManagedInstanceProxyOverride {
+  Proxy = "Proxy",
+  Redirect = "Redirect",
+  Default = "Default"
+}
+
+/**
+ * Defines values for ManagedInstanceProxyOverride. \
+ * {@link KnownManagedInstanceProxyOverride} can be used interchangeably with ManagedInstanceProxyOverride,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Proxy** \
+ * **Redirect** \
+ * **Default**
+ */
+export type ManagedInstanceProxyOverride = string;
+
+/**
+ * Known values of {@link ReplicaType} that the service accepts.
+ */
+export const enum KnownReplicaType {
+  Primary = "Primary",
+  ReadableSecondary = "ReadableSecondary"
+}
+
+/**
+ * Defines values for ReplicaType. \
+ * {@link KnownReplicaType} can be used interchangeably with ReplicaType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Primary** \
+ * **ReadableSecondary**
+ */
+export type ReplicaType = string;
+
+/**
+ * Known values of {@link PrivateLinkServiceConnectionStateStatus} that the service accepts.
+ */
+export const enum KnownPrivateLinkServiceConnectionStateStatus {
+  Approved = "Approved",
+  Pending = "Pending",
+  Rejected = "Rejected",
+  Disconnected = "Disconnected"
+}
+
+/**
+ * Defines values for PrivateLinkServiceConnectionStateStatus. \
+ * {@link KnownPrivateLinkServiceConnectionStateStatus} can be used interchangeably with PrivateLinkServiceConnectionStateStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Approved** \
+ * **Pending** \
+ * **Rejected** \
+ * **Disconnected**
+ */
+export type PrivateLinkServiceConnectionStateStatus = string;
+
+/**
+ * Known values of {@link PrivateLinkServiceConnectionStateActionsRequire} that the service accepts.
+ */
+export const enum KnownPrivateLinkServiceConnectionStateActionsRequire {
+  None = "None"
+}
+
+/**
+ * Defines values for PrivateLinkServiceConnectionStateActionsRequire. \
+ * {@link KnownPrivateLinkServiceConnectionStateActionsRequire} can be used interchangeably with PrivateLinkServiceConnectionStateActionsRequire,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None**
+ */
+export type PrivateLinkServiceConnectionStateActionsRequire = string;
+
+/**
+ * Known values of {@link PrivateEndpointProvisioningState} that the service accepts.
+ */
+export const enum KnownPrivateEndpointProvisioningState {
+  Approving = "Approving",
+  Ready = "Ready",
+  Dropping = "Dropping",
+  Failed = "Failed",
+  Rejecting = "Rejecting"
+}
+
+/**
+ * Defines values for PrivateEndpointProvisioningState. \
+ * {@link KnownPrivateEndpointProvisioningState} can be used interchangeably with PrivateEndpointProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Approving** \
+ * **Ready** \
+ * **Dropping** \
+ * **Failed** \
+ * **Rejecting**
+ */
+export type PrivateEndpointProvisioningState = string;
+
+/**
+ * Known values of {@link ServerPublicNetworkAccess} that the service accepts.
+ */
+export const enum KnownServerPublicNetworkAccess {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for ServerPublicNetworkAccess. \
+ * {@link KnownServerPublicNetworkAccess} can be used interchangeably with ServerPublicNetworkAccess,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
+ */
+export type ServerPublicNetworkAccess = string;
+
+/**
+ * Known values of {@link CapabilityGroup} that the service accepts.
+ */
+export const enum KnownCapabilityGroup {
+  SupportedEditions = "supportedEditions",
+  SupportedElasticPoolEditions = "supportedElasticPoolEditions",
+  SupportedManagedInstanceVersions = "supportedManagedInstanceVersions",
+  SupportedInstancePoolEditions = "supportedInstancePoolEditions",
+  SupportedManagedInstanceEditions = "supportedManagedInstanceEditions"
+}
+
+/**
+ * Defines values for CapabilityGroup. \
+ * {@link KnownCapabilityGroup} can be used interchangeably with CapabilityGroup,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **supportedEditions** \
+ * **supportedElasticPoolEditions** \
+ * **supportedManagedInstanceVersions** \
+ * **supportedInstancePoolEditions** \
+ * **supportedManagedInstanceEditions**
+ */
+export type CapabilityGroup = string;
+
+/**
+ * Known values of {@link MaxSizeUnit} that the service accepts.
+ */
+export const enum KnownMaxSizeUnit {
+  Megabytes = "Megabytes",
+  Gigabytes = "Gigabytes",
+  Terabytes = "Terabytes",
+  Petabytes = "Petabytes"
+}
+
+/**
+ * Defines values for MaxSizeUnit. \
+ * {@link KnownMaxSizeUnit} can be used interchangeably with MaxSizeUnit,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Megabytes** \
+ * **Gigabytes** \
+ * **Terabytes** \
+ * **Petabytes**
+ */
+export type MaxSizeUnit = string;
+
+/**
+ * Known values of {@link LogSizeUnit} that the service accepts.
+ */
+export const enum KnownLogSizeUnit {
+  Megabytes = "Megabytes",
+  Gigabytes = "Gigabytes",
+  Terabytes = "Terabytes",
+  Petabytes = "Petabytes",
+  Percent = "Percent"
+}
+
+/**
+ * Defines values for LogSizeUnit. \
+ * {@link KnownLogSizeUnit} can be used interchangeably with LogSizeUnit,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Megabytes** \
+ * **Gigabytes** \
+ * **Terabytes** \
+ * **Petabytes** \
+ * **Percent**
+ */
+export type LogSizeUnit = string;
+
+/**
+ * Known values of {@link PerformanceLevelUnit} that the service accepts.
+ */
+export const enum KnownPerformanceLevelUnit {
+  DTU = "DTU",
+  VCores = "VCores"
+}
+
+/**
+ * Defines values for PerformanceLevelUnit. \
+ * {@link KnownPerformanceLevelUnit} can be used interchangeably with PerformanceLevelUnit,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **DTU** \
+ * **VCores**
+ */
+export type PerformanceLevelUnit = string;
+
+/**
+ * Known values of {@link PauseDelayTimeUnit} that the service accepts.
+ */
+export const enum KnownPauseDelayTimeUnit {
+  Minutes = "Minutes"
+}
+
+/**
+ * Defines values for PauseDelayTimeUnit. \
+ * {@link KnownPauseDelayTimeUnit} can be used interchangeably with PauseDelayTimeUnit,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Minutes**
+ */
+export type PauseDelayTimeUnit = string;
+
+/**
+ * Known values of {@link StorageCapabilityStorageAccountType} that the service accepts.
+ */
+export const enum KnownStorageCapabilityStorageAccountType {
+  GRS = "GRS",
+  LRS = "LRS",
+  ZRS = "ZRS"
+}
+
+/**
+ * Defines values for StorageCapabilityStorageAccountType. \
+ * {@link KnownStorageCapabilityStorageAccountType} can be used interchangeably with StorageCapabilityStorageAccountType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **GRS** \
+ * **LRS** \
+ * **ZRS**
+ */
+export type StorageCapabilityStorageAccountType = string;
+
+/**
+ * Known values of {@link DatabaseState} that the service accepts.
+ */
+export const enum KnownDatabaseState {
+  All = "All",
+  Live = "Live",
+  Deleted = "Deleted"
+}
+
+/**
+ * Defines values for DatabaseState. \
+ * {@link KnownDatabaseState} can be used interchangeably with DatabaseState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **All** \
+ * **Live** \
+ * **Deleted**
+ */
+export type DatabaseState = string;
+
+/**
+ * Known values of {@link ManagedInstanceLongTermRetentionPolicyName} that the service accepts.
+ */
+export const enum KnownManagedInstanceLongTermRetentionPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for ManagedInstanceLongTermRetentionPolicyName. \
+ * {@link KnownManagedInstanceLongTermRetentionPolicyName} can be used interchangeably with ManagedInstanceLongTermRetentionPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type ManagedInstanceLongTermRetentionPolicyName = string;
+
+/**
+ * Known values of {@link RestoreDetailsName} that the service accepts.
+ */
+export const enum KnownRestoreDetailsName {
+  Default = "Default"
+}
+
+/**
+ * Defines values for RestoreDetailsName. \
+ * {@link KnownRestoreDetailsName} can be used interchangeably with RestoreDetailsName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default**
+ */
+export type RestoreDetailsName = string;
+
+/**
+ * Known values of {@link ManagedDatabaseStatus} that the service accepts.
+ */
+export const enum KnownManagedDatabaseStatus {
+  Online = "Online",
+  Offline = "Offline",
+  Shutdown = "Shutdown",
+  Creating = "Creating",
+  Inaccessible = "Inaccessible",
+  Restoring = "Restoring",
+  Updating = "Updating"
+}
+
+/**
+ * Defines values for ManagedDatabaseStatus. \
+ * {@link KnownManagedDatabaseStatus} can be used interchangeably with ManagedDatabaseStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Online** \
+ * **Offline** \
+ * **Shutdown** \
+ * **Creating** \
+ * **Inaccessible** \
+ * **Restoring** \
+ * **Updating**
+ */
+export type ManagedDatabaseStatus = string;
+
+/**
+ * Known values of {@link ManagedDatabaseCreateMode} that the service accepts.
+ */
+export const enum KnownManagedDatabaseCreateMode {
+  Default = "Default",
+  RestoreExternalBackup = "RestoreExternalBackup",
+  PointInTimeRestore = "PointInTimeRestore",
+  Recovery = "Recovery",
+  RestoreLongTermRetentionBackup = "RestoreLongTermRetentionBackup"
+}
+
+/**
+ * Defines values for ManagedDatabaseCreateMode. \
+ * {@link KnownManagedDatabaseCreateMode} can be used interchangeably with ManagedDatabaseCreateMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Default** \
+ * **RestoreExternalBackup** \
+ * **PointInTimeRestore** \
+ * **Recovery** \
+ * **RestoreLongTermRetentionBackup**
+ */
+export type ManagedDatabaseCreateMode = string;
+
+/**
+ * Known values of {@link AdministratorName} that the service accepts.
+ */
+export const enum KnownAdministratorName {
+  ActiveDirectory = "ActiveDirectory"
+}
+
+/**
+ * Defines values for AdministratorName. \
+ * {@link KnownAdministratorName} can be used interchangeably with AdministratorName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ActiveDirectory**
+ */
+export type AdministratorName = string;
+
+/**
+ * Known values of {@link AdministratorType} that the service accepts.
+ */
+export const enum KnownAdministratorType {
+  ActiveDirectory = "ActiveDirectory"
+}
+
+/**
+ * Defines values for AdministratorType. \
+ * {@link KnownAdministratorType} can be used interchangeably with AdministratorType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ActiveDirectory**
+ */
+export type AdministratorType = string;
 /**
  * Defines values for ServerConnectionType.
  */

--- a/test/smoke/generated/sql-resource-manager/temp/sql-resource-manager.api.json
+++ b/test/smoke/generated/sql-resource-manager/temp/sql-resource-manager.api.json
@@ -89,7 +89,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!AdministratorName:type",
-          "docComment": "/**\n * Defines values for AdministratorName.\n */\n",
+          "docComment": "/**\n * Defines values for AdministratorName. \\ {@link KnownAdministratorName} can be used interchangeably with AdministratorName, this enum contains the known values that the service supports. ### Know values supported by the service **ActiveDirectory**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -97,7 +97,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ActiveDirectory\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -114,7 +114,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!AdministratorType:type",
-          "docComment": "/**\n * Defines values for AdministratorType.\n */\n",
+          "docComment": "/**\n * Defines values for AdministratorType. \\ {@link KnownAdministratorType} can be used interchangeably with AdministratorType, this enum contains the known values that the service supports. ### Know values supported by the service **ActiveDirectory**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -122,7 +122,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ActiveDirectory\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1421,7 +1421,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!CapabilityGroup:type",
-          "docComment": "/**\n * Defines values for CapabilityGroup.\n */\n",
+          "docComment": "/**\n * Defines values for CapabilityGroup. \\ {@link KnownCapabilityGroup} can be used interchangeably with CapabilityGroup, this enum contains the known values that the service supports. ### Know values supported by the service **supportedEditions** \\ **supportedElasticPoolEditions** \\ **supportedManagedInstanceVersions** \\ **supportedInstancePoolEditions** \\ **supportedManagedInstanceEditions**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1429,7 +1429,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"supportedEditions\" | \"supportedElasticPoolEditions\" | \"supportedManagedInstanceVersions\" | \"supportedInstancePoolEditions\" | \"supportedManagedInstanceEditions\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1471,7 +1471,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!CatalogCollationType:type",
-          "docComment": "/**\n * Defines values for CatalogCollationType.\n */\n",
+          "docComment": "/**\n * Defines values for CatalogCollationType. \\ {@link KnownCatalogCollationType} can be used interchangeably with CatalogCollationType, this enum contains the known values that the service supports. ### Know values supported by the service **DATABASE_DEFAULT** \\ **SQL_Latin1_General_CP1_CI_AS**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1479,7 +1479,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"DATABASE_DEFAULT\" | \"SQL_Latin1_General_CP1_CI_AS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1745,7 +1745,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ConnectionPolicyName:type",
-          "docComment": "/**\n * Defines values for ConnectionPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for ConnectionPolicyName. \\ {@link KnownConnectionPolicyName} can be used interchangeably with ConnectionPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1753,7 +1753,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1811,7 +1811,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!CreateMode:type",
-          "docComment": "/**\n * Defines values for CreateMode.\n */\n",
+          "docComment": "/**\n * Defines values for CreateMode. \\ {@link KnownCreateMode} can be used interchangeably with CreateMode, this enum contains the known values that the service supports. ### Know values supported by the service **Default** \\ **Copy** \\ **Secondary** \\ **PointInTimeRestore** \\ **Restore** \\ **Recovery** \\ **RestoreExternalBackup** \\ **RestoreExternalBackupSecondary** \\ **RestoreLongTermRetentionBackup** \\ **OnlineSecondary**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1819,7 +1819,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | \"Copy\" | \"Secondary\" | \"PointInTimeRestore\" | \"Restore\" | \"Recovery\" | \"RestoreExternalBackup\" | \"RestoreExternalBackupSecondary\" | \"RestoreLongTermRetentionBackup\" | \"OnlineSecondary\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2447,7 +2447,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!DatabaseEdition:type",
-          "docComment": "/**\n * Defines values for DatabaseEdition.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseEdition. \\ {@link KnownDatabaseEdition} can be used interchangeably with DatabaseEdition, this enum contains the known values that the service supports. ### Know values supported by the service **Web** \\ **Business** \\ **Basic** \\ **Standard** \\ **Premium** \\ **PremiumRS** \\ **Free** \\ **Stretch** \\ **DataWarehouse** \\ **System** \\ **System2** \\ **GeneralPurpose** \\ **BusinessCritical** \\ **Hyperscale**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2455,7 +2455,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Web\" | \"Business\" | \"Basic\" | \"Standard\" | \"Premium\" | \"PremiumRS\" | \"Free\" | \"Stretch\" | \"DataWarehouse\" | \"System\" | \"System2\" | \"GeneralPurpose\" | \"BusinessCritical\" | \"Hyperscale\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2472,7 +2472,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!DatabaseLicenseType:type",
-          "docComment": "/**\n * Defines values for DatabaseLicenseType.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseLicenseType. \\ {@link KnownDatabaseLicenseType} can be used interchangeably with DatabaseLicenseType, this enum contains the known values that the service supports. ### Know values supported by the service **LicenseIncluded** \\ **BasePrice**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2480,7 +2480,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"LicenseIncluded\" | \"BasePrice\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2792,7 +2792,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!DatabaseReadScale:type",
-          "docComment": "/**\n * Defines values for DatabaseReadScale.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseReadScale. \\ {@link KnownDatabaseReadScale} can be used interchangeably with DatabaseReadScale, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2800,7 +2800,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3666,7 +3666,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!DatabaseState:type",
-          "docComment": "/**\n * Defines values for DatabaseState.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseState. \\ {@link KnownDatabaseState} can be used interchangeably with DatabaseState, this enum contains the known values that the service supports. ### Know values supported by the service **All** \\ **Live** \\ **Deleted**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3674,7 +3674,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"All\" | \"Live\" | \"Deleted\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3691,7 +3691,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!DatabaseStatus:type",
-          "docComment": "/**\n * Defines values for DatabaseStatus.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseStatus. \\ {@link KnownDatabaseStatus} can be used interchangeably with DatabaseStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Online** \\ **Restoring** \\ **RecoveryPending** \\ **Recovering** \\ **Suspect** \\ **Offline** \\ **Standby** \\ **Shutdown** \\ **EmergencyMode** \\ **AutoClosed** \\ **Copying** \\ **Creating** \\ **Inaccessible** \\ **OfflineSecondary** \\ **Pausing** \\ **Paused** \\ **Resuming** \\ **Scaling** \\ **OfflineChangingDwPerformanceTiers** \\ **OnlineChangingDwPerformanceTiers** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3699,7 +3699,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Online\" | \"Restoring\" | \"RecoveryPending\" | \"Recovering\" | \"Suspect\" | \"Offline\" | \"Standby\" | \"Shutdown\" | \"EmergencyMode\" | \"AutoClosed\" | \"Copying\" | \"Creating\" | \"Inaccessible\" | \"OfflineSecondary\" | \"Pausing\" | \"Paused\" | \"Resuming\" | \"Scaling\" | \"OfflineChangingDwPerformanceTiers\" | \"OnlineChangingDwPerformanceTiers\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6681,7 +6681,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ElasticPoolEdition:type",
-          "docComment": "/**\n * Defines values for ElasticPoolEdition.\n */\n",
+          "docComment": "/**\n * Defines values for ElasticPoolEdition. \\ {@link KnownElasticPoolEdition} can be used interchangeably with ElasticPoolEdition, this enum contains the known values that the service supports. ### Know values supported by the service **Basic** \\ **Standard** \\ **Premium** \\ **GeneralPurpose** \\ **BusinessCritical**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6689,7 +6689,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Basic\" | \"Standard\" | \"Premium\" | \"GeneralPurpose\" | \"BusinessCritical\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6853,7 +6853,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ElasticPoolLicenseType:type",
-          "docComment": "/**\n * Defines values for ElasticPoolLicenseType.\n */\n",
+          "docComment": "/**\n * Defines values for ElasticPoolLicenseType. \\ {@link KnownElasticPoolLicenseType} can be used interchangeably with ElasticPoolLicenseType, this enum contains the known values that the service supports. ### Know values supported by the service **LicenseIncluded** \\ **BasePrice**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6861,7 +6861,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"LicenseIncluded\" | \"BasePrice\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8235,7 +8235,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ElasticPoolState:type",
-          "docComment": "/**\n * Defines values for ElasticPoolState.\n */\n",
+          "docComment": "/**\n * Defines values for ElasticPoolState. \\ {@link KnownElasticPoolState} can be used interchangeably with ElasticPoolState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Ready** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8243,7 +8243,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Ready\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8605,7 +8605,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!EncryptionProtectorName:type",
-          "docComment": "/**\n * Defines values for EncryptionProtectorName.\n */\n",
+          "docComment": "/**\n * Defines values for EncryptionProtectorName. \\ {@link KnownEncryptionProtectorName} can be used interchangeably with EncryptionProtectorName, this enum contains the known values that the service supports. ### Know values supported by the service **current**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8613,7 +8613,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"current\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8840,7 +8840,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!Enum21:type",
-          "docComment": "/**\n * Defines values for Enum21.\n */\n",
+          "docComment": "/**\n * Defines values for Enum21. \\ {@link KnownEnum21} can be used interchangeably with Enum21, this enum contains the known values that the service supports. ### Know values supported by the service **All** \\ **Error** \\ **Warning** \\ **Success**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8848,7 +8848,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"All\" | \"Error\" | \"Warning\" | \"Success\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9655,7 +9655,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ExtensionName:type",
-          "docComment": "/**\n * Defines values for ExtensionName.\n */\n",
+          "docComment": "/**\n * Defines values for ExtensionName. \\ {@link KnownExtensionName} can be used interchangeably with ExtensionName, this enum contains the known values that the service supports. ### Know values supported by the service **import**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9663,7 +9663,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"import\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9926,7 +9926,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!FailoverGroupReplicationRole:type",
-          "docComment": "/**\n * Defines values for FailoverGroupReplicationRole.\n */\n",
+          "docComment": "/**\n * Defines values for FailoverGroupReplicationRole. \\ {@link KnownFailoverGroupReplicationRole} can be used interchangeably with FailoverGroupReplicationRole, this enum contains the known values that the service supports. ### Know values supported by the service **Primary** \\ **Secondary**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9934,7 +9934,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Primary\" | \"Secondary\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10926,7 +10926,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!GeoBackupPolicyName:type",
-          "docComment": "/**\n * Defines values for GeoBackupPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for GeoBackupPolicyName. \\ {@link KnownGeoBackupPolicyName} can be used interchangeably with GeoBackupPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **Default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10934,7 +10934,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10976,7 +10976,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!IdentityType:type",
-          "docComment": "/**\n * Defines values for IdentityType.\n */\n",
+          "docComment": "/**\n * Defines values for IdentityType. \\ {@link KnownIdentityType} can be used interchangeably with IdentityType, this enum contains the known values that the service supports. ### Know values supported by the service **SystemAssigned**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10984,7 +10984,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SystemAssigned\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11607,7 +11607,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!InstanceFailoverGroupReplicationRole:type",
-          "docComment": "/**\n * Defines values for InstanceFailoverGroupReplicationRole.\n */\n",
+          "docComment": "/**\n * Defines values for InstanceFailoverGroupReplicationRole. \\ {@link KnownInstanceFailoverGroupReplicationRole} can be used interchangeably with InstanceFailoverGroupReplicationRole, this enum contains the known values that the service supports. ### Know values supported by the service **Primary** \\ **Secondary**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11615,7 +11615,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Primary\" | \"Secondary\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -12296,7 +12296,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!InstancePoolLicenseType:type",
-          "docComment": "/**\n * Defines values for InstancePoolLicenseType.\n */\n",
+          "docComment": "/**\n * Defines values for InstancePoolLicenseType. \\ {@link KnownInstancePoolLicenseType} can be used interchangeably with InstancePoolLicenseType, this enum contains the known values that the service supports. ### Know values supported by the service **LicenseIncluded** \\ **BasePrice**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -12304,7 +12304,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"LicenseIncluded\" | \"BasePrice\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -13316,7 +13316,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!JobAgentState:type",
-          "docComment": "/**\n * Defines values for JobAgentState.\n */\n",
+          "docComment": "/**\n * Defines values for JobAgentState. \\ {@link KnownJobAgentState} can be used interchangeably with JobAgentState, this enum contains the known values that the service supports. ### Know values supported by the service **Creating** \\ **Ready** \\ **Updating** \\ **Deleting** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -13324,7 +13324,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Creating\" | \"Ready\" | \"Updating\" | \"Deleting\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -13834,7 +13834,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!JobExecutionLifecycle:type",
-          "docComment": "/**\n * Defines values for JobExecutionLifecycle.\n */\n",
+          "docComment": "/**\n * Defines values for JobExecutionLifecycle. \\ {@link KnownJobExecutionLifecycle} can be used interchangeably with JobExecutionLifecycle, this enum contains the known values that the service supports. ### Know values supported by the service **Created** \\ **InProgress** \\ **WaitingForChildJobExecutions** \\ **WaitingForRetry** \\ **Succeeded** \\ **SucceededWithSkipped** \\ **Failed** \\ **TimedOut** \\ **Canceled** \\ **Skipped**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -13842,7 +13842,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Created\" | \"InProgress\" | \"WaitingForChildJobExecutions\" | \"WaitingForRetry\" | \"Succeeded\" | \"SucceededWithSkipped\" | \"Failed\" | \"TimedOut\" | \"Canceled\" | \"Skipped\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15828,7 +15828,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!JobStepActionSource:type",
-          "docComment": "/**\n * Defines values for JobStepActionSource.\n */\n",
+          "docComment": "/**\n * Defines values for JobStepActionSource. \\ {@link KnownJobStepActionSource} can be used interchangeably with JobStepActionSource, this enum contains the known values that the service supports. ### Know values supported by the service **Inline**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15836,7 +15836,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Inline\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -15853,7 +15853,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!JobStepActionType:type",
-          "docComment": "/**\n * Defines values for JobStepActionType.\n */\n",
+          "docComment": "/**\n * Defines values for JobStepActionType. \\ {@link KnownJobStepActionType} can be used interchangeably with JobStepActionType, this enum contains the known values that the service supports. ### Know values supported by the service **TSql**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -15861,7 +15861,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TSql\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -16877,7 +16877,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!JobStepOutputType:type",
-          "docComment": "/**\n * Defines values for JobStepOutputType.\n */\n",
+          "docComment": "/**\n * Defines values for JobStepOutputType. \\ {@link KnownJobStepOutputType} can be used interchangeably with JobStepOutputType, this enum contains the known values that the service supports. ### Know values supported by the service **SqlDatabase**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -16885,7 +16885,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SqlDatabase\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -18850,7 +18850,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!JobTargetType:type",
-          "docComment": "/**\n * Defines values for JobTargetType.\n */\n",
+          "docComment": "/**\n * Defines values for JobTargetType. \\ {@link KnownJobTargetType} can be used interchangeably with JobTargetType, this enum contains the known values that the service supports. ### Know values supported by the service **TargetGroup** \\ **SqlDatabase** \\ **SqlElasticPool** \\ **SqlShardMap** \\ **SqlServer**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -18858,7 +18858,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TargetGroup\" | \"SqlDatabase\" | \"SqlElasticPool\" | \"SqlShardMap\" | \"SqlServer\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -19116,6 +19116,8070 @@
             "startIndex": 1,
             "endIndex": 7
           }
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownAdministratorName:enum",
+          "docComment": "/**\n * Known values of {@link AdministratorName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAdministratorName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAdministratorName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownAdministratorName.ActiveDirectory:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ActiveDirectory = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ActiveDirectory\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ActiveDirectory",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownAdministratorType:enum",
+          "docComment": "/**\n * Known values of {@link AdministratorType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAdministratorType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAdministratorType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownAdministratorType.ActiveDirectory:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ActiveDirectory = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ActiveDirectory\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ActiveDirectory",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownCapabilityGroup:enum",
+          "docComment": "/**\n * Known values of {@link CapabilityGroup} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCapabilityGroup "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCapabilityGroup",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCapabilityGroup.SupportedEditions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SupportedEditions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"supportedEditions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SupportedEditions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCapabilityGroup.SupportedElasticPoolEditions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SupportedElasticPoolEditions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"supportedElasticPoolEditions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SupportedElasticPoolEditions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCapabilityGroup.SupportedInstancePoolEditions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SupportedInstancePoolEditions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"supportedInstancePoolEditions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SupportedInstancePoolEditions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCapabilityGroup.SupportedManagedInstanceEditions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SupportedManagedInstanceEditions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"supportedManagedInstanceEditions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SupportedManagedInstanceEditions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCapabilityGroup.SupportedManagedInstanceVersions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SupportedManagedInstanceVersions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"supportedManagedInstanceVersions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SupportedManagedInstanceVersions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownCatalogCollationType:enum",
+          "docComment": "/**\n * Known values of {@link CatalogCollationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCatalogCollationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCatalogCollationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCatalogCollationType.DatabaseDefault:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DatabaseDefault = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DATABASE_DEFAULT\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DatabaseDefault",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCatalogCollationType.SQLLatin1GeneralCP1CIAS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SQLLatin1GeneralCP1CIAS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SQL_Latin1_General_CP1_CI_AS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SQLLatin1GeneralCP1CIAS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownConnectionPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link ConnectionPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownConnectionPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownConnectionPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownConnectionPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownCreateMode:enum",
+          "docComment": "/**\n * Known values of {@link CreateMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCreateMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCreateMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.Copy:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Copy = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Copy\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Copy",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.OnlineSecondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OnlineSecondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OnlineSecondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OnlineSecondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.PointInTimeRestore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PointInTimeRestore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PointInTimeRestore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PointInTimeRestore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.Recovery:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recovery = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Recovery\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recovery",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.Restore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Restore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.RestoreExternalBackup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RestoreExternalBackup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RestoreExternalBackup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RestoreExternalBackup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.RestoreExternalBackupSecondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RestoreExternalBackupSecondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RestoreExternalBackupSecondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RestoreExternalBackupSecondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.RestoreLongTermRetentionBackup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RestoreLongTermRetentionBackup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RestoreLongTermRetentionBackup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RestoreLongTermRetentionBackup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownCreateMode.Secondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Secondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Secondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Secondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownDatabaseEdition:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseEdition} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseEdition "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseEdition",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Business:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Business = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Business\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Business",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.BusinessCritical:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BusinessCritical = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BusinessCritical\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BusinessCritical",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.DataWarehouse:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DataWarehouse = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DataWarehouse\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DataWarehouse",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Free:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Free = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Free\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Free",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.GeneralPurpose:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GeneralPurpose = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GeneralPurpose\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GeneralPurpose",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Hyperscale:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Hyperscale = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Hyperscale\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Hyperscale",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Premium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Premium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Premium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.PremiumRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PremiumRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Stretch:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Stretch = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Stretch\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Stretch",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.System:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.System2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseEdition.Web:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Web = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Web\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Web",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownDatabaseLicenseType:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseLicenseType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseLicenseType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseLicenseType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseLicenseType.BasePrice:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasePrice = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BasePrice\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasePrice",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseLicenseType.LicenseIncluded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LicenseIncluded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LicenseIncluded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LicenseIncluded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownDatabaseReadScale:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseReadScale} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseReadScale "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseReadScale",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseReadScale.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseReadScale.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownDatabaseState:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseState.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseState.Deleted:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleted = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleted\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleted",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseState.Live:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Live = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Live\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Live",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownDatabaseStatus:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.AutoClosed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AutoClosed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AutoClosed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AutoClosed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Copying:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Copying = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Copying\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Copying",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.EmergencyMode:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "EmergencyMode = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"EmergencyMode\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "EmergencyMode",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Inaccessible:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inaccessible = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inaccessible\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inaccessible",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Offline:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Offline = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Offline\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Offline",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.OfflineChangingDwPerformanceTiers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OfflineChangingDwPerformanceTiers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OfflineChangingDwPerformanceTiers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OfflineChangingDwPerformanceTiers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.OfflineSecondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OfflineSecondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OfflineSecondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OfflineSecondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Online:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Online = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Online\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Online",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.OnlineChangingDwPerformanceTiers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OnlineChangingDwPerformanceTiers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OnlineChangingDwPerformanceTiers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OnlineChangingDwPerformanceTiers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Paused:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Paused = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Paused\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Paused",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Pausing:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pausing = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Pausing\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pausing",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Recovering:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recovering = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Recovering\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recovering",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.RecoveryPending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RecoveryPending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RecoveryPending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RecoveryPending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Restoring:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restoring = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Restoring\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restoring",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Resuming:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Resuming = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Resuming\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Resuming",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Scaling:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Scaling = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Scaling\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Scaling",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Shutdown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Shutdown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Shutdown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Shutdown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Standby:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standby = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standby\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standby",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownDatabaseStatus.Suspect:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Suspect = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Suspect\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Suspect",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownElasticPoolEdition:enum",
+          "docComment": "/**\n * Known values of {@link ElasticPoolEdition} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownElasticPoolEdition "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownElasticPoolEdition",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolEdition.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolEdition.BusinessCritical:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BusinessCritical = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BusinessCritical\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BusinessCritical",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolEdition.GeneralPurpose:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GeneralPurpose = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GeneralPurpose\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GeneralPurpose",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolEdition.Premium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Premium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Premium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolEdition.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownElasticPoolLicenseType:enum",
+          "docComment": "/**\n * Known values of {@link ElasticPoolLicenseType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownElasticPoolLicenseType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownElasticPoolLicenseType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolLicenseType.BasePrice:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasePrice = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BasePrice\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasePrice",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolLicenseType.LicenseIncluded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LicenseIncluded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LicenseIncluded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LicenseIncluded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownElasticPoolState:enum",
+          "docComment": "/**\n * Known values of {@link ElasticPoolState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownElasticPoolState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownElasticPoolState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownElasticPoolState.Ready:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ready = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ready\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ready",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownEncryptionProtectorName:enum",
+          "docComment": "/**\n * Known values of {@link EncryptionProtectorName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEncryptionProtectorName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEncryptionProtectorName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownEncryptionProtectorName.Current:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Current = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"current\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Current",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownEnum21:enum",
+          "docComment": "/**\n * Known values of {@link Enum21} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEnum21 "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEnum21",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownEnum21.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownEnum21.Error:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Error = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Error\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Error",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownEnum21.Success:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Success = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Success\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Success",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownEnum21.Warning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Warning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Warning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Warning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownExtensionName:enum",
+          "docComment": "/**\n * Known values of {@link ExtensionName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownExtensionName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownExtensionName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownExtensionName.Import:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Import = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"import\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Import",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownFailoverGroupReplicationRole:enum",
+          "docComment": "/**\n * Known values of {@link FailoverGroupReplicationRole} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFailoverGroupReplicationRole "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFailoverGroupReplicationRole",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownFailoverGroupReplicationRole.Primary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Primary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Primary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Primary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownFailoverGroupReplicationRole.Secondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Secondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Secondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Secondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownGeoBackupPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link GeoBackupPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGeoBackupPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGeoBackupPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownGeoBackupPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownIdentityType:enum",
+          "docComment": "/**\n * Known values of {@link IdentityType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownIdentityType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownIdentityType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownIdentityType.SystemAssigned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SystemAssigned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SystemAssigned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SystemAssigned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownInstanceFailoverGroupReplicationRole:enum",
+          "docComment": "/**\n * Known values of {@link InstanceFailoverGroupReplicationRole} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownInstanceFailoverGroupReplicationRole "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownInstanceFailoverGroupReplicationRole",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownInstanceFailoverGroupReplicationRole.Primary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Primary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Primary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Primary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownInstanceFailoverGroupReplicationRole.Secondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Secondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Secondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Secondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownInstancePoolLicenseType:enum",
+          "docComment": "/**\n * Known values of {@link InstancePoolLicenseType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownInstancePoolLicenseType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownInstancePoolLicenseType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownInstancePoolLicenseType.BasePrice:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasePrice = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BasePrice\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasePrice",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownInstancePoolLicenseType.LicenseIncluded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LicenseIncluded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LicenseIncluded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LicenseIncluded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownJobAgentState:enum",
+          "docComment": "/**\n * Known values of {@link JobAgentState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownJobAgentState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownJobAgentState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobAgentState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobAgentState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobAgentState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobAgentState.Ready:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ready = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ready\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ready",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobAgentState.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle:enum",
+          "docComment": "/**\n * Known values of {@link JobExecutionLifecycle} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownJobExecutionLifecycle "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownJobExecutionLifecycle",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.Canceled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Canceled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Canceled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Canceled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.Created:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Created = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Created\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Created",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.Skipped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Skipped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Skipped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Skipped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.SucceededWithSkipped:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SucceededWithSkipped = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SucceededWithSkipped\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SucceededWithSkipped",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.TimedOut:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TimedOut = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TimedOut\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TimedOut",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.WaitingForChildJobExecutions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WaitingForChildJobExecutions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WaitingForChildJobExecutions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WaitingForChildJobExecutions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobExecutionLifecycle.WaitingForRetry:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WaitingForRetry = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WaitingForRetry\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WaitingForRetry",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownJobStepActionSource:enum",
+          "docComment": "/**\n * Known values of {@link JobStepActionSource} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownJobStepActionSource "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownJobStepActionSource",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobStepActionSource.Inline:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inline = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inline\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inline",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownJobStepActionType:enum",
+          "docComment": "/**\n * Known values of {@link JobStepActionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownJobStepActionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownJobStepActionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobStepActionType.TSql:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TSql = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TSql\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TSql",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownJobStepOutputType:enum",
+          "docComment": "/**\n * Known values of {@link JobStepOutputType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownJobStepOutputType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownJobStepOutputType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobStepOutputType.SqlDatabase:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlDatabase = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlDatabase\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlDatabase",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownJobTargetType:enum",
+          "docComment": "/**\n * Known values of {@link JobTargetType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownJobTargetType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownJobTargetType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobTargetType.SqlDatabase:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlDatabase = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlDatabase\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlDatabase",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobTargetType.SqlElasticPool:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlElasticPool = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlElasticPool\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlElasticPool",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobTargetType.SqlServer:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlServer = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlServer\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlServer",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobTargetType.SqlShardMap:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlShardMap = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlShardMap\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlShardMap",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownJobTargetType.TargetGroup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TargetGroup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TargetGroup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TargetGroup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownLogSizeUnit:enum",
+          "docComment": "/**\n * Known values of {@link LogSizeUnit} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLogSizeUnit "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLogSizeUnit",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLogSizeUnit.Gigabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gigabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Gigabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gigabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLogSizeUnit.Megabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Megabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Megabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Megabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLogSizeUnit.Percent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Percent = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Percent\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Percent",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLogSizeUnit.Petabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Petabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Petabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Petabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLogSizeUnit.Terabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Terabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Terabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Terabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownLongTermRetentionDatabaseState:enum",
+          "docComment": "/**\n * Known values of {@link LongTermRetentionDatabaseState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLongTermRetentionDatabaseState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLongTermRetentionDatabaseState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLongTermRetentionDatabaseState.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLongTermRetentionDatabaseState.Deleted:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleted = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleted\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleted",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLongTermRetentionDatabaseState.Live:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Live = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Live\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Live",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownLongTermRetentionPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link LongTermRetentionPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLongTermRetentionPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLongTermRetentionPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownLongTermRetentionPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedDatabaseCreateMode:enum",
+          "docComment": "/**\n * Known values of {@link ManagedDatabaseCreateMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedDatabaseCreateMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedDatabaseCreateMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseCreateMode.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseCreateMode.PointInTimeRestore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PointInTimeRestore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PointInTimeRestore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PointInTimeRestore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseCreateMode.Recovery:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recovery = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Recovery\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recovery",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseCreateMode.RestoreExternalBackup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RestoreExternalBackup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RestoreExternalBackup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RestoreExternalBackup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseCreateMode.RestoreLongTermRetentionBackup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RestoreLongTermRetentionBackup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RestoreLongTermRetentionBackup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RestoreLongTermRetentionBackup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus:enum",
+          "docComment": "/**\n * Known values of {@link ManagedDatabaseStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedDatabaseStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedDatabaseStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Inaccessible:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inaccessible = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Inaccessible\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inaccessible",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Offline:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Offline = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Offline\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Offline",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Online:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Online = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Online\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Online",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Restoring:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Restoring = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Restoring\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Restoring",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Shutdown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Shutdown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Shutdown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Shutdown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedDatabaseStatus.Updating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Updating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Updating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Updating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedInstanceAdministratorType:enum",
+          "docComment": "/**\n * Known values of {@link ManagedInstanceAdministratorType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedInstanceAdministratorType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedInstanceAdministratorType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceAdministratorType.ActiveDirectory:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ActiveDirectory = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ActiveDirectory\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ActiveDirectory",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedInstanceLicenseType:enum",
+          "docComment": "/**\n * Known values of {@link ManagedInstanceLicenseType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedInstanceLicenseType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedInstanceLicenseType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceLicenseType.BasePrice:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BasePrice = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BasePrice\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BasePrice",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceLicenseType.LicenseIncluded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LicenseIncluded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LicenseIncluded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LicenseIncluded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedInstanceLongTermRetentionPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link ManagedInstanceLongTermRetentionPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedInstanceLongTermRetentionPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedInstanceLongTermRetentionPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceLongTermRetentionPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedInstanceProxyOverride:enum",
+          "docComment": "/**\n * Known values of {@link ManagedInstanceProxyOverride} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedInstanceProxyOverride "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedInstanceProxyOverride",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceProxyOverride.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceProxyOverride.Proxy:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Proxy = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Proxy\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Proxy",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedInstanceProxyOverride.Redirect:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Redirect = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Redirect\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Redirect",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedServerCreateMode:enum",
+          "docComment": "/**\n * Known values of {@link ManagedServerCreateMode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedServerCreateMode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedServerCreateMode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedServerCreateMode.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedServerCreateMode.PointInTimeRestore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PointInTimeRestore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PointInTimeRestore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PointInTimeRestore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagedShortTermRetentionPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link ManagedShortTermRetentionPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagedShortTermRetentionPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagedShortTermRetentionPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagedShortTermRetentionPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownManagementOperationState:enum",
+          "docComment": "/**\n * Known values of {@link ManagementOperationState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagementOperationState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagementOperationState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagementOperationState.CancelInProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CancelInProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CancelInProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CancelInProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagementOperationState.Cancelled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Cancelled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Cancelled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Cancelled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagementOperationState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagementOperationState.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagementOperationState.Pending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Pending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownManagementOperationState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownMaxSizeUnit:enum",
+          "docComment": "/**\n * Known values of {@link MaxSizeUnit} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownMaxSizeUnit "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownMaxSizeUnit",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownMaxSizeUnit.Gigabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Gigabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Gigabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Gigabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownMaxSizeUnit.Megabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Megabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Megabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Megabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownMaxSizeUnit.Petabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Petabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Petabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Petabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownMaxSizeUnit.Terabytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Terabytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Terabytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Terabytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownOperationOrigin:enum",
+          "docComment": "/**\n * Known values of {@link OperationOrigin} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownOperationOrigin "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownOperationOrigin",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownOperationOrigin.System:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"system\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownOperationOrigin.User:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "User = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"user\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "User",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownPauseDelayTimeUnit:enum",
+          "docComment": "/**\n * Known values of {@link PauseDelayTimeUnit} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPauseDelayTimeUnit "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPauseDelayTimeUnit",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPauseDelayTimeUnit.Minutes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Minutes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Minutes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Minutes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownPerformanceLevelUnit:enum",
+          "docComment": "/**\n * Known values of {@link PerformanceLevelUnit} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPerformanceLevelUnit "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPerformanceLevelUnit",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPerformanceLevelUnit.DTU:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DTU = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DTU\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DTU",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPerformanceLevelUnit.VCores:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VCores = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VCores\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VCores",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType:enum",
+          "docComment": "/**\n * Known values of {@link PrimaryAggregationType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrimaryAggregationType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrimaryAggregationType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType.Average:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Average = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Average\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Average",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType.Count:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Count = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Count\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Count",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType.Maximum:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Maximum = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Maximum\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Maximum",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType.Minimum:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Minimum = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Minimum\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Minimum",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrimaryAggregationType.Total:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Total = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Total\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Total",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownPrivateEndpointProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link PrivateEndpointProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateEndpointProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateEndpointProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateEndpointProvisioningState.Approving:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Approving = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Approving\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Approving",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateEndpointProvisioningState.Dropping:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dropping = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Dropping\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dropping",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateEndpointProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateEndpointProvisioningState.Ready:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ready = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ready\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ready",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateEndpointProvisioningState.Rejecting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Rejecting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Rejecting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Rejecting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateActionsRequire:enum",
+          "docComment": "/**\n * Known values of {@link PrivateLinkServiceConnectionStateActionsRequire} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateLinkServiceConnectionStateActionsRequire "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateLinkServiceConnectionStateActionsRequire",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateActionsRequire.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateStatus:enum",
+          "docComment": "/**\n * Known values of {@link PrivateLinkServiceConnectionStateStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateLinkServiceConnectionStateStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateLinkServiceConnectionStateStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateStatus.Approved:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Approved = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Approved\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Approved",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateStatus.Disconnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disconnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disconnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disconnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateStatus.Pending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Pending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownPrivateLinkServiceConnectionStateStatus.Rejected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Rejected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Rejected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Rejected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link ProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownProvisioningState.Canceled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Canceled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Canceled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Canceled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownProvisioningState.Created:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Created = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Created\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Created",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownProvisioningState.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownReadOnlyEndpointFailoverPolicy:enum",
+          "docComment": "/**\n * Known values of {@link ReadOnlyEndpointFailoverPolicy} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReadOnlyEndpointFailoverPolicy "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReadOnlyEndpointFailoverPolicy",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReadOnlyEndpointFailoverPolicy.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReadOnlyEndpointFailoverPolicy.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownReadWriteEndpointFailoverPolicy:enum",
+          "docComment": "/**\n * Known values of {@link ReadWriteEndpointFailoverPolicy} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReadWriteEndpointFailoverPolicy "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReadWriteEndpointFailoverPolicy",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReadWriteEndpointFailoverPolicy.Automatic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Automatic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Automatic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Automatic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReadWriteEndpointFailoverPolicy.Manual:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Manual = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Manual\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Manual",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownReplicationState:enum",
+          "docComment": "/**\n * Known values of {@link ReplicationState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReplicationState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReplicationState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReplicationState.CatchUP:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CatchUP = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CATCH_UP\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CatchUP",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReplicationState.Pending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PENDING\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReplicationState.Seeding:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Seeding = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SEEDING\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Seeding",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReplicationState.Suspended:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Suspended = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SUSPENDED\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Suspended",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownReplicaType:enum",
+          "docComment": "/**\n * Known values of {@link ReplicaType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReplicaType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReplicaType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReplicaType.Primary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Primary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Primary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Primary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownReplicaType.ReadableSecondary:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ReadableSecondary = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ReadableSecondary\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ReadableSecondary",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownRestoreDetailsName:enum",
+          "docComment": "/**\n * Known values of {@link RestoreDetailsName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRestoreDetailsName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRestoreDetailsName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownRestoreDetailsName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSampleName:enum",
+          "docComment": "/**\n * Known values of {@link SampleName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSampleName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSampleName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSampleName.AdventureWorksLT:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AdventureWorksLT = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AdventureWorksLT\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AdventureWorksLT",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSampleName.WideWorldImportersFull:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WideWorldImportersFull = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WideWorldImportersFull\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WideWorldImportersFull",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSampleName.WideWorldImportersStd:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WideWorldImportersStd = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WideWorldImportersStd\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WideWorldImportersStd",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSecurityAlertPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link SecurityAlertPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityAlertPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityAlertPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSecurityAlertPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSecurityAlertPolicyNameAutoGenerated:enum",
+          "docComment": "/**\n * Known values of {@link SecurityAlertPolicyNameAutoGenerated} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSecurityAlertPolicyNameAutoGenerated "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSecurityAlertPolicyNameAutoGenerated",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSecurityAlertPolicyNameAutoGenerated.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownServerKeyType:enum",
+          "docComment": "/**\n * Known values of {@link ServerKeyType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownServerKeyType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownServerKeyType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServerKeyType.AzureKeyVault:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzureKeyVault = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzureKeyVault\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzureKeyVault",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServerKeyType.ServiceManaged:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ServiceManaged = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ServiceManaged\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ServiceManaged",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownServerPublicNetworkAccess:enum",
+          "docComment": "/**\n * Known values of {@link ServerPublicNetworkAccess} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownServerPublicNetworkAccess "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownServerPublicNetworkAccess",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServerPublicNetworkAccess.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServerPublicNetworkAccess.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName:enum",
+          "docComment": "/**\n * Known values of {@link ServiceObjectiveName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownServiceObjectiveName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownServiceObjectiveName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS100:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS100 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS100\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS100",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS1000:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS1000 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS1000\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS1000",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS1200:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS1200 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS1200\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS1200",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS1500:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS1500 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS1500\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS1500",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS200:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS200 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS200\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS200",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS2000:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS2000 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS2000\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS2000",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS300:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS300 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS300\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS300",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS400:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS400 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS400\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS400",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS500:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS500 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS500\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS500",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DS600:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DS600 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DS600\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DS600",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW100:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW100 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW100\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW100",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW1000:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW1000 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW1000\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW1000",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW10000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW10000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW10000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW10000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW1000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW1000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW1000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW1000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW1200:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW1200 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW1200\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW1200",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW1500:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW1500 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW1500\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW1500",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW15000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW15000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW15000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW15000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW1500C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW1500C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW1500c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW1500C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW200:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW200 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW200\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW200",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW2000:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW2000 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW2000\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW2000",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW2000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW2000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW2000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW2000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW2500C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW2500C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW2500c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW2500C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW300:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW300 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW300\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW300",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW3000:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW3000 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW3000\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW3000",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW30000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW30000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW30000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW30000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW3000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW3000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW3000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW3000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW400:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW400 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW400\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW400",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW500:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW500 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW500\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW500",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW5000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW5000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW5000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW5000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW600:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW600 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW600\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW600",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW6000:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW6000 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW6000\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW6000",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW6000C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW6000C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW6000c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW6000C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.DW7500C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DW7500C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DW7500c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DW7500C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.ElasticPool:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ElasticPool = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ElasticPool\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ElasticPool",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.Free:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Free = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Free\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Free",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P11:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P11 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P11\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P11",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P15:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P15 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P15\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P15",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.P6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"P6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.PRS1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PRS1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PRS1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PRS1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.PRS2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PRS2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PRS2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PRS2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.PRS4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PRS4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PRS4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PRS4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.PRS6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PRS6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PRS6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PRS6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S0:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S0 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S0",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S12:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S12 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S12\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S12",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S6:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S6 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S6\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S6",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S7:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S7 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S7\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S7",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.S9:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S9 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"S9\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S9",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System0:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System0 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System0",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System2L:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System2L = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System2L\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System2L",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System3L:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System3L = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System3L\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System3L",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System4:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System4 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System4\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System4",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownServiceObjectiveName.System4L:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "System4L = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"System4L\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "System4L",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownShortTermRetentionPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link ShortTermRetentionPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownShortTermRetentionPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownShortTermRetentionPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownShortTermRetentionPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownStorageCapabilityStorageAccountType:enum",
+          "docComment": "/**\n * Known values of {@link StorageCapabilityStorageAccountType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownStorageCapabilityStorageAccountType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownStorageCapabilityStorageAccountType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownStorageCapabilityStorageAccountType.GRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownStorageCapabilityStorageAccountType.LRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownStorageCapabilityStorageAccountType.ZRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ZRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ZRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncAgentState:enum",
+          "docComment": "/**\n * Known values of {@link SyncAgentState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncAgentState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncAgentState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncAgentState.NeverConnected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NeverConnected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NeverConnected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NeverConnected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncAgentState.Offline:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Offline = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Offline\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Offline",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncAgentState.Online:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Online = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Online\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Online",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncConflictResolutionPolicy:enum",
+          "docComment": "/**\n * Known values of {@link SyncConflictResolutionPolicy} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncConflictResolutionPolicy "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncConflictResolutionPolicy",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncConflictResolutionPolicy.HubWin:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HubWin = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HubWin\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HubWin",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncConflictResolutionPolicy.MemberWin:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MemberWin = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MemberWin\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MemberWin",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncDirection:enum",
+          "docComment": "/**\n * Known values of {@link SyncDirection} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncDirection "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncDirection",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncDirection.Bidirectional:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Bidirectional = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Bidirectional\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Bidirectional",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncDirection.OneWayHubToMember:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OneWayHubToMember = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OneWayHubToMember\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OneWayHubToMember",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncDirection.OneWayMemberToHub:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OneWayMemberToHub = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OneWayMemberToHub\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OneWayMemberToHub",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncGroupLogType:enum",
+          "docComment": "/**\n * Known values of {@link SyncGroupLogType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncGroupLogType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncGroupLogType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupLogType.All:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "All = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"All\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "All",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupLogType.Error:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Error = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Error\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Error",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupLogType.Success:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Success = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Success\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Success",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupLogType.Warning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Warning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Warning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Warning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncGroupState:enum",
+          "docComment": "/**\n * Known values of {@link SyncGroupState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncGroupState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncGroupState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupState.Error:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Error = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Error\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Error",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupState.Good:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Good = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Good\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Good",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupState.NotReady:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotReady = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotReady\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotReady",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupState.Progressing:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Progressing = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Progressing\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Progressing",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncGroupState.Warning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Warning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Warning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Warning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncMemberDbType:enum",
+          "docComment": "/**\n * Known values of {@link SyncMemberDbType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncMemberDbType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncMemberDbType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberDbType.AzureSqlDatabase:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzureSqlDatabase = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzureSqlDatabase\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzureSqlDatabase",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberDbType.SqlServerDatabase:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlServerDatabase = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlServerDatabase\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlServerDatabase",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownSyncMemberState:enum",
+          "docComment": "/**\n * Known values of {@link SyncMemberState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSyncMemberState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSyncMemberState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.DeProvisioned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DeProvisioned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DeProvisioned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DeProvisioned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.DeProvisionFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DeProvisionFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DeProvisionFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DeProvisionFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.DeProvisioning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DeProvisioning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DeProvisioning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DeProvisioning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.DisabledBackupRestore:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DisabledBackupRestore = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DisabledBackupRestore\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DisabledBackupRestore",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.DisabledTombstoneCleanup:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "DisabledTombstoneCleanup = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DisabledTombstoneCleanup\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "DisabledTombstoneCleanup",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.Provisioned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Provisioned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Provisioned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Provisioned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.ProvisionFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ProvisionFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ProvisionFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ProvisionFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.Provisioning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Provisioning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Provisioning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Provisioning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.ReprovisionFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ReprovisionFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ReprovisionFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ReprovisionFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.Reprovisioning:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Reprovisioning = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Reprovisioning\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Reprovisioning",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.SyncCancelled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SyncCancelled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SyncCancelled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SyncCancelled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.SyncCancelling:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SyncCancelling = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SyncCancelling\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SyncCancelling",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.SyncFailed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SyncFailed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SyncFailed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SyncFailed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.SyncInProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SyncInProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SyncInProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SyncInProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.SyncSucceeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SyncSucceeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SyncSucceeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SyncSucceeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.SyncSucceededWithWarnings:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SyncSucceededWithWarnings = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SyncSucceededWithWarnings\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SyncSucceededWithWarnings",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.UnProvisioned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UnProvisioned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UnProvisioned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UnProvisioned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownSyncMemberState.UnReprovisioned:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "UnReprovisioned = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"UnReprovisioned\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "UnReprovisioned",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownTransparentDataEncryptionActivityStatus:enum",
+          "docComment": "/**\n * Known values of {@link TransparentDataEncryptionActivityStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTransparentDataEncryptionActivityStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTransparentDataEncryptionActivityStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownTransparentDataEncryptionActivityStatus.Decrypting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Decrypting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Decrypting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Decrypting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownTransparentDataEncryptionActivityStatus.Encrypting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Encrypting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Encrypting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Encrypting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownTransparentDataEncryptionName:enum",
+          "docComment": "/**\n * Known values of {@link TransparentDataEncryptionName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTransparentDataEncryptionName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTransparentDataEncryptionName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownTransparentDataEncryptionName.Current:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Current = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"current\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Current",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType:enum",
+          "docComment": "/**\n * Known values of {@link UnitDefinitionType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownUnitDefinitionType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownUnitDefinitionType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType.Bytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Bytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Bytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Bytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType.BytesPerSecond:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BytesPerSecond = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BytesPerSecond\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BytesPerSecond",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType.Count:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Count = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Count\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Count",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType.CountPerSecond:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CountPerSecond = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CountPerSecond\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CountPerSecond",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType.Percent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Percent = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Percent\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Percent",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitDefinitionType.Seconds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Seconds = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Seconds\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Seconds",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownUnitType:enum",
+          "docComment": "/**\n * Known values of {@link UnitType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownUnitType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownUnitType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitType.Bytes:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Bytes = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"bytes\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Bytes",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitType.BytesPerSecond:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BytesPerSecond = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"bytesPerSecond\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BytesPerSecond",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitType.Count:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Count = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"count\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Count",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitType.CountPerSecond:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CountPerSecond = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"countPerSecond\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CountPerSecond",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitType.Percent:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Percent = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"percent\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Percent",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownUnitType.Seconds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Seconds = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"seconds\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Seconds",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownVirtualNetworkRuleState:enum",
+          "docComment": "/**\n * Known values of {@link VirtualNetworkRuleState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVirtualNetworkRuleState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVirtualNetworkRuleState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVirtualNetworkRuleState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVirtualNetworkRuleState.Initializing:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Initializing = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Initializing\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Initializing",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVirtualNetworkRuleState.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVirtualNetworkRuleState.Ready:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ready = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ready\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ready",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVirtualNetworkRuleState.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentName:enum",
+          "docComment": "/**\n * Known values of {@link VulnerabilityAssessmentName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVulnerabilityAssessmentName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVulnerabilityAssessmentName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanState:enum",
+          "docComment": "/**\n * Known values of {@link VulnerabilityAssessmentScanState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVulnerabilityAssessmentScanState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVulnerabilityAssessmentScanState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanState.FailedToRun:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FailedToRun = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FailedToRun\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FailedToRun",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanState.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanState.Passed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Passed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Passed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Passed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanTriggerType:enum",
+          "docComment": "/**\n * Known values of {@link VulnerabilityAssessmentScanTriggerType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownVulnerabilityAssessmentScanTriggerType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownVulnerabilityAssessmentScanTriggerType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanTriggerType.OnDemand:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OnDemand = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OnDemand\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OnDemand",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "sql-resource-manager!KnownVulnerabilityAssessmentScanTriggerType.Recurring:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Recurring = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Recurring\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Recurring",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -19502,7 +27566,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!LogSizeUnit:type",
-          "docComment": "/**\n * Defines values for LogSizeUnit.\n */\n",
+          "docComment": "/**\n * Defines values for LogSizeUnit. \\ {@link KnownLogSizeUnit} can be used interchangeably with LogSizeUnit, this enum contains the known values that the service supports. ### Know values supported by the service **Megabytes** \\ **Gigabytes** \\ **Terabytes** \\ **Petabytes** \\ **Percent**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -19510,7 +27574,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Megabytes\" | \"Gigabytes\" | \"Terabytes\" | \"Petabytes\" | \"Percent\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -21356,7 +29420,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!LongTermRetentionDatabaseState:type",
-          "docComment": "/**\n * Defines values for LongTermRetentionDatabaseState.\n */\n",
+          "docComment": "/**\n * Defines values for LongTermRetentionDatabaseState. \\ {@link KnownLongTermRetentionDatabaseState} can be used interchangeably with LongTermRetentionDatabaseState, this enum contains the known values that the service supports. ### Know values supported by the service **All** \\ **Live** \\ **Deleted**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21364,7 +29428,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"All\" | \"Live\" | \"Deleted\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -23073,7 +31137,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!LongTermRetentionPolicyName:type",
-          "docComment": "/**\n * Defines values for LongTermRetentionPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for LongTermRetentionPolicyName. \\ {@link KnownLongTermRetentionPolicyName} can be used interchangeably with LongTermRetentionPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -23081,7 +31145,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -23559,7 +31623,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedDatabaseCreateMode:type",
-          "docComment": "/**\n * Defines values for ManagedDatabaseCreateMode.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedDatabaseCreateMode. \\ {@link KnownManagedDatabaseCreateMode} can be used interchangeably with ManagedDatabaseCreateMode, this enum contains the known values that the service supports. ### Know values supported by the service **Default** \\ **RestoreExternalBackup** \\ **PointInTimeRestore** \\ **Recovery** \\ **RestoreLongTermRetentionBackup**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -23567,7 +31631,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | \"RestoreExternalBackup\" | \"PointInTimeRestore\" | \"Recovery\" | \"RestoreLongTermRetentionBackup\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -24992,7 +33056,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedDatabaseStatus:type",
-          "docComment": "/**\n * Defines values for ManagedDatabaseStatus.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedDatabaseStatus. \\ {@link KnownManagedDatabaseStatus} can be used interchangeably with ManagedDatabaseStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Online** \\ **Offline** \\ **Shutdown** \\ **Creating** \\ **Inaccessible** \\ **Restoring** \\ **Updating**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -25000,7 +33064,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Online\" | \"Offline\" | \"Shutdown\" | \"Creating\" | \"Inaccessible\" | \"Restoring\" | \"Updating\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -26389,7 +34453,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedInstanceAdministratorType:type",
-          "docComment": "/**\n * Defines values for ManagedInstanceAdministratorType.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedInstanceAdministratorType. \\ {@link KnownManagedInstanceAdministratorType} can be used interchangeably with ManagedInstanceAdministratorType, this enum contains the known values that the service supports. ### Know values supported by the service **ActiveDirectory**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -26397,7 +34461,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ActiveDirectory\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -27480,7 +35544,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedInstanceLicenseType:type",
-          "docComment": "/**\n * Defines values for ManagedInstanceLicenseType.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedInstanceLicenseType. \\ {@link KnownManagedInstanceLicenseType} can be used interchangeably with ManagedInstanceLicenseType, this enum contains the known values that the service supports. ### Know values supported by the service **LicenseIncluded** \\ **BasePrice**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -27488,7 +35552,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"LicenseIncluded\" | \"BasePrice\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28024,7 +36088,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedInstanceLongTermRetentionPolicyName:type",
-          "docComment": "/**\n * Defines values for ManagedInstanceLongTermRetentionPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedInstanceLongTermRetentionPolicyName. \\ {@link KnownManagedInstanceLongTermRetentionPolicyName} can be used interchangeably with ManagedInstanceLongTermRetentionPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28032,7 +36096,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -28387,7 +36451,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedInstanceProxyOverride:type",
-          "docComment": "/**\n * Defines values for ManagedInstanceProxyOverride.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedInstanceProxyOverride. \\ {@link KnownManagedInstanceProxyOverride} can be used interchangeably with ManagedInstanceProxyOverride, this enum contains the known values that the service supports. ### Know values supported by the service **Proxy** \\ **Redirect** \\ **Default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -28395,7 +36459,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Proxy\" | \"Redirect\" | \"Default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -30379,7 +38443,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedServerCreateMode:type",
-          "docComment": "/**\n * Defines values for ManagedServerCreateMode.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedServerCreateMode. \\ {@link KnownManagedServerCreateMode} can be used interchangeably with ManagedServerCreateMode, this enum contains the known values that the service supports. ### Know values supported by the service **Default** \\ **PointInTimeRestore**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -30387,7 +38451,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | \"PointInTimeRestore\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -30733,7 +38797,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagedShortTermRetentionPolicyName:type",
-          "docComment": "/**\n * Defines values for ManagedShortTermRetentionPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for ManagedShortTermRetentionPolicyName. \\ {@link KnownManagedShortTermRetentionPolicyName} can be used interchangeably with ManagedShortTermRetentionPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -30741,7 +38805,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -30758,7 +38822,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ManagementOperationState:type",
-          "docComment": "/**\n * Defines values for ManagementOperationState.\n */\n",
+          "docComment": "/**\n * Defines values for ManagementOperationState. \\ {@link KnownManagementOperationState} can be used interchangeably with ManagementOperationState, this enum contains the known values that the service supports. ### Know values supported by the service **Pending** \\ **InProgress** \\ **Succeeded** \\ **Failed** \\ **CancelInProgress** \\ **Cancelled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -30766,7 +38830,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Pending\" | \"InProgress\" | \"Succeeded\" | \"Failed\" | \"CancelInProgress\" | \"Cancelled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -31021,7 +39085,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!MaxSizeUnit:type",
-          "docComment": "/**\n * Defines values for MaxSizeUnit.\n */\n",
+          "docComment": "/**\n * Defines values for MaxSizeUnit. \\ {@link KnownMaxSizeUnit} can be used interchangeably with MaxSizeUnit, this enum contains the known values that the service supports. ### Know values supported by the service **Megabytes** \\ **Gigabytes** \\ **Terabytes** \\ **Petabytes**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -31029,7 +39093,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Megabytes\" | \"Gigabytes\" | \"Terabytes\" | \"Petabytes\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32340,7 +40404,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!OperationOrigin:type",
-          "docComment": "/**\n * Defines values for OperationOrigin.\n */\n",
+          "docComment": "/**\n * Defines values for OperationOrigin. \\ {@link KnownOperationOrigin} can be used interchangeably with OperationOrigin, this enum contains the known values that the service supports. ### Know values supported by the service **user** \\ **system**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32348,7 +40412,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"user\" | \"system\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32620,7 +40684,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!PauseDelayTimeUnit:type",
-          "docComment": "/**\n * Defines values for PauseDelayTimeUnit.\n */\n",
+          "docComment": "/**\n * Defines values for PauseDelayTimeUnit. \\ {@link KnownPauseDelayTimeUnit} can be used interchangeably with PauseDelayTimeUnit, this enum contains the known values that the service supports. ### Know values supported by the service **Minutes**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32628,7 +40692,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Minutes\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32712,7 +40776,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!PerformanceLevelUnit:type",
-          "docComment": "/**\n * Defines values for PerformanceLevelUnit.\n */\n",
+          "docComment": "/**\n * Defines values for PerformanceLevelUnit. \\ {@link KnownPerformanceLevelUnit} can be used interchangeably with PerformanceLevelUnit, this enum contains the known values that the service supports. ### Know values supported by the service **DTU** \\ **VCores**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32720,7 +40784,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"DTU\" | \"VCores\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32737,7 +40801,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!PrimaryAggregationType:type",
-          "docComment": "/**\n * Defines values for PrimaryAggregationType.\n */\n",
+          "docComment": "/**\n * Defines values for PrimaryAggregationType. \\ {@link KnownPrimaryAggregationType} can be used interchangeably with PrimaryAggregationType, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **Average** \\ **Count** \\ **Minimum** \\ **Maximum** \\ **Total**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32745,7 +40809,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"Average\" | \"Count\" | \"Minimum\" | \"Maximum\" | \"Total\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33226,7 +41290,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!PrivateEndpointProvisioningState:type",
-          "docComment": "/**\n * Defines values for PrivateEndpointProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateEndpointProvisioningState. \\ {@link KnownPrivateEndpointProvisioningState} can be used interchangeably with PrivateEndpointProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Approving** \\ **Ready** \\ **Dropping** \\ **Failed** \\ **Rejecting**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33234,7 +41298,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Approving\" | \"Ready\" | \"Dropping\" | \"Failed\" | \"Rejecting\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33571,7 +41635,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!PrivateLinkServiceConnectionStateActionsRequire:type",
-          "docComment": "/**\n * Defines values for PrivateLinkServiceConnectionStateActionsRequire.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateLinkServiceConnectionStateActionsRequire. \\ {@link KnownPrivateLinkServiceConnectionStateActionsRequire} can be used interchangeably with PrivateLinkServiceConnectionStateActionsRequire, this enum contains the known values that the service supports. ### Know values supported by the service **None**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33579,7 +41643,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33780,7 +41844,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!PrivateLinkServiceConnectionStateStatus:type",
-          "docComment": "/**\n * Defines values for PrivateLinkServiceConnectionStateStatus.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateLinkServiceConnectionStateStatus. \\ {@link KnownPrivateLinkServiceConnectionStateStatus} can be used interchangeably with PrivateLinkServiceConnectionStateStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Approved** \\ **Pending** \\ **Rejected** \\ **Disconnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33788,7 +41852,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Approved\" | \"Pending\" | \"Rejected\" | \"Disconnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33805,7 +41869,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ProvisioningState:type",
-          "docComment": "/**\n * Defines values for ProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for ProvisioningState. \\ {@link KnownProvisioningState} can be used interchangeably with ProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Created** \\ **InProgress** \\ **Succeeded** \\ **Failed** \\ **Canceled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33813,7 +41877,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Created\" | \"InProgress\" | \"Succeeded\" | \"Failed\" | \"Canceled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33860,7 +41924,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ReadOnlyEndpointFailoverPolicy:type",
-          "docComment": "/**\n * Defines values for ReadOnlyEndpointFailoverPolicy.\n */\n",
+          "docComment": "/**\n * Defines values for ReadOnlyEndpointFailoverPolicy. \\ {@link KnownReadOnlyEndpointFailoverPolicy} can be used interchangeably with ReadOnlyEndpointFailoverPolicy, this enum contains the known values that the service supports. ### Know values supported by the service **Disabled** \\ **Enabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33868,7 +41932,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Disabled\" | \"Enabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -33977,7 +42041,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ReadWriteEndpointFailoverPolicy:type",
-          "docComment": "/**\n * Defines values for ReadWriteEndpointFailoverPolicy.\n */\n",
+          "docComment": "/**\n * Defines values for ReadWriteEndpointFailoverPolicy. \\ {@link KnownReadWriteEndpointFailoverPolicy} can be used interchangeably with ReadWriteEndpointFailoverPolicy, this enum contains the known values that the service supports. ### Know values supported by the service **Manual** \\ **Automatic**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -33985,7 +42049,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Manual\" | \"Automatic\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -35232,7 +43296,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ReplicationState:type",
-          "docComment": "/**\n * Defines values for ReplicationState.\n */\n",
+          "docComment": "/**\n * Defines values for ReplicationState. \\ {@link KnownReplicationState} can be used interchangeably with ReplicationState, this enum contains the known values that the service supports. ### Know values supported by the service **PENDING** \\ **SEEDING** \\ **CATCH_UP** \\ **SUSPENDED**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -35240,7 +43304,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"PENDING\" | \"SEEDING\" | \"CATCH_UP\" | \"SUSPENDED\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -35257,7 +43321,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ReplicaType:type",
-          "docComment": "/**\n * Defines values for ReplicaType.\n */\n",
+          "docComment": "/**\n * Defines values for ReplicaType. \\ {@link KnownReplicaType} can be used interchangeably with ReplicaType, this enum contains the known values that the service supports. ### Know values supported by the service **Primary** \\ **ReadableSecondary**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -35265,7 +43329,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Primary\" | \"ReadableSecondary\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -35977,7 +44041,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!RestoreDetailsName:type",
-          "docComment": "/**\n * Defines values for RestoreDetailsName.\n */\n",
+          "docComment": "/**\n * Defines values for RestoreDetailsName. \\ {@link KnownRestoreDetailsName} can be used interchangeably with RestoreDetailsName, this enum contains the known values that the service supports. ### Know values supported by the service **Default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -35985,7 +44049,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -36317,7 +44381,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SampleName:type",
-          "docComment": "/**\n * Defines values for SampleName.\n */\n",
+          "docComment": "/**\n * Defines values for SampleName. \\ {@link KnownSampleName} can be used interchangeably with SampleName, this enum contains the known values that the service supports. ### Know values supported by the service **AdventureWorksLT** \\ **WideWorldImportersStd** \\ **WideWorldImportersFull**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36325,7 +44389,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AdventureWorksLT\" | \"WideWorldImportersStd\" | \"WideWorldImportersFull\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -36367,7 +44431,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SecurityAlertPolicyName:type",
-          "docComment": "/**\n * Defines values for SecurityAlertPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityAlertPolicyName. \\ {@link KnownSecurityAlertPolicyName} can be used interchangeably with SecurityAlertPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36375,7 +44439,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -36392,7 +44456,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SecurityAlertPolicyNameAutoGenerated:type",
-          "docComment": "/**\n * Defines values for SecurityAlertPolicyNameAutoGenerated.\n */\n",
+          "docComment": "/**\n * Defines values for SecurityAlertPolicyNameAutoGenerated. \\ {@link KnownSecurityAlertPolicyNameAutoGenerated} can be used interchangeably with SecurityAlertPolicyNameAutoGenerated, this enum contains the known values that the service supports. ### Know values supported by the service **Default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36400,7 +44464,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -39175,7 +47239,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ServerKeyType:type",
-          "docComment": "/**\n * Defines values for ServerKeyType.\n */\n",
+          "docComment": "/**\n * Defines values for ServerKeyType. \\ {@link KnownServerKeyType} can be used interchangeably with ServerKeyType, this enum contains the known values that the service supports. ### Know values supported by the service **ServiceManaged** \\ **AzureKeyVault**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -39183,7 +47247,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ServiceManaged\" | \"AzureKeyVault\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -39338,7 +47402,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ServerPublicNetworkAccess:type",
-          "docComment": "/**\n * Defines values for ServerPublicNetworkAccess.\n */\n",
+          "docComment": "/**\n * Defines values for ServerPublicNetworkAccess. \\ {@link KnownServerPublicNetworkAccess} can be used interchangeably with ServerPublicNetworkAccess, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -39346,7 +47410,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -41465,7 +49529,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ServiceObjectiveName:type",
-          "docComment": "/**\n * Defines values for ServiceObjectiveName.\n */\n",
+          "docComment": "/**\n * Defines values for ServiceObjectiveName. \\ {@link KnownServiceObjectiveName} can be used interchangeably with ServiceObjectiveName, this enum contains the known values that the service supports. ### Know values supported by the service **System** \\ **System0** \\ **System1** \\ **System2** \\ **System3** \\ **System4** \\ **System2L** \\ **System3L** \\ **System4L** \\ **Free** \\ **Basic** \\ **S0** \\ **S1** \\ **S2** \\ **S3** \\ **S4** \\ **S6** \\ **S7** \\ **S9** \\ **S12** \\ **P1** \\ **P2** \\ **P3** \\ **P4** \\ **P6** \\ **P11** \\ **P15** \\ **PRS1** \\ **PRS2** \\ **PRS4** \\ **PRS6** \\ **DW100** \\ **DW200** \\ **DW300** \\ **DW400** \\ **DW500** \\ **DW600** \\ **DW1000** \\ **DW1200** \\ **DW1000c** \\ **DW1500** \\ **DW1500c** \\ **DW2000** \\ **DW2000c** \\ **DW3000** \\ **DW2500c** \\ **DW3000c** \\ **DW6000** \\ **DW5000c** \\ **DW6000c** \\ **DW7500c** \\ **DW10000c** \\ **DW15000c** \\ **DW30000c** \\ **DS100** \\ **DS200** \\ **DS300** \\ **DS400** \\ **DS500** \\ **DS600** \\ **DS1000** \\ **DS1200** \\ **DS1500** \\ **DS2000** \\ **ElasticPool**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -41473,7 +49537,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"System\" | \"System0\" | \"System1\" | \"System2\" | \"System3\" | \"System4\" | \"System2L\" | \"System3L\" | \"System4L\" | \"Free\" | \"Basic\" | \"S0\" | \"S1\" | \"S2\" | \"S3\" | \"S4\" | \"S6\" | \"S7\" | \"S9\" | \"S12\" | \"P1\" | \"P2\" | \"P3\" | \"P4\" | \"P6\" | \"P11\" | \"P15\" | \"PRS1\" | \"PRS2\" | \"PRS4\" | \"PRS6\" | \"DW100\" | \"DW200\" | \"DW300\" | \"DW400\" | \"DW500\" | \"DW600\" | \"DW1000\" | \"DW1200\" | \"DW1000c\" | \"DW1500\" | \"DW1500c\" | \"DW2000\" | \"DW2000c\" | \"DW3000\" | \"DW2500c\" | \"DW3000c\" | \"DW6000\" | \"DW5000c\" | \"DW6000c\" | \"DW7500c\" | \"DW10000c\" | \"DW15000c\" | \"DW30000c\" | \"DS100\" | \"DS200\" | \"DS300\" | \"DS400\" | \"DS500\" | \"DS600\" | \"DS1000\" | \"DS1200\" | \"DS1500\" | \"DS2000\" | \"ElasticPool\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -41785,7 +49849,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!ShortTermRetentionPolicyName:type",
-          "docComment": "/**\n * Defines values for ShortTermRetentionPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for ShortTermRetentionPolicyName. \\ {@link KnownShortTermRetentionPolicyName} can be used interchangeably with ShortTermRetentionPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -41793,7 +49857,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -44941,7 +53005,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!StorageCapabilityStorageAccountType:type",
-          "docComment": "/**\n * Defines values for StorageCapabilityStorageAccountType.\n */\n",
+          "docComment": "/**\n * Defines values for StorageCapabilityStorageAccountType. \\ {@link KnownStorageCapabilityStorageAccountType} can be used interchangeably with StorageCapabilityStorageAccountType, this enum contains the known values that the service supports. ### Know values supported by the service **GRS** \\ **LRS** \\ **ZRS**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -44949,7 +53013,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"GRS\" | \"LRS\" | \"ZRS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -45869,7 +53933,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncAgentState:type",
-          "docComment": "/**\n * Defines values for SyncAgentState.\n */\n",
+          "docComment": "/**\n * Defines values for SyncAgentState. \\ {@link KnownSyncAgentState} can be used interchangeably with SyncAgentState, this enum contains the known values that the service supports. ### Know values supported by the service **Online** \\ **Offline** \\ **NeverConnected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -45877,7 +53941,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Online\" | \"Offline\" | \"NeverConnected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -45894,7 +53958,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncConflictResolutionPolicy:type",
-          "docComment": "/**\n * Defines values for SyncConflictResolutionPolicy.\n */\n",
+          "docComment": "/**\n * Defines values for SyncConflictResolutionPolicy. \\ {@link KnownSyncConflictResolutionPolicy} can be used interchangeably with SyncConflictResolutionPolicy, this enum contains the known values that the service supports. ### Know values supported by the service **HubWin** \\ **MemberWin**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -45902,7 +53966,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"HubWin\" | \"MemberWin\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -46031,7 +54095,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncDirection:type",
-          "docComment": "/**\n * Defines values for SyncDirection.\n */\n",
+          "docComment": "/**\n * Defines values for SyncDirection. \\ {@link KnownSyncDirection} can be used interchangeably with SyncDirection, this enum contains the known values that the service supports. ### Know values supported by the service **Bidirectional** \\ **OneWayMemberToHub** \\ **OneWayHubToMember**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -46039,7 +54103,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Bidirectional\" | \"OneWayMemberToHub\" | \"OneWayHubToMember\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -46912,7 +54976,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncGroupLogType:type",
-          "docComment": "/**\n * Defines values for SyncGroupLogType.\n */\n",
+          "docComment": "/**\n * Defines values for SyncGroupLogType. \\ {@link KnownSyncGroupLogType} can be used interchangeably with SyncGroupLogType, this enum contains the known values that the service supports. ### Know values supported by the service **All** \\ **Error** \\ **Warning** \\ **Success**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -46920,7 +54984,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"All\" | \"Error\" | \"Warning\" | \"Success\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -47786,7 +55850,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncGroupState:type",
-          "docComment": "/**\n * Defines values for SyncGroupState.\n */\n",
+          "docComment": "/**\n * Defines values for SyncGroupState. \\ {@link KnownSyncGroupState} can be used interchangeably with SyncGroupState, this enum contains the known values that the service supports. ### Know values supported by the service **NotReady** \\ **Error** \\ **Warning** \\ **Progressing** \\ **Good**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -47794,7 +55858,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NotReady\" | \"Error\" | \"Warning\" | \"Progressing\" | \"Good\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -47934,7 +55998,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncMemberDbType:type",
-          "docComment": "/**\n * Defines values for SyncMemberDbType.\n */\n",
+          "docComment": "/**\n * Defines values for SyncMemberDbType. \\ {@link KnownSyncMemberDbType} can be used interchangeably with SyncMemberDbType, this enum contains the known values that the service supports. ### Know values supported by the service **AzureSqlDatabase** \\ **SqlServerDatabase**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -47942,7 +56006,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AzureSqlDatabase\" | \"SqlServerDatabase\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -48336,7 +56400,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!SyncMemberState:type",
-          "docComment": "/**\n * Defines values for SyncMemberState.\n */\n",
+          "docComment": "/**\n * Defines values for SyncMemberState. \\ {@link KnownSyncMemberState} can be used interchangeably with SyncMemberState, this enum contains the known values that the service supports. ### Know values supported by the service **SyncInProgress** \\ **SyncSucceeded** \\ **SyncFailed** \\ **DisabledTombstoneCleanup** \\ **DisabledBackupRestore** \\ **SyncSucceededWithWarnings** \\ **SyncCancelling** \\ **SyncCancelled** \\ **UnProvisioned** \\ **Provisioning** \\ **Provisioned** \\ **ProvisionFailed** \\ **DeProvisioning** \\ **DeProvisioned** \\ **DeProvisionFailed** \\ **Reprovisioning** \\ **ReprovisionFailed** \\ **UnReprovisioned**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -48344,7 +56408,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SyncInProgress\" | \"SyncSucceeded\" | \"SyncFailed\" | \"DisabledTombstoneCleanup\" | \"DisabledBackupRestore\" | \"SyncSucceededWithWarnings\" | \"SyncCancelling\" | \"SyncCancelled\" | \"UnProvisioned\" | \"Provisioning\" | \"Provisioned\" | \"ProvisionFailed\" | \"DeProvisioning\" | \"DeProvisioned\" | \"DeProvisionFailed\" | \"Reprovisioning\" | \"ReprovisionFailed\" | \"UnReprovisioned\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -48659,7 +56723,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!TransparentDataEncryptionActivityStatus:type",
-          "docComment": "/**\n * Defines values for TransparentDataEncryptionActivityStatus.\n */\n",
+          "docComment": "/**\n * Defines values for TransparentDataEncryptionActivityStatus. \\ {@link KnownTransparentDataEncryptionActivityStatus} can be used interchangeably with TransparentDataEncryptionActivityStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Encrypting** \\ **Decrypting**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -48667,7 +56731,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Encrypting\" | \"Decrypting\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -48684,7 +56748,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!TransparentDataEncryptionName:type",
-          "docComment": "/**\n * Defines values for TransparentDataEncryptionName.\n */\n",
+          "docComment": "/**\n * Defines values for TransparentDataEncryptionName. \\ {@link KnownTransparentDataEncryptionName} can be used interchangeably with TransparentDataEncryptionName, this enum contains the known values that the service supports. ### Know values supported by the service **current**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -48692,7 +56756,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"current\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -48830,7 +56894,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!UnitDefinitionType:type",
-          "docComment": "/**\n * Defines values for UnitDefinitionType.\n */\n",
+          "docComment": "/**\n * Defines values for UnitDefinitionType. \\ {@link KnownUnitDefinitionType} can be used interchangeably with UnitDefinitionType, this enum contains the known values that the service supports. ### Know values supported by the service **Count** \\ **Bytes** \\ **Seconds** \\ **Percent** \\ **CountPerSecond** \\ **BytesPerSecond**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -48838,7 +56902,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Count\" | \"Bytes\" | \"Seconds\" | \"Percent\" | \"CountPerSecond\" | \"BytesPerSecond\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -48855,7 +56919,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!UnitType:type",
-          "docComment": "/**\n * Defines values for UnitType.\n */\n",
+          "docComment": "/**\n * Defines values for UnitType. \\ {@link KnownUnitType} can be used interchangeably with UnitType, this enum contains the known values that the service supports. ### Know values supported by the service **count** \\ **bytes** \\ **seconds** \\ **percent** \\ **countPerSecond** \\ **bytesPerSecond**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -48863,7 +56927,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"count\" | \"bytes\" | \"seconds\" | \"percent\" | \"countPerSecond\" | \"bytesPerSecond\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50241,7 +58305,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!VirtualNetworkRuleState:type",
-          "docComment": "/**\n * Defines values for VirtualNetworkRuleState.\n */\n",
+          "docComment": "/**\n * Defines values for VirtualNetworkRuleState. \\ {@link KnownVirtualNetworkRuleState} can be used interchangeably with VirtualNetworkRuleState, this enum contains the known values that the service supports. ### Know values supported by the service **Initializing** \\ **InProgress** \\ **Ready** \\ **Deleting** \\ **Unknown**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50249,7 +58313,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Initializing\" | \"InProgress\" | \"Ready\" | \"Deleting\" | \"Unknown\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50266,7 +58330,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!VulnerabilityAssessmentName:type",
-          "docComment": "/**\n * Defines values for VulnerabilityAssessmentName.\n */\n",
+          "docComment": "/**\n * Defines values for VulnerabilityAssessmentName. \\ {@link KnownVulnerabilityAssessmentName} can be used interchangeably with VulnerabilityAssessmentName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50274,7 +58338,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50619,7 +58683,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!VulnerabilityAssessmentScanState:type",
-          "docComment": "/**\n * Defines values for VulnerabilityAssessmentScanState.\n */\n",
+          "docComment": "/**\n * Defines values for VulnerabilityAssessmentScanState. \\ {@link KnownVulnerabilityAssessmentScanState} can be used interchangeably with VulnerabilityAssessmentScanState, this enum contains the known values that the service supports. ### Know values supported by the service **Passed** \\ **Failed** \\ **FailedToRun** \\ **InProgress**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50627,7 +58691,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Passed\" | \"Failed\" | \"FailedToRun\" | \"InProgress\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -50644,7 +58708,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "sql-resource-manager!VulnerabilityAssessmentScanTriggerType:type",
-          "docComment": "/**\n * Defines values for VulnerabilityAssessmentScanTriggerType.\n */\n",
+          "docComment": "/**\n * Defines values for VulnerabilityAssessmentScanTriggerType. \\ {@link KnownVulnerabilityAssessmentScanTriggerType} can be used interchangeably with VulnerabilityAssessmentScanTriggerType, this enum contains the known values that the service supports. ### Know values supported by the service **OnDemand** \\ **Recurring**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -50652,7 +58716,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"OnDemand\" | \"Recurring\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/sql-resource-manager/temp/sql-resource-manager.api.md
+++ b/test/smoke/generated/sql-resource-manager/temp/sql-resource-manager.api.md
@@ -21,10 +21,10 @@ export interface AdministratorListResult {
 }
 
 // @public
-export type AdministratorName = "ActiveDirectory" | string;
+export type AdministratorName = string;
 
 // @public
-export type AdministratorType = "ActiveDirectory" | string;
+export type AdministratorType = string;
 
 // @public
 export type AuthenticationType = "SQL" | "ADPassword";
@@ -176,13 +176,13 @@ export type CapabilitiesListByLocationResponse = LocationCapabilities & {
 };
 
 // @public
-export type CapabilityGroup = "supportedEditions" | "supportedElasticPoolEditions" | "supportedManagedInstanceVersions" | "supportedInstancePoolEditions" | "supportedManagedInstanceEditions" | string;
+export type CapabilityGroup = string;
 
 // @public
 export type CapabilityStatus = "Visible" | "Available" | "Default" | "Disabled";
 
 // @public
-export type CatalogCollationType = "DATABASE_DEFAULT" | "SQL_Latin1_General_CP1_CI_AS" | string;
+export type CatalogCollationType = string;
 
 // @public
 export type CheckNameAvailabilityReason = "Invalid" | "AlreadyExists";
@@ -209,7 +209,7 @@ export interface CompleteDatabaseRestoreDefinition {
 }
 
 // @public
-export type ConnectionPolicyName = "default" | string;
+export type ConnectionPolicyName = string;
 
 // @public
 export interface CreateDatabaseRestorePointDefinition {
@@ -217,7 +217,7 @@ export interface CreateDatabaseRestorePointDefinition {
 }
 
 // @public
-export type CreateMode = "Default" | "Copy" | "Secondary" | "PointInTimeRestore" | "Restore" | "Recovery" | "RestoreExternalBackup" | "RestoreExternalBackupSecondary" | "RestoreLongTermRetentionBackup" | "OnlineSecondary" | string;
+export type CreateMode = string;
 
 // @public
 export type Database = TrackedResource & {
@@ -335,10 +335,10 @@ export interface DatabaseBlobAuditingPolicyListResult {
 }
 
 // @public
-export type DatabaseEdition = "Web" | "Business" | "Basic" | "Standard" | "Premium" | "PremiumRS" | "Free" | "Stretch" | "DataWarehouse" | "System" | "System2" | "GeneralPurpose" | "BusinessCritical" | "Hyperscale" | string;
+export type DatabaseEdition = string;
 
 // @public
-export type DatabaseLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type DatabaseLicenseType = string;
 
 // @public
 export interface DatabaseListResult {
@@ -387,7 +387,7 @@ export type DatabaseOperationsListByDatabaseResponse = DatabaseOperationListResu
 };
 
 // @public
-export type DatabaseReadScale = "Enabled" | "Disabled" | string;
+export type DatabaseReadScale = string;
 
 // @public
 export type DatabasesCreateImportOperationResponse = ImportExportResponse & {
@@ -519,10 +519,10 @@ export type DatabasesResumeResponse = Database & {
 };
 
 // @public
-export type DatabaseState = "All" | "Live" | "Deleted" | string;
+export type DatabaseState = string;
 
 // @public
-export type DatabaseStatus = "Online" | "Restoring" | "RecoveryPending" | "Recovering" | "Suspect" | "Offline" | "Standby" | "Shutdown" | "EmergencyMode" | "AutoClosed" | "Copying" | "Creating" | "Inaccessible" | "OfflineSecondary" | "Pausing" | "Paused" | "Resuming" | "Scaling" | "OfflineChangingDwPerformanceTiers" | "OnlineChangingDwPerformanceTiers" | "Disabled" | string;
+export type DatabaseStatus = string;
 
 // @public
 export type DatabasesUpdateResponse = Database & {
@@ -890,7 +890,7 @@ export interface ElasticPoolDatabaseActivityListResult {
 }
 
 // @public
-export type ElasticPoolEdition = "Basic" | "Standard" | "Premium" | "GeneralPurpose" | "BusinessCritical" | string;
+export type ElasticPoolEdition = string;
 
 // @public
 export interface ElasticPoolEditionCapability {
@@ -902,7 +902,7 @@ export interface ElasticPoolEditionCapability {
 }
 
 // @public
-export type ElasticPoolLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type ElasticPoolLicenseType = string;
 
 // @public
 export interface ElasticPoolListResult {
@@ -1048,7 +1048,7 @@ export type ElasticPoolsListMetricsResponse = MetricListResult & {
 };
 
 // @public
-export type ElasticPoolState = "Creating" | "Ready" | "Disabled" | string;
+export type ElasticPoolState = string;
 
 // @public
 export type ElasticPoolsUpdateResponse = ElasticPool & {
@@ -1089,7 +1089,7 @@ export interface EncryptionProtectorListResult {
 }
 
 // @public
-export type EncryptionProtectorName = "current" | string;
+export type EncryptionProtectorName = string;
 
 // @public
 export type EncryptionProtectorsCreateOrUpdateResponse = EncryptionProtector & {
@@ -1125,7 +1125,7 @@ export type EncryptionProtectorsListByServerResponse = EncryptionProtectorListRe
 };
 
 // @public
-export type Enum21 = "All" | "Error" | "Warning" | "Success" | string;
+export type Enum21 = string;
 
 // @public
 export interface ExportRequest {
@@ -1243,7 +1243,7 @@ export interface ExtendedServerBlobAuditingPolicyListResult {
 }
 
 // @public
-export type ExtensionName = "import" | string;
+export type ExtensionName = string;
 
 // @public
 export type FailoverGroup = Resource & {
@@ -1277,7 +1277,7 @@ export interface FailoverGroupReadWriteEndpoint {
 }
 
 // @public
-export type FailoverGroupReplicationRole = "Primary" | "Secondary" | string;
+export type FailoverGroupReplicationRole = string;
 
 // @public
 export type FailoverGroupsCreateOrUpdateResponse = FailoverGroup & {
@@ -1424,13 +1424,13 @@ export interface GeoBackupPolicyListResult {
 }
 
 // @public
-export type GeoBackupPolicyName = "Default" | string;
+export type GeoBackupPolicyName = string;
 
 // @public
 export type GeoBackupPolicyState = "Disabled" | "Enabled";
 
 // @public
-export type IdentityType = "SystemAssigned" | string;
+export type IdentityType = string;
 
 // @public
 export type ImportExportResponse = Resource & {
@@ -1499,7 +1499,7 @@ export interface InstanceFailoverGroupReadWriteEndpoint {
 }
 
 // @public
-export type InstanceFailoverGroupReplicationRole = "Primary" | "Secondary" | string;
+export type InstanceFailoverGroupReplicationRole = string;
 
 // @public
 export type InstanceFailoverGroupsCreateOrUpdateResponse = InstanceFailoverGroup & {
@@ -1578,7 +1578,7 @@ export interface InstancePoolFamilyCapability {
 }
 
 // @public
-export type InstancePoolLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type InstancePoolLicenseType = string;
 
 // @public
 export interface InstancePoolListResult {
@@ -1714,7 +1714,7 @@ export type JobAgentsListByServerResponse = JobAgentListResult & {
 };
 
 // @public
-export type JobAgentState = "Creating" | "Ready" | "Updating" | "Deleting" | "Disabled" | string;
+export type JobAgentState = string;
 
 // @public
 export type JobAgentsUpdateResponse = JobAgent & {
@@ -1794,7 +1794,7 @@ export type JobExecution = Resource & {
 };
 
 // @public
-export type JobExecutionLifecycle = "Created" | "InProgress" | "WaitingForChildJobExecutions" | "WaitingForRetry" | "Succeeded" | "SucceededWithSkipped" | "Failed" | "TimedOut" | "Canceled" | "Skipped" | string;
+export type JobExecutionLifecycle = string;
 
 // @public
 export interface JobExecutionListResult {
@@ -1979,10 +1979,10 @@ export interface JobStepAction {
 }
 
 // @public
-export type JobStepActionSource = "Inline" | string;
+export type JobStepActionSource = string;
 
 // @public
-export type JobStepActionType = "TSql" | string;
+export type JobStepActionType = string;
 
 // @public
 export interface JobStepExecutionOptions {
@@ -2058,7 +2058,7 @@ export interface JobStepOutput {
 }
 
 // @public
-export type JobStepOutputType = "SqlDatabase" | string;
+export type JobStepOutputType = string;
 
 // @public
 export type JobStepsCreateOrUpdateResponse = JobStep & {
@@ -2258,7 +2258,7 @@ export type JobTargetGroupsListByAgentResponse = JobTargetGroupListResult & {
 };
 
 // @public
-export type JobTargetType = "TargetGroup" | "SqlDatabase" | "SqlElasticPool" | "SqlShardMap" | "SqlServer" | string;
+export type JobTargetType = string;
 
 // @public
 export type JobVersion = Resource & {};
@@ -2294,6 +2294,972 @@ export type JobVersionsListByJobResponse = JobVersionListResult & {
 };
 
 // @public
+export const enum KnownAdministratorName {
+    // (undocumented)
+    ActiveDirectory = "ActiveDirectory"
+}
+
+// @public
+export const enum KnownAdministratorType {
+    // (undocumented)
+    ActiveDirectory = "ActiveDirectory"
+}
+
+// @public
+export const enum KnownCapabilityGroup {
+    // (undocumented)
+    SupportedEditions = "supportedEditions",
+    // (undocumented)
+    SupportedElasticPoolEditions = "supportedElasticPoolEditions",
+    // (undocumented)
+    SupportedInstancePoolEditions = "supportedInstancePoolEditions",
+    // (undocumented)
+    SupportedManagedInstanceEditions = "supportedManagedInstanceEditions",
+    // (undocumented)
+    SupportedManagedInstanceVersions = "supportedManagedInstanceVersions"
+}
+
+// @public
+export const enum KnownCatalogCollationType {
+    // (undocumented)
+    DatabaseDefault = "DATABASE_DEFAULT",
+    // (undocumented)
+    SQLLatin1GeneralCP1CIAS = "SQL_Latin1_General_CP1_CI_AS"
+}
+
+// @public
+export const enum KnownConnectionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownCreateMode {
+    // (undocumented)
+    Copy = "Copy",
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    OnlineSecondary = "OnlineSecondary",
+    // (undocumented)
+    PointInTimeRestore = "PointInTimeRestore",
+    // (undocumented)
+    Recovery = "Recovery",
+    // (undocumented)
+    Restore = "Restore",
+    // (undocumented)
+    RestoreExternalBackup = "RestoreExternalBackup",
+    // (undocumented)
+    RestoreExternalBackupSecondary = "RestoreExternalBackupSecondary",
+    // (undocumented)
+    RestoreLongTermRetentionBackup = "RestoreLongTermRetentionBackup",
+    // (undocumented)
+    Secondary = "Secondary"
+}
+
+// @public
+export const enum KnownDatabaseEdition {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Business = "Business",
+    // (undocumented)
+    BusinessCritical = "BusinessCritical",
+    // (undocumented)
+    DataWarehouse = "DataWarehouse",
+    // (undocumented)
+    Free = "Free",
+    // (undocumented)
+    GeneralPurpose = "GeneralPurpose",
+    // (undocumented)
+    Hyperscale = "Hyperscale",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    PremiumRS = "PremiumRS",
+    // (undocumented)
+    Standard = "Standard",
+    // (undocumented)
+    Stretch = "Stretch",
+    // (undocumented)
+    System = "System",
+    // (undocumented)
+    System2 = "System2",
+    // (undocumented)
+    Web = "Web"
+}
+
+// @public
+export const enum KnownDatabaseLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownDatabaseReadScale {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownDatabaseState {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Deleted = "Deleted",
+    // (undocumented)
+    Live = "Live"
+}
+
+// @public
+export const enum KnownDatabaseStatus {
+    // (undocumented)
+    AutoClosed = "AutoClosed",
+    // (undocumented)
+    Copying = "Copying",
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    EmergencyMode = "EmergencyMode",
+    // (undocumented)
+    Inaccessible = "Inaccessible",
+    // (undocumented)
+    Offline = "Offline",
+    // (undocumented)
+    OfflineChangingDwPerformanceTiers = "OfflineChangingDwPerformanceTiers",
+    // (undocumented)
+    OfflineSecondary = "OfflineSecondary",
+    // (undocumented)
+    Online = "Online",
+    // (undocumented)
+    OnlineChangingDwPerformanceTiers = "OnlineChangingDwPerformanceTiers",
+    // (undocumented)
+    Paused = "Paused",
+    // (undocumented)
+    Pausing = "Pausing",
+    // (undocumented)
+    Recovering = "Recovering",
+    // (undocumented)
+    RecoveryPending = "RecoveryPending",
+    // (undocumented)
+    Restoring = "Restoring",
+    // (undocumented)
+    Resuming = "Resuming",
+    // (undocumented)
+    Scaling = "Scaling",
+    // (undocumented)
+    Shutdown = "Shutdown",
+    // (undocumented)
+    Standby = "Standby",
+    // (undocumented)
+    Suspect = "Suspect"
+}
+
+// @public
+export const enum KnownElasticPoolEdition {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    BusinessCritical = "BusinessCritical",
+    // (undocumented)
+    GeneralPurpose = "GeneralPurpose",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownElasticPoolLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownElasticPoolState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Ready = "Ready"
+}
+
+// @public
+export const enum KnownEncryptionProtectorName {
+    // (undocumented)
+    Current = "current"
+}
+
+// @public
+export const enum KnownEnum21 {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Success = "Success",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownExtensionName {
+    // (undocumented)
+    Import = "import"
+}
+
+// @public
+export const enum KnownFailoverGroupReplicationRole {
+    // (undocumented)
+    Primary = "Primary",
+    // (undocumented)
+    Secondary = "Secondary"
+}
+
+// @public
+export const enum KnownGeoBackupPolicyName {
+    // (undocumented)
+    Default = "Default"
+}
+
+// @public
+export const enum KnownIdentityType {
+    // (undocumented)
+    SystemAssigned = "SystemAssigned"
+}
+
+// @public
+export const enum KnownInstanceFailoverGroupReplicationRole {
+    // (undocumented)
+    Primary = "Primary",
+    // (undocumented)
+    Secondary = "Secondary"
+}
+
+// @public
+export const enum KnownInstancePoolLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownJobAgentState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownJobExecutionLifecycle {
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Created = "Created",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Skipped = "Skipped",
+    // (undocumented)
+    Succeeded = "Succeeded",
+    // (undocumented)
+    SucceededWithSkipped = "SucceededWithSkipped",
+    // (undocumented)
+    TimedOut = "TimedOut",
+    // (undocumented)
+    WaitingForChildJobExecutions = "WaitingForChildJobExecutions",
+    // (undocumented)
+    WaitingForRetry = "WaitingForRetry"
+}
+
+// @public
+export const enum KnownJobStepActionSource {
+    // (undocumented)
+    Inline = "Inline"
+}
+
+// @public
+export const enum KnownJobStepActionType {
+    // (undocumented)
+    TSql = "TSql"
+}
+
+// @public
+export const enum KnownJobStepOutputType {
+    // (undocumented)
+    SqlDatabase = "SqlDatabase"
+}
+
+// @public
+export const enum KnownJobTargetType {
+    // (undocumented)
+    SqlDatabase = "SqlDatabase",
+    // (undocumented)
+    SqlElasticPool = "SqlElasticPool",
+    // (undocumented)
+    SqlServer = "SqlServer",
+    // (undocumented)
+    SqlShardMap = "SqlShardMap",
+    // (undocumented)
+    TargetGroup = "TargetGroup"
+}
+
+// @public
+export const enum KnownLogSizeUnit {
+    // (undocumented)
+    Gigabytes = "Gigabytes",
+    // (undocumented)
+    Megabytes = "Megabytes",
+    // (undocumented)
+    Percent = "Percent",
+    // (undocumented)
+    Petabytes = "Petabytes",
+    // (undocumented)
+    Terabytes = "Terabytes"
+}
+
+// @public
+export const enum KnownLongTermRetentionDatabaseState {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Deleted = "Deleted",
+    // (undocumented)
+    Live = "Live"
+}
+
+// @public
+export const enum KnownLongTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownManagedDatabaseCreateMode {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    PointInTimeRestore = "PointInTimeRestore",
+    // (undocumented)
+    Recovery = "Recovery",
+    // (undocumented)
+    RestoreExternalBackup = "RestoreExternalBackup",
+    // (undocumented)
+    RestoreLongTermRetentionBackup = "RestoreLongTermRetentionBackup"
+}
+
+// @public
+export const enum KnownManagedDatabaseStatus {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Inaccessible = "Inaccessible",
+    // (undocumented)
+    Offline = "Offline",
+    // (undocumented)
+    Online = "Online",
+    // (undocumented)
+    Restoring = "Restoring",
+    // (undocumented)
+    Shutdown = "Shutdown",
+    // (undocumented)
+    Updating = "Updating"
+}
+
+// @public
+export const enum KnownManagedInstanceAdministratorType {
+    // (undocumented)
+    ActiveDirectory = "ActiveDirectory"
+}
+
+// @public
+export const enum KnownManagedInstanceLicenseType {
+    // (undocumented)
+    BasePrice = "BasePrice",
+    // (undocumented)
+    LicenseIncluded = "LicenseIncluded"
+}
+
+// @public
+export const enum KnownManagedInstanceLongTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownManagedInstanceProxyOverride {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    Proxy = "Proxy",
+    // (undocumented)
+    Redirect = "Redirect"
+}
+
+// @public
+export const enum KnownManagedServerCreateMode {
+    // (undocumented)
+    Default = "Default",
+    // (undocumented)
+    PointInTimeRestore = "PointInTimeRestore"
+}
+
+// @public
+export const enum KnownManagedShortTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownManagementOperationState {
+    // (undocumented)
+    CancelInProgress = "CancelInProgress",
+    // (undocumented)
+    Cancelled = "Cancelled",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownMaxSizeUnit {
+    // (undocumented)
+    Gigabytes = "Gigabytes",
+    // (undocumented)
+    Megabytes = "Megabytes",
+    // (undocumented)
+    Petabytes = "Petabytes",
+    // (undocumented)
+    Terabytes = "Terabytes"
+}
+
+// @public
+export const enum KnownOperationOrigin {
+    // (undocumented)
+    System = "system",
+    // (undocumented)
+    User = "user"
+}
+
+// @public
+export const enum KnownPauseDelayTimeUnit {
+    // (undocumented)
+    Minutes = "Minutes"
+}
+
+// @public
+export const enum KnownPerformanceLevelUnit {
+    // (undocumented)
+    DTU = "DTU",
+    // (undocumented)
+    VCores = "VCores"
+}
+
+// @public
+export const enum KnownPrimaryAggregationType {
+    // (undocumented)
+    Average = "Average",
+    // (undocumented)
+    Count = "Count",
+    // (undocumented)
+    Maximum = "Maximum",
+    // (undocumented)
+    Minimum = "Minimum",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    Total = "Total"
+}
+
+// @public
+export const enum KnownPrivateEndpointProvisioningState {
+    // (undocumented)
+    Approving = "Approving",
+    // (undocumented)
+    Dropping = "Dropping",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Rejecting = "Rejecting"
+}
+
+// @public
+export const enum KnownPrivateLinkServiceConnectionStateActionsRequire {
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownPrivateLinkServiceConnectionStateStatus {
+    // (undocumented)
+    Approved = "Approved",
+    // (undocumented)
+    Disconnected = "Disconnected",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Rejected = "Rejected"
+}
+
+// @public
+export const enum KnownProvisioningState {
+    // (undocumented)
+    Canceled = "Canceled",
+    // (undocumented)
+    Created = "Created",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownReadOnlyEndpointFailoverPolicy {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownReadWriteEndpointFailoverPolicy {
+    // (undocumented)
+    Automatic = "Automatic",
+    // (undocumented)
+    Manual = "Manual"
+}
+
+// @public
+export const enum KnownReplicationState {
+    // (undocumented)
+    CatchUP = "CATCH_UP",
+    // (undocumented)
+    Pending = "PENDING",
+    // (undocumented)
+    Seeding = "SEEDING",
+    // (undocumented)
+    Suspended = "SUSPENDED"
+}
+
+// @public
+export const enum KnownReplicaType {
+    // (undocumented)
+    Primary = "Primary",
+    // (undocumented)
+    ReadableSecondary = "ReadableSecondary"
+}
+
+// @public
+export const enum KnownRestoreDetailsName {
+    // (undocumented)
+    Default = "Default"
+}
+
+// @public
+export const enum KnownSampleName {
+    // (undocumented)
+    AdventureWorksLT = "AdventureWorksLT",
+    // (undocumented)
+    WideWorldImportersFull = "WideWorldImportersFull",
+    // (undocumented)
+    WideWorldImportersStd = "WideWorldImportersStd"
+}
+
+// @public
+export const enum KnownSecurityAlertPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownSecurityAlertPolicyNameAutoGenerated {
+    // (undocumented)
+    Default = "Default"
+}
+
+// @public
+export const enum KnownServerKeyType {
+    // (undocumented)
+    AzureKeyVault = "AzureKeyVault",
+    // (undocumented)
+    ServiceManaged = "ServiceManaged"
+}
+
+// @public
+export const enum KnownServerPublicNetworkAccess {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownServiceObjectiveName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    DS100 = "DS100",
+    // (undocumented)
+    DS1000 = "DS1000",
+    // (undocumented)
+    DS1200 = "DS1200",
+    // (undocumented)
+    DS1500 = "DS1500",
+    // (undocumented)
+    DS200 = "DS200",
+    // (undocumented)
+    DS2000 = "DS2000",
+    // (undocumented)
+    DS300 = "DS300",
+    // (undocumented)
+    DS400 = "DS400",
+    // (undocumented)
+    DS500 = "DS500",
+    // (undocumented)
+    DS600 = "DS600",
+    // (undocumented)
+    DW100 = "DW100",
+    // (undocumented)
+    DW1000 = "DW1000",
+    // (undocumented)
+    DW10000C = "DW10000c",
+    // (undocumented)
+    DW1000C = "DW1000c",
+    // (undocumented)
+    DW1200 = "DW1200",
+    // (undocumented)
+    DW1500 = "DW1500",
+    // (undocumented)
+    DW15000C = "DW15000c",
+    // (undocumented)
+    DW1500C = "DW1500c",
+    // (undocumented)
+    DW200 = "DW200",
+    // (undocumented)
+    DW2000 = "DW2000",
+    // (undocumented)
+    DW2000C = "DW2000c",
+    // (undocumented)
+    DW2500C = "DW2500c",
+    // (undocumented)
+    DW300 = "DW300",
+    // (undocumented)
+    DW3000 = "DW3000",
+    // (undocumented)
+    DW30000C = "DW30000c",
+    // (undocumented)
+    DW3000C = "DW3000c",
+    // (undocumented)
+    DW400 = "DW400",
+    // (undocumented)
+    DW500 = "DW500",
+    // (undocumented)
+    DW5000C = "DW5000c",
+    // (undocumented)
+    DW600 = "DW600",
+    // (undocumented)
+    DW6000 = "DW6000",
+    // (undocumented)
+    DW6000C = "DW6000c",
+    // (undocumented)
+    DW7500C = "DW7500c",
+    // (undocumented)
+    ElasticPool = "ElasticPool",
+    // (undocumented)
+    Free = "Free",
+    // (undocumented)
+    P1 = "P1",
+    // (undocumented)
+    P11 = "P11",
+    // (undocumented)
+    P15 = "P15",
+    // (undocumented)
+    P2 = "P2",
+    // (undocumented)
+    P3 = "P3",
+    // (undocumented)
+    P4 = "P4",
+    // (undocumented)
+    P6 = "P6",
+    // (undocumented)
+    PRS1 = "PRS1",
+    // (undocumented)
+    PRS2 = "PRS2",
+    // (undocumented)
+    PRS4 = "PRS4",
+    // (undocumented)
+    PRS6 = "PRS6",
+    // (undocumented)
+    S0 = "S0",
+    // (undocumented)
+    S1 = "S1",
+    // (undocumented)
+    S12 = "S12",
+    // (undocumented)
+    S2 = "S2",
+    // (undocumented)
+    S3 = "S3",
+    // (undocumented)
+    S4 = "S4",
+    // (undocumented)
+    S6 = "S6",
+    // (undocumented)
+    S7 = "S7",
+    // (undocumented)
+    S9 = "S9",
+    // (undocumented)
+    System = "System",
+    // (undocumented)
+    System0 = "System0",
+    // (undocumented)
+    System1 = "System1",
+    // (undocumented)
+    System2 = "System2",
+    // (undocumented)
+    System2L = "System2L",
+    // (undocumented)
+    System3 = "System3",
+    // (undocumented)
+    System3L = "System3L",
+    // (undocumented)
+    System4 = "System4",
+    // (undocumented)
+    System4L = "System4L"
+}
+
+// @public
+export const enum KnownShortTermRetentionPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownStorageCapabilityStorageAccountType {
+    // (undocumented)
+    GRS = "GRS",
+    // (undocumented)
+    LRS = "LRS",
+    // (undocumented)
+    ZRS = "ZRS"
+}
+
+// @public
+export const enum KnownSyncAgentState {
+    // (undocumented)
+    NeverConnected = "NeverConnected",
+    // (undocumented)
+    Offline = "Offline",
+    // (undocumented)
+    Online = "Online"
+}
+
+// @public
+export const enum KnownSyncConflictResolutionPolicy {
+    // (undocumented)
+    HubWin = "HubWin",
+    // (undocumented)
+    MemberWin = "MemberWin"
+}
+
+// @public
+export const enum KnownSyncDirection {
+    // (undocumented)
+    Bidirectional = "Bidirectional",
+    // (undocumented)
+    OneWayHubToMember = "OneWayHubToMember",
+    // (undocumented)
+    OneWayMemberToHub = "OneWayMemberToHub"
+}
+
+// @public
+export const enum KnownSyncGroupLogType {
+    // (undocumented)
+    All = "All",
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Success = "Success",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownSyncGroupState {
+    // (undocumented)
+    Error = "Error",
+    // (undocumented)
+    Good = "Good",
+    // (undocumented)
+    NotReady = "NotReady",
+    // (undocumented)
+    Progressing = "Progressing",
+    // (undocumented)
+    Warning = "Warning"
+}
+
+// @public
+export const enum KnownSyncMemberDbType {
+    // (undocumented)
+    AzureSqlDatabase = "AzureSqlDatabase",
+    // (undocumented)
+    SqlServerDatabase = "SqlServerDatabase"
+}
+
+// @public
+export const enum KnownSyncMemberState {
+    // (undocumented)
+    DeProvisioned = "DeProvisioned",
+    // (undocumented)
+    DeProvisionFailed = "DeProvisionFailed",
+    // (undocumented)
+    DeProvisioning = "DeProvisioning",
+    // (undocumented)
+    DisabledBackupRestore = "DisabledBackupRestore",
+    // (undocumented)
+    DisabledTombstoneCleanup = "DisabledTombstoneCleanup",
+    // (undocumented)
+    Provisioned = "Provisioned",
+    // (undocumented)
+    ProvisionFailed = "ProvisionFailed",
+    // (undocumented)
+    Provisioning = "Provisioning",
+    // (undocumented)
+    ReprovisionFailed = "ReprovisionFailed",
+    // (undocumented)
+    Reprovisioning = "Reprovisioning",
+    // (undocumented)
+    SyncCancelled = "SyncCancelled",
+    // (undocumented)
+    SyncCancelling = "SyncCancelling",
+    // (undocumented)
+    SyncFailed = "SyncFailed",
+    // (undocumented)
+    SyncInProgress = "SyncInProgress",
+    // (undocumented)
+    SyncSucceeded = "SyncSucceeded",
+    // (undocumented)
+    SyncSucceededWithWarnings = "SyncSucceededWithWarnings",
+    // (undocumented)
+    UnProvisioned = "UnProvisioned",
+    // (undocumented)
+    UnReprovisioned = "UnReprovisioned"
+}
+
+// @public
+export const enum KnownTransparentDataEncryptionActivityStatus {
+    // (undocumented)
+    Decrypting = "Decrypting",
+    // (undocumented)
+    Encrypting = "Encrypting"
+}
+
+// @public
+export const enum KnownTransparentDataEncryptionName {
+    // (undocumented)
+    Current = "current"
+}
+
+// @public
+export const enum KnownUnitDefinitionType {
+    // (undocumented)
+    Bytes = "Bytes",
+    // (undocumented)
+    BytesPerSecond = "BytesPerSecond",
+    // (undocumented)
+    Count = "Count",
+    // (undocumented)
+    CountPerSecond = "CountPerSecond",
+    // (undocumented)
+    Percent = "Percent",
+    // (undocumented)
+    Seconds = "Seconds"
+}
+
+// @public
+export const enum KnownUnitType {
+    // (undocumented)
+    Bytes = "bytes",
+    // (undocumented)
+    BytesPerSecond = "bytesPerSecond",
+    // (undocumented)
+    Count = "count",
+    // (undocumented)
+    CountPerSecond = "countPerSecond",
+    // (undocumented)
+    Percent = "percent",
+    // (undocumented)
+    Seconds = "seconds"
+}
+
+// @public
+export const enum KnownVirtualNetworkRuleState {
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Initializing = "Initializing",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownVulnerabilityAssessmentName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownVulnerabilityAssessmentScanState {
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    FailedToRun = "FailedToRun",
+    // (undocumented)
+    InProgress = "InProgress",
+    // (undocumented)
+    Passed = "Passed"
+}
+
+// @public
+export const enum KnownVulnerabilityAssessmentScanTriggerType {
+    // (undocumented)
+    OnDemand = "OnDemand",
+    // (undocumented)
+    Recurring = "Recurring"
+}
+
+// @public
 export interface LicenseTypeCapability {
     readonly name?: string;
     reason?: string;
@@ -2322,7 +3288,7 @@ export interface LogSizeCapability {
 }
 
 // @public
-export type LogSizeUnit = "Megabytes" | "Gigabytes" | "Terabytes" | "Petabytes" | "Percent" | string;
+export type LogSizeUnit = string;
 
 // @public
 export type LongTermRetentionBackup = Resource & {
@@ -2525,7 +3491,7 @@ export type LongTermRetentionBackupsListByServerResponse = LongTermRetentionBack
 };
 
 // @public
-export type LongTermRetentionDatabaseState = "All" | "Live" | "Deleted" | string;
+export type LongTermRetentionDatabaseState = string;
 
 // @public
 export type LongTermRetentionManagedInstanceBackupsGetByResourceGroupResponse = ManagedInstanceLongTermRetentionBackup & {
@@ -2712,7 +3678,7 @@ export type LongTermRetentionManagedInstanceBackupsListByResourceGroupLocationRe
 };
 
 // @public
-export type LongTermRetentionPolicyName = "default" | string;
+export type LongTermRetentionPolicyName = string;
 
 // @public
 export type ManagedBackupShortTermRetentionPoliciesCreateOrUpdateResponse = ManagedBackupShortTermRetentionPolicy & {
@@ -2787,7 +3753,7 @@ export type ManagedDatabase = TrackedResource & {
 };
 
 // @public
-export type ManagedDatabaseCreateMode = "Default" | "RestoreExternalBackup" | "PointInTimeRestore" | "Recovery" | "RestoreLongTermRetentionBackup" | string;
+export type ManagedDatabaseCreateMode = string;
 
 // @public
 export interface ManagedDatabaseListResult {
@@ -2991,7 +3957,7 @@ export type ManagedDatabasesListInaccessibleByInstanceResponse = ManagedDatabase
 };
 
 // @public
-export type ManagedDatabaseStatus = "Online" | "Offline" | "Shutdown" | "Creating" | "Inaccessible" | "Restoring" | "Updating" | string;
+export type ManagedDatabaseStatus = string;
 
 // @public
 export type ManagedDatabasesUpdateResponse = ManagedDatabase & {
@@ -3177,7 +4143,7 @@ export type ManagedInstanceAdministratorsListByInstanceResponse = ManagedInstanc
 };
 
 // @public
-export type ManagedInstanceAdministratorType = "ActiveDirectory" | string;
+export type ManagedInstanceAdministratorType = string;
 
 // @public
 export interface ManagedInstanceEditionCapability {
@@ -3304,7 +4270,7 @@ export type ManagedInstanceKeysListByInstanceResponse = ManagedInstanceKeyListRe
 };
 
 // @public
-export type ManagedInstanceLicenseType = "LicenseIncluded" | "BasePrice" | string;
+export type ManagedInstanceLicenseType = string;
 
 // @public
 export interface ManagedInstanceListResult {
@@ -3376,7 +4342,7 @@ export interface ManagedInstanceLongTermRetentionPolicyListResult {
 }
 
 // @public
-export type ManagedInstanceLongTermRetentionPolicyName = "default" | string;
+export type ManagedInstanceLongTermRetentionPolicyName = string;
 
 // @public
 export type ManagedInstanceOperation = Resource & {
@@ -3432,7 +4398,7 @@ export interface ManagedInstancePairInfo {
 }
 
 // @public
-export type ManagedInstanceProxyOverride = "Proxy" | "Redirect" | "Default" | string;
+export type ManagedInstanceProxyOverride = string;
 
 // @public
 export type ManagedInstancesCreateOrUpdateResponse = ManagedInstance & {
@@ -3645,7 +4611,7 @@ export type ManagedRestorableDroppedDatabaseBackupShortTermRetentionPoliciesUpda
 };
 
 // @public
-export type ManagedServerCreateMode = "Default" | "PointInTimeRestore" | string;
+export type ManagedServerCreateMode = string;
 
 // @public
 export type ManagedServerSecurityAlertPoliciesCreateOrUpdateResponse = ManagedServerSecurityAlertPolicy & {
@@ -3699,10 +4665,10 @@ export interface ManagedServerSecurityAlertPolicyListResult {
 }
 
 // @public
-export type ManagedShortTermRetentionPolicyName = "default" | string;
+export type ManagedShortTermRetentionPolicyName = string;
 
 // @public
-export type ManagementOperationState = "Pending" | "InProgress" | "Succeeded" | "Failed" | "CancelInProgress" | "Cancelled" | string;
+export type ManagementOperationState = string;
 
 // @public
 export interface MaxSizeCapability {
@@ -3721,7 +4687,7 @@ export interface MaxSizeRangeCapability {
 }
 
 // @public
-export type MaxSizeUnit = "Megabytes" | "Gigabytes" | "Terabytes" | "Petabytes" | string;
+export type MaxSizeUnit = string;
 
 // @public
 export interface Metric {
@@ -3820,7 +4786,7 @@ export interface OperationListResult {
 }
 
 // @public
-export type OperationOrigin = "user" | "system" | string;
+export type OperationOrigin = string;
 
 // @public
 export type OperationsListNextResponse = OperationListResult & {
@@ -3852,7 +4818,7 @@ export interface PartnerRegionInfo {
 }
 
 // @public
-export type PauseDelayTimeUnit = "Minutes" | string;
+export type PauseDelayTimeUnit = string;
 
 // @public
 export interface PerformanceLevelCapability {
@@ -3861,10 +4827,10 @@ export interface PerformanceLevelCapability {
 }
 
 // @public
-export type PerformanceLevelUnit = "DTU" | "VCores" | string;
+export type PerformanceLevelUnit = string;
 
 // @public
-export type PrimaryAggregationType = "None" | "Average" | "Count" | "Minimum" | "Maximum" | "Total" | string;
+export type PrimaryAggregationType = string;
 
 // @public
 export type PrivateEndpointConnection = Resource & {
@@ -3925,7 +4891,7 @@ export interface PrivateEndpointProperty {
 }
 
 // @public
-export type PrivateEndpointProvisioningState = "Approving" | "Ready" | "Dropping" | "Failed" | "Rejecting" | string;
+export type PrivateEndpointProvisioningState = string;
 
 // @public
 export type PrivateLinkResource = Resource & {
@@ -3969,7 +4935,7 @@ export type PrivateLinkResourcesListByServerResponse = PrivateLinkResourceListRe
 };
 
 // @public
-export type PrivateLinkServiceConnectionStateActionsRequire = "None" | string;
+export type PrivateLinkServiceConnectionStateActionsRequire = string;
 
 // @public (undocumented)
 export interface PrivateLinkServiceConnectionStateProperty {
@@ -3986,16 +4952,16 @@ export interface PrivateLinkServiceConnectionStatePropertyAutoGenerated {
 }
 
 // @public
-export type PrivateLinkServiceConnectionStateStatus = "Approved" | "Pending" | "Rejected" | "Disconnected" | string;
+export type PrivateLinkServiceConnectionStateStatus = string;
 
 // @public
-export type ProvisioningState = "Created" | "InProgress" | "Succeeded" | "Failed" | "Canceled" | string;
+export type ProvisioningState = string;
 
 // @public
 export type ProxyResource = Resource & {};
 
 // @public
-export type ReadOnlyEndpointFailoverPolicy = "Disabled" | "Enabled" | string;
+export type ReadOnlyEndpointFailoverPolicy = string;
 
 // @public
 export interface ReadScaleCapability {
@@ -4005,7 +4971,7 @@ export interface ReadScaleCapability {
 }
 
 // @public
-export type ReadWriteEndpointFailoverPolicy = "Manual" | "Automatic" | string;
+export type ReadWriteEndpointFailoverPolicy = string;
 
 // @public
 export type RecommendedElasticPool = Resource & {
@@ -4192,10 +5158,10 @@ export type ReplicationLinksListByDatabaseResponse = ReplicationLinkListResult &
 export type ReplicationRole = "Primary" | "Secondary" | "NonReadableSecondary" | "Source" | "Copy";
 
 // @public
-export type ReplicationState = "PENDING" | "SEEDING" | "CATCH_UP" | "SUSPENDED" | string;
+export type ReplicationState = string;
 
 // @public
-export type ReplicaType = "Primary" | "ReadableSecondary" | string;
+export type ReplicaType = string;
 
 // @public
 export interface Resource {
@@ -4289,7 +5255,7 @@ export type RestorableDroppedManagedDatabasesListByInstanceResponse = Restorable
 };
 
 // @public
-export type RestoreDetailsName = "Default" | string;
+export type RestoreDetailsName = string;
 
 // @public
 export type RestorePoint = Resource & {
@@ -4335,16 +5301,16 @@ export type RestorePointsListByDatabaseResponse = RestorePointListResult & {
 export type RestorePointType = "CONTINUOUS" | "DISCRETE";
 
 // @public
-export type SampleName = "AdventureWorksLT" | "WideWorldImportersStd" | "WideWorldImportersFull" | string;
+export type SampleName = string;
 
 // @public
 export type SecurityAlertPolicyEmailAccountAdmins = "Enabled" | "Disabled";
 
 // @public
-export type SecurityAlertPolicyName = "default" | string;
+export type SecurityAlertPolicyName = string;
 
 // @public
-export type SecurityAlertPolicyNameAutoGenerated = "Default" | string;
+export type SecurityAlertPolicyNameAutoGenerated = string;
 
 // @public
 export type SecurityAlertPolicyState = "New" | "Enabled" | "Disabled";
@@ -4754,7 +5720,7 @@ export type ServerKeysListByServerResponse = ServerKeyListResult & {
 };
 
 // @public
-export type ServerKeyType = "ServiceManaged" | "AzureKeyVault" | string;
+export type ServerKeyType = string;
 
 // @public
 export interface ServerListResult {
@@ -4769,7 +5735,7 @@ export interface ServerPrivateEndpointConnection {
 }
 
 // @public
-export type ServerPublicNetworkAccess = "Enabled" | "Disabled" | string;
+export type ServerPublicNetworkAccess = string;
 
 // @public
 export type ServersCheckNameAvailabilityResponse = CheckNameAvailabilityResponse & {
@@ -5008,7 +5974,7 @@ export interface ServiceObjectiveListResult {
 }
 
 // @public
-export type ServiceObjectiveName = "System" | "System0" | "System1" | "System2" | "System3" | "System4" | "System2L" | "System3L" | "System4L" | "Free" | "Basic" | "S0" | "S1" | "S2" | "S3" | "S4" | "S6" | "S7" | "S9" | "S12" | "P1" | "P2" | "P3" | "P4" | "P6" | "P11" | "P15" | "PRS1" | "PRS2" | "PRS4" | "PRS6" | "DW100" | "DW200" | "DW300" | "DW400" | "DW500" | "DW600" | "DW1000" | "DW1200" | "DW1000c" | "DW1500" | "DW1500c" | "DW2000" | "DW2000c" | "DW3000" | "DW2500c" | "DW3000c" | "DW6000" | "DW5000c" | "DW6000c" | "DW7500c" | "DW10000c" | "DW15000c" | "DW30000c" | "DS100" | "DS200" | "DS300" | "DS400" | "DS500" | "DS600" | "DS1000" | "DS1200" | "DS1500" | "DS2000" | "ElasticPool" | string;
+export type ServiceObjectiveName = string;
 
 // @public
 export type ServiceObjectivesGetResponse = ServiceObjective & {
@@ -5071,7 +6037,7 @@ export type ServiceTierAdvisorsListByDatabaseResponse = ServiceTierAdvisorListRe
 };
 
 // @public
-export type ShortTermRetentionPolicyName = "default" | string;
+export type ShortTermRetentionPolicyName = string;
 
 // @public
 export interface Sku {
@@ -5481,7 +6447,7 @@ export interface StorageCapability {
 }
 
 // @public
-export type StorageCapabilityStorageAccountType = "GRS" | "LRS" | "ZRS" | string;
+export type StorageCapabilityStorageAccountType = string;
 
 // @public
 export type StorageKeyType = "StorageAccessKey" | "SharedAccessKey";
@@ -5620,10 +6586,10 @@ export type SyncAgentsListLinkedDatabasesResponse = SyncAgentLinkedDatabaseListR
 };
 
 // @public
-export type SyncAgentState = "Online" | "Offline" | "NeverConnected" | string;
+export type SyncAgentState = string;
 
 // @public
-export type SyncConflictResolutionPolicy = "HubWin" | "MemberWin" | string;
+export type SyncConflictResolutionPolicy = string;
 
 // @public
 export interface SyncDatabaseIdListResult {
@@ -5637,7 +6603,7 @@ export interface SyncDatabaseIdProperties {
 }
 
 // @public
-export type SyncDirection = "Bidirectional" | "OneWayMemberToHub" | "OneWayHubToMember" | string;
+export type SyncDirection = string;
 
 // @public
 export interface SyncFullSchemaProperties {
@@ -5706,7 +6672,7 @@ export interface SyncGroupLogProperties {
 }
 
 // @public
-export type SyncGroupLogType = "All" | "Error" | "Warning" | "Success" | string;
+export type SyncGroupLogType = string;
 
 // @public
 export interface SyncGroupSchema {
@@ -5819,7 +6785,7 @@ export type SyncGroupsListSyncDatabaseIdsResponse = SyncDatabaseIdListResult & {
 };
 
 // @public
-export type SyncGroupState = "NotReady" | "Error" | "Warning" | "Progressing" | "Good" | string;
+export type SyncGroupState = string;
 
 // @public
 export type SyncGroupsUpdateResponse = SyncGroup & {
@@ -5844,7 +6810,7 @@ export type SyncMember = Resource & {
 };
 
 // @public
-export type SyncMemberDbType = "AzureSqlDatabase" | "SqlServerDatabase" | string;
+export type SyncMemberDbType = string;
 
 // @public
 export interface SyncMemberListResult {
@@ -5902,7 +6868,7 @@ export type SyncMembersListMemberSchemasResponse = SyncFullSchemaPropertiesListR
 };
 
 // @public
-export type SyncMemberState = "SyncInProgress" | "SyncSucceeded" | "SyncFailed" | "DisabledTombstoneCleanup" | "DisabledBackupRestore" | "SyncSucceededWithWarnings" | "SyncCancelling" | "SyncCancelled" | "UnProvisioned" | "Provisioning" | "Provisioned" | "ProvisionFailed" | "DeProvisioning" | "DeProvisioned" | "DeProvisionFailed" | "Reprovisioning" | "ReprovisionFailed" | "UnReprovisioned" | string;
+export type SyncMemberState = string;
 
 // @public
 export type SyncMembersUpdateResponse = SyncMember & {
@@ -5954,10 +6920,10 @@ export interface TransparentDataEncryptionActivityListResult {
 }
 
 // @public
-export type TransparentDataEncryptionActivityStatus = "Encrypting" | "Decrypting" | string;
+export type TransparentDataEncryptionActivityStatus = string;
 
 // @public
-export type TransparentDataEncryptionName = "current" | string;
+export type TransparentDataEncryptionName = string;
 
 // @public
 export type TransparentDataEncryptionsCreateOrUpdateResponse = TransparentDataEncryption & {
@@ -5979,10 +6945,10 @@ export type TransparentDataEncryptionsGetResponse = TransparentDataEncryption & 
 export type TransparentDataEncryptionStatus = "Enabled" | "Disabled";
 
 // @public
-export type UnitDefinitionType = "Count" | "Bytes" | "Seconds" | "Percent" | "CountPerSecond" | "BytesPerSecond" | string;
+export type UnitDefinitionType = string;
 
 // @public
-export type UnitType = "count" | "bytes" | "seconds" | "percent" | "countPerSecond" | "bytesPerSecond" | string;
+export type UnitType = string;
 
 // @public
 export interface UnlinkParameters {
@@ -6151,10 +7117,10 @@ export type VirtualNetworkRulesListByServerResponse = VirtualNetworkRuleListResu
 };
 
 // @public
-export type VirtualNetworkRuleState = "Initializing" | "InProgress" | "Ready" | "Deleting" | "Unknown" | string;
+export type VirtualNetworkRuleState = string;
 
 // @public
-export type VulnerabilityAssessmentName = "default" | string;
+export type VulnerabilityAssessmentName = string;
 
 // @public
 export type VulnerabilityAssessmentPolicyBaselineName = "master" | "default";
@@ -6191,10 +7157,10 @@ export interface VulnerabilityAssessmentScanRecordListResult {
 }
 
 // @public
-export type VulnerabilityAssessmentScanState = "Passed" | "Failed" | "FailedToRun" | "InProgress" | string;
+export type VulnerabilityAssessmentScanState = string;
 
 // @public
-export type VulnerabilityAssessmentScanTriggerType = "OnDemand" | "Recurring" | string;
+export type VulnerabilityAssessmentScanTriggerType = string;
 
 // @public
 export type WorkloadClassifier = Resource & {
@@ -6297,7 +7263,7 @@ export type WorkloadGroupsListByDatabaseResponse = WorkloadGroupListResult & {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:12501:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:13631:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/sql-resource-manager/tsconfig.json
+++ b/test/smoke/generated/sql-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/storage-resource-manager/review/storage-resource-manager.api.md
+++ b/test/smoke/generated/storage-resource-manager/review/storage-resource-manager.api.md
@@ -245,7 +245,7 @@ export interface BlobRestoreParameters {
 }
 
 // @public
-export type BlobRestoreProgressStatus = "InProgress" | "Complete" | "Failed" | string;
+export type BlobRestoreProgressStatus = string;
 
 // @public
 export interface BlobRestoreRange {
@@ -304,7 +304,7 @@ export type BlobServicesSetServicePropertiesResponse = BlobServiceProperties & {
 };
 
 // @public
-export type Bypass = "None" | "Logging" | "Metrics" | "AzureServices" | string;
+export type Bypass = string;
 
 // @public
 export interface ChangeFeed {
@@ -341,7 +341,7 @@ export interface CorsRule {
 }
 
 // @public
-export type CorsRuleAllowedMethodsItem = "DELETE" | "GET" | "HEAD" | "MERGE" | "POST" | "OPTIONS" | "PUT" | string;
+export type CorsRuleAllowedMethodsItem = string;
 
 // @public
 export interface CorsRules {
@@ -386,10 +386,10 @@ export interface Dimension {
 }
 
 // @public
-export type DirectoryServiceOptions = "None" | "AADDS" | "AD" | string;
+export type DirectoryServiceOptions = string;
 
 // @public
-export type EnabledProtocols = "SMB" | "NFS" | string;
+export type EnabledProtocols = string;
 
 // @public
 export interface Encryption {
@@ -443,7 +443,7 @@ export type EncryptionScopesListResponse = EncryptionScopeListResult & {
 };
 
 // @public
-export type EncryptionScopeSource = "Microsoft.Storage" | "Microsoft.KeyVault" | string;
+export type EncryptionScopeSource = string;
 
 // @public
 export type EncryptionScopesPatchResponse = EncryptionScope & {
@@ -462,7 +462,7 @@ export type EncryptionScopesPutResponse = EncryptionScope & {
 };
 
 // @public
-export type EncryptionScopeState = "Enabled" | "Disabled" | string;
+export type EncryptionScopeState = string;
 
 // @public
 export interface EncryptionService {
@@ -637,7 +637,7 @@ export interface GeoReplicationStats {
 }
 
 // @public
-export type GeoReplicationStatus = "Live" | "Bootstrap" | "Unavailable" | string;
+export type GeoReplicationStatus = string;
 
 // @public
 export type HttpProtocol = "https,http" | "https";
@@ -666,10 +666,10 @@ export interface ImmutabilityPolicyProperties {
 }
 
 // @public
-export type ImmutabilityPolicyState = "Locked" | "Unlocked" | string;
+export type ImmutabilityPolicyState = string;
 
 // @public
-export type ImmutabilityPolicyUpdateType = "put" | "lock" | "extend" | string;
+export type ImmutabilityPolicyUpdateType = string;
 
 // @public
 export interface IPRule {
@@ -681,10 +681,10 @@ export interface IPRule {
 export type KeyPermission = "Read" | "Full";
 
 // @public
-export type KeySource = "Microsoft.Storage" | "Microsoft.Keyvault" | string;
+export type KeySource = string;
 
 // @public
-type KeyType_2 = "Service" | "Account" | string;
+type KeyType_2 = string;
 
 export { KeyType_2 as KeyType }
 
@@ -698,10 +698,340 @@ export interface KeyVaultProperties {
 }
 
 // @public
-export type Kind = "Storage" | "StorageV2" | "BlobStorage" | "FileStorage" | "BlockBlobStorage" | string;
+export type Kind = string;
 
 // @public
-export type LargeFileSharesState = "Disabled" | "Enabled" | string;
+export const enum KnownBlobRestoreProgressStatus {
+    // (undocumented)
+    Complete = "Complete",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress"
+}
+
+// @public
+export const enum KnownBypass {
+    // (undocumented)
+    AzureServices = "AzureServices",
+    // (undocumented)
+    Logging = "Logging",
+    // (undocumented)
+    Metrics = "Metrics",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownCorsRuleAllowedMethodsItem {
+    // (undocumented)
+    Delete = "DELETE",
+    // (undocumented)
+    GET = "GET",
+    // (undocumented)
+    Head = "HEAD",
+    // (undocumented)
+    Merge = "MERGE",
+    // (undocumented)
+    Options = "OPTIONS",
+    // (undocumented)
+    Post = "POST",
+    // (undocumented)
+    PUT = "PUT"
+}
+
+// @public
+export const enum KnownDirectoryServiceOptions {
+    // (undocumented)
+    Aadds = "AADDS",
+    // (undocumented)
+    AD = "AD",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownEnabledProtocols {
+    // (undocumented)
+    NFS = "NFS",
+    // (undocumented)
+    SMB = "SMB"
+}
+
+// @public
+export const enum KnownEncryptionScopeSource {
+    // (undocumented)
+    MicrosoftKeyVault = "Microsoft.KeyVault",
+    // (undocumented)
+    MicrosoftStorage = "Microsoft.Storage"
+}
+
+// @public
+export const enum KnownEncryptionScopeState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownGeoReplicationStatus {
+    // (undocumented)
+    Bootstrap = "Bootstrap",
+    // (undocumented)
+    Live = "Live",
+    // (undocumented)
+    Unavailable = "Unavailable"
+}
+
+// @public
+export const enum KnownImmutabilityPolicyState {
+    // (undocumented)
+    Locked = "Locked",
+    // (undocumented)
+    Unlocked = "Unlocked"
+}
+
+// @public
+export const enum KnownImmutabilityPolicyUpdateType {
+    // (undocumented)
+    Extend = "extend",
+    // (undocumented)
+    Lock = "lock",
+    // (undocumented)
+    Put = "put"
+}
+
+// @public
+export const enum KnownKeySource {
+    // (undocumented)
+    MicrosoftKeyvault = "Microsoft.Keyvault",
+    // (undocumented)
+    MicrosoftStorage = "Microsoft.Storage"
+}
+
+// @public
+export const enum KnownKeyType {
+    // (undocumented)
+    Account = "Account",
+    // (undocumented)
+    Service = "Service"
+}
+
+// @public
+export const enum KnownKind {
+    // (undocumented)
+    BlobStorage = "BlobStorage",
+    // (undocumented)
+    BlockBlobStorage = "BlockBlobStorage",
+    // (undocumented)
+    FileStorage = "FileStorage",
+    // (undocumented)
+    Storage = "Storage",
+    // (undocumented)
+    StorageV2 = "StorageV2"
+}
+
+// @public
+export const enum KnownLargeFileSharesState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownLeaseContainerRequestAction {
+    // (undocumented)
+    Acquire = "Acquire",
+    // (undocumented)
+    Break = "Break",
+    // (undocumented)
+    Change = "Change",
+    // (undocumented)
+    Release = "Release",
+    // (undocumented)
+    Renew = "Renew"
+}
+
+// @public
+export const enum KnownLeaseDuration {
+    // (undocumented)
+    Fixed = "Fixed",
+    // (undocumented)
+    Infinite = "Infinite"
+}
+
+// @public
+export const enum KnownLeaseState {
+    // (undocumented)
+    Available = "Available",
+    // (undocumented)
+    Breaking = "Breaking",
+    // (undocumented)
+    Broken = "Broken",
+    // (undocumented)
+    Expired = "Expired",
+    // (undocumented)
+    Leased = "Leased"
+}
+
+// @public
+export const enum KnownLeaseStatus {
+    // (undocumented)
+    Locked = "Locked",
+    // (undocumented)
+    Unlocked = "Unlocked"
+}
+
+// @public
+export const enum KnownManagementPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownPermissions {
+    // (undocumented)
+    A = "a",
+    // (undocumented)
+    C = "c",
+    // (undocumented)
+    D = "d",
+    // (undocumented)
+    L = "l",
+    // (undocumented)
+    P = "p",
+    // (undocumented)
+    R = "r",
+    // (undocumented)
+    U = "u",
+    // (undocumented)
+    W = "w"
+}
+
+// @public
+export const enum KnownPrivateEndpointConnectionProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownPrivateEndpointServiceConnectionStatus {
+    // (undocumented)
+    Approved = "Approved",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Rejected = "Rejected"
+}
+
+// @public
+export const enum KnownReasonCode {
+    // (undocumented)
+    NotAvailableForSubscription = "NotAvailableForSubscription",
+    // (undocumented)
+    QuotaId = "QuotaId"
+}
+
+// @public
+export const enum KnownRootSquashType {
+    // (undocumented)
+    AllSquash = "AllSquash",
+    // (undocumented)
+    NoRootSquash = "NoRootSquash",
+    // (undocumented)
+    RootSquash = "RootSquash"
+}
+
+// @public
+export const enum KnownRoutingChoice {
+    // (undocumented)
+    InternetRouting = "InternetRouting",
+    // (undocumented)
+    MicrosoftRouting = "MicrosoftRouting"
+}
+
+// @public
+export const enum KnownRuleType {
+    // (undocumented)
+    Lifecycle = "Lifecycle"
+}
+
+// @public
+export const enum KnownServices {
+    // (undocumented)
+    B = "b",
+    // (undocumented)
+    F = "f",
+    // (undocumented)
+    Q = "q",
+    // (undocumented)
+    T = "t"
+}
+
+// @public
+export const enum KnownShareAccessTier {
+    // (undocumented)
+    Cool = "Cool",
+    // (undocumented)
+    Hot = "Hot",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    TransactionOptimized = "TransactionOptimized"
+}
+
+// @public
+export const enum KnownSignedResource {
+    // (undocumented)
+    B = "b",
+    // (undocumented)
+    C = "c",
+    // (undocumented)
+    F = "f",
+    // (undocumented)
+    S = "s"
+}
+
+// @public
+export const enum KnownSignedResourceTypes {
+    // (undocumented)
+    C = "c",
+    // (undocumented)
+    O = "o",
+    // (undocumented)
+    S = "s"
+}
+
+// @public
+export const enum KnownSkuName {
+    // (undocumented)
+    PremiumLRS = "Premium_LRS",
+    // (undocumented)
+    PremiumZRS = "Premium_ZRS",
+    // (undocumented)
+    StandardGRS = "Standard_GRS",
+    // (undocumented)
+    StandardGzrs = "Standard_GZRS",
+    // (undocumented)
+    StandardLRS = "Standard_LRS",
+    // (undocumented)
+    StandardRagrs = "Standard_RAGRS",
+    // (undocumented)
+    StandardRagzrs = "Standard_RAGZRS",
+    // (undocumented)
+    StandardZRS = "Standard_ZRS"
+}
+
+// @public
+export type LargeFileSharesState = string;
 
 // @public
 export interface LeaseContainerRequest {
@@ -713,7 +1043,7 @@ export interface LeaseContainerRequest {
 }
 
 // @public
-export type LeaseContainerRequestAction = "Acquire" | "Renew" | "Change" | "Release" | "Break" | string;
+export type LeaseContainerRequestAction = string;
 
 // @public
 export interface LeaseContainerResponse {
@@ -722,13 +1052,13 @@ export interface LeaseContainerResponse {
 }
 
 // @public
-export type LeaseDuration = "Infinite" | "Fixed" | string;
+export type LeaseDuration = string;
 
 // @public
-export type LeaseState = "Available" | "Leased" | "Expired" | "Breaking" | "Broken" | string;
+export type LeaseState = string;
 
 // @public
-export type LeaseStatus = "Locked" | "Unlocked" | string;
+export type LeaseStatus = string;
 
 // @public
 export interface LegalHold {
@@ -825,7 +1155,7 @@ export interface ManagementPolicyFilter {
 }
 
 // @public
-export type ManagementPolicyName = "default" | string;
+export type ManagementPolicyName = string;
 
 // @public
 export interface ManagementPolicyRule {
@@ -948,7 +1278,7 @@ export type OperationsListResponse = OperationListResult & {
 };
 
 // @public
-type Permissions_2 = "r" | "d" | "w" | "l" | "a" | "c" | "u" | "p" | string;
+type Permissions_2 = string;
 
 export { Permissions_2 as Permissions }
 
@@ -970,7 +1300,7 @@ export interface PrivateEndpointConnectionListResult {
 }
 
 // @public
-export type PrivateEndpointConnectionProvisioningState = "Succeeded" | "Creating" | "Deleting" | "Failed" | string;
+export type PrivateEndpointConnectionProvisioningState = string;
 
 // @public
 export type PrivateEndpointConnectionsGetResponse = PrivateEndpointConnection & {
@@ -997,7 +1327,7 @@ export type PrivateEndpointConnectionsPutResponse = PrivateEndpointConnection & 
 };
 
 // @public
-export type PrivateEndpointServiceConnectionStatus = "Pending" | "Approved" | "Rejected" | string;
+export type PrivateEndpointServiceConnectionStatus = string;
 
 // @public
 export type PrivateLinkResource = Resource & {
@@ -1036,7 +1366,7 @@ export type PublicAccess = "Container" | "Blob" | "None";
 export type Reason = "AccountNameInvalid" | "AlreadyExists";
 
 // @public
-export type ReasonCode = "QuotaId" | "NotAvailableForSubscription" | string;
+export type ReasonCode = string;
 
 // @public (undocumented)
 export interface Resource {
@@ -1060,10 +1390,10 @@ export interface Restriction {
 }
 
 // @public
-export type RootSquashType = "NoRootSquash" | "RootSquash" | "AllSquash" | string;
+export type RootSquashType = string;
 
 // @public
-export type RoutingChoice = "MicrosoftRouting" | "InternetRouting" | string;
+export type RoutingChoice = string;
 
 // @public
 export interface RoutingPreference {
@@ -1073,10 +1403,10 @@ export interface RoutingPreference {
 }
 
 // @public
-export type RuleType = "Lifecycle" | string;
+export type RuleType = string;
 
 // @public
-export type Services = "b" | "q" | "t" | "f" | string;
+export type Services = string;
 
 // @public
 export interface ServiceSasParameters {
@@ -1106,13 +1436,13 @@ export interface ServiceSpecification {
 }
 
 // @public
-export type ShareAccessTier = "TransactionOptimized" | "Hot" | "Cool" | "Premium" | string;
+export type ShareAccessTier = string;
 
 // @public
-export type SignedResource = "b" | "c" | "f" | "s" | string;
+export type SignedResource = string;
 
 // @public
-export type SignedResourceTypes = "s" | "c" | "o" | string;
+export type SignedResourceTypes = string;
 
 // @public
 export interface Sku {
@@ -1138,7 +1468,7 @@ export interface SkuInformation {
 }
 
 // @public
-export type SkuName = "Standard_LRS" | "Standard_GRS" | "Standard_RAGRS" | "Standard_ZRS" | "Premium_LRS" | "Premium_ZRS" | "Standard_GZRS" | "Standard_RAGZRS" | string;
+export type SkuName = string;
 
 // @public
 export type SkusListResponse = StorageSkuListResult & {
@@ -1528,7 +1858,7 @@ export interface VirtualNetworkRule {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:2670:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:3112:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/storage-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/storage-resource-manager/src/models/index.ts
@@ -2331,202 +2331,644 @@ export interface BlobContainersExtendImmutabilityPolicyHeaders {
 }
 
 /**
- * Defines values for SkuName.
+ * Known values of {@link SkuName} that the service accepts.
  */
-export type SkuName =
-  | "Standard_LRS"
-  | "Standard_GRS"
-  | "Standard_RAGRS"
-  | "Standard_ZRS"
-  | "Premium_LRS"
-  | "Premium_ZRS"
-  | "Standard_GZRS"
-  | "Standard_RAGZRS"
-  | string;
+export const enum KnownSkuName {
+  StandardLRS = "Standard_LRS",
+  StandardGRS = "Standard_GRS",
+  StandardRagrs = "Standard_RAGRS",
+  StandardZRS = "Standard_ZRS",
+  PremiumLRS = "Premium_LRS",
+  PremiumZRS = "Premium_ZRS",
+  StandardGzrs = "Standard_GZRS",
+  StandardRagzrs = "Standard_RAGZRS"
+}
+
 /**
- * Defines values for Kind.
+ * Defines values for SkuName. \
+ * {@link KnownSkuName} can be used interchangeably with SkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Standard_LRS** \
+ * **Standard_GRS** \
+ * **Standard_RAGRS** \
+ * **Standard_ZRS** \
+ * **Premium_LRS** \
+ * **Premium_ZRS** \
+ * **Standard_GZRS** \
+ * **Standard_RAGZRS**
  */
-export type Kind =
-  | "Storage"
-  | "StorageV2"
-  | "BlobStorage"
-  | "FileStorage"
-  | "BlockBlobStorage"
-  | string;
+export type SkuName = string;
+
 /**
- * Defines values for ReasonCode.
+ * Known values of {@link Kind} that the service accepts.
  */
-export type ReasonCode = "QuotaId" | "NotAvailableForSubscription" | string;
+export const enum KnownKind {
+  Storage = "Storage",
+  StorageV2 = "StorageV2",
+  BlobStorage = "BlobStorage",
+  FileStorage = "FileStorage",
+  BlockBlobStorage = "BlockBlobStorage"
+}
+
 /**
- * Defines values for KeyType.
+ * Defines values for Kind. \
+ * {@link KnownKind} can be used interchangeably with Kind,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Storage** \
+ * **StorageV2** \
+ * **BlobStorage** \
+ * **FileStorage** \
+ * **BlockBlobStorage**
  */
-export type KeyType = "Service" | "Account" | string;
+export type Kind = string;
+
 /**
- * Defines values for KeySource.
+ * Known values of {@link ReasonCode} that the service accepts.
  */
-export type KeySource = "Microsoft.Storage" | "Microsoft.Keyvault" | string;
+export const enum KnownReasonCode {
+  QuotaId = "QuotaId",
+  NotAvailableForSubscription = "NotAvailableForSubscription"
+}
+
 /**
- * Defines values for Bypass.
+ * Defines values for ReasonCode. \
+ * {@link KnownReasonCode} can be used interchangeably with ReasonCode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **QuotaId** \
+ * **NotAvailableForSubscription**
  */
-export type Bypass = "None" | "Logging" | "Metrics" | "AzureServices" | string;
+export type ReasonCode = string;
+
 /**
- * Defines values for DirectoryServiceOptions.
+ * Known values of {@link KeyType} that the service accepts.
  */
-export type DirectoryServiceOptions = "None" | "AADDS" | "AD" | string;
+export const enum KnownKeyType {
+  Service = "Service",
+  Account = "Account"
+}
+
 /**
- * Defines values for LargeFileSharesState.
+ * Defines values for KeyType. \
+ * {@link KnownKeyType} can be used interchangeably with KeyType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Service** \
+ * **Account**
  */
-export type LargeFileSharesState = "Disabled" | "Enabled" | string;
+export type KeyType = string;
+
 /**
- * Defines values for RoutingChoice.
+ * Known values of {@link KeySource} that the service accepts.
  */
-export type RoutingChoice = "MicrosoftRouting" | "InternetRouting" | string;
+export const enum KnownKeySource {
+  MicrosoftStorage = "Microsoft.Storage",
+  MicrosoftKeyvault = "Microsoft.Keyvault"
+}
+
 /**
- * Defines values for GeoReplicationStatus.
+ * Defines values for KeySource. \
+ * {@link KnownKeySource} can be used interchangeably with KeySource,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Microsoft.Storage** \
+ * **Microsoft.Keyvault**
  */
-export type GeoReplicationStatus =
-  | "Live"
-  | "Bootstrap"
-  | "Unavailable"
-  | string;
+export type KeySource = string;
+
 /**
- * Defines values for PrivateEndpointServiceConnectionStatus.
+ * Known values of {@link Bypass} that the service accepts.
  */
-export type PrivateEndpointServiceConnectionStatus =
-  | "Pending"
-  | "Approved"
-  | "Rejected"
-  | string;
+export const enum KnownBypass {
+  None = "None",
+  Logging = "Logging",
+  Metrics = "Metrics",
+  AzureServices = "AzureServices"
+}
+
 /**
- * Defines values for PrivateEndpointConnectionProvisioningState.
+ * Defines values for Bypass. \
+ * {@link KnownBypass} can be used interchangeably with Bypass,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **Logging** \
+ * **Metrics** \
+ * **AzureServices**
  */
-export type PrivateEndpointConnectionProvisioningState =
-  | "Succeeded"
-  | "Creating"
-  | "Deleting"
-  | "Failed"
-  | string;
+export type Bypass = string;
+
 /**
- * Defines values for BlobRestoreProgressStatus.
+ * Known values of {@link DirectoryServiceOptions} that the service accepts.
  */
-export type BlobRestoreProgressStatus =
-  | "InProgress"
-  | "Complete"
-  | "Failed"
-  | string;
+export const enum KnownDirectoryServiceOptions {
+  None = "None",
+  Aadds = "AADDS",
+  AD = "AD"
+}
+
 /**
- * Defines values for Services.
+ * Defines values for DirectoryServiceOptions. \
+ * {@link KnownDirectoryServiceOptions} can be used interchangeably with DirectoryServiceOptions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **AADDS** \
+ * **AD**
  */
-export type Services = "b" | "q" | "t" | "f" | string;
+export type DirectoryServiceOptions = string;
+
 /**
- * Defines values for SignedResourceTypes.
+ * Known values of {@link LargeFileSharesState} that the service accepts.
  */
-export type SignedResourceTypes = "s" | "c" | "o" | string;
+export const enum KnownLargeFileSharesState {
+  Disabled = "Disabled",
+  Enabled = "Enabled"
+}
+
 /**
- * Defines values for Permissions.
+ * Defines values for LargeFileSharesState. \
+ * {@link KnownLargeFileSharesState} can be used interchangeably with LargeFileSharesState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Disabled** \
+ * **Enabled**
  */
-export type Permissions =
-  | "r"
-  | "d"
-  | "w"
-  | "l"
-  | "a"
-  | "c"
-  | "u"
-  | "p"
-  | string;
+export type LargeFileSharesState = string;
+
 /**
- * Defines values for SignedResource.
+ * Known values of {@link RoutingChoice} that the service accepts.
  */
-export type SignedResource = "b" | "c" | "f" | "s" | string;
+export const enum KnownRoutingChoice {
+  MicrosoftRouting = "MicrosoftRouting",
+  InternetRouting = "InternetRouting"
+}
+
 /**
- * Defines values for ManagementPolicyName.
+ * Defines values for RoutingChoice. \
+ * {@link KnownRoutingChoice} can be used interchangeably with RoutingChoice,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **MicrosoftRouting** \
+ * **InternetRouting**
  */
-export type ManagementPolicyName = "default" | string;
+export type RoutingChoice = string;
+
 /**
- * Defines values for RuleType.
+ * Known values of {@link GeoReplicationStatus} that the service accepts.
  */
-export type RuleType = "Lifecycle" | string;
+export const enum KnownGeoReplicationStatus {
+  Live = "Live",
+  Bootstrap = "Bootstrap",
+  Unavailable = "Unavailable"
+}
+
 /**
- * Defines values for EncryptionScopeSource.
+ * Defines values for GeoReplicationStatus. \
+ * {@link KnownGeoReplicationStatus} can be used interchangeably with GeoReplicationStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Live** \
+ * **Bootstrap** \
+ * **Unavailable**
  */
-export type EncryptionScopeSource =
-  | "Microsoft.Storage"
-  | "Microsoft.KeyVault"
-  | string;
+export type GeoReplicationStatus = string;
+
 /**
- * Defines values for EncryptionScopeState.
+ * Known values of {@link PrivateEndpointServiceConnectionStatus} that the service accepts.
  */
-export type EncryptionScopeState = "Enabled" | "Disabled" | string;
+export const enum KnownPrivateEndpointServiceConnectionStatus {
+  Pending = "Pending",
+  Approved = "Approved",
+  Rejected = "Rejected"
+}
+
 /**
- * Defines values for CorsRuleAllowedMethodsItem.
+ * Defines values for PrivateEndpointServiceConnectionStatus. \
+ * {@link KnownPrivateEndpointServiceConnectionStatus} can be used interchangeably with PrivateEndpointServiceConnectionStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Pending** \
+ * **Approved** \
+ * **Rejected**
  */
-export type CorsRuleAllowedMethodsItem =
-  | "DELETE"
-  | "GET"
-  | "HEAD"
-  | "MERGE"
-  | "POST"
-  | "OPTIONS"
-  | "PUT"
-  | string;
+export type PrivateEndpointServiceConnectionStatus = string;
+
 /**
- * Defines values for LeaseStatus.
+ * Known values of {@link PrivateEndpointConnectionProvisioningState} that the service accepts.
  */
-export type LeaseStatus = "Locked" | "Unlocked" | string;
+export const enum KnownPrivateEndpointConnectionProvisioningState {
+  Succeeded = "Succeeded",
+  Creating = "Creating",
+  Deleting = "Deleting",
+  Failed = "Failed"
+}
+
 /**
- * Defines values for LeaseState.
+ * Defines values for PrivateEndpointConnectionProvisioningState. \
+ * {@link KnownPrivateEndpointConnectionProvisioningState} can be used interchangeably with PrivateEndpointConnectionProvisioningState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Succeeded** \
+ * **Creating** \
+ * **Deleting** \
+ * **Failed**
  */
-export type LeaseState =
-  | "Available"
-  | "Leased"
-  | "Expired"
-  | "Breaking"
-  | "Broken"
-  | string;
+export type PrivateEndpointConnectionProvisioningState = string;
+
 /**
- * Defines values for LeaseDuration.
+ * Known values of {@link BlobRestoreProgressStatus} that the service accepts.
  */
-export type LeaseDuration = "Infinite" | "Fixed" | string;
+export const enum KnownBlobRestoreProgressStatus {
+  InProgress = "InProgress",
+  Complete = "Complete",
+  Failed = "Failed"
+}
+
 /**
- * Defines values for ImmutabilityPolicyState.
+ * Defines values for BlobRestoreProgressStatus. \
+ * {@link KnownBlobRestoreProgressStatus} can be used interchangeably with BlobRestoreProgressStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **InProgress** \
+ * **Complete** \
+ * **Failed**
  */
-export type ImmutabilityPolicyState = "Locked" | "Unlocked" | string;
+export type BlobRestoreProgressStatus = string;
+
 /**
- * Defines values for ImmutabilityPolicyUpdateType.
+ * Known values of {@link Services} that the service accepts.
  */
-export type ImmutabilityPolicyUpdateType = "put" | "lock" | "extend" | string;
+export const enum KnownServices {
+  B = "b",
+  Q = "q",
+  T = "t",
+  F = "f"
+}
+
 /**
- * Defines values for LeaseContainerRequestAction.
+ * Defines values for Services. \
+ * {@link KnownServices} can be used interchangeably with Services,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **b** \
+ * **q** \
+ * **t** \
+ * **f**
  */
-export type LeaseContainerRequestAction =
-  | "Acquire"
-  | "Renew"
-  | "Change"
-  | "Release"
-  | "Break"
-  | string;
+export type Services = string;
+
 /**
- * Defines values for EnabledProtocols.
+ * Known values of {@link SignedResourceTypes} that the service accepts.
  */
-export type EnabledProtocols = "SMB" | "NFS" | string;
+export const enum KnownSignedResourceTypes {
+  S = "s",
+  C = "c",
+  O = "o"
+}
+
 /**
- * Defines values for RootSquashType.
+ * Defines values for SignedResourceTypes. \
+ * {@link KnownSignedResourceTypes} can be used interchangeably with SignedResourceTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **s** \
+ * **c** \
+ * **o**
  */
-export type RootSquashType =
-  | "NoRootSquash"
-  | "RootSquash"
-  | "AllSquash"
-  | string;
+export type SignedResourceTypes = string;
+
 /**
- * Defines values for ShareAccessTier.
+ * Known values of {@link Permissions} that the service accepts.
  */
-export type ShareAccessTier =
-  | "TransactionOptimized"
-  | "Hot"
-  | "Cool"
-  | "Premium"
-  | string;
+export const enum KnownPermissions {
+  R = "r",
+  D = "d",
+  W = "w",
+  L = "l",
+  A = "a",
+  C = "c",
+  U = "u",
+  P = "p"
+}
+
+/**
+ * Defines values for Permissions. \
+ * {@link KnownPermissions} can be used interchangeably with Permissions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **r** \
+ * **d** \
+ * **w** \
+ * **l** \
+ * **a** \
+ * **c** \
+ * **u** \
+ * **p**
+ */
+export type Permissions = string;
+
+/**
+ * Known values of {@link SignedResource} that the service accepts.
+ */
+export const enum KnownSignedResource {
+  B = "b",
+  C = "c",
+  F = "f",
+  S = "s"
+}
+
+/**
+ * Defines values for SignedResource. \
+ * {@link KnownSignedResource} can be used interchangeably with SignedResource,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **b** \
+ * **c** \
+ * **f** \
+ * **s**
+ */
+export type SignedResource = string;
+
+/**
+ * Known values of {@link ManagementPolicyName} that the service accepts.
+ */
+export const enum KnownManagementPolicyName {
+  Default = "default"
+}
+
+/**
+ * Defines values for ManagementPolicyName. \
+ * {@link KnownManagementPolicyName} can be used interchangeably with ManagementPolicyName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **default**
+ */
+export type ManagementPolicyName = string;
+
+/**
+ * Known values of {@link RuleType} that the service accepts.
+ */
+export const enum KnownRuleType {
+  Lifecycle = "Lifecycle"
+}
+
+/**
+ * Defines values for RuleType. \
+ * {@link KnownRuleType} can be used interchangeably with RuleType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Lifecycle**
+ */
+export type RuleType = string;
+
+/**
+ * Known values of {@link EncryptionScopeSource} that the service accepts.
+ */
+export const enum KnownEncryptionScopeSource {
+  MicrosoftStorage = "Microsoft.Storage",
+  MicrosoftKeyVault = "Microsoft.KeyVault"
+}
+
+/**
+ * Defines values for EncryptionScopeSource. \
+ * {@link KnownEncryptionScopeSource} can be used interchangeably with EncryptionScopeSource,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Microsoft.Storage** \
+ * **Microsoft.KeyVault**
+ */
+export type EncryptionScopeSource = string;
+
+/**
+ * Known values of {@link EncryptionScopeState} that the service accepts.
+ */
+export const enum KnownEncryptionScopeState {
+  Enabled = "Enabled",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for EncryptionScopeState. \
+ * {@link KnownEncryptionScopeState} can be used interchangeably with EncryptionScopeState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Enabled** \
+ * **Disabled**
+ */
+export type EncryptionScopeState = string;
+
+/**
+ * Known values of {@link CorsRuleAllowedMethodsItem} that the service accepts.
+ */
+export const enum KnownCorsRuleAllowedMethodsItem {
+  Delete = "DELETE",
+  GET = "GET",
+  Head = "HEAD",
+  Merge = "MERGE",
+  Post = "POST",
+  Options = "OPTIONS",
+  PUT = "PUT"
+}
+
+/**
+ * Defines values for CorsRuleAllowedMethodsItem. \
+ * {@link KnownCorsRuleAllowedMethodsItem} can be used interchangeably with CorsRuleAllowedMethodsItem,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **DELETE** \
+ * **GET** \
+ * **HEAD** \
+ * **MERGE** \
+ * **POST** \
+ * **OPTIONS** \
+ * **PUT**
+ */
+export type CorsRuleAllowedMethodsItem = string;
+
+/**
+ * Known values of {@link LeaseStatus} that the service accepts.
+ */
+export const enum KnownLeaseStatus {
+  Locked = "Locked",
+  Unlocked = "Unlocked"
+}
+
+/**
+ * Defines values for LeaseStatus. \
+ * {@link KnownLeaseStatus} can be used interchangeably with LeaseStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Locked** \
+ * **Unlocked**
+ */
+export type LeaseStatus = string;
+
+/**
+ * Known values of {@link LeaseState} that the service accepts.
+ */
+export const enum KnownLeaseState {
+  Available = "Available",
+  Leased = "Leased",
+  Expired = "Expired",
+  Breaking = "Breaking",
+  Broken = "Broken"
+}
+
+/**
+ * Defines values for LeaseState. \
+ * {@link KnownLeaseState} can be used interchangeably with LeaseState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Available** \
+ * **Leased** \
+ * **Expired** \
+ * **Breaking** \
+ * **Broken**
+ */
+export type LeaseState = string;
+
+/**
+ * Known values of {@link LeaseDuration} that the service accepts.
+ */
+export const enum KnownLeaseDuration {
+  Infinite = "Infinite",
+  Fixed = "Fixed"
+}
+
+/**
+ * Defines values for LeaseDuration. \
+ * {@link KnownLeaseDuration} can be used interchangeably with LeaseDuration,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Infinite** \
+ * **Fixed**
+ */
+export type LeaseDuration = string;
+
+/**
+ * Known values of {@link ImmutabilityPolicyState} that the service accepts.
+ */
+export const enum KnownImmutabilityPolicyState {
+  Locked = "Locked",
+  Unlocked = "Unlocked"
+}
+
+/**
+ * Defines values for ImmutabilityPolicyState. \
+ * {@link KnownImmutabilityPolicyState} can be used interchangeably with ImmutabilityPolicyState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Locked** \
+ * **Unlocked**
+ */
+export type ImmutabilityPolicyState = string;
+
+/**
+ * Known values of {@link ImmutabilityPolicyUpdateType} that the service accepts.
+ */
+export const enum KnownImmutabilityPolicyUpdateType {
+  Put = "put",
+  Lock = "lock",
+  Extend = "extend"
+}
+
+/**
+ * Defines values for ImmutabilityPolicyUpdateType. \
+ * {@link KnownImmutabilityPolicyUpdateType} can be used interchangeably with ImmutabilityPolicyUpdateType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **put** \
+ * **lock** \
+ * **extend**
+ */
+export type ImmutabilityPolicyUpdateType = string;
+
+/**
+ * Known values of {@link LeaseContainerRequestAction} that the service accepts.
+ */
+export const enum KnownLeaseContainerRequestAction {
+  Acquire = "Acquire",
+  Renew = "Renew",
+  Change = "Change",
+  Release = "Release",
+  Break = "Break"
+}
+
+/**
+ * Defines values for LeaseContainerRequestAction. \
+ * {@link KnownLeaseContainerRequestAction} can be used interchangeably with LeaseContainerRequestAction,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Acquire** \
+ * **Renew** \
+ * **Change** \
+ * **Release** \
+ * **Break**
+ */
+export type LeaseContainerRequestAction = string;
+
+/**
+ * Known values of {@link EnabledProtocols} that the service accepts.
+ */
+export const enum KnownEnabledProtocols {
+  SMB = "SMB",
+  NFS = "NFS"
+}
+
+/**
+ * Defines values for EnabledProtocols. \
+ * {@link KnownEnabledProtocols} can be used interchangeably with EnabledProtocols,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SMB** \
+ * **NFS**
+ */
+export type EnabledProtocols = string;
+
+/**
+ * Known values of {@link RootSquashType} that the service accepts.
+ */
+export const enum KnownRootSquashType {
+  NoRootSquash = "NoRootSquash",
+  RootSquash = "RootSquash",
+  AllSquash = "AllSquash"
+}
+
+/**
+ * Defines values for RootSquashType. \
+ * {@link KnownRootSquashType} can be used interchangeably with RootSquashType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **NoRootSquash** \
+ * **RootSquash** \
+ * **AllSquash**
+ */
+export type RootSquashType = string;
+
+/**
+ * Known values of {@link ShareAccessTier} that the service accepts.
+ */
+export const enum KnownShareAccessTier {
+  TransactionOptimized = "TransactionOptimized",
+  Hot = "Hot",
+  Cool = "Cool",
+  Premium = "Premium"
+}
+
+/**
+ * Defines values for ShareAccessTier. \
+ * {@link KnownShareAccessTier} can be used interchangeably with ShareAccessTier,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **TransactionOptimized** \
+ * **Hot** \
+ * **Cool** \
+ * **Premium**
+ */
+export type ShareAccessTier = string;
 /**
  * Defines values for SkuTier.
  */

--- a/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.json
+++ b/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.json
@@ -2070,7 +2070,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!BlobRestoreProgressStatus:type",
-          "docComment": "/**\n * Defines values for BlobRestoreProgressStatus.\n */\n",
+          "docComment": "/**\n * Defines values for BlobRestoreProgressStatus. \\ {@link KnownBlobRestoreProgressStatus} can be used interchangeably with BlobRestoreProgressStatus, this enum contains the known values that the service supports. ### Know values supported by the service **InProgress** \\ **Complete** \\ **Failed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2078,7 +2078,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"InProgress\" | \"Complete\" | \"Failed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -2553,7 +2553,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!Bypass:type",
-          "docComment": "/**\n * Defines values for Bypass.\n */\n",
+          "docComment": "/**\n * Defines values for Bypass. \\ {@link KnownBypass} can be used interchangeably with Bypass, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **Logging** \\ **Metrics** \\ **AzureServices**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -2561,7 +2561,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"Logging\" | \"Metrics\" | \"AzureServices\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3020,7 +3020,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!CorsRuleAllowedMethodsItem:type",
-          "docComment": "/**\n * Defines values for CorsRuleAllowedMethodsItem.\n */\n",
+          "docComment": "/**\n * Defines values for CorsRuleAllowedMethodsItem. \\ {@link KnownCorsRuleAllowedMethodsItem} can be used interchangeably with CorsRuleAllowedMethodsItem, this enum contains the known values that the service supports. ### Know values supported by the service **DELETE** \\ **GET** \\ **HEAD** \\ **MERGE** \\ **POST** \\ **OPTIONS** \\ **PUT**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3028,7 +3028,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"DELETE\" | \"GET\" | \"HEAD\" | \"MERGE\" | \"POST\" | \"OPTIONS\" | \"PUT\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3462,7 +3462,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!DirectoryServiceOptions:type",
-          "docComment": "/**\n * Defines values for DirectoryServiceOptions.\n */\n",
+          "docComment": "/**\n * Defines values for DirectoryServiceOptions. \\ {@link KnownDirectoryServiceOptions} can be used interchangeably with DirectoryServiceOptions, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **AADDS** \\ **AD**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3470,7 +3470,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"AADDS\" | \"AD\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3487,7 +3487,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!EnabledProtocols:type",
-          "docComment": "/**\n * Defines values for EnabledProtocols.\n */\n",
+          "docComment": "/**\n * Defines values for EnabledProtocols. \\ {@link KnownEnabledProtocols} can be used interchangeably with EnabledProtocols, this enum contains the known values that the service supports. ### Know values supported by the service **SMB** \\ **NFS**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3495,7 +3495,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SMB\" | \"NFS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -3937,7 +3937,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!EncryptionScopeSource:type",
-          "docComment": "/**\n * Defines values for EncryptionScopeSource.\n */\n",
+          "docComment": "/**\n * Defines values for EncryptionScopeSource. \\ {@link KnownEncryptionScopeSource} can be used interchangeably with EncryptionScopeSource, this enum contains the known values that the service supports. ### Know values supported by the service **Microsoft.Storage** \\ **Microsoft.KeyVault**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -3945,7 +3945,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Microsoft.Storage\" | \"Microsoft.KeyVault\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -4058,7 +4058,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!EncryptionScopeState:type",
-          "docComment": "/**\n * Defines values for EncryptionScopeState.\n */\n",
+          "docComment": "/**\n * Defines values for EncryptionScopeState. \\ {@link KnownEncryptionScopeState} can be used interchangeably with EncryptionScopeState, this enum contains the known values that the service supports. ### Know values supported by the service **Enabled** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -4066,7 +4066,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Enabled\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5567,7 +5567,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!GeoReplicationStatus:type",
-          "docComment": "/**\n * Defines values for GeoReplicationStatus.\n */\n",
+          "docComment": "/**\n * Defines values for GeoReplicationStatus. \\ {@link KnownGeoReplicationStatus} can be used interchangeably with GeoReplicationStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Live** \\ **Bootstrap** \\ **Unavailable**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5575,7 +5575,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Live\" | \"Bootstrap\" | \"Unavailable\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5894,7 +5894,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!ImmutabilityPolicyState:type",
-          "docComment": "/**\n * Defines values for ImmutabilityPolicyState.\n */\n",
+          "docComment": "/**\n * Defines values for ImmutabilityPolicyState. \\ {@link KnownImmutabilityPolicyState} can be used interchangeably with ImmutabilityPolicyState, this enum contains the known values that the service supports. ### Know values supported by the service **Locked** \\ **Unlocked**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5902,7 +5902,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Locked\" | \"Unlocked\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -5919,7 +5919,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!ImmutabilityPolicyUpdateType:type",
-          "docComment": "/**\n * Defines values for ImmutabilityPolicyUpdateType.\n */\n",
+          "docComment": "/**\n * Defines values for ImmutabilityPolicyUpdateType. \\ {@link KnownImmutabilityPolicyUpdateType} can be used interchangeably with ImmutabilityPolicyUpdateType, this enum contains the known values that the service supports. ### Know values supported by the service **put** \\ **lock** \\ **extend**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -5927,7 +5927,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"put\" | \"lock\" | \"extend\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6035,7 +6035,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!KeySource:type",
-          "docComment": "/**\n * Defines values for KeySource.\n */\n",
+          "docComment": "/**\n * Defines values for KeySource. \\ {@link KnownKeySource} can be used interchangeably with KeySource, this enum contains the known values that the service supports. ### Know values supported by the service **Microsoft.Storage** \\ **Microsoft.Keyvault**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6043,7 +6043,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Microsoft.Storage\" | \"Microsoft.Keyvault\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6060,7 +6060,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!KeyType_2:type",
-          "docComment": "/**\n * Defines values for KeyType.\n */\n",
+          "docComment": "/**\n * Defines values for KeyType. \\ {@link KnownKeyType} can be used interchangeably with KeyType, this enum contains the known values that the service supports. ### Know values supported by the service **Service** \\ **Account**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6068,7 +6068,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Service\" | \"Account\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6227,7 +6227,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!Kind:type",
-          "docComment": "/**\n * Defines values for Kind.\n */\n",
+          "docComment": "/**\n * Defines values for Kind. \\ {@link KnownKind} can be used interchangeably with Kind, this enum contains the known values that the service supports. ### Know values supported by the service **Storage** \\ **StorageV2** \\ **BlobStorage** \\ **FileStorage** \\ **BlockBlobStorage**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6235,7 +6235,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Storage\" | \"StorageV2\" | \"BlobStorage\" | \"FileStorage\" | \"BlockBlobStorage\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6250,9 +6250,2637 @@
           }
         },
         {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownBlobRestoreProgressStatus:enum",
+          "docComment": "/**\n * Known values of {@link BlobRestoreProgressStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownBlobRestoreProgressStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownBlobRestoreProgressStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBlobRestoreProgressStatus.Complete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Complete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Complete\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Complete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBlobRestoreProgressStatus.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBlobRestoreProgressStatus.InProgress:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InProgress = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InProgress\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InProgress",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownBypass:enum",
+          "docComment": "/**\n * Known values of {@link Bypass} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownBypass "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownBypass",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBypass.AzureServices:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AzureServices = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AzureServices\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AzureServices",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBypass.Logging:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Logging = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Logging\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Logging",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBypass.Metrics:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Metrics = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Metrics\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Metrics",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownBypass.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem:enum",
+          "docComment": "/**\n * Known values of {@link CorsRuleAllowedMethodsItem} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCorsRuleAllowedMethodsItem "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCorsRuleAllowedMethodsItem",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.Delete:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Delete = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DELETE\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Delete",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.GET:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GET = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GET\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GET",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.Head:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Head = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HEAD\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Head",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.Merge:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Merge = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MERGE\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Merge",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.Options:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Options = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OPTIONS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Options",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.Post:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Post = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"POST\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Post",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownCorsRuleAllowedMethodsItem.PUT:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PUT = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PUT\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PUT",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownDirectoryServiceOptions:enum",
+          "docComment": "/**\n * Known values of {@link DirectoryServiceOptions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDirectoryServiceOptions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDirectoryServiceOptions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownDirectoryServiceOptions.Aadds:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Aadds = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AADDS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Aadds",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownDirectoryServiceOptions.AD:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AD = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AD\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AD",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownDirectoryServiceOptions.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownEnabledProtocols:enum",
+          "docComment": "/**\n * Known values of {@link EnabledProtocols} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEnabledProtocols "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEnabledProtocols",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownEnabledProtocols.NFS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NFS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NFS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NFS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownEnabledProtocols.SMB:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SMB = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SMB\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SMB",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownEncryptionScopeSource:enum",
+          "docComment": "/**\n * Known values of {@link EncryptionScopeSource} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEncryptionScopeSource "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEncryptionScopeSource",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownEncryptionScopeSource.MicrosoftKeyVault:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftKeyVault = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.KeyVault\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftKeyVault",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownEncryptionScopeSource.MicrosoftStorage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftStorage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Storage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftStorage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownEncryptionScopeState:enum",
+          "docComment": "/**\n * Known values of {@link EncryptionScopeState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEncryptionScopeState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEncryptionScopeState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownEncryptionScopeState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownEncryptionScopeState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownGeoReplicationStatus:enum",
+          "docComment": "/**\n * Known values of {@link GeoReplicationStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownGeoReplicationStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownGeoReplicationStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownGeoReplicationStatus.Bootstrap:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Bootstrap = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Bootstrap\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Bootstrap",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownGeoReplicationStatus.Live:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Live = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Live\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Live",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownGeoReplicationStatus.Unavailable:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unavailable = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unavailable\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unavailable",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyState:enum",
+          "docComment": "/**\n * Known values of {@link ImmutabilityPolicyState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownImmutabilityPolicyState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownImmutabilityPolicyState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyState.Locked:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Locked = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Locked\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Locked",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyState.Unlocked:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unlocked = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unlocked\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unlocked",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyUpdateType:enum",
+          "docComment": "/**\n * Known values of {@link ImmutabilityPolicyUpdateType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownImmutabilityPolicyUpdateType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownImmutabilityPolicyUpdateType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyUpdateType.Extend:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Extend = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"extend\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Extend",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyUpdateType.Lock:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Lock = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"lock\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Lock",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownImmutabilityPolicyUpdateType.Put:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Put = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"put\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Put",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownKeySource:enum",
+          "docComment": "/**\n * Known values of {@link KeySource} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownKeySource "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownKeySource",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKeySource.MicrosoftKeyvault:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftKeyvault = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Keyvault\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftKeyvault",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKeySource.MicrosoftStorage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftStorage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Storage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftStorage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownKeyType:enum",
+          "docComment": "/**\n * Known values of {@link KeyType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownKeyType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownKeyType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKeyType.Account:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Account = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Account\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Account",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKeyType.Service:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Service = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Service\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Service",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownKind:enum",
+          "docComment": "/**\n * Known values of {@link Kind} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownKind "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownKind",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKind.BlobStorage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BlobStorage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BlobStorage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BlobStorage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKind.BlockBlobStorage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BlockBlobStorage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BlockBlobStorage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BlockBlobStorage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKind.FileStorage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FileStorage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FileStorage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FileStorage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKind.Storage:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Storage = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Storage\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Storage",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownKind.StorageV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StorageV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"StorageV2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StorageV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownLargeFileSharesState:enum",
+          "docComment": "/**\n * Known values of {@link LargeFileSharesState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLargeFileSharesState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLargeFileSharesState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLargeFileSharesState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLargeFileSharesState.Enabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Enabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Enabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Enabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownLeaseContainerRequestAction:enum",
+          "docComment": "/**\n * Known values of {@link LeaseContainerRequestAction} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLeaseContainerRequestAction "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLeaseContainerRequestAction",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseContainerRequestAction.Acquire:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Acquire = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Acquire\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Acquire",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseContainerRequestAction.Break:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Break = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Break\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Break",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseContainerRequestAction.Change:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Change = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Change\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Change",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseContainerRequestAction.Release:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Release = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Release\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Release",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseContainerRequestAction.Renew:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Renew = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Renew\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Renew",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownLeaseDuration:enum",
+          "docComment": "/**\n * Known values of {@link LeaseDuration} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLeaseDuration "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLeaseDuration",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseDuration.Fixed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Fixed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Fixed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Fixed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseDuration.Infinite:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Infinite = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Infinite\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Infinite",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownLeaseState:enum",
+          "docComment": "/**\n * Known values of {@link LeaseState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLeaseState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLeaseState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseState.Available:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Available = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Available\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Available",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseState.Breaking:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Breaking = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Breaking\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Breaking",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseState.Broken:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Broken = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Broken\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Broken",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseState.Expired:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Expired = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Expired\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Expired",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseState.Leased:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Leased = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Leased\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Leased",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownLeaseStatus:enum",
+          "docComment": "/**\n * Known values of {@link LeaseStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownLeaseStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownLeaseStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseStatus.Locked:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Locked = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Locked\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Locked",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownLeaseStatus.Unlocked:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unlocked = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unlocked\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unlocked",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownManagementPolicyName:enum",
+          "docComment": "/**\n * Known values of {@link ManagementPolicyName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownManagementPolicyName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownManagementPolicyName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownManagementPolicyName.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"default\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownPermissions:enum",
+          "docComment": "/**\n * Known values of {@link Permissions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPermissions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPermissions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.A:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "A = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"a\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "A",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.D:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "D = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"d\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "D",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.L:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "L = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"l\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "L",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.P:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "P = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"p\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "P",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.R:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "R = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"r\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "R",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.U:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "U = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"u\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "U",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPermissions.W:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "W = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"w\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "W",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownPrivateEndpointConnectionProvisioningState:enum",
+          "docComment": "/**\n * Known values of {@link PrivateEndpointConnectionProvisioningState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateEndpointConnectionProvisioningState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateEndpointConnectionProvisioningState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Creating:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Creating = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Creating\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Creating",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointConnectionProvisioningState.Succeeded:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Succeeded = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Succeeded\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Succeeded",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownPrivateEndpointServiceConnectionStatus:enum",
+          "docComment": "/**\n * Known values of {@link PrivateEndpointServiceConnectionStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPrivateEndpointServiceConnectionStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPrivateEndpointServiceConnectionStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Approved:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Approved = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Approved\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Approved",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Pending:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Pending = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Pending\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Pending",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownPrivateEndpointServiceConnectionStatus.Rejected:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Rejected = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Rejected\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Rejected",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownReasonCode:enum",
+          "docComment": "/**\n * Known values of {@link ReasonCode} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownReasonCode "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownReasonCode",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownReasonCode.NotAvailableForSubscription:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NotAvailableForSubscription = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NotAvailableForSubscription\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NotAvailableForSubscription",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownReasonCode.QuotaId:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "QuotaId = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"QuotaId\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "QuotaId",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownRootSquashType:enum",
+          "docComment": "/**\n * Known values of {@link RootSquashType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRootSquashType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRootSquashType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownRootSquashType.AllSquash:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AllSquash = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AllSquash\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AllSquash",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownRootSquashType.NoRootSquash:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "NoRootSquash = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"NoRootSquash\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "NoRootSquash",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownRootSquashType.RootSquash:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RootSquash = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RootSquash\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RootSquash",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownRoutingChoice:enum",
+          "docComment": "/**\n * Known values of {@link RoutingChoice} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRoutingChoice "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRoutingChoice",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownRoutingChoice.InternetRouting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "InternetRouting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"InternetRouting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "InternetRouting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownRoutingChoice.MicrosoftRouting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftRouting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MicrosoftRouting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftRouting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownRuleType:enum",
+          "docComment": "/**\n * Known values of {@link RuleType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRuleType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRuleType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownRuleType.Lifecycle:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Lifecycle = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Lifecycle\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Lifecycle",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownServices:enum",
+          "docComment": "/**\n * Known values of {@link Services} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownServices "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownServices",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownServices.B:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "B = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"b\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "B",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownServices.F:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "F = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"f\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "F",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownServices.Q:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Q = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"q\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Q",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownServices.T:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "T = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"t\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "T",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownShareAccessTier:enum",
+          "docComment": "/**\n * Known values of {@link ShareAccessTier} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownShareAccessTier "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownShareAccessTier",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownShareAccessTier.Cool:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Cool = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Cool\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Cool",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownShareAccessTier.Hot:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Hot = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Hot\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Hot",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownShareAccessTier.Premium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Premium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Premium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownShareAccessTier.TransactionOptimized:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "TransactionOptimized = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"TransactionOptimized\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "TransactionOptimized",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownSignedResource:enum",
+          "docComment": "/**\n * Known values of {@link SignedResource} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSignedResource "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSignedResource",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResource.B:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "B = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"b\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "B",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResource.C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResource.F:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "F = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"f\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "F",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResource.S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownSignedResourceTypes:enum",
+          "docComment": "/**\n * Known values of {@link SignedResourceTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSignedResourceTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSignedResourceTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResourceTypes.C:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "C = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"c\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "C",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResourceTypes.O:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "O = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"o\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "O",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSignedResourceTypes.S:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "S = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"s\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "S",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "storage-resource-manager!KnownSkuName:enum",
+          "docComment": "/**\n * Known values of {@link SkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.PremiumLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.PremiumZRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumZRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium_ZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumZRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.StandardGRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.StandardGzrs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardGzrs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_GZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardGzrs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.StandardLRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardLRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_LRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardLRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.StandardRagrs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardRagrs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_RAGRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardRagrs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.StandardRagzrs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardRagzrs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_RAGZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardRagzrs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "storage-resource-manager!KnownSkuName.StandardZRS:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "StandardZRS = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard_ZRS\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "StandardZRS",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!LargeFileSharesState:type",
-          "docComment": "/**\n * Defines values for LargeFileSharesState.\n */\n",
+          "docComment": "/**\n * Defines values for LargeFileSharesState. \\ {@link KnownLargeFileSharesState} can be used interchangeably with LargeFileSharesState, this enum contains the known values that the service supports. ### Know values supported by the service **Disabled** \\ **Enabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6260,7 +8888,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Disabled\" | \"Enabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6419,7 +9047,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!LeaseContainerRequestAction:type",
-          "docComment": "/**\n * Defines values for LeaseContainerRequestAction.\n */\n",
+          "docComment": "/**\n * Defines values for LeaseContainerRequestAction. \\ {@link KnownLeaseContainerRequestAction} can be used interchangeably with LeaseContainerRequestAction, this enum contains the known values that the service supports. ### Know values supported by the service **Acquire** \\ **Renew** \\ **Change** \\ **Release** \\ **Break**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6427,7 +9055,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Acquire\" | \"Renew\" | \"Change\" | \"Release\" | \"Break\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6510,7 +9138,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!LeaseDuration:type",
-          "docComment": "/**\n * Defines values for LeaseDuration.\n */\n",
+          "docComment": "/**\n * Defines values for LeaseDuration. \\ {@link KnownLeaseDuration} can be used interchangeably with LeaseDuration, this enum contains the known values that the service supports. ### Know values supported by the service **Infinite** \\ **Fixed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6518,7 +9146,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Infinite\" | \"Fixed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6535,7 +9163,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!LeaseState:type",
-          "docComment": "/**\n * Defines values for LeaseState.\n */\n",
+          "docComment": "/**\n * Defines values for LeaseState. \\ {@link KnownLeaseState} can be used interchangeably with LeaseState, this enum contains the known values that the service supports. ### Know values supported by the service **Available** \\ **Leased** \\ **Expired** \\ **Breaking** \\ **Broken**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6543,7 +9171,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Available\" | \"Leased\" | \"Expired\" | \"Breaking\" | \"Broken\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -6560,7 +9188,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!LeaseStatus:type",
-          "docComment": "/**\n * Defines values for LeaseStatus.\n */\n",
+          "docComment": "/**\n * Defines values for LeaseStatus. \\ {@link KnownLeaseStatus} can be used interchangeably with LeaseStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Locked** \\ **Unlocked**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -6568,7 +9196,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Locked\" | \"Unlocked\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -7438,7 +10066,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!ManagementPolicyName:type",
-          "docComment": "/**\n * Defines values for ManagementPolicyName.\n */\n",
+          "docComment": "/**\n * Defines values for ManagementPolicyName. \\ {@link KnownManagementPolicyName} can be used interchangeably with ManagementPolicyName, this enum contains the known values that the service supports. ### Know values supported by the service **default**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -7446,7 +10074,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"default\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8792,7 +11420,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!Permissions_2:type",
-          "docComment": "/**\n * Defines values for Permissions.\n */\n",
+          "docComment": "/**\n * Defines values for Permissions. \\ {@link KnownPermissions} can be used interchangeably with Permissions, this enum contains the known values that the service supports. ### Know values supported by the service **r** \\ **d** \\ **w** \\ **l** \\ **a** \\ **c** \\ **u** \\ **p**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8800,7 +11428,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"r\" | \"d\" | \"w\" | \"l\" | \"a\" | \"c\" | \"u\" | \"p\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -8961,7 +11589,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!PrivateEndpointConnectionProvisioningState:type",
-          "docComment": "/**\n * Defines values for PrivateEndpointConnectionProvisioningState.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateEndpointConnectionProvisioningState. \\ {@link KnownPrivateEndpointConnectionProvisioningState} can be used interchangeably with PrivateEndpointConnectionProvisioningState, this enum contains the known values that the service supports. ### Know values supported by the service **Succeeded** \\ **Creating** \\ **Deleting** \\ **Failed**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -8969,7 +11597,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Succeeded\" | \"Creating\" | \"Deleting\" | \"Failed\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9130,7 +11758,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!PrivateEndpointServiceConnectionStatus:type",
-          "docComment": "/**\n * Defines values for PrivateEndpointServiceConnectionStatus.\n */\n",
+          "docComment": "/**\n * Defines values for PrivateEndpointServiceConnectionStatus. \\ {@link KnownPrivateEndpointServiceConnectionStatus} can be used interchangeably with PrivateEndpointServiceConnectionStatus, this enum contains the known values that the service supports. ### Know values supported by the service **Pending** \\ **Approved** \\ **Rejected**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9138,7 +11766,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Pending\" | \"Approved\" | \"Rejected\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9446,7 +12074,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!ReasonCode:type",
-          "docComment": "/**\n * Defines values for ReasonCode.\n */\n",
+          "docComment": "/**\n * Defines values for ReasonCode. \\ {@link KnownReasonCode} can be used interchangeably with ReasonCode, this enum contains the known values that the service supports. ### Know values supported by the service **QuotaId** \\ **NotAvailableForSubscription**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9454,7 +12082,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"QuotaId\" | \"NotAvailableForSubscription\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9746,7 +12374,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!RootSquashType:type",
-          "docComment": "/**\n * Defines values for RootSquashType.\n */\n",
+          "docComment": "/**\n * Defines values for RootSquashType. \\ {@link KnownRootSquashType} can be used interchangeably with RootSquashType, this enum contains the known values that the service supports. ### Know values supported by the service **NoRootSquash** \\ **RootSquash** \\ **AllSquash**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9754,7 +12382,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"NoRootSquash\" | \"RootSquash\" | \"AllSquash\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9771,7 +12399,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!RoutingChoice:type",
-          "docComment": "/**\n * Defines values for RoutingChoice.\n */\n",
+          "docComment": "/**\n * Defines values for RoutingChoice. \\ {@link KnownRoutingChoice} can be used interchangeably with RoutingChoice, this enum contains the known values that the service supports. ### Know values supported by the service **MicrosoftRouting** \\ **InternetRouting**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9779,7 +12407,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"MicrosoftRouting\" | \"InternetRouting\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9888,7 +12516,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!RuleType:type",
-          "docComment": "/**\n * Defines values for RuleType.\n */\n",
+          "docComment": "/**\n * Defines values for RuleType. \\ {@link KnownRuleType} can be used interchangeably with RuleType, this enum contains the known values that the service supports. ### Know values supported by the service **Lifecycle**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9896,7 +12524,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Lifecycle\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -9913,7 +12541,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!Services:type",
-          "docComment": "/**\n * Defines values for Services.\n */\n",
+          "docComment": "/**\n * Defines values for Services. \\ {@link KnownServices} can be used interchangeably with Services, this enum contains the known values that the service supports. ### Know values supported by the service **b** \\ **q** \\ **t** \\ **f**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -9921,7 +12549,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"b\" | \"q\" | \"t\" | \"f\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10455,7 +13083,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!ShareAccessTier:type",
-          "docComment": "/**\n * Defines values for ShareAccessTier.\n */\n",
+          "docComment": "/**\n * Defines values for ShareAccessTier. \\ {@link KnownShareAccessTier} can be used interchangeably with ShareAccessTier, this enum contains the known values that the service supports. ### Know values supported by the service **TransactionOptimized** \\ **Hot** \\ **Cool** \\ **Premium**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10463,7 +13091,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"TransactionOptimized\" | \"Hot\" | \"Cool\" | \"Premium\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10480,7 +13108,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!SignedResource:type",
-          "docComment": "/**\n * Defines values for SignedResource.\n */\n",
+          "docComment": "/**\n * Defines values for SignedResource. \\ {@link KnownSignedResource} can be used interchangeably with SignedResource, this enum contains the known values that the service supports. ### Know values supported by the service **b** \\ **c** \\ **f** \\ **s**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10488,7 +13116,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"b\" | \"c\" | \"f\" | \"s\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10505,7 +13133,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!SignedResourceTypes:type",
-          "docComment": "/**\n * Defines values for SignedResourceTypes.\n */\n",
+          "docComment": "/**\n * Defines values for SignedResourceTypes. \\ {@link KnownSignedResourceTypes} can be used interchangeably with SignedResourceTypes, this enum contains the known values that the service supports. ### Know values supported by the service **s** \\ **c** \\ **o**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10513,7 +13141,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"s\" | \"c\" | \"o\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10868,7 +13496,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "storage-resource-manager!SkuName:type",
-          "docComment": "/**\n * Defines values for SkuName.\n */\n",
+          "docComment": "/**\n * Defines values for SkuName. \\ {@link KnownSkuName} can be used interchangeably with SkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Standard_LRS** \\ **Standard_GRS** \\ **Standard_RAGRS** \\ **Standard_ZRS** \\ **Premium_LRS** \\ **Premium_ZRS** \\ **Standard_GZRS** \\ **Standard_RAGZRS**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10876,7 +13504,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Standard_LRS\" | \"Standard_GRS\" | \"Standard_RAGRS\" | \"Standard_ZRS\" | \"Premium_LRS\" | \"Premium_ZRS\" | \"Standard_GZRS\" | \"Standard_RAGZRS\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.md
+++ b/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.md
@@ -245,7 +245,7 @@ export interface BlobRestoreParameters {
 }
 
 // @public
-export type BlobRestoreProgressStatus = "InProgress" | "Complete" | "Failed" | string;
+export type BlobRestoreProgressStatus = string;
 
 // @public
 export interface BlobRestoreRange {
@@ -304,7 +304,7 @@ export type BlobServicesSetServicePropertiesResponse = BlobServiceProperties & {
 };
 
 // @public
-export type Bypass = "None" | "Logging" | "Metrics" | "AzureServices" | string;
+export type Bypass = string;
 
 // @public
 export interface ChangeFeed {
@@ -341,7 +341,7 @@ export interface CorsRule {
 }
 
 // @public
-export type CorsRuleAllowedMethodsItem = "DELETE" | "GET" | "HEAD" | "MERGE" | "POST" | "OPTIONS" | "PUT" | string;
+export type CorsRuleAllowedMethodsItem = string;
 
 // @public
 export interface CorsRules {
@@ -386,10 +386,10 @@ export interface Dimension {
 }
 
 // @public
-export type DirectoryServiceOptions = "None" | "AADDS" | "AD" | string;
+export type DirectoryServiceOptions = string;
 
 // @public
-export type EnabledProtocols = "SMB" | "NFS" | string;
+export type EnabledProtocols = string;
 
 // @public
 export interface Encryption {
@@ -443,7 +443,7 @@ export type EncryptionScopesListResponse = EncryptionScopeListResult & {
 };
 
 // @public
-export type EncryptionScopeSource = "Microsoft.Storage" | "Microsoft.KeyVault" | string;
+export type EncryptionScopeSource = string;
 
 // @public
 export type EncryptionScopesPatchResponse = EncryptionScope & {
@@ -462,7 +462,7 @@ export type EncryptionScopesPutResponse = EncryptionScope & {
 };
 
 // @public
-export type EncryptionScopeState = "Enabled" | "Disabled" | string;
+export type EncryptionScopeState = string;
 
 // @public
 export interface EncryptionService {
@@ -637,7 +637,7 @@ export interface GeoReplicationStats {
 }
 
 // @public
-export type GeoReplicationStatus = "Live" | "Bootstrap" | "Unavailable" | string;
+export type GeoReplicationStatus = string;
 
 // @public
 export type HttpProtocol = "https,http" | "https";
@@ -666,10 +666,10 @@ export interface ImmutabilityPolicyProperties {
 }
 
 // @public
-export type ImmutabilityPolicyState = "Locked" | "Unlocked" | string;
+export type ImmutabilityPolicyState = string;
 
 // @public
-export type ImmutabilityPolicyUpdateType = "put" | "lock" | "extend" | string;
+export type ImmutabilityPolicyUpdateType = string;
 
 // @public
 export interface IPRule {
@@ -681,10 +681,10 @@ export interface IPRule {
 export type KeyPermission = "Read" | "Full";
 
 // @public
-export type KeySource = "Microsoft.Storage" | "Microsoft.Keyvault" | string;
+export type KeySource = string;
 
 // @public
-type KeyType_2 = "Service" | "Account" | string;
+type KeyType_2 = string;
 
 export { KeyType_2 as KeyType }
 
@@ -698,10 +698,340 @@ export interface KeyVaultProperties {
 }
 
 // @public
-export type Kind = "Storage" | "StorageV2" | "BlobStorage" | "FileStorage" | "BlockBlobStorage" | string;
+export type Kind = string;
 
 // @public
-export type LargeFileSharesState = "Disabled" | "Enabled" | string;
+export const enum KnownBlobRestoreProgressStatus {
+    // (undocumented)
+    Complete = "Complete",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    InProgress = "InProgress"
+}
+
+// @public
+export const enum KnownBypass {
+    // (undocumented)
+    AzureServices = "AzureServices",
+    // (undocumented)
+    Logging = "Logging",
+    // (undocumented)
+    Metrics = "Metrics",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownCorsRuleAllowedMethodsItem {
+    // (undocumented)
+    Delete = "DELETE",
+    // (undocumented)
+    GET = "GET",
+    // (undocumented)
+    Head = "HEAD",
+    // (undocumented)
+    Merge = "MERGE",
+    // (undocumented)
+    Options = "OPTIONS",
+    // (undocumented)
+    Post = "POST",
+    // (undocumented)
+    PUT = "PUT"
+}
+
+// @public
+export const enum KnownDirectoryServiceOptions {
+    // (undocumented)
+    Aadds = "AADDS",
+    // (undocumented)
+    AD = "AD",
+    // (undocumented)
+    None = "None"
+}
+
+// @public
+export const enum KnownEnabledProtocols {
+    // (undocumented)
+    NFS = "NFS",
+    // (undocumented)
+    SMB = "SMB"
+}
+
+// @public
+export const enum KnownEncryptionScopeSource {
+    // (undocumented)
+    MicrosoftKeyVault = "Microsoft.KeyVault",
+    // (undocumented)
+    MicrosoftStorage = "Microsoft.Storage"
+}
+
+// @public
+export const enum KnownEncryptionScopeState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownGeoReplicationStatus {
+    // (undocumented)
+    Bootstrap = "Bootstrap",
+    // (undocumented)
+    Live = "Live",
+    // (undocumented)
+    Unavailable = "Unavailable"
+}
+
+// @public
+export const enum KnownImmutabilityPolicyState {
+    // (undocumented)
+    Locked = "Locked",
+    // (undocumented)
+    Unlocked = "Unlocked"
+}
+
+// @public
+export const enum KnownImmutabilityPolicyUpdateType {
+    // (undocumented)
+    Extend = "extend",
+    // (undocumented)
+    Lock = "lock",
+    // (undocumented)
+    Put = "put"
+}
+
+// @public
+export const enum KnownKeySource {
+    // (undocumented)
+    MicrosoftKeyvault = "Microsoft.Keyvault",
+    // (undocumented)
+    MicrosoftStorage = "Microsoft.Storage"
+}
+
+// @public
+export const enum KnownKeyType {
+    // (undocumented)
+    Account = "Account",
+    // (undocumented)
+    Service = "Service"
+}
+
+// @public
+export const enum KnownKind {
+    // (undocumented)
+    BlobStorage = "BlobStorage",
+    // (undocumented)
+    BlockBlobStorage = "BlockBlobStorage",
+    // (undocumented)
+    FileStorage = "FileStorage",
+    // (undocumented)
+    Storage = "Storage",
+    // (undocumented)
+    StorageV2 = "StorageV2"
+}
+
+// @public
+export const enum KnownLargeFileSharesState {
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    Enabled = "Enabled"
+}
+
+// @public
+export const enum KnownLeaseContainerRequestAction {
+    // (undocumented)
+    Acquire = "Acquire",
+    // (undocumented)
+    Break = "Break",
+    // (undocumented)
+    Change = "Change",
+    // (undocumented)
+    Release = "Release",
+    // (undocumented)
+    Renew = "Renew"
+}
+
+// @public
+export const enum KnownLeaseDuration {
+    // (undocumented)
+    Fixed = "Fixed",
+    // (undocumented)
+    Infinite = "Infinite"
+}
+
+// @public
+export const enum KnownLeaseState {
+    // (undocumented)
+    Available = "Available",
+    // (undocumented)
+    Breaking = "Breaking",
+    // (undocumented)
+    Broken = "Broken",
+    // (undocumented)
+    Expired = "Expired",
+    // (undocumented)
+    Leased = "Leased"
+}
+
+// @public
+export const enum KnownLeaseStatus {
+    // (undocumented)
+    Locked = "Locked",
+    // (undocumented)
+    Unlocked = "Unlocked"
+}
+
+// @public
+export const enum KnownManagementPolicyName {
+    // (undocumented)
+    Default = "default"
+}
+
+// @public
+export const enum KnownPermissions {
+    // (undocumented)
+    A = "a",
+    // (undocumented)
+    C = "c",
+    // (undocumented)
+    D = "d",
+    // (undocumented)
+    L = "l",
+    // (undocumented)
+    P = "p",
+    // (undocumented)
+    R = "r",
+    // (undocumented)
+    U = "u",
+    // (undocumented)
+    W = "w"
+}
+
+// @public
+export const enum KnownPrivateEndpointConnectionProvisioningState {
+    // (undocumented)
+    Creating = "Creating",
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Succeeded = "Succeeded"
+}
+
+// @public
+export const enum KnownPrivateEndpointServiceConnectionStatus {
+    // (undocumented)
+    Approved = "Approved",
+    // (undocumented)
+    Pending = "Pending",
+    // (undocumented)
+    Rejected = "Rejected"
+}
+
+// @public
+export const enum KnownReasonCode {
+    // (undocumented)
+    NotAvailableForSubscription = "NotAvailableForSubscription",
+    // (undocumented)
+    QuotaId = "QuotaId"
+}
+
+// @public
+export const enum KnownRootSquashType {
+    // (undocumented)
+    AllSquash = "AllSquash",
+    // (undocumented)
+    NoRootSquash = "NoRootSquash",
+    // (undocumented)
+    RootSquash = "RootSquash"
+}
+
+// @public
+export const enum KnownRoutingChoice {
+    // (undocumented)
+    InternetRouting = "InternetRouting",
+    // (undocumented)
+    MicrosoftRouting = "MicrosoftRouting"
+}
+
+// @public
+export const enum KnownRuleType {
+    // (undocumented)
+    Lifecycle = "Lifecycle"
+}
+
+// @public
+export const enum KnownServices {
+    // (undocumented)
+    B = "b",
+    // (undocumented)
+    F = "f",
+    // (undocumented)
+    Q = "q",
+    // (undocumented)
+    T = "t"
+}
+
+// @public
+export const enum KnownShareAccessTier {
+    // (undocumented)
+    Cool = "Cool",
+    // (undocumented)
+    Hot = "Hot",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    TransactionOptimized = "TransactionOptimized"
+}
+
+// @public
+export const enum KnownSignedResource {
+    // (undocumented)
+    B = "b",
+    // (undocumented)
+    C = "c",
+    // (undocumented)
+    F = "f",
+    // (undocumented)
+    S = "s"
+}
+
+// @public
+export const enum KnownSignedResourceTypes {
+    // (undocumented)
+    C = "c",
+    // (undocumented)
+    O = "o",
+    // (undocumented)
+    S = "s"
+}
+
+// @public
+export const enum KnownSkuName {
+    // (undocumented)
+    PremiumLRS = "Premium_LRS",
+    // (undocumented)
+    PremiumZRS = "Premium_ZRS",
+    // (undocumented)
+    StandardGRS = "Standard_GRS",
+    // (undocumented)
+    StandardGzrs = "Standard_GZRS",
+    // (undocumented)
+    StandardLRS = "Standard_LRS",
+    // (undocumented)
+    StandardRagrs = "Standard_RAGRS",
+    // (undocumented)
+    StandardRagzrs = "Standard_RAGZRS",
+    // (undocumented)
+    StandardZRS = "Standard_ZRS"
+}
+
+// @public
+export type LargeFileSharesState = string;
 
 // @public
 export interface LeaseContainerRequest {
@@ -713,7 +1043,7 @@ export interface LeaseContainerRequest {
 }
 
 // @public
-export type LeaseContainerRequestAction = "Acquire" | "Renew" | "Change" | "Release" | "Break" | string;
+export type LeaseContainerRequestAction = string;
 
 // @public
 export interface LeaseContainerResponse {
@@ -722,13 +1052,13 @@ export interface LeaseContainerResponse {
 }
 
 // @public
-export type LeaseDuration = "Infinite" | "Fixed" | string;
+export type LeaseDuration = string;
 
 // @public
-export type LeaseState = "Available" | "Leased" | "Expired" | "Breaking" | "Broken" | string;
+export type LeaseState = string;
 
 // @public
-export type LeaseStatus = "Locked" | "Unlocked" | string;
+export type LeaseStatus = string;
 
 // @public
 export interface LegalHold {
@@ -825,7 +1155,7 @@ export interface ManagementPolicyFilter {
 }
 
 // @public
-export type ManagementPolicyName = "default" | string;
+export type ManagementPolicyName = string;
 
 // @public
 export interface ManagementPolicyRule {
@@ -948,7 +1278,7 @@ export type OperationsListResponse = OperationListResult & {
 };
 
 // @public
-type Permissions_2 = "r" | "d" | "w" | "l" | "a" | "c" | "u" | "p" | string;
+type Permissions_2 = string;
 
 export { Permissions_2 as Permissions }
 
@@ -970,7 +1300,7 @@ export interface PrivateEndpointConnectionListResult {
 }
 
 // @public
-export type PrivateEndpointConnectionProvisioningState = "Succeeded" | "Creating" | "Deleting" | "Failed" | string;
+export type PrivateEndpointConnectionProvisioningState = string;
 
 // @public
 export type PrivateEndpointConnectionsGetResponse = PrivateEndpointConnection & {
@@ -997,7 +1327,7 @@ export type PrivateEndpointConnectionsPutResponse = PrivateEndpointConnection & 
 };
 
 // @public
-export type PrivateEndpointServiceConnectionStatus = "Pending" | "Approved" | "Rejected" | string;
+export type PrivateEndpointServiceConnectionStatus = string;
 
 // @public
 export type PrivateLinkResource = Resource & {
@@ -1036,7 +1366,7 @@ export type PublicAccess = "Container" | "Blob" | "None";
 export type Reason = "AccountNameInvalid" | "AlreadyExists";
 
 // @public
-export type ReasonCode = "QuotaId" | "NotAvailableForSubscription" | string;
+export type ReasonCode = string;
 
 // @public (undocumented)
 export interface Resource {
@@ -1060,10 +1390,10 @@ export interface Restriction {
 }
 
 // @public
-export type RootSquashType = "NoRootSquash" | "RootSquash" | "AllSquash" | string;
+export type RootSquashType = string;
 
 // @public
-export type RoutingChoice = "MicrosoftRouting" | "InternetRouting" | string;
+export type RoutingChoice = string;
 
 // @public
 export interface RoutingPreference {
@@ -1073,10 +1403,10 @@ export interface RoutingPreference {
 }
 
 // @public
-export type RuleType = "Lifecycle" | string;
+export type RuleType = string;
 
 // @public
-export type Services = "b" | "q" | "t" | "f" | string;
+export type Services = string;
 
 // @public
 export interface ServiceSasParameters {
@@ -1106,13 +1436,13 @@ export interface ServiceSpecification {
 }
 
 // @public
-export type ShareAccessTier = "TransactionOptimized" | "Hot" | "Cool" | "Premium" | string;
+export type ShareAccessTier = string;
 
 // @public
-export type SignedResource = "b" | "c" | "f" | "s" | string;
+export type SignedResource = string;
 
 // @public
-export type SignedResourceTypes = "s" | "c" | "o" | string;
+export type SignedResourceTypes = string;
 
 // @public
 export interface Sku {
@@ -1138,7 +1468,7 @@ export interface SkuInformation {
 }
 
 // @public
-export type SkuName = "Standard_LRS" | "Standard_GRS" | "Standard_RAGRS" | "Standard_ZRS" | "Premium_LRS" | "Premium_ZRS" | "Standard_GZRS" | "Standard_RAGZRS" | string;
+export type SkuName = string;
 
 // @public
 export type SkusListResponse = StorageSkuListResult & {
@@ -1528,7 +1858,7 @@ export interface VirtualNetworkRule {
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:2670:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:3112:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/storage-resource-manager/tsconfig.json
+++ b/test/smoke/generated/storage-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/smoke/generated/web-resource-manager/review/web-resource-manager.api.md
+++ b/test/smoke/generated/web-resource-manager/review/web-resource-manager.api.md
@@ -189,10 +189,10 @@ export type AppServiceCertificateOrderPatchResource = ProxyOnlyResource & {
 };
 
 // @public
-export type AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem = string;
 
 // @public
-export type AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem = string;
 
 // @public
 export type AppServiceCertificateOrdersCreateOrUpdateCertificateResponse = AppServiceCertificateResource & {
@@ -1404,7 +1404,7 @@ export interface BillingMeterCollection {
 }
 
 // @public
-export type BuildStatus = "WaitingForDeployment" | "Uploading" | "Deploying" | "Ready" | "Failed" | "Deleting" | "Detached" | string;
+export type BuildStatus = string;
 
 // @public
 export type BuiltInAuthenticationProvider = "AzureActiveDirectory" | "Facebook" | "Google" | "MicrosoftAccount" | "Twitter";
@@ -1580,7 +1580,7 @@ export type CertificatesUpdateResponse = Certificate & {
 export type Channels = "Notification" | "Api" | "Email" | "Webhook" | "All";
 
 // @public
-export type CheckNameResourceTypes = "Site" | "Slot" | "HostingEnvironment" | "PublishingUser" | "Microsoft.Web/sites" | "Microsoft.Web/sites/slots" | "Microsoft.Web/hostingEnvironments" | "Microsoft.Web/publishingUsers" | string;
+export type CheckNameResourceTypes = string;
 
 // @public
 export type CloneAbilityResult = "Cloneable" | "PartiallyCloneable" | "NotCloneable";
@@ -1864,7 +1864,7 @@ export interface DatabaseBackupSetting {
 }
 
 // @public
-export type DatabaseType = "SqlAzure" | "MySql" | "LocalMySql" | "PostgreSql" | string;
+export type DatabaseType = string;
 
 // @public
 export interface DataSource {
@@ -2505,10 +2505,10 @@ export type DomainPatchResource = ProxyOnlyResource & {
 };
 
 // @public
-export type DomainPatchResourcePropertiesDomainNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type DomainPatchResourcePropertiesDomainNotRenewableReasonsItem = string;
 
 // @public
-export type DomainPropertiesDomainNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type DomainPropertiesDomainNotRenewableReasonsItem = string;
 
 // @public
 export interface DomainPurchaseConsent {
@@ -2699,10 +2699,10 @@ export interface EndpointDetail {
 }
 
 // @public
-export type Enum4 = "Windows" | "Linux" | "WindowsFunctions" | "LinuxFunctions" | string;
+export type Enum4 = string;
 
 // @public
-export type Enum5 = "Windows" | "Linux" | "WindowsFunctions" | "LinuxFunctions" | string;
+export type Enum5 = string;
 
 // @public
 export interface ErrorEntity {
@@ -2735,7 +2735,7 @@ export interface FileSystemHttpLogsConfig {
 export type FrequencyUnit = "Day" | "Hour";
 
 // @public
-export type FtpsState = "AllAllowed" | "FtpsOnly" | "Disabled" | string;
+export type FtpsState = string;
 
 // @public
 export type FunctionEnvelope = ProxyOnlyResource & {
@@ -2925,7 +2925,7 @@ export interface IdentifierCollection {
 }
 
 // @public
-export type InAvailabilityReasonType = "Invalid" | "AlreadyExists" | string;
+export type InAvailabilityReasonType = string;
 
 // @public
 export interface InboundEnvironmentEndpoint {
@@ -2991,6 +2991,250 @@ export type KeyVaultReferenceResource = ProxyOnlyResource & {
 
 // @public
 export type KeyVaultSecretStatus = "Initialized" | "WaitingOnCertificateOrder" | "Succeeded" | "CertificateOrderFailed" | "OperationNotPermittedOnKeyVault" | "AzureServiceUnauthorizedToAccessKeyVault" | "KeyVaultDoesNotExist" | "KeyVaultSecretDoesNotExist" | "UnknownError" | "ExternalPrivateKey" | "Unknown";
+
+// @public
+export const enum KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownBuildStatus {
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Deploying = "Deploying",
+    // (undocumented)
+    Detached = "Detached",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Uploading = "Uploading",
+    // (undocumented)
+    WaitingForDeployment = "WaitingForDeployment"
+}
+
+// @public
+export const enum KnownCheckNameResourceTypes {
+    // (undocumented)
+    HostingEnvironment = "HostingEnvironment",
+    // (undocumented)
+    MicrosoftWebHostingEnvironments = "Microsoft.Web/hostingEnvironments",
+    // (undocumented)
+    MicrosoftWebPublishingUsers = "Microsoft.Web/publishingUsers",
+    // (undocumented)
+    MicrosoftWebSites = "Microsoft.Web/sites",
+    // (undocumented)
+    MicrosoftWebSitesSlots = "Microsoft.Web/sites/slots",
+    // (undocumented)
+    PublishingUser = "PublishingUser",
+    // (undocumented)
+    Site = "Site",
+    // (undocumented)
+    Slot = "Slot"
+}
+
+// @public
+export const enum KnownDatabaseType {
+    // (undocumented)
+    LocalMySql = "LocalMySql",
+    // (undocumented)
+    MySql = "MySql",
+    // (undocumented)
+    PostgreSql = "PostgreSql",
+    // (undocumented)
+    SqlAzure = "SqlAzure"
+}
+
+// @public
+export const enum KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownDomainPropertiesDomainNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownEnum4 {
+    // (undocumented)
+    Linux = "Linux",
+    // (undocumented)
+    LinuxFunctions = "LinuxFunctions",
+    // (undocumented)
+    Windows = "Windows",
+    // (undocumented)
+    WindowsFunctions = "WindowsFunctions"
+}
+
+// @public
+export const enum KnownEnum5 {
+    // (undocumented)
+    Linux = "Linux",
+    // (undocumented)
+    LinuxFunctions = "LinuxFunctions",
+    // (undocumented)
+    Windows = "Windows",
+    // (undocumented)
+    WindowsFunctions = "WindowsFunctions"
+}
+
+// @public
+export const enum KnownFtpsState {
+    // (undocumented)
+    AllAllowed = "AllAllowed",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    FtpsOnly = "FtpsOnly"
+}
+
+// @public
+export const enum KnownInAvailabilityReasonType {
+    // (undocumented)
+    AlreadyExists = "AlreadyExists",
+    // (undocumented)
+    Invalid = "Invalid"
+}
+
+// @public
+export const enum KnownPublishingProfileFormat {
+    // (undocumented)
+    FileZilla3 = "FileZilla3",
+    // (undocumented)
+    Ftp = "Ftp",
+    // (undocumented)
+    WebDeploy = "WebDeploy"
+}
+
+// @public
+export const enum KnownResourceScopeType {
+    // (undocumented)
+    ServerFarm = "ServerFarm",
+    // (undocumented)
+    Subscription = "Subscription",
+    // (undocumented)
+    WebSite = "WebSite"
+}
+
+// @public
+export const enum KnownRouteType {
+    // (undocumented)
+    Default = "DEFAULT",
+    // (undocumented)
+    Inherited = "INHERITED",
+    // (undocumented)
+    Static = "STATIC"
+}
+
+// @public
+export const enum KnownScmType {
+    // (undocumented)
+    BitbucketGit = "BitbucketGit",
+    // (undocumented)
+    BitbucketHg = "BitbucketHg",
+    // (undocumented)
+    CodePlexGit = "CodePlexGit",
+    // (undocumented)
+    CodePlexHg = "CodePlexHg",
+    // (undocumented)
+    Dropbox = "Dropbox",
+    // (undocumented)
+    ExternalGit = "ExternalGit",
+    // (undocumented)
+    ExternalHg = "ExternalHg",
+    // (undocumented)
+    GitHub = "GitHub",
+    // (undocumented)
+    LocalGit = "LocalGit",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    OneDrive = "OneDrive",
+    // (undocumented)
+    Tfs = "Tfs",
+    // (undocumented)
+    VSO = "VSO",
+    // (undocumented)
+    Vstsrm = "VSTSRM"
+}
+
+// @public
+export const enum KnownSkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Dynamic = "Dynamic",
+    // (undocumented)
+    ElasticIsolated = "ElasticIsolated",
+    // (undocumented)
+    ElasticPremium = "ElasticPremium",
+    // (undocumented)
+    Free = "Free",
+    // (undocumented)
+    Isolated = "Isolated",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    PremiumV2 = "PremiumV2",
+    // (undocumented)
+    Shared = "Shared",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownSupportedTlsVersions {
+    // (undocumented)
+    One0 = "1.0",
+    // (undocumented)
+    One1 = "1.1",
+    // (undocumented)
+    One2 = "1.2"
+}
+
+// @public
+export const enum KnownTriggerTypes {
+    // (undocumented)
+    HttpTrigger = "HttpTrigger",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownValidateResourceTypes {
+    // (undocumented)
+    ServerFarm = "ServerFarm",
+    // (undocumented)
+    Site = "Site"
+}
 
 // @public
 export interface LocalizableString {
@@ -3517,7 +3761,7 @@ export interface PublicCertificateCollection {
 export type PublicCertificateLocation = "CurrentUserMy" | "LocalMachineMy" | "Unknown";
 
 // @public
-export type PublishingProfileFormat = "FileZilla3" | "WebDeploy" | "Ftp" | string;
+export type PublishingProfileFormat = string;
 
 // @public
 export type PushSettings = ProxyOnlyResource & {
@@ -3953,7 +4197,7 @@ export interface ResourceNameAvailabilityRequest {
 }
 
 // @public
-export type ResourceScopeType = "ServerFarm" | "Subscription" | "WebSite" | string;
+export type ResourceScopeType = string;
 
 // @public (undocumented)
 export interface ResponseMetaData {
@@ -3976,10 +4220,10 @@ export type RestoreRequest = ProxyOnlyResource & {
 };
 
 // @public
-export type RouteType = "DEFAULT" | "INHERITED" | "STATIC" | string;
+export type RouteType = string;
 
 // @public
-export type ScmType = "None" | "Dropbox" | "Tfs" | "LocalGit" | "GitHub" | "CodePlexGit" | "CodePlexHg" | "BitbucketGit" | "BitbucketHg" | "ExternalGit" | "ExternalHg" | "OneDrive" | "VSO" | "VSTSRM" | string;
+export type ScmType = string;
 
 // @public
 export interface ServiceSpecification {
@@ -4388,7 +4632,7 @@ export interface SkuInfos {
 }
 
 // @public
-export type SkuName = "Free" | "Shared" | "Basic" | "Standard" | "Premium" | "Dynamic" | "Isolated" | "PremiumV2" | "ElasticPremium" | "ElasticIsolated" | string;
+export type SkuName = string;
 
 // @public
 export type SlotConfigNamesResource = ProxyOnlyResource & {
@@ -4878,7 +5122,7 @@ export type StringDictionary = ProxyOnlyResource & {
 };
 
 // @public
-export type SupportedTlsVersions = "1.0" | "1.1" | "1.2" | string;
+export type SupportedTlsVersions = string;
 
 // @public
 export type SwiftVirtualNetwork = ProxyOnlyResource & {
@@ -5009,7 +5253,7 @@ export interface TriggeredWebJobCollection {
 export type TriggeredWebJobStatus = "Success" | "Failed" | "Error";
 
 // @public
-export type TriggerTypes = "HttpTrigger" | "Unknown" | string;
+export type TriggerTypes = string;
 
 // @public
 export type UnauthenticatedClientAction = "RedirectToLoginPage" | "AllowAnonymous";
@@ -5065,7 +5309,7 @@ export interface ValidateRequest {
 }
 
 // @public
-export type ValidateResourceTypes = "ServerFarm" | "Site" | string;
+export type ValidateResourceTypes = string;
 
 // @public
 export interface ValidateResponse {
@@ -8344,7 +8588,7 @@ export type WorkerSizeOptions = "Small" | "Medium" | "Large" | "D1" | "D2" | "D3
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:9399:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:9675:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/web-resource-manager/src/models/index.ts
+++ b/test/smoke/generated/web-resource-manager/src/models/index.ts
@@ -8674,164 +8674,440 @@ export type ResourceHealthMetadata = ProxyOnlyResource & {
    */
   signalAvailability?: boolean;
 };
+
 /**
- * Defines values for AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem.
+ * Known values of {@link AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem} that the service accepts.
  */
-export type AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem =
-  | "RegistrationStatusNotSupportedForRenewal"
-  | "ExpirationNotInRenewalTimeRange"
-  | "SubscriptionNotActive"
-  | string;
+export const enum KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem {
+  RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+  ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+  SubscriptionNotActive = "SubscriptionNotActive"
+}
+
 /**
- * Defines values for AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem.
+ * Defines values for AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem. \
+ * {@link KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem} can be used interchangeably with AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **RegistrationStatusNotSupportedForRenewal** \
+ * **ExpirationNotInRenewalTimeRange** \
+ * **SubscriptionNotActive**
  */
-export type AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem =
-  | "RegistrationStatusNotSupportedForRenewal"
-  | "ExpirationNotInRenewalTimeRange"
-  | "SubscriptionNotActive"
-  | string;
+export type AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem = string;
+
 /**
- * Defines values for DomainPropertiesDomainNotRenewableReasonsItem.
+ * Known values of {@link AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem} that the service accepts.
  */
-export type DomainPropertiesDomainNotRenewableReasonsItem =
-  | "RegistrationStatusNotSupportedForRenewal"
-  | "ExpirationNotInRenewalTimeRange"
-  | "SubscriptionNotActive"
-  | string;
+export const enum KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem {
+  RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+  ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+  SubscriptionNotActive = "SubscriptionNotActive"
+}
+
 /**
- * Defines values for DomainPatchResourcePropertiesDomainNotRenewableReasonsItem.
+ * Defines values for AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem. \
+ * {@link KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem} can be used interchangeably with AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **RegistrationStatusNotSupportedForRenewal** \
+ * **ExpirationNotInRenewalTimeRange** \
+ * **SubscriptionNotActive**
  */
-export type DomainPatchResourcePropertiesDomainNotRenewableReasonsItem =
-  | "RegistrationStatusNotSupportedForRenewal"
-  | "ExpirationNotInRenewalTimeRange"
-  | "SubscriptionNotActive"
-  | string;
+export type AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem = string;
+
 /**
- * Defines values for Enum4.
+ * Known values of {@link DomainPropertiesDomainNotRenewableReasonsItem} that the service accepts.
  */
-export type Enum4 =
-  | "Windows"
-  | "Linux"
-  | "WindowsFunctions"
-  | "LinuxFunctions"
-  | string;
+export const enum KnownDomainPropertiesDomainNotRenewableReasonsItem {
+  RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+  ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+  SubscriptionNotActive = "SubscriptionNotActive"
+}
+
 /**
- * Defines values for Enum5.
+ * Defines values for DomainPropertiesDomainNotRenewableReasonsItem. \
+ * {@link KnownDomainPropertiesDomainNotRenewableReasonsItem} can be used interchangeably with DomainPropertiesDomainNotRenewableReasonsItem,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **RegistrationStatusNotSupportedForRenewal** \
+ * **ExpirationNotInRenewalTimeRange** \
+ * **SubscriptionNotActive**
  */
-export type Enum5 =
-  | "Windows"
-  | "Linux"
-  | "WindowsFunctions"
-  | "LinuxFunctions"
-  | string;
+export type DomainPropertiesDomainNotRenewableReasonsItem = string;
+
 /**
- * Defines values for ResourceScopeType.
+ * Known values of {@link DomainPatchResourcePropertiesDomainNotRenewableReasonsItem} that the service accepts.
  */
-export type ResourceScopeType =
-  | "ServerFarm"
-  | "Subscription"
-  | "WebSite"
-  | string;
+export const enum KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem {
+  RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+  ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+  SubscriptionNotActive = "SubscriptionNotActive"
+}
+
 /**
- * Defines values for CheckNameResourceTypes.
+ * Defines values for DomainPatchResourcePropertiesDomainNotRenewableReasonsItem. \
+ * {@link KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem} can be used interchangeably with DomainPatchResourcePropertiesDomainNotRenewableReasonsItem,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **RegistrationStatusNotSupportedForRenewal** \
+ * **ExpirationNotInRenewalTimeRange** \
+ * **SubscriptionNotActive**
  */
-export type CheckNameResourceTypes =
-  | "Site"
-  | "Slot"
-  | "HostingEnvironment"
-  | "PublishingUser"
-  | "Microsoft.Web/sites"
-  | "Microsoft.Web/sites/slots"
-  | "Microsoft.Web/hostingEnvironments"
-  | "Microsoft.Web/publishingUsers"
-  | string;
+export type DomainPatchResourcePropertiesDomainNotRenewableReasonsItem = string;
+
 /**
- * Defines values for InAvailabilityReasonType.
+ * Known values of {@link Enum4} that the service accepts.
  */
-export type InAvailabilityReasonType = "Invalid" | "AlreadyExists" | string;
+export const enum KnownEnum4 {
+  Windows = "Windows",
+  Linux = "Linux",
+  WindowsFunctions = "WindowsFunctions",
+  LinuxFunctions = "LinuxFunctions"
+}
+
 /**
- * Defines values for SkuName.
+ * Defines values for Enum4. \
+ * {@link KnownEnum4} can be used interchangeably with Enum4,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Windows** \
+ * **Linux** \
+ * **WindowsFunctions** \
+ * **LinuxFunctions**
  */
-export type SkuName =
-  | "Free"
-  | "Shared"
-  | "Basic"
-  | "Standard"
-  | "Premium"
-  | "Dynamic"
-  | "Isolated"
-  | "PremiumV2"
-  | "ElasticPremium"
-  | "ElasticIsolated"
-  | string;
+export type Enum4 = string;
+
 /**
- * Defines values for ValidateResourceTypes.
+ * Known values of {@link Enum5} that the service accepts.
  */
-export type ValidateResourceTypes = "ServerFarm" | "Site" | string;
+export const enum KnownEnum5 {
+  Windows = "Windows",
+  Linux = "Linux",
+  WindowsFunctions = "WindowsFunctions",
+  LinuxFunctions = "LinuxFunctions"
+}
+
 /**
- * Defines values for ScmType.
+ * Defines values for Enum5. \
+ * {@link KnownEnum5} can be used interchangeably with Enum5,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Windows** \
+ * **Linux** \
+ * **WindowsFunctions** \
+ * **LinuxFunctions**
  */
-export type ScmType =
-  | "None"
-  | "Dropbox"
-  | "Tfs"
-  | "LocalGit"
-  | "GitHub"
-  | "CodePlexGit"
-  | "CodePlexHg"
-  | "BitbucketGit"
-  | "BitbucketHg"
-  | "ExternalGit"
-  | "ExternalHg"
-  | "OneDrive"
-  | "VSO"
-  | "VSTSRM"
-  | string;
+export type Enum5 = string;
+
 /**
- * Defines values for SupportedTlsVersions.
+ * Known values of {@link ResourceScopeType} that the service accepts.
  */
-export type SupportedTlsVersions = "1.0" | "1.1" | "1.2" | string;
+export const enum KnownResourceScopeType {
+  ServerFarm = "ServerFarm",
+  Subscription = "Subscription",
+  WebSite = "WebSite"
+}
+
 /**
- * Defines values for FtpsState.
+ * Defines values for ResourceScopeType. \
+ * {@link KnownResourceScopeType} can be used interchangeably with ResourceScopeType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ServerFarm** \
+ * **Subscription** \
+ * **WebSite**
  */
-export type FtpsState = "AllAllowed" | "FtpsOnly" | "Disabled" | string;
+export type ResourceScopeType = string;
+
 /**
- * Defines values for DatabaseType.
+ * Known values of {@link CheckNameResourceTypes} that the service accepts.
  */
-export type DatabaseType =
-  | "SqlAzure"
-  | "MySql"
-  | "LocalMySql"
-  | "PostgreSql"
-  | string;
+export const enum KnownCheckNameResourceTypes {
+  Site = "Site",
+  Slot = "Slot",
+  HostingEnvironment = "HostingEnvironment",
+  PublishingUser = "PublishingUser",
+  MicrosoftWebSites = "Microsoft.Web/sites",
+  MicrosoftWebSitesSlots = "Microsoft.Web/sites/slots",
+  MicrosoftWebHostingEnvironments = "Microsoft.Web/hostingEnvironments",
+  MicrosoftWebPublishingUsers = "Microsoft.Web/publishingUsers"
+}
+
 /**
- * Defines values for RouteType.
+ * Defines values for CheckNameResourceTypes. \
+ * {@link KnownCheckNameResourceTypes} can be used interchangeably with CheckNameResourceTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Site** \
+ * **Slot** \
+ * **HostingEnvironment** \
+ * **PublishingUser** \
+ * **Microsoft.Web/sites** \
+ * **Microsoft.Web/sites/slots** \
+ * **Microsoft.Web/hostingEnvironments** \
+ * **Microsoft.Web/publishingUsers**
  */
-export type RouteType = "DEFAULT" | "INHERITED" | "STATIC" | string;
+export type CheckNameResourceTypes = string;
+
 /**
- * Defines values for PublishingProfileFormat.
+ * Known values of {@link InAvailabilityReasonType} that the service accepts.
  */
-export type PublishingProfileFormat =
-  | "FileZilla3"
-  | "WebDeploy"
-  | "Ftp"
-  | string;
+export const enum KnownInAvailabilityReasonType {
+  Invalid = "Invalid",
+  AlreadyExists = "AlreadyExists"
+}
+
 /**
- * Defines values for BuildStatus.
+ * Defines values for InAvailabilityReasonType. \
+ * {@link KnownInAvailabilityReasonType} can be used interchangeably with InAvailabilityReasonType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Invalid** \
+ * **AlreadyExists**
  */
-export type BuildStatus =
-  | "WaitingForDeployment"
-  | "Uploading"
-  | "Deploying"
-  | "Ready"
-  | "Failed"
-  | "Deleting"
-  | "Detached"
-  | string;
+export type InAvailabilityReasonType = string;
+
 /**
- * Defines values for TriggerTypes.
+ * Known values of {@link SkuName} that the service accepts.
  */
-export type TriggerTypes = "HttpTrigger" | "Unknown" | string;
+export const enum KnownSkuName {
+  Free = "Free",
+  Shared = "Shared",
+  Basic = "Basic",
+  Standard = "Standard",
+  Premium = "Premium",
+  Dynamic = "Dynamic",
+  Isolated = "Isolated",
+  PremiumV2 = "PremiumV2",
+  ElasticPremium = "ElasticPremium",
+  ElasticIsolated = "ElasticIsolated"
+}
+
+/**
+ * Defines values for SkuName. \
+ * {@link KnownSkuName} can be used interchangeably with SkuName,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Free** \
+ * **Shared** \
+ * **Basic** \
+ * **Standard** \
+ * **Premium** \
+ * **Dynamic** \
+ * **Isolated** \
+ * **PremiumV2** \
+ * **ElasticPremium** \
+ * **ElasticIsolated**
+ */
+export type SkuName = string;
+
+/**
+ * Known values of {@link ValidateResourceTypes} that the service accepts.
+ */
+export const enum KnownValidateResourceTypes {
+  ServerFarm = "ServerFarm",
+  Site = "Site"
+}
+
+/**
+ * Defines values for ValidateResourceTypes. \
+ * {@link KnownValidateResourceTypes} can be used interchangeably with ValidateResourceTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **ServerFarm** \
+ * **Site**
+ */
+export type ValidateResourceTypes = string;
+
+/**
+ * Known values of {@link ScmType} that the service accepts.
+ */
+export const enum KnownScmType {
+  None = "None",
+  Dropbox = "Dropbox",
+  Tfs = "Tfs",
+  LocalGit = "LocalGit",
+  GitHub = "GitHub",
+  CodePlexGit = "CodePlexGit",
+  CodePlexHg = "CodePlexHg",
+  BitbucketGit = "BitbucketGit",
+  BitbucketHg = "BitbucketHg",
+  ExternalGit = "ExternalGit",
+  ExternalHg = "ExternalHg",
+  OneDrive = "OneDrive",
+  VSO = "VSO",
+  Vstsrm = "VSTSRM"
+}
+
+/**
+ * Defines values for ScmType. \
+ * {@link KnownScmType} can be used interchangeably with ScmType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **None** \
+ * **Dropbox** \
+ * **Tfs** \
+ * **LocalGit** \
+ * **GitHub** \
+ * **CodePlexGit** \
+ * **CodePlexHg** \
+ * **BitbucketGit** \
+ * **BitbucketHg** \
+ * **ExternalGit** \
+ * **ExternalHg** \
+ * **OneDrive** \
+ * **VSO** \
+ * **VSTSRM**
+ */
+export type ScmType = string;
+
+/**
+ * Known values of {@link SupportedTlsVersions} that the service accepts.
+ */
+export const enum KnownSupportedTlsVersions {
+  One0 = "1.0",
+  One1 = "1.1",
+  One2 = "1.2"
+}
+
+/**
+ * Defines values for SupportedTlsVersions. \
+ * {@link KnownSupportedTlsVersions} can be used interchangeably with SupportedTlsVersions,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **1.0** \
+ * **1.1** \
+ * **1.2**
+ */
+export type SupportedTlsVersions = string;
+
+/**
+ * Known values of {@link FtpsState} that the service accepts.
+ */
+export const enum KnownFtpsState {
+  AllAllowed = "AllAllowed",
+  FtpsOnly = "FtpsOnly",
+  Disabled = "Disabled"
+}
+
+/**
+ * Defines values for FtpsState. \
+ * {@link KnownFtpsState} can be used interchangeably with FtpsState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **AllAllowed** \
+ * **FtpsOnly** \
+ * **Disabled**
+ */
+export type FtpsState = string;
+
+/**
+ * Known values of {@link DatabaseType} that the service accepts.
+ */
+export const enum KnownDatabaseType {
+  SqlAzure = "SqlAzure",
+  MySql = "MySql",
+  LocalMySql = "LocalMySql",
+  PostgreSql = "PostgreSql"
+}
+
+/**
+ * Defines values for DatabaseType. \
+ * {@link KnownDatabaseType} can be used interchangeably with DatabaseType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **SqlAzure** \
+ * **MySql** \
+ * **LocalMySql** \
+ * **PostgreSql**
+ */
+export type DatabaseType = string;
+
+/**
+ * Known values of {@link RouteType} that the service accepts.
+ */
+export const enum KnownRouteType {
+  Default = "DEFAULT",
+  Inherited = "INHERITED",
+  Static = "STATIC"
+}
+
+/**
+ * Defines values for RouteType. \
+ * {@link KnownRouteType} can be used interchangeably with RouteType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **DEFAULT** \
+ * **INHERITED** \
+ * **STATIC**
+ */
+export type RouteType = string;
+
+/**
+ * Known values of {@link PublishingProfileFormat} that the service accepts.
+ */
+export const enum KnownPublishingProfileFormat {
+  FileZilla3 = "FileZilla3",
+  WebDeploy = "WebDeploy",
+  Ftp = "Ftp"
+}
+
+/**
+ * Defines values for PublishingProfileFormat. \
+ * {@link KnownPublishingProfileFormat} can be used interchangeably with PublishingProfileFormat,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **FileZilla3** \
+ * **WebDeploy** \
+ * **Ftp**
+ */
+export type PublishingProfileFormat = string;
+
+/**
+ * Known values of {@link BuildStatus} that the service accepts.
+ */
+export const enum KnownBuildStatus {
+  WaitingForDeployment = "WaitingForDeployment",
+  Uploading = "Uploading",
+  Deploying = "Deploying",
+  Ready = "Ready",
+  Failed = "Failed",
+  Deleting = "Deleting",
+  Detached = "Detached"
+}
+
+/**
+ * Defines values for BuildStatus. \
+ * {@link KnownBuildStatus} can be used interchangeably with BuildStatus,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **WaitingForDeployment** \
+ * **Uploading** \
+ * **Deploying** \
+ * **Ready** \
+ * **Failed** \
+ * **Deleting** \
+ * **Detached**
+ */
+export type BuildStatus = string;
+
+/**
+ * Known values of {@link TriggerTypes} that the service accepts.
+ */
+export const enum KnownTriggerTypes {
+  HttpTrigger = "HttpTrigger",
+  Unknown = "Unknown"
+}
+
+/**
+ * Defines values for TriggerTypes. \
+ * {@link KnownTriggerTypes} can be used interchangeably with TriggerTypes,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **HttpTrigger** \
+ * **Unknown**
+ */
+export type TriggerTypes = string;
 /**
  * Defines values for KeyVaultSecretStatus.
  */

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
@@ -1740,7 +1740,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem:type",
-          "docComment": "/**\n * Defines values for AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem.\n */\n",
+          "docComment": "/**\n * Defines values for AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem. \\ {@link KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem} can be used interchangeably with AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem, this enum contains the known values that the service supports. ### Know values supported by the service **RegistrationStatusNotSupportedForRenewal** \\ **ExpirationNotInRenewalTimeRange** \\ **SubscriptionNotActive**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1748,7 +1748,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"RegistrationStatusNotSupportedForRenewal\" | \"ExpirationNotInRenewalTimeRange\" | \"SubscriptionNotActive\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -1765,7 +1765,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem:type",
-          "docComment": "/**\n * Defines values for AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem.\n */\n",
+          "docComment": "/**\n * Defines values for AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem. \\ {@link KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem} can be used interchangeably with AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem, this enum contains the known values that the service supports. ### Know values supported by the service **RegistrationStatusNotSupportedForRenewal** \\ **ExpirationNotInRenewalTimeRange** \\ **SubscriptionNotActive**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -1773,7 +1773,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"RegistrationStatusNotSupportedForRenewal\" | \"ExpirationNotInRenewalTimeRange\" | \"SubscriptionNotActive\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -10558,7 +10558,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!BuildStatus:type",
-          "docComment": "/**\n * Defines values for BuildStatus.\n */\n",
+          "docComment": "/**\n * Defines values for BuildStatus. \\ {@link KnownBuildStatus} can be used interchangeably with BuildStatus, this enum contains the known values that the service supports. ### Know values supported by the service **WaitingForDeployment** \\ **Uploading** \\ **Deploying** \\ **Ready** \\ **Failed** \\ **Deleting** \\ **Detached**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -10566,7 +10566,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"WaitingForDeployment\" | \"Uploading\" | \"Deploying\" | \"Ready\" | \"Failed\" | \"Deleting\" | \"Detached\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -11800,7 +11800,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!CheckNameResourceTypes:type",
-          "docComment": "/**\n * Defines values for CheckNameResourceTypes.\n */\n",
+          "docComment": "/**\n * Defines values for CheckNameResourceTypes. \\ {@link KnownCheckNameResourceTypes} can be used interchangeably with CheckNameResourceTypes, this enum contains the known values that the service supports. ### Know values supported by the service **Site** \\ **Slot** \\ **HostingEnvironment** \\ **PublishingUser** \\ **Microsoft.Web/sites** \\ **Microsoft.Web/sites/slots** \\ **Microsoft.Web/hostingEnvironments** \\ **Microsoft.Web/publishingUsers**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -11808,7 +11808,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Site\" | \"Slot\" | \"HostingEnvironment\" | \"PublishingUser\" | \"Microsoft.Web/sites\" | \"Microsoft.Web/sites/slots\" | \"Microsoft.Web/hostingEnvironments\" | \"Microsoft.Web/publishingUsers\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -14778,7 +14778,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!DatabaseType:type",
-          "docComment": "/**\n * Defines values for DatabaseType.\n */\n",
+          "docComment": "/**\n * Defines values for DatabaseType. \\ {@link KnownDatabaseType} can be used interchangeably with DatabaseType, this enum contains the known values that the service supports. ### Know values supported by the service **SqlAzure** \\ **MySql** \\ **LocalMySql** \\ **PostgreSql**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -14786,7 +14786,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"SqlAzure\" | \"MySql\" | \"LocalMySql\" | \"PostgreSql\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -20347,7 +20347,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!DomainPatchResourcePropertiesDomainNotRenewableReasonsItem:type",
-          "docComment": "/**\n * Defines values for DomainPatchResourcePropertiesDomainNotRenewableReasonsItem.\n */\n",
+          "docComment": "/**\n * Defines values for DomainPatchResourcePropertiesDomainNotRenewableReasonsItem. \\ {@link KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem} can be used interchangeably with DomainPatchResourcePropertiesDomainNotRenewableReasonsItem, this enum contains the known values that the service supports. ### Know values supported by the service **RegistrationStatusNotSupportedForRenewal** \\ **ExpirationNotInRenewalTimeRange** \\ **SubscriptionNotActive**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -20355,7 +20355,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"RegistrationStatusNotSupportedForRenewal\" | \"ExpirationNotInRenewalTimeRange\" | \"SubscriptionNotActive\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -20372,7 +20372,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!DomainPropertiesDomainNotRenewableReasonsItem:type",
-          "docComment": "/**\n * Defines values for DomainPropertiesDomainNotRenewableReasonsItem.\n */\n",
+          "docComment": "/**\n * Defines values for DomainPropertiesDomainNotRenewableReasonsItem. \\ {@link KnownDomainPropertiesDomainNotRenewableReasonsItem} can be used interchangeably with DomainPropertiesDomainNotRenewableReasonsItem, this enum contains the known values that the service supports. ### Know values supported by the service **RegistrationStatusNotSupportedForRenewal** \\ **ExpirationNotInRenewalTimeRange** \\ **SubscriptionNotActive**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -20380,7 +20380,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"RegistrationStatusNotSupportedForRenewal\" | \"ExpirationNotInRenewalTimeRange\" | \"SubscriptionNotActive\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -21774,7 +21774,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!Enum4:type",
-          "docComment": "/**\n * Defines values for Enum4.\n */\n",
+          "docComment": "/**\n * Defines values for Enum4. \\ {@link KnownEnum4} can be used interchangeably with Enum4, this enum contains the known values that the service supports. ### Know values supported by the service **Windows** \\ **Linux** \\ **WindowsFunctions** \\ **LinuxFunctions**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21782,7 +21782,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Windows\" | \"Linux\" | \"WindowsFunctions\" | \"LinuxFunctions\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -21799,7 +21799,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!Enum5:type",
-          "docComment": "/**\n * Defines values for Enum5.\n */\n",
+          "docComment": "/**\n * Defines values for Enum5. \\ {@link KnownEnum5} can be used interchangeably with Enum5, this enum contains the known values that the service supports. ### Know values supported by the service **Windows** \\ **Linux** \\ **WindowsFunctions** \\ **LinuxFunctions**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -21807,7 +21807,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Windows\" | \"Linux\" | \"WindowsFunctions\" | \"LinuxFunctions\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -22199,7 +22199,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!FtpsState:type",
-          "docComment": "/**\n * Defines values for FtpsState.\n */\n",
+          "docComment": "/**\n * Defines values for FtpsState. \\ {@link KnownFtpsState} can be used interchangeably with FtpsState, this enum contains the known values that the service supports. ### Know values supported by the service **AllAllowed** \\ **FtpsOnly** \\ **Disabled**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -22207,7 +22207,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"AllAllowed\" | \"FtpsOnly\" | \"Disabled\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -23937,7 +23937,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!InAvailabilityReasonType:type",
-          "docComment": "/**\n * Defines values for InAvailabilityReasonType.\n */\n",
+          "docComment": "/**\n * Defines values for InAvailabilityReasonType. \\ {@link KnownInAvailabilityReasonType} can be used interchangeably with InAvailabilityReasonType, this enum contains the known values that the service supports. ### Know values supported by the service **Invalid** \\ **AlreadyExists**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -23945,7 +23945,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Invalid\" | \"AlreadyExists\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -24640,6 +24640,2055 @@
             "startIndex": 1,
             "endIndex": 2
           }
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem:enum",
+          "docComment": "/**\n * Known values of {@link AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem.ExpirationNotInRenewalTimeRange:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExpirationNotInRenewalTimeRange = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExpirationNotInRenewalTimeRange\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExpirationNotInRenewalTimeRange",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem.RegistrationStatusNotSupportedForRenewal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RegistrationStatusNotSupportedForRenewal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RegistrationStatusNotSupportedForRenewal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RegistrationStatusNotSupportedForRenewal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem.SubscriptionNotActive:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SubscriptionNotActive = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SubscriptionNotActive\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SubscriptionNotActive",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem:enum",
+          "docComment": "/**\n * Known values of {@link AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem.ExpirationNotInRenewalTimeRange:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExpirationNotInRenewalTimeRange = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExpirationNotInRenewalTimeRange\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExpirationNotInRenewalTimeRange",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem.RegistrationStatusNotSupportedForRenewal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RegistrationStatusNotSupportedForRenewal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RegistrationStatusNotSupportedForRenewal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RegistrationStatusNotSupportedForRenewal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem.SubscriptionNotActive:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SubscriptionNotActive = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SubscriptionNotActive\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SubscriptionNotActive",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownBuildStatus:enum",
+          "docComment": "/**\n * Known values of {@link BuildStatus} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownBuildStatus "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownBuildStatus",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.Deleting:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deleting = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deleting\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deleting",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.Deploying:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Deploying = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Deploying\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Deploying",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.Detached:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Detached = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Detached\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Detached",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.Failed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Failed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Failed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Failed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.Ready:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ready = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ready\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ready",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.Uploading:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Uploading = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Uploading\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Uploading",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownBuildStatus.WaitingForDeployment:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WaitingForDeployment = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WaitingForDeployment\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WaitingForDeployment",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes:enum",
+          "docComment": "/**\n * Known values of {@link CheckNameResourceTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownCheckNameResourceTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownCheckNameResourceTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.HostingEnvironment:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HostingEnvironment = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HostingEnvironment\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HostingEnvironment",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.MicrosoftWebHostingEnvironments:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftWebHostingEnvironments = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Web/hostingEnvironments\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftWebHostingEnvironments",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.MicrosoftWebPublishingUsers:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftWebPublishingUsers = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Web/publishingUsers\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftWebPublishingUsers",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.MicrosoftWebSites:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftWebSites = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Web/sites\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftWebSites",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.MicrosoftWebSitesSlots:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MicrosoftWebSitesSlots = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Microsoft.Web/sites/slots\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MicrosoftWebSitesSlots",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.PublishingUser:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PublishingUser = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PublishingUser\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PublishingUser",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.Site:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Site = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Site\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Site",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownCheckNameResourceTypes.Slot:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Slot = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Slot\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Slot",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownDatabaseType:enum",
+          "docComment": "/**\n * Known values of {@link DatabaseType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDatabaseType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDatabaseType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDatabaseType.LocalMySql:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LocalMySql = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LocalMySql\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LocalMySql",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDatabaseType.MySql:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "MySql = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"MySql\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "MySql",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDatabaseType.PostgreSql:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PostgreSql = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PostgreSql\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PostgreSql",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDatabaseType.SqlAzure:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SqlAzure = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SqlAzure\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SqlAzure",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem:enum",
+          "docComment": "/**\n * Known values of {@link DomainPatchResourcePropertiesDomainNotRenewableReasonsItem} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem.ExpirationNotInRenewalTimeRange:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExpirationNotInRenewalTimeRange = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExpirationNotInRenewalTimeRange\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExpirationNotInRenewalTimeRange",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem.RegistrationStatusNotSupportedForRenewal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RegistrationStatusNotSupportedForRenewal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RegistrationStatusNotSupportedForRenewal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RegistrationStatusNotSupportedForRenewal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem.SubscriptionNotActive:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SubscriptionNotActive = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SubscriptionNotActive\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SubscriptionNotActive",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownDomainPropertiesDomainNotRenewableReasonsItem:enum",
+          "docComment": "/**\n * Known values of {@link DomainPropertiesDomainNotRenewableReasonsItem} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownDomainPropertiesDomainNotRenewableReasonsItem "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownDomainPropertiesDomainNotRenewableReasonsItem",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDomainPropertiesDomainNotRenewableReasonsItem.ExpirationNotInRenewalTimeRange:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExpirationNotInRenewalTimeRange = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExpirationNotInRenewalTimeRange\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExpirationNotInRenewalTimeRange",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDomainPropertiesDomainNotRenewableReasonsItem.RegistrationStatusNotSupportedForRenewal:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "RegistrationStatusNotSupportedForRenewal = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"RegistrationStatusNotSupportedForRenewal\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "RegistrationStatusNotSupportedForRenewal",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownDomainPropertiesDomainNotRenewableReasonsItem.SubscriptionNotActive:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "SubscriptionNotActive = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"SubscriptionNotActive\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "SubscriptionNotActive",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownEnum4:enum",
+          "docComment": "/**\n * Known values of {@link Enum4} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEnum4 "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEnum4",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum4.Linux:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Linux = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Linux\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Linux",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum4.LinuxFunctions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LinuxFunctions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LinuxFunctions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LinuxFunctions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum4.Windows:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Windows = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Windows\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Windows",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum4.WindowsFunctions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WindowsFunctions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WindowsFunctions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WindowsFunctions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownEnum5:enum",
+          "docComment": "/**\n * Known values of {@link Enum5} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownEnum5 "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownEnum5",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum5.Linux:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Linux = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Linux\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Linux",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum5.LinuxFunctions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LinuxFunctions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LinuxFunctions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LinuxFunctions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum5.Windows:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Windows = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Windows\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Windows",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownEnum5.WindowsFunctions:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WindowsFunctions = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WindowsFunctions\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WindowsFunctions",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownFtpsState:enum",
+          "docComment": "/**\n * Known values of {@link FtpsState} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownFtpsState "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownFtpsState",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownFtpsState.AllAllowed:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AllAllowed = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AllAllowed\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AllAllowed",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownFtpsState.Disabled:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Disabled = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Disabled\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Disabled",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownFtpsState.FtpsOnly:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FtpsOnly = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FtpsOnly\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FtpsOnly",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownInAvailabilityReasonType:enum",
+          "docComment": "/**\n * Known values of {@link InAvailabilityReasonType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownInAvailabilityReasonType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownInAvailabilityReasonType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownInAvailabilityReasonType.AlreadyExists:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "AlreadyExists = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"AlreadyExists\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "AlreadyExists",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownInAvailabilityReasonType.Invalid:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Invalid = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Invalid\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Invalid",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownPublishingProfileFormat:enum",
+          "docComment": "/**\n * Known values of {@link PublishingProfileFormat} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownPublishingProfileFormat "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownPublishingProfileFormat",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownPublishingProfileFormat.FileZilla3:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "FileZilla3 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"FileZilla3\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "FileZilla3",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownPublishingProfileFormat.Ftp:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Ftp = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Ftp\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Ftp",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownPublishingProfileFormat.WebDeploy:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WebDeploy = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WebDeploy\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WebDeploy",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownResourceScopeType:enum",
+          "docComment": "/**\n * Known values of {@link ResourceScopeType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownResourceScopeType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownResourceScopeType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownResourceScopeType.ServerFarm:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ServerFarm = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ServerFarm\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ServerFarm",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownResourceScopeType.Subscription:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Subscription = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Subscription\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Subscription",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownResourceScopeType.WebSite:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "WebSite = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"WebSite\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "WebSite",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownRouteType:enum",
+          "docComment": "/**\n * Known values of {@link RouteType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownRouteType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownRouteType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownRouteType.Default:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Default = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"DEFAULT\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Default",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownRouteType.Inherited:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Inherited = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"INHERITED\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Inherited",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownRouteType.Static:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Static = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"STATIC\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Static",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownScmType:enum",
+          "docComment": "/**\n * Known values of {@link ScmType} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownScmType "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownScmType",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.BitbucketGit:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BitbucketGit = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BitbucketGit\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BitbucketGit",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.BitbucketHg:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "BitbucketHg = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"BitbucketHg\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "BitbucketHg",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.CodePlexGit:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CodePlexGit = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CodePlexGit\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CodePlexGit",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.CodePlexHg:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "CodePlexHg = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"CodePlexHg\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "CodePlexHg",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.Dropbox:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dropbox = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Dropbox\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dropbox",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.ExternalGit:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExternalGit = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExternalGit\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExternalGit",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.ExternalHg:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ExternalHg = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ExternalHg\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ExternalHg",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.GitHub:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "GitHub = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"GitHub\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "GitHub",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.LocalGit:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "LocalGit = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"LocalGit\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "LocalGit",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.None:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "None = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"None\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "None",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.OneDrive:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "OneDrive = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"OneDrive\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "OneDrive",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.Tfs:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Tfs = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Tfs\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Tfs",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.VSO:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "VSO = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VSO\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "VSO",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownScmType.Vstsrm:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Vstsrm = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"VSTSRM\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Vstsrm",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownSkuName:enum",
+          "docComment": "/**\n * Known values of {@link SkuName} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSkuName "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSkuName",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Basic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Basic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Basic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Basic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Dynamic:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Dynamic = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Dynamic\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Dynamic",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.ElasticIsolated:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ElasticIsolated = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ElasticIsolated\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ElasticIsolated",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.ElasticPremium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ElasticPremium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ElasticPremium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ElasticPremium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Free:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Free = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Free\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Free",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Isolated:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Isolated = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Isolated\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Isolated",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Premium:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Premium = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Premium\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Premium",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.PremiumV2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "PremiumV2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"PremiumV2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "PremiumV2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Shared:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Shared = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Shared\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Shared",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSkuName.Standard:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Standard = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Standard\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Standard",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownSupportedTlsVersions:enum",
+          "docComment": "/**\n * Known values of {@link SupportedTlsVersions} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownSupportedTlsVersions "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownSupportedTlsVersions",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSupportedTlsVersions.One0:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "One0 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"1.0\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "One0",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSupportedTlsVersions.One1:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "One1 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"1.1\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "One1",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownSupportedTlsVersions.One2:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "One2 = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"1.2\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "One2",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownTriggerTypes:enum",
+          "docComment": "/**\n * Known values of {@link TriggerTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownTriggerTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownTriggerTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownTriggerTypes.HttpTrigger:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "HttpTrigger = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"HttpTrigger\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "HttpTrigger",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownTriggerTypes.Unknown:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Unknown = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Unknown\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Unknown",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
+        },
+        {
+          "kind": "Enum",
+          "canonicalReference": "web-resource-manager!KnownValidateResourceTypes:enum",
+          "docComment": "/**\n * Known values of {@link ValidateResourceTypes} that the service accepts.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare const enum KnownValidateResourceTypes "
+            }
+          ],
+          "releaseTag": "Public",
+          "name": "KnownValidateResourceTypes",
+          "members": [
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownValidateResourceTypes.ServerFarm:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "ServerFarm = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"ServerFarm\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "ServerFarm",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            },
+            {
+              "kind": "EnumMember",
+              "canonicalReference": "web-resource-manager!KnownValidateResourceTypes.Site:member",
+              "docComment": "",
+              "excerptTokens": [
+                {
+                  "kind": "Content",
+                  "text": "Site = "
+                },
+                {
+                  "kind": "Content",
+                  "text": "\"Site\""
+                }
+              ],
+              "releaseTag": "Public",
+              "name": "Site",
+              "initializerTokenRange": {
+                "startIndex": 1,
+                "endIndex": 2
+              }
+            }
+          ]
         },
         {
           "kind": "Interface",
@@ -29118,7 +31167,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!PublishingProfileFormat:type",
-          "docComment": "/**\n * Defines values for PublishingProfileFormat.\n */\n",
+          "docComment": "/**\n * Defines values for PublishingProfileFormat. \\ {@link KnownPublishingProfileFormat} can be used interchangeably with PublishingProfileFormat, this enum contains the known values that the service supports. ### Know values supported by the service **FileZilla3** \\ **WebDeploy** \\ **Ftp**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -29126,7 +31175,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"FileZilla3\" | \"WebDeploy\" | \"Ftp\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32699,7 +34748,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!ResourceScopeType:type",
-          "docComment": "/**\n * Defines values for ResourceScopeType.\n */\n",
+          "docComment": "/**\n * Defines values for ResourceScopeType. \\ {@link KnownResourceScopeType} can be used interchangeably with ResourceScopeType, this enum contains the known values that the service supports. ### Know values supported by the service **ServerFarm** \\ **Subscription** \\ **WebSite**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32707,7 +34756,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ServerFarm\" | \"Subscription\" | \"WebSite\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32814,7 +34863,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!RouteType:type",
-          "docComment": "/**\n * Defines values for RouteType.\n */\n",
+          "docComment": "/**\n * Defines values for RouteType. \\ {@link KnownRouteType} can be used interchangeably with RouteType, this enum contains the known values that the service supports. ### Know values supported by the service **DEFAULT** \\ **INHERITED** \\ **STATIC**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32822,7 +34871,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"DEFAULT\" | \"INHERITED\" | \"STATIC\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -32839,7 +34888,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!ScmType:type",
-          "docComment": "/**\n * Defines values for ScmType.\n */\n",
+          "docComment": "/**\n * Defines values for ScmType. \\ {@link KnownScmType} can be used interchangeably with ScmType, this enum contains the known values that the service supports. ### Know values supported by the service **None** \\ **Dropbox** \\ **Tfs** \\ **LocalGit** \\ **GitHub** \\ **CodePlexGit** \\ **CodePlexHg** \\ **BitbucketGit** \\ **BitbucketHg** \\ **ExternalGit** \\ **ExternalHg** \\ **OneDrive** \\ **VSO** \\ **VSTSRM**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -32847,7 +34896,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"None\" | \"Dropbox\" | \"Tfs\" | \"LocalGit\" | \"GitHub\" | \"CodePlexGit\" | \"CodePlexHg\" | \"BitbucketGit\" | \"BitbucketHg\" | \"ExternalGit\" | \"ExternalHg\" | \"OneDrive\" | \"VSO\" | \"VSTSRM\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -36541,7 +38590,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!SkuName:type",
-          "docComment": "/**\n * Defines values for SkuName.\n */\n",
+          "docComment": "/**\n * Defines values for SkuName. \\ {@link KnownSkuName} can be used interchangeably with SkuName, this enum contains the known values that the service supports. ### Know values supported by the service **Free** \\ **Shared** \\ **Basic** \\ **Standard** \\ **Premium** \\ **Dynamic** \\ **Isolated** \\ **PremiumV2** \\ **ElasticPremium** \\ **ElasticIsolated**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -36549,7 +38598,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"Free\" | \"Shared\" | \"Basic\" | \"Standard\" | \"Premium\" | \"Dynamic\" | \"Isolated\" | \"PremiumV2\" | \"ElasticPremium\" | \"ElasticIsolated\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -40450,7 +42499,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!SupportedTlsVersions:type",
-          "docComment": "/**\n * Defines values for SupportedTlsVersions.\n */\n",
+          "docComment": "/**\n * Defines values for SupportedTlsVersions. \\ {@link KnownSupportedTlsVersions} can be used interchangeably with SupportedTlsVersions, this enum contains the known values that the service supports. ### Know values supported by the service **1.0** \\ **1.1** \\ **1.2**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -40458,7 +42507,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"1.0\" | \"1.1\" | \"1.2\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -41410,7 +43459,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!TriggerTypes:type",
-          "docComment": "/**\n * Defines values for TriggerTypes.\n */\n",
+          "docComment": "/**\n * Defines values for TriggerTypes. \\ {@link KnownTriggerTypes} can be used interchangeably with TriggerTypes, this enum contains the known values that the service supports. ### Know values supported by the service **HttpTrigger** \\ **Unknown**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -41418,7 +43467,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"HttpTrigger\" | \"Unknown\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",
@@ -42051,7 +44100,7 @@
         {
           "kind": "TypeAlias",
           "canonicalReference": "web-resource-manager!ValidateResourceTypes:type",
-          "docComment": "/**\n * Defines values for ValidateResourceTypes.\n */\n",
+          "docComment": "/**\n * Defines values for ValidateResourceTypes. \\ {@link KnownValidateResourceTypes} can be used interchangeably with ValidateResourceTypes, this enum contains the known values that the service supports. ### Know values supported by the service **ServerFarm** \\ **Site**\n */\n",
           "excerptTokens": [
             {
               "kind": "Content",
@@ -42059,7 +44108,7 @@
             },
             {
               "kind": "Content",
-              "text": "\"ServerFarm\" | \"Site\" | string"
+              "text": "string"
             },
             {
               "kind": "Content",

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.md
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.md
@@ -189,10 +189,10 @@ export type AppServiceCertificateOrderPatchResource = ProxyOnlyResource & {
 };
 
 // @public
-export type AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type AppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem = string;
 
 // @public
-export type AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type AppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem = string;
 
 // @public
 export type AppServiceCertificateOrdersCreateOrUpdateCertificateResponse = AppServiceCertificateResource & {
@@ -1404,7 +1404,7 @@ export interface BillingMeterCollection {
 }
 
 // @public
-export type BuildStatus = "WaitingForDeployment" | "Uploading" | "Deploying" | "Ready" | "Failed" | "Deleting" | "Detached" | string;
+export type BuildStatus = string;
 
 // @public
 export type BuiltInAuthenticationProvider = "AzureActiveDirectory" | "Facebook" | "Google" | "MicrosoftAccount" | "Twitter";
@@ -1580,7 +1580,7 @@ export type CertificatesUpdateResponse = Certificate & {
 export type Channels = "Notification" | "Api" | "Email" | "Webhook" | "All";
 
 // @public
-export type CheckNameResourceTypes = "Site" | "Slot" | "HostingEnvironment" | "PublishingUser" | "Microsoft.Web/sites" | "Microsoft.Web/sites/slots" | "Microsoft.Web/hostingEnvironments" | "Microsoft.Web/publishingUsers" | string;
+export type CheckNameResourceTypes = string;
 
 // @public
 export type CloneAbilityResult = "Cloneable" | "PartiallyCloneable" | "NotCloneable";
@@ -1864,7 +1864,7 @@ export interface DatabaseBackupSetting {
 }
 
 // @public
-export type DatabaseType = "SqlAzure" | "MySql" | "LocalMySql" | "PostgreSql" | string;
+export type DatabaseType = string;
 
 // @public
 export interface DataSource {
@@ -2505,10 +2505,10 @@ export type DomainPatchResource = ProxyOnlyResource & {
 };
 
 // @public
-export type DomainPatchResourcePropertiesDomainNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type DomainPatchResourcePropertiesDomainNotRenewableReasonsItem = string;
 
 // @public
-export type DomainPropertiesDomainNotRenewableReasonsItem = "RegistrationStatusNotSupportedForRenewal" | "ExpirationNotInRenewalTimeRange" | "SubscriptionNotActive" | string;
+export type DomainPropertiesDomainNotRenewableReasonsItem = string;
 
 // @public
 export interface DomainPurchaseConsent {
@@ -2699,10 +2699,10 @@ export interface EndpointDetail {
 }
 
 // @public
-export type Enum4 = "Windows" | "Linux" | "WindowsFunctions" | "LinuxFunctions" | string;
+export type Enum4 = string;
 
 // @public
-export type Enum5 = "Windows" | "Linux" | "WindowsFunctions" | "LinuxFunctions" | string;
+export type Enum5 = string;
 
 // @public
 export interface ErrorEntity {
@@ -2735,7 +2735,7 @@ export interface FileSystemHttpLogsConfig {
 export type FrequencyUnit = "Day" | "Hour";
 
 // @public
-export type FtpsState = "AllAllowed" | "FtpsOnly" | "Disabled" | string;
+export type FtpsState = string;
 
 // @public
 export type FunctionEnvelope = ProxyOnlyResource & {
@@ -2925,7 +2925,7 @@ export interface IdentifierCollection {
 }
 
 // @public
-export type InAvailabilityReasonType = "Invalid" | "AlreadyExists" | string;
+export type InAvailabilityReasonType = string;
 
 // @public
 export interface InboundEnvironmentEndpoint {
@@ -2991,6 +2991,250 @@ export type KeyVaultReferenceResource = ProxyOnlyResource & {
 
 // @public
 export type KeyVaultSecretStatus = "Initialized" | "WaitingOnCertificateOrder" | "Succeeded" | "CertificateOrderFailed" | "OperationNotPermittedOnKeyVault" | "AzureServiceUnauthorizedToAccessKeyVault" | "KeyVaultDoesNotExist" | "KeyVaultSecretDoesNotExist" | "UnknownError" | "ExternalPrivateKey" | "Unknown";
+
+// @public
+export const enum KnownAppServiceCertificateOrderPatchResourcePropertiesAppServiceCertificateNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownAppServiceCertificateOrderPropertiesAppServiceCertificateNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownBuildStatus {
+    // (undocumented)
+    Deleting = "Deleting",
+    // (undocumented)
+    Deploying = "Deploying",
+    // (undocumented)
+    Detached = "Detached",
+    // (undocumented)
+    Failed = "Failed",
+    // (undocumented)
+    Ready = "Ready",
+    // (undocumented)
+    Uploading = "Uploading",
+    // (undocumented)
+    WaitingForDeployment = "WaitingForDeployment"
+}
+
+// @public
+export const enum KnownCheckNameResourceTypes {
+    // (undocumented)
+    HostingEnvironment = "HostingEnvironment",
+    // (undocumented)
+    MicrosoftWebHostingEnvironments = "Microsoft.Web/hostingEnvironments",
+    // (undocumented)
+    MicrosoftWebPublishingUsers = "Microsoft.Web/publishingUsers",
+    // (undocumented)
+    MicrosoftWebSites = "Microsoft.Web/sites",
+    // (undocumented)
+    MicrosoftWebSitesSlots = "Microsoft.Web/sites/slots",
+    // (undocumented)
+    PublishingUser = "PublishingUser",
+    // (undocumented)
+    Site = "Site",
+    // (undocumented)
+    Slot = "Slot"
+}
+
+// @public
+export const enum KnownDatabaseType {
+    // (undocumented)
+    LocalMySql = "LocalMySql",
+    // (undocumented)
+    MySql = "MySql",
+    // (undocumented)
+    PostgreSql = "PostgreSql",
+    // (undocumented)
+    SqlAzure = "SqlAzure"
+}
+
+// @public
+export const enum KnownDomainPatchResourcePropertiesDomainNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownDomainPropertiesDomainNotRenewableReasonsItem {
+    // (undocumented)
+    ExpirationNotInRenewalTimeRange = "ExpirationNotInRenewalTimeRange",
+    // (undocumented)
+    RegistrationStatusNotSupportedForRenewal = "RegistrationStatusNotSupportedForRenewal",
+    // (undocumented)
+    SubscriptionNotActive = "SubscriptionNotActive"
+}
+
+// @public
+export const enum KnownEnum4 {
+    // (undocumented)
+    Linux = "Linux",
+    // (undocumented)
+    LinuxFunctions = "LinuxFunctions",
+    // (undocumented)
+    Windows = "Windows",
+    // (undocumented)
+    WindowsFunctions = "WindowsFunctions"
+}
+
+// @public
+export const enum KnownEnum5 {
+    // (undocumented)
+    Linux = "Linux",
+    // (undocumented)
+    LinuxFunctions = "LinuxFunctions",
+    // (undocumented)
+    Windows = "Windows",
+    // (undocumented)
+    WindowsFunctions = "WindowsFunctions"
+}
+
+// @public
+export const enum KnownFtpsState {
+    // (undocumented)
+    AllAllowed = "AllAllowed",
+    // (undocumented)
+    Disabled = "Disabled",
+    // (undocumented)
+    FtpsOnly = "FtpsOnly"
+}
+
+// @public
+export const enum KnownInAvailabilityReasonType {
+    // (undocumented)
+    AlreadyExists = "AlreadyExists",
+    // (undocumented)
+    Invalid = "Invalid"
+}
+
+// @public
+export const enum KnownPublishingProfileFormat {
+    // (undocumented)
+    FileZilla3 = "FileZilla3",
+    // (undocumented)
+    Ftp = "Ftp",
+    // (undocumented)
+    WebDeploy = "WebDeploy"
+}
+
+// @public
+export const enum KnownResourceScopeType {
+    // (undocumented)
+    ServerFarm = "ServerFarm",
+    // (undocumented)
+    Subscription = "Subscription",
+    // (undocumented)
+    WebSite = "WebSite"
+}
+
+// @public
+export const enum KnownRouteType {
+    // (undocumented)
+    Default = "DEFAULT",
+    // (undocumented)
+    Inherited = "INHERITED",
+    // (undocumented)
+    Static = "STATIC"
+}
+
+// @public
+export const enum KnownScmType {
+    // (undocumented)
+    BitbucketGit = "BitbucketGit",
+    // (undocumented)
+    BitbucketHg = "BitbucketHg",
+    // (undocumented)
+    CodePlexGit = "CodePlexGit",
+    // (undocumented)
+    CodePlexHg = "CodePlexHg",
+    // (undocumented)
+    Dropbox = "Dropbox",
+    // (undocumented)
+    ExternalGit = "ExternalGit",
+    // (undocumented)
+    ExternalHg = "ExternalHg",
+    // (undocumented)
+    GitHub = "GitHub",
+    // (undocumented)
+    LocalGit = "LocalGit",
+    // (undocumented)
+    None = "None",
+    // (undocumented)
+    OneDrive = "OneDrive",
+    // (undocumented)
+    Tfs = "Tfs",
+    // (undocumented)
+    VSO = "VSO",
+    // (undocumented)
+    Vstsrm = "VSTSRM"
+}
+
+// @public
+export const enum KnownSkuName {
+    // (undocumented)
+    Basic = "Basic",
+    // (undocumented)
+    Dynamic = "Dynamic",
+    // (undocumented)
+    ElasticIsolated = "ElasticIsolated",
+    // (undocumented)
+    ElasticPremium = "ElasticPremium",
+    // (undocumented)
+    Free = "Free",
+    // (undocumented)
+    Isolated = "Isolated",
+    // (undocumented)
+    Premium = "Premium",
+    // (undocumented)
+    PremiumV2 = "PremiumV2",
+    // (undocumented)
+    Shared = "Shared",
+    // (undocumented)
+    Standard = "Standard"
+}
+
+// @public
+export const enum KnownSupportedTlsVersions {
+    // (undocumented)
+    One0 = "1.0",
+    // (undocumented)
+    One1 = "1.1",
+    // (undocumented)
+    One2 = "1.2"
+}
+
+// @public
+export const enum KnownTriggerTypes {
+    // (undocumented)
+    HttpTrigger = "HttpTrigger",
+    // (undocumented)
+    Unknown = "Unknown"
+}
+
+// @public
+export const enum KnownValidateResourceTypes {
+    // (undocumented)
+    ServerFarm = "ServerFarm",
+    // (undocumented)
+    Site = "Site"
+}
 
 // @public
 export interface LocalizableString {
@@ -3517,7 +3761,7 @@ export interface PublicCertificateCollection {
 export type PublicCertificateLocation = "CurrentUserMy" | "LocalMachineMy" | "Unknown";
 
 // @public
-export type PublishingProfileFormat = "FileZilla3" | "WebDeploy" | "Ftp" | string;
+export type PublishingProfileFormat = string;
 
 // @public
 export type PushSettings = ProxyOnlyResource & {
@@ -3953,7 +4197,7 @@ export interface ResourceNameAvailabilityRequest {
 }
 
 // @public
-export type ResourceScopeType = "ServerFarm" | "Subscription" | "WebSite" | string;
+export type ResourceScopeType = string;
 
 // @public (undocumented)
 export interface ResponseMetaData {
@@ -3976,10 +4220,10 @@ export type RestoreRequest = ProxyOnlyResource & {
 };
 
 // @public
-export type RouteType = "DEFAULT" | "INHERITED" | "STATIC" | string;
+export type RouteType = string;
 
 // @public
-export type ScmType = "None" | "Dropbox" | "Tfs" | "LocalGit" | "GitHub" | "CodePlexGit" | "CodePlexHg" | "BitbucketGit" | "BitbucketHg" | "ExternalGit" | "ExternalHg" | "OneDrive" | "VSO" | "VSTSRM" | string;
+export type ScmType = string;
 
 // @public
 export interface ServiceSpecification {
@@ -4388,7 +4632,7 @@ export interface SkuInfos {
 }
 
 // @public
-export type SkuName = "Free" | "Shared" | "Basic" | "Standard" | "Premium" | "Dynamic" | "Isolated" | "PremiumV2" | "ElasticPremium" | "ElasticIsolated" | string;
+export type SkuName = string;
 
 // @public
 export type SlotConfigNamesResource = ProxyOnlyResource & {
@@ -4878,7 +5122,7 @@ export type StringDictionary = ProxyOnlyResource & {
 };
 
 // @public
-export type SupportedTlsVersions = "1.0" | "1.1" | "1.2" | string;
+export type SupportedTlsVersions = string;
 
 // @public
 export type SwiftVirtualNetwork = ProxyOnlyResource & {
@@ -5009,7 +5253,7 @@ export interface TriggeredWebJobCollection {
 export type TriggeredWebJobStatus = "Success" | "Failed" | "Error";
 
 // @public
-export type TriggerTypes = "HttpTrigger" | "Unknown" | string;
+export type TriggerTypes = string;
 
 // @public
 export type UnauthenticatedClientAction = "RedirectToLoginPage" | "AllowAnonymous";
@@ -5065,7 +5309,7 @@ export interface ValidateRequest {
 }
 
 // @public
-export type ValidateResourceTypes = "ServerFarm" | "Site" | string;
+export type ValidateResourceTypes = string;
 
 // @public
 export interface ValidateResponse {
@@ -8344,7 +8588,7 @@ export type WorkerSizeOptions = "Small" | "Medium" | "Large" | "D1" | "D2" | "D3
 
 // Warnings were encountered during analysis:
 //
-// src/models/index.ts:9399:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
+// src/models/index.ts:9675:5 - (ae-forgotten-export) The symbol "LROResponseInfo" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/test/smoke/generated/web-resource-manager/tsconfig.json
+++ b/test/smoke/generated/web-resource-manager/tsconfig.json
@@ -9,6 +9,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",

--- a/test/unit/transforms/transforms.spec.ts
+++ b/test/unit/transforms/transforms.spec.ts
@@ -102,7 +102,7 @@ describe("Transforms", () => {
       assert.strictEqual(colorUnion.description, "Defines values for Color.");
       assert.deepEqual(
         colorUnion.properties.map(p => p.value),
-        [`"red"`, `"green"`, `"blue"`]
+        [`red`, `green`, `blue`]
       );
     });
   });


### PR DESCRIPTION
**Problem:**
Currently Autorest generates extensible enums as an union type of the options plus the type i.e

```typescript
type Status = "success" | "failure" | "canceled" | string
```

However Typescript collapses it and the type ends up being `string` and IDEs such as VSCode don't provide any auto complete help.

**Soulution:**
The solution involves 2 parts:

1. Document all possible options with JSDoc while typing the "enum" as string
2. Generate a helper enum with the know options supported by the service.

**Note:** The helper enum is only generated for string and numbers. Other types only get (1). Autorest only supports enums of types `string`, `number` and `boolean`.


### Before

```typescript
/**
 * Defines values for EnforcementMode.
 */
export type EnforcementMode = "Default" | "DoNotEnforce" | string;
```

**VSCode docs:**
![image](https://user-images.githubusercontent.com/21109913/99742503-6e564b00-2a88-11eb-84b0-1180a764aae5.png)


### After
**Generated Code**
```typescript
/**
 * Known values of {@link EnforcementMode} that the service accepts.
 */
export const enum KnownEnforcementMode {
  /**
   * The policy effect is enforced during resource creation or update.
   */
  Default = "Default",
  /**
   * The policy effect is not enforced during resource creation or update.
   */
  DoNotEnforce = "DoNotEnforce"
}

/**
 * Defines values for EnforcementMode. \
 * {@link KnownEnforcementMode} can be used interchangeably with EnforcementMode,
 *  this enum contains the known values that the service supports.
 * ### Know values supported by the service
 * **Default**: The policy effect is enforced during resource creation or update. \
 * **DoNotEnforce**: The policy effect is not enforced during resource creation or update.
 */
export type EnforcementMode = string;

```

**VSCode docs**
![image](https://user-images.githubusercontent.com/21109913/99742408-3ea74300-2a88-11eb-86bd-4ce9b76c727d.png)
