### PR TITLE
Reliably add generated pipeline policies to default

### DIFF
--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -174,16 +174,33 @@ const writeStatements = (lines: string[], shouldAddBlankLine = false) => (
 };
 
 function writeDefaultOptions(hasCredentials: boolean, hasLRO: boolean) {
-  const policies = ` 
-  const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-  ? options.requestPolicyFactories
-  : coreHttp.createPipelineFromOptions(options)
-      .requestPolicyFactories as coreHttp.RequestPolicyFactory[];
-
-  options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };`;
+  const addLROPolicy = hasLRO
+    ? `
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [lroPolicy(), ...options.requestPolicyFactories]
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = defaultFactories => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+     
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add 
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => ([lroPolicy(), ...defaultFactories])
+    }`
+    : "";
 
   return `// Initializing default values for options
   if (!options) {
@@ -194,8 +211,8 @@ function writeDefaultOptions(hasCredentials: boolean, hasLRO: boolean) {
      const defaultUserAgent = coreHttp.getDefaultUserAgentValue();
      options.userAgent = \`\${packageName}/\${packageVersion} \${defaultUserAgent}\`;
    }
-  
-   ${hasLRO ? policies : ""}
+
+  ${addLROPolicy}
 
   super(${hasCredentials ? "credentials" : `undefined`}, options);
   

--- a/src/generators/clientContextFileGenerator.ts
+++ b/src/generators/clientContextFileGenerator.ts
@@ -176,7 +176,7 @@ const writeStatements = (lines: string[], shouldAddBlankLine = false) => (
 function writeDefaultOptions(hasCredentials: boolean, hasLRO: boolean) {
   const addLROPolicy = hasLRO
     ? `
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/integration/azureSpecialProperties.spec.ts
+++ b/test/integration/azureSpecialProperties.spec.ts
@@ -3,6 +3,7 @@ import {
   AzureSpecialPropertiesClientOptionalParams
 } from "./generated/azureSpecialProperties/src";
 import { assert } from "chai";
+
 import {
   OperationOptions,
   RestError,
@@ -11,6 +12,35 @@ import {
   TokenCredential,
   HttpHeaders
 } from "@azure/core-http";
+
+describe.only("auth validation", () => {
+  it("should add authorization header", async () => {
+    const mockCredential: TokenCredential = {
+      getToken: async _scopes => {
+        return {
+          token: "test-token",
+          expiresOnTimestamp: 111111
+        };
+      }
+    };
+
+    const client = new AzureSpecialPropertiesClient(
+      mockCredential,
+      "1234-5678-9012-3456"
+    );
+
+    const result = await client.apiVersionDefault.getMethodGlobalValid();
+
+    // Validate operation
+    assert.equal(result._response.status, 200);
+
+    // Validate auth header
+    assert.equal(
+      result._response.request.headers.get("authorization"),
+      "Bearer test-token"
+    );
+  });
+});
 
 describe("AzureSpecialProperties", () => {
   let client: AzureSpecialPropertiesClient;

--- a/test/integration/generated/lro/src/lROClientContext.ts
+++ b/test/integration/generated/lro/src/lROClientContext.ts
@@ -31,7 +31,7 @@ export class LROClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/integration/generated/lro/src/lROClientContext.ts
+++ b/test/integration/generated/lro/src/lROClientContext.ts
@@ -31,15 +31,35 @@ export class LROClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(undefined, options);
 

--- a/test/integration/generated/lroParametrizedEndpoints/src/lroParametrizedEndpointsClientContext.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lroParametrizedEndpointsClientContext.ts
@@ -31,7 +31,7 @@ export class LroParametrizedEndpointsClientContext extends coreHttp.ServiceClien
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/integration/generated/lroParametrizedEndpoints/src/lroParametrizedEndpointsClientContext.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lroParametrizedEndpointsClientContext.ts
@@ -31,15 +31,35 @@ export class LroParametrizedEndpointsClientContext extends coreHttp.ServiceClien
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(undefined, options);
 

--- a/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
@@ -36,7 +36,7 @@ export class MediaTypesV3LROClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/mediaTypesV3LROClientContext.ts
@@ -36,15 +36,35 @@ export class MediaTypesV3LROClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(undefined, options);
 

--- a/test/integration/generated/paging/src/pagingClientContext.ts
+++ b/test/integration/generated/paging/src/pagingClientContext.ts
@@ -31,15 +31,35 @@ export class PagingClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(undefined, options);
 

--- a/test/integration/generated/paging/src/pagingClientContext.ts
+++ b/test/integration/generated/paging/src/pagingClientContext.ts
@@ -31,7 +31,7 @@ export class PagingClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/integration/generated/pagingNoIterators/src/pagingNoIteratorsClientContext.ts
+++ b/test/integration/generated/pagingNoIterators/src/pagingNoIteratorsClientContext.ts
@@ -31,7 +31,7 @@ export class PagingNoIteratorsClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/integration/generated/pagingNoIterators/src/pagingNoIteratorsClientContext.ts
+++ b/test/integration/generated/pagingNoIterators/src/pagingNoIteratorsClientContext.ts
@@ -31,15 +31,35 @@ export class PagingNoIteratorsClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(undefined, options);
 

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClientContext.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClientContext.ts
@@ -46,7 +46,7 @@ export class DeploymentScriptsClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClientContext.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClientContext.ts
@@ -46,15 +46,35 @@ export class DeploymentScriptsClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClientContext.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClientContext.ts
@@ -46,15 +46,35 @@ export class ApplicationClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClientContext.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClientContext.ts
@@ -46,7 +46,7 @@ export class ApplicationClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClientContext.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClientContext.ts
@@ -46,15 +46,35 @@ export class ResourceManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClientContext.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClientContext.ts
@@ -46,7 +46,7 @@ export class ResourceManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
+++ b/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
@@ -46,7 +46,7 @@ export class ComputeManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
+++ b/test/smoke/generated/compute-resource-manager/src/computeManagementClientContext.ts
@@ -46,15 +46,35 @@ export class ComputeManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
@@ -45,7 +45,7 @@ export class CosmosDBManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClientContext.ts
@@ -45,15 +45,35 @@ export class CosmosDBManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
@@ -47,15 +47,35 @@ export class KeyVaultManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClientContext.ts
@@ -47,7 +47,7 @@ export class KeyVaultManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
+++ b/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
@@ -46,7 +46,7 @@ export class NetworkManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
+++ b/test/smoke/generated/network-resource-manager/src/networkManagementClientContext.ts
@@ -46,15 +46,35 @@ export class NetworkManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/sql-resource-manager/src/sqlManagementClientContext.ts
+++ b/test/smoke/generated/sql-resource-manager/src/sqlManagementClientContext.ts
@@ -45,15 +45,35 @@ export class SqlManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/sql-resource-manager/src/sqlManagementClientContext.ts
+++ b/test/smoke/generated/sql-resource-manager/src/sqlManagementClientContext.ts
@@ -45,7 +45,7 @@ export class SqlManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
@@ -46,7 +46,7 @@ export class StorageManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClientContext.ts
@@ -46,15 +46,35 @@ export class StorageManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClientContext.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClientContext.ts
@@ -47,7 +47,7 @@ export class WebSiteManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    // Building the rquest policy fatories based on the passed factories and the
+    // Building the request policy fatories based on the passed factories and the
     // any required factories needed by the client.
     if (Array.isArray(options.requestPolicyFactories)) {
       // When an array of factories is passed in, we'll just add the required factories,

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClientContext.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClientContext.ts
@@ -47,15 +47,35 @@ export class WebSiteManagementClientContext extends coreHttp.ServiceClient {
       options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
     }
 
-    const defaultPipelines = Array.isArray(options.requestPolicyFactories)
-      ? options.requestPolicyFactories
-      : (coreHttp.createPipelineFromOptions(options)
-          .requestPolicyFactories as coreHttp.RequestPolicyFactory[]);
-
-    options = {
-      ...options,
-      requestPolicyFactories: [lroPolicy(), ...defaultPipelines]
-    };
+    // Building the rquest policy fatories based on the passed factories and the
+    // any required factories needed by the client.
+    if (Array.isArray(options.requestPolicyFactories)) {
+      // When an array of factories is passed in, we'll just add the required factories,
+      // in this case lroPolicy(). It is important to note that passing an array of factories
+      // to a new client, bypasses core-http default factories. Just the pipelines provided will be run.
+      options.requestPolicyFactories = [
+        lroPolicy(),
+        ...options.requestPolicyFactories
+      ];
+    } else if (options.requestPolicyFactories) {
+      // When we were passed a requestPolicyFactories as a function, we'll create a new one that adds the factories provided
+      // in the options plus the required policies. When using this path, the pipelines passed to the client will be added to the
+      // default policies added by core-http
+      const optionsPolicies = options.requestPolicyFactories([lroPolicy()]) || [
+        lroPolicy()
+      ];
+      options.requestPolicyFactories = (defaultFactories) => [
+        ...optionsPolicies,
+        ...defaultFactories
+      ];
+    } else {
+      // In case no request policy factories were provided, we'll just need to create a function that will add
+      // the lroPolicy to the default pipelines added by core-http
+      options.requestPolicyFactories = (defaultFactories) => [
+        lroPolicy(),
+        ...defaultFactories
+      ];
+    }
 
     super(credentials, options);
 

--- a/test/utils/smoke-test-list.ts
+++ b/test/utils/smoke-test-list.ts
@@ -14,12 +14,12 @@ export enum AutorestParams {
 
 const getArmReadmes = (): SpecDefinition[] => {
   const armTags = [
-    "package-features-2015-12",
-    "package-locks-2016-09",
-    "package-policy-2019-09",
+    // "package-features-2015-12",
+    // "package-locks-2016-09",
+    // "package-policy-2019-09",
     "package-resources-2019-08",
-    "package-subscriptions-2019-06",
-    "package-links-2016-09",
+    // "package-subscriptions-2019-06",
+    // "package-links-2016-09",
     "package-managedapplications-2018-06",
     "package-deploymentscripts-2019-10-preview"
   ];
@@ -27,7 +27,7 @@ const getArmReadmes = (): SpecDefinition[] => {
     path: "./.tmp/specs/specification/resources/resource-manager/readme.md",
     params: [`--tag=${tag}`],
     outputFolderName: `arm-${tag}`,
-    buildTag: "ci_1"
+    buildTag: "debug"
   }));
 };
 
@@ -36,11 +36,11 @@ export const readmes: SpecDefinition[] = [
   {
     path: "./.tmp/specs/specification/sql/resource-manager/readme.md",
     params: [AutorestParams.ModelDedup],
-    buildTag: "ci_1"
+    buildTag: "debug"
   },
   {
     path: "./.tmp/specs/specification/web/resource-manager/readme.md",
-    buildTag: "ci_2"
+    buildTag: "debug"
   },
   {
     path: "./.tmp/specs/specification/monitor/data-plane/readme.md",
@@ -53,7 +53,7 @@ export const readmes: SpecDefinition[] = [
   {
     path: "./.tmp/specs/specification/cosmos-db/resource-manager/readme.md",
     params: [AutorestParams.ModelDedup],
-    buildTag: "ci_2"
+    buildTag: "debug"
   },
   {
     path: "./.tmp/specs/specification/compute/resource-manager/readme.md",
@@ -61,16 +61,16 @@ export const readmes: SpecDefinition[] = [
   },
   {
     path: "./.tmp/specs/specification/network/resource-manager/readme.md",
-    buildTag: "ci_3"
+    buildTag: "debug"
   },
   {
     path: "./.tmp/specs/specification/keyvault/resource-manager/readme.md",
-    buildTag: "ci_3"
+    buildTag: "debug"
   },
   {
     path: "./.tmp/specs/specification/storage/resource-manager/readme.md",
     params: [AutorestParams.ModelDedup],
-    buildTag: "ci_3"
+    buildTag: "debug"
   },
   {
     path: "./.tmp/specs/specification/msi/resource-manager/readme.md",

--- a/test/utils/smoke-test-list.ts
+++ b/test/utils/smoke-test-list.ts
@@ -14,12 +14,12 @@ export enum AutorestParams {
 
 const getArmReadmes = (): SpecDefinition[] => {
   const armTags = [
-    // "package-features-2015-12",
-    // "package-locks-2016-09",
-    // "package-policy-2019-09",
+    "package-features-2015-12",
+    "package-locks-2016-09",
+    "package-policy-2019-09",
     "package-resources-2019-08",
-    // "package-subscriptions-2019-06",
-    // "package-links-2016-09",
+    "package-subscriptions-2019-06",
+    "package-links-2016-09",
     "package-managedapplications-2018-06",
     "package-deploymentscripts-2019-10-preview"
   ];
@@ -27,7 +27,7 @@ const getArmReadmes = (): SpecDefinition[] => {
     path: "./.tmp/specs/specification/resources/resource-manager/readme.md",
     params: [`--tag=${tag}`],
     outputFolderName: `arm-${tag}`,
-    buildTag: "debug"
+    buildTag: "ci_1"
   }));
 };
 
@@ -36,11 +36,11 @@ export const readmes: SpecDefinition[] = [
   {
     path: "./.tmp/specs/specification/sql/resource-manager/readme.md",
     params: [AutorestParams.ModelDedup],
-    buildTag: "debug"
+    buildTag: "ci_1"
   },
   {
     path: "./.tmp/specs/specification/web/resource-manager/readme.md",
-    buildTag: "debug"
+    buildTag: "ci_2"
   },
   {
     path: "./.tmp/specs/specification/monitor/data-plane/readme.md",
@@ -53,7 +53,7 @@ export const readmes: SpecDefinition[] = [
   {
     path: "./.tmp/specs/specification/cosmos-db/resource-manager/readme.md",
     params: [AutorestParams.ModelDedup],
-    buildTag: "debug"
+    buildTag: "ci_2"
   },
   {
     path: "./.tmp/specs/specification/compute/resource-manager/readme.md",
@@ -61,16 +61,16 @@ export const readmes: SpecDefinition[] = [
   },
   {
     path: "./.tmp/specs/specification/network/resource-manager/readme.md",
-    buildTag: "debug"
+    buildTag: "ci_3"
   },
   {
     path: "./.tmp/specs/specification/keyvault/resource-manager/readme.md",
-    buildTag: "debug"
+    buildTag: "ci_3"
   },
   {
     path: "./.tmp/specs/specification/storage/resource-manager/readme.md",
     params: [AutorestParams.ModelDedup],
-    buildTag: "debug"
+    buildTag: "ci_3"
   },
   {
     path: "./.tmp/specs/specification/msi/resource-manager/readme.md",


### PR DESCRIPTION
They way we add LRO policy and honor policies passed in `options.requestPolicyFactories` is not reliable  as we effectively bypass the default policyFactories added by `core-http`, the reason for this is that passing requestPolicyFactories as an array of factories tells `core-http` to not try adding any of the default policies see [here](https://github.com/Azure/azure-sdk-for-js/blob/98d87615a511484ed797cb1b91102432e1b16e70/sdk/core/core-http/src/serviceClient.ts#L201).

The fix in this PR is to handle the 3 scenarios we can face when working with LRO and policies

1) We are given an array of policy factories by the user. In this scenario the user decides to provide a list of all the pipelines they want to have and `core-http` won't add any default pipelines. We append the LRO policy to the array provided

2) We are given a function in the form `(defaultPolicies) =>  {}` which is for the scenario where the user wants to provide a set of policies to add to the default policies created by `core-http` in this scenario we append the LRO policy to the policies provided by the user which will eventually get added to the default policies by `core-http`

3) The user doesn't provide any pipelinePolicies, in this case we just add the LRO policy to the default policies that core-http will eventually add.

This fix addresses a related issue where the Authorization header is not being set, this was caused by us passing the LRO policy in an array by itself in `options.requestPolicyPipelines` which bypasses all default pipelines, including the auth pipeline