### PR TITLE
Exclude flattened parameters from method signature

### DIFF
--- a/src/generators/utils/parameterUtils.ts
+++ b/src/generators/utils/parameterUtils.ts
@@ -113,7 +113,7 @@ export function getOperationParameterSignatures(
 ) {
   const operationParameters = filterOperationParameters(parameters, operation, {
     includeContentType: true
-  });
+  }).filter(p => !p.isFlattened);
 
   const operationRequests = operation.requests;
   const overloadParameterDeclarations: ParameterWithDescription[][] = [];

--- a/test/smoke/generated/web-resource-manager/review/web-resource-manager.api.md
+++ b/test/smoke/generated/web-resource-manager/review/web-resource-manager.api.md
@@ -8052,7 +8052,7 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
     //
     // (undocumented)
     certificates: Certificates;
-    checkNameAvailability(request: ResourceNameAvailabilityRequest, name: string, typeParam: CheckNameResourceTypes, options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
+    checkNameAvailability(name: string, typeParam: CheckNameResourceTypes, options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
     // Warning: (ae-forgotten-export) The symbol "DeletedWebApps" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
@@ -47,7 +47,6 @@ import {
   WebSiteManagementClientGetSourceControlResponse,
   WebSiteManagementClientUpdateSourceControlResponse,
   WebSiteManagementClientListBillingMetersResponse,
-  ResourceNameAvailabilityRequest,
   CheckNameResourceTypes,
   WebSiteManagementClientCheckNameAvailabilityOptionalParams,
   WebSiteManagementClientCheckNameAvailabilityResponse,
@@ -444,19 +443,16 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
 
   /**
    * Description for Check if a resource name is available.
-   * @param request Name availability request.
    * @param name Resource name to verify.
    * @param typeParam Resource type used for verification.
    * @param options The options parameters.
    */
   checkNameAvailability(
-    request: ResourceNameAvailabilityRequest,
     name: string,
     typeParam: CheckNameResourceTypes,
     options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams
   ): Promise<WebSiteManagementClientCheckNameAvailabilityResponse> {
     const operationArguments: coreHttp.OperationArguments = {
-      request,
       name,
       typeParam,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.json
@@ -61699,20 +61699,11 @@
             {
               "kind": "Method",
               "canonicalReference": "web-resource-manager!WebSiteManagementClient#checkNameAvailability:member(1)",
-              "docComment": "/**\n * Description for Check if a resource name is available.\n *\n * @param request - Name availability request.\n *\n * @param name - Resource name to verify.\n *\n * @param typeParam - Resource type used for verification.\n *\n * @param options - The options parameters.\n */\n",
+              "docComment": "/**\n * Description for Check if a resource name is available.\n *\n * @param name - Resource name to verify.\n *\n * @param typeParam - Resource type used for verification.\n *\n * @param options - The options parameters.\n */\n",
               "excerptTokens": [
                 {
                   "kind": "Content",
-                  "text": "checkNameAvailability(request: "
-                },
-                {
-                  "kind": "Reference",
-                  "text": "ResourceNameAvailabilityRequest",
-                  "canonicalReference": "web-resource-manager!ResourceNameAvailabilityRequest:interface"
-                },
-                {
-                  "kind": "Content",
-                  "text": ", name: "
+                  "text": "checkNameAvailability(name: "
                 },
                 {
                   "kind": "Content",
@@ -61765,38 +61756,31 @@
               ],
               "isStatic": false,
               "returnTypeTokenRange": {
-                "startIndex": 9,
-                "endIndex": 13
+                "startIndex": 7,
+                "endIndex": 11
               },
               "releaseTag": "Public",
               "overloadIndex": 1,
               "parameters": [
                 {
-                  "parameterName": "request",
+                  "parameterName": "name",
                   "parameterTypeTokenRange": {
                     "startIndex": 1,
                     "endIndex": 2
                   }
                 },
                 {
-                  "parameterName": "name",
+                  "parameterName": "typeParam",
                   "parameterTypeTokenRange": {
                     "startIndex": 3,
                     "endIndex": 4
                   }
                 },
                 {
-                  "parameterName": "typeParam",
+                  "parameterName": "options",
                   "parameterTypeTokenRange": {
                     "startIndex": 5,
                     "endIndex": 6
-                  }
-                },
-                {
-                  "parameterName": "options",
-                  "parameterTypeTokenRange": {
-                    "startIndex": 7,
-                    "endIndex": 8
                   }
                 }
               ],

--- a/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.md
+++ b/test/smoke/generated/web-resource-manager/temp/web-resource-manager.api.md
@@ -8052,7 +8052,7 @@ export class WebSiteManagementClient extends WebSiteManagementClientContext {
     //
     // (undocumented)
     certificates: Certificates;
-    checkNameAvailability(request: ResourceNameAvailabilityRequest, name: string, typeParam: CheckNameResourceTypes, options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
+    checkNameAvailability(name: string, typeParam: CheckNameResourceTypes, options?: WebSiteManagementClientCheckNameAvailabilityOptionalParams): Promise<WebSiteManagementClientCheckNameAvailabilityResponse>;
     // Warning: (ae-forgotten-export) The symbol "DeletedWebApps" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)


### PR DESCRIPTION
**Problem**
We're including the original parameter that got flattened in the operation signature for paging operations

**Fix:**
Filter out parameters marked as flattened when getting the signature parameters