### PR TITLE
Fix operations export

### DIFF
--- a/src/generators/indexGenerator.ts
+++ b/src/generators/indexGenerator.ts
@@ -1,5 +1,6 @@
 import { Project } from "ts-morph";
 import { ClientDetails } from "../models/clientDetails";
+import { OperationGroupDetails } from "../models/operationDetails";
 
 export function generateIndexFile(
   clientDetails: ClientDetails,
@@ -20,7 +21,10 @@ export function generateIndexFile(
     indexFile.addStatements([`/// <reference lib="esnext.asynciterable" />`]);
   }
 
-  indexFile.addExportDeclarations([
+  let exportDeclarations = [
+    {
+      moduleSpecifier: "./operations"
+    },
     {
       moduleSpecifier: "./models"
     },
@@ -32,5 +36,28 @@ export function generateIndexFile(
       moduleSpecifier: `./${clientDetails.sourceFileName}Context`,
       namedExports: [`${clientDetails.className}Context`]
     }
-  ]);
+  ];
+
+  if (
+    !isOperationsAvailable(
+      clientDetails.operationGroups,
+      clientDetails.className
+    )
+  ) {
+    exportDeclarations.shift();
+  }
+
+  indexFile.addExportDeclarations(exportDeclarations);
+}
+
+function isOperationsAvailable(
+  operationGroups: OperationGroupDetails[],
+  sourceFileName: string
+): boolean {
+  for (let og of operationGroups) {
+    if (og.name !== sourceFileName) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/src/generators/indexGenerator.ts
+++ b/src/generators/indexGenerator.ts
@@ -52,10 +52,10 @@ export function generateIndexFile(
 
 function isOperationsAvailable(
   operationGroups: OperationGroupDetails[],
-  sourceFileName: string
+  className: string
 ): boolean {
   for (let og of operationGroups) {
-    if (og.name !== sourceFileName) {
+    if (og.name !== className) {
       return true;
     }
   }

--- a/src/generators/static/rollupConfigFileGenerator.ts
+++ b/src/generators/static/rollupConfigFileGenerator.ts
@@ -36,8 +36,7 @@ export function generateRollupConfig(
   const rollupConfig = `{
     input: "./esm/${clientDetails.sourceFileName}.js",
     external: [
-      "@azure/core-http",
-      "@azure/core-arm"
+      "@azure/core-http"
     ],
     output: {
       file: "./dist/${packageDetails.nameWithoutScope}.js",
@@ -45,8 +44,7 @@ export function generateRollupConfig(
       name: "${browserNameSpace}",
       sourcemap: true,
       globals: {
-        "@azure/core-http": "coreHttp",
-        "@azure/core-arm": "coreArm"
+        "@azure/core-http": "coreHttp"
       },
       banner: \`/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/bodyComplex.spec.ts
+++ b/test/integration/bodyComplex.spec.ts
@@ -29,12 +29,12 @@ const clientOptions = {
           testClient = new Client(clientOptions);
         });
         it("should get and put valid basic type properties", async function() {
-          const result = await testClient.basic.getValid();
+          const result = await testClient.basicop.getValid();
           assert.strictEqual(result.id, 2);
           assert.strictEqual(result.name, "abc");
           assert.strictEqual(result.color, "YELLOW");
 
-          const putResult = await testClient.basic.putValid({
+          const putResult = await testClient.basicop.putValid({
             id: 2,
             name: "abc",
             color: "Magenta"
@@ -44,25 +44,25 @@ const clientOptions = {
         });
 
         it("should get null basic type properties", async function() {
-          const result = await testClient.basic.getNull();
+          const result = await testClient.basicop.getNull();
           assert.strictEqual(null, result.id);
           assert.strictEqual(null, result.name);
         });
 
         it("should get empty basic type properties", async () => {
-          const result = await testClient.basic.getEmpty();
+          const result = await testClient.basicop.getEmpty();
           assert.strictEqual(result.id, undefined);
           assert.strictEqual(result.name, undefined);
         });
 
         it("should get basic type properties when the payload is empty", async () => {
-          await testClient.basic.getNotProvided();
+          await testClient.basicop.getNotProvided();
           assert.ok("Request succeeded with no errors");
         });
 
         it("should deserialize invalid basic types without throwing", async () => {
           // TODO double check
-          const result = await testClient.basic.getInvalid();
+          const result = await testClient.basicop.getInvalid();
           assert.ok("Deserialized invalid basic types without throwing");
         });
       });
@@ -756,7 +756,7 @@ describe("Validate pipelines", () => {
       endpoint: "http://localhost:3000",
       requestPolicyFactories: [customPolicy]
     });
-    const result = await client.basic.getValid();
+    const result = await client.basicop.getValid();
 
     // Valiedate Operation
     // Verify that the operation works as expected
@@ -786,7 +786,7 @@ describe("Validate pipelines", () => {
         ...defaultPolicies
       ]
     });
-    const { _response, ...result } = await client.basic.getValid();
+    const { _response, ...result } = await client.basicop.getValid();
 
     // Valiedate Operation
     assert.deepStrictEqual(result, { id: 2, name: "abc", color: "YELLOW" });

--- a/test/integration/extensibleEnums.spec.ts
+++ b/test/integration/extensibleEnums.spec.ts
@@ -1,7 +1,7 @@
 import { assert } from "chai";
 import {
   ExtensibleEnumsClient,
-  PetGetByPetIdResponse
+  PetopGetByPetIdResponse
 } from "./generated/extensibleEnums/src";
 
 describe("Integration tests for extensible enums", () => {
@@ -12,8 +12,8 @@ describe("Integration tests for extensible enums", () => {
   });
 
   it("sends an unexpected enum value successfully", async () => {
-    const response = await client.pet.getByPetId("casper");
-    const expected: Partial<PetGetByPetIdResponse> = {
+    const response = await client.petop.getByPetId("casper");
+    const expected: Partial<PetopGetByPetIdResponse> = {
       daysOfWeek: "Weekend",
       intEnum: "2",
       name: "Casper Ghosty"
@@ -23,8 +23,8 @@ describe("Integration tests for extensible enums", () => {
   });
 
   it("sends an expected enum value successfully", async () => {
-    const response = await client.pet.getByPetId("tommy");
-    const expected: Partial<PetGetByPetIdResponse> = {
+    const response = await client.petop.getByPetId("tommy");
+    const expected: Partial<PetopGetByPetIdResponse> = {
       daysOfWeek: "Monday",
       intEnum: "1",
       name: "Tommy Tomson"
@@ -34,8 +34,8 @@ describe("Integration tests for extensible enums", () => {
   });
 
   it("sends an allowed enum value successfully", async () => {
-    const response = await client.pet.getByPetId("scooby");
-    const expected: Partial<PetGetByPetIdResponse> = {
+    const response = await client.petop.getByPetId("scooby");
+    const expected: Partial<PetopGetByPetIdResponse> = {
       daysOfWeek: "Thursday",
       intEnum: "2.1",
       name: "Scooby Scarface"
@@ -45,13 +45,13 @@ describe("Integration tests for extensible enums", () => {
   });
 
   it("sends and receives enum value successfully", async () => {
-    const expected: Partial<PetGetByPetIdResponse> = {
+    const expected: Partial<PetopGetByPetIdResponse> = {
       name: "Retriever",
       intEnum: "3",
       daysOfWeek: "Sunday"
     };
 
-    const response = await client.pet.addPet({
+    const response = await client.petop.addPet({
       petParam: {
         name: "Retriever",
         intEnum: "3",

--- a/test/integration/generated/additionalProperties/rollup.config.js
+++ b/test/integration/generated/additionalProperties/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/additionalPropertiesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/additional-properties.js",
     format: "umd",
     name: "AdditionalProperties",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/additionalProperties/src/index.ts
+++ b/test/integration/generated/additionalProperties/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { AdditionalPropertiesClient } from "./additionalPropertiesClient";
 export { AdditionalPropertiesClientContext } from "./additionalPropertiesClientContext";

--- a/test/integration/generated/arrayConstraints/rollup.config.js
+++ b/test/integration/generated/arrayConstraints/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/arrayConstraintsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/array-constraints-client.js",
     format: "umd",
     name: "ArrayConstraintsClient",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureParameterGrouping/rollup.config.js
+++ b/test/integration/generated/azureParameterGrouping/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/azureParameterGroupingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/azure-parameter-grouping.js",
     format: "umd",
     name: "AzureParameterGrouping",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureParameterGrouping/src/index.ts
+++ b/test/integration/generated/azureParameterGrouping/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { AzureParameterGroupingClient } from "./azureParameterGroupingClient";
 export { AzureParameterGroupingClientContext } from "./azureParameterGroupingClientContext";

--- a/test/integration/generated/azureReport/rollup.config.js
+++ b/test/integration/generated/azureReport/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/reportClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/zzzAzureReport.js",
     format: "umd",
     name: "ZzzAzureReport",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureSpecialProperties/rollup.config.js
+++ b/test/integration/generated/azureSpecialProperties/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/azureSpecialPropertiesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/azure-special-properties.js",
     format: "umd",
     name: "AzureSpecialProperties",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureSpecialProperties/src/index.ts
+++ b/test/integration/generated/azureSpecialProperties/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { AzureSpecialPropertiesClient } from "./azureSpecialPropertiesClient";
 export { AzureSpecialPropertiesClientContext } from "./azureSpecialPropertiesClientContext";

--- a/test/integration/generated/bodyArray/rollup.config.js
+++ b/test/integration/generated/bodyArray/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyArrayClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-array.js",
     format: "umd",
     name: "BodyArray",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyArray/src/index.ts
+++ b/test/integration/generated/bodyArray/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyArrayClient } from "./bodyArrayClient";
 export { BodyArrayClientContext } from "./bodyArrayClientContext";

--- a/test/integration/generated/bodyBoolean/rollup.config.js
+++ b/test/integration/generated/bodyBoolean/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyBooleanClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-boolean.js",
     format: "umd",
     name: "BodyBoolean",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyBoolean/src/index.ts
+++ b/test/integration/generated/bodyBoolean/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyBooleanClient } from "./bodyBooleanClient";
 export { BodyBooleanClientContext } from "./bodyBooleanClientContext";

--- a/test/integration/generated/bodyBooleanQuirks/rollup.config.js
+++ b/test/integration/generated/bodyBooleanQuirks/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyBooleanQuirksClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-boolean-quirks.js",
     format: "umd",
     name: "BodyBooleanQuirks",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyBooleanQuirks/src/index.ts
+++ b/test/integration/generated/bodyBooleanQuirks/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyBooleanQuirksClient } from "./bodyBooleanQuirksClient";
 export { BodyBooleanQuirksClientContext } from "./bodyBooleanQuirksClientContext";

--- a/test/integration/generated/bodyByte/rollup.config.js
+++ b/test/integration/generated/bodyByte/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyByteClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-byte.js",
     format: "umd",
     name: "BodyByte",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyByte/src/index.ts
+++ b/test/integration/generated/bodyByte/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyByteClient } from "./bodyByteClient";
 export { BodyByteClientContext } from "./bodyByteClientContext";

--- a/test/integration/generated/bodyComplex/rollup.config.js
+++ b/test/integration/generated/bodyComplex/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyComplexClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-complex.js",
     format: "umd",
     name: "BodyComplex",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  Basic,
+  Basicop,
   Primitive,
   Array,
   Dictionary,
@@ -27,7 +27,7 @@ export class BodyComplexClient extends BodyComplexClientContext {
    */
   constructor(options?: BodyComplexClientOptionalParams) {
     super(options);
-    this.basic = new Basic(this);
+    this.basicop = new Basicop(this);
     this.primitive = new Primitive(this);
     this.array = new Array(this);
     this.dictionary = new Dictionary(this);
@@ -38,7 +38,7 @@ export class BodyComplexClient extends BodyComplexClientContext {
     this.flattencomplex = new Flattencomplex(this);
   }
 
-  basic: Basic;
+  basicop: Basicop;
   primitive: Primitive;
   array: Array;
   dictionary: Dictionary;

--- a/test/integration/generated/bodyComplex/src/index.ts
+++ b/test/integration/generated/bodyComplex/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyComplexClient } from "./bodyComplexClient";
 export { BodyComplexClientContext } from "./bodyComplexClientContext";

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -307,7 +307,7 @@ export type GoblinSharkColor = string;
 /**
  * Contains response data for the getValid operation.
  */
-export type BasicGetValidResponse = Basic & {
+export type BasicopGetValidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -327,7 +327,7 @@ export type BasicGetValidResponse = Basic & {
 /**
  * Contains response data for the getInvalid operation.
  */
-export type BasicGetInvalidResponse = Basic & {
+export type BasicopGetInvalidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -347,7 +347,7 @@ export type BasicGetInvalidResponse = Basic & {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type BasicGetEmptyResponse = Basic & {
+export type BasicopGetEmptyResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -367,7 +367,7 @@ export type BasicGetEmptyResponse = Basic & {
 /**
  * Contains response data for the getNull operation.
  */
-export type BasicGetNullResponse = Basic & {
+export type BasicopGetNullResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -387,7 +387,7 @@ export type BasicGetNullResponse = Basic & {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type BasicGetNotProvidedResponse = Basic & {
+export type BasicopGetNotProvidedResponse = Basic & {
   /**
    * The underlying HTTP response.
    */

--- a/test/integration/generated/bodyComplex/src/operations/basicop.ts
+++ b/test/integration/generated/bodyComplex/src/operations/basicop.ts
@@ -11,22 +11,22 @@ import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
 import { BodyComplexClient } from "../bodyComplexClient";
 import {
-  BasicGetValidResponse,
-  Basic as BasicModel,
-  BasicGetInvalidResponse,
-  BasicGetEmptyResponse,
-  BasicGetNullResponse,
-  BasicGetNotProvidedResponse
+  BasicopGetValidResponse,
+  Basic,
+  BasicopGetInvalidResponse,
+  BasicopGetEmptyResponse,
+  BasicopGetNullResponse,
+  BasicopGetNotProvidedResponse
 } from "../models";
 
 /**
- * Class representing a Basic.
+ * Class representing a Basicop.
  */
-export class Basic {
+export class Basicop {
   private readonly client: BodyComplexClient;
 
   /**
-   * Initialize a new instance of the class Basic class.
+   * Initialize a new instance of the class Basicop class.
    * @param client Reference to the service client
    */
   constructor(client: BodyComplexClient) {
@@ -39,14 +39,14 @@ export class Basic {
    */
   getValid(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetValidResponse> {
+  ): Promise<BasicopGetValidResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.client.sendOperationRequest(
       operationArguments,
       getValidOperationSpec
-    ) as Promise<BasicGetValidResponse>;
+    ) as Promise<BasicopGetValidResponse>;
   }
 
   /**
@@ -55,7 +55,7 @@ export class Basic {
    * @param options The options parameters.
    */
   putValid(
-    complexBody: BasicModel,
+    complexBody: Basic,
     options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     const operationArguments: coreHttp.OperationArguments = {
@@ -74,14 +74,14 @@ export class Basic {
    */
   getInvalid(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetInvalidResponse> {
+  ): Promise<BasicopGetInvalidResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.client.sendOperationRequest(
       operationArguments,
       getInvalidOperationSpec
-    ) as Promise<BasicGetInvalidResponse>;
+    ) as Promise<BasicopGetInvalidResponse>;
   }
 
   /**
@@ -90,28 +90,30 @@ export class Basic {
    */
   getEmpty(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetEmptyResponse> {
+  ): Promise<BasicopGetEmptyResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.client.sendOperationRequest(
       operationArguments,
       getEmptyOperationSpec
-    ) as Promise<BasicGetEmptyResponse>;
+    ) as Promise<BasicopGetEmptyResponse>;
   }
 
   /**
    * Get a basic complex type whose properties are null
    * @param options The options parameters.
    */
-  getNull(options?: coreHttp.OperationOptions): Promise<BasicGetNullResponse> {
+  getNull(
+    options?: coreHttp.OperationOptions
+  ): Promise<BasicopGetNullResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.client.sendOperationRequest(
       operationArguments,
       getNullOperationSpec
-    ) as Promise<BasicGetNullResponse>;
+    ) as Promise<BasicopGetNullResponse>;
   }
 
   /**
@@ -120,14 +122,14 @@ export class Basic {
    */
   getNotProvided(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetNotProvidedResponse> {
+  ): Promise<BasicopGetNotProvidedResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.client.sendOperationRequest(
       operationArguments,
       getNotProvidedOperationSpec
-    ) as Promise<BasicGetNotProvidedResponse>;
+    ) as Promise<BasicopGetNotProvidedResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/bodyComplex/src/operations/index.ts
+++ b/test/integration/generated/bodyComplex/src/operations/index.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export * from "./basic";
+export * from "./basicop";
 export * from "./primitive";
 export * from "./array";
 export * from "./dictionary";

--- a/test/integration/generated/bodyComplexWithTracing/rollup.config.js
+++ b/test/integration/generated/bodyComplexWithTracing/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyComplexWithTracing.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-complex-tracing.js",
     format: "umd",
     name: "BodyComplexTracing",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyComplexWithTracing/src/bodyComplexWithTracing.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/bodyComplexWithTracing.ts
@@ -7,7 +7,7 @@
  */
 
 import {
-  Basic,
+  Basicop,
   Primitive,
   Array,
   Dictionary,
@@ -27,7 +27,7 @@ export class BodyComplexWithTracing extends BodyComplexWithTracingContext {
    */
   constructor(options?: BodyComplexWithTracingOptionalParams) {
     super(options);
-    this.basic = new Basic(this);
+    this.basicop = new Basicop(this);
     this.primitive = new Primitive(this);
     this.array = new Array(this);
     this.dictionary = new Dictionary(this);
@@ -38,7 +38,7 @@ export class BodyComplexWithTracing extends BodyComplexWithTracingContext {
     this.flattencomplex = new Flattencomplex(this);
   }
 
-  basic: Basic;
+  basicop: Basicop;
   primitive: Primitive;
   array: Array;
   dictionary: Dictionary;

--- a/test/integration/generated/bodyComplexWithTracing/src/index.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyComplexWithTracing } from "./bodyComplexWithTracing";
 export { BodyComplexWithTracingContext } from "./bodyComplexWithTracingContext";

--- a/test/integration/generated/bodyComplexWithTracing/src/models/index.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/models/index.ts
@@ -307,7 +307,7 @@ export type GoblinSharkColor = string;
 /**
  * Contains response data for the getValid operation.
  */
-export type BasicGetValidResponse = Basic & {
+export type BasicopGetValidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -327,7 +327,7 @@ export type BasicGetValidResponse = Basic & {
 /**
  * Contains response data for the getInvalid operation.
  */
-export type BasicGetInvalidResponse = Basic & {
+export type BasicopGetInvalidResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -347,7 +347,7 @@ export type BasicGetInvalidResponse = Basic & {
 /**
  * Contains response data for the getEmpty operation.
  */
-export type BasicGetEmptyResponse = Basic & {
+export type BasicopGetEmptyResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -367,7 +367,7 @@ export type BasicGetEmptyResponse = Basic & {
 /**
  * Contains response data for the getNull operation.
  */
-export type BasicGetNullResponse = Basic & {
+export type BasicopGetNullResponse = Basic & {
   /**
    * The underlying HTTP response.
    */
@@ -387,7 +387,7 @@ export type BasicGetNullResponse = Basic & {
 /**
  * Contains response data for the getNotProvided operation.
  */
-export type BasicGetNotProvidedResponse = Basic & {
+export type BasicopGetNotProvidedResponse = Basic & {
   /**
    * The underlying HTTP response.
    */

--- a/test/integration/generated/bodyComplexWithTracing/src/operations/basicop.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/operations/basicop.ts
@@ -13,22 +13,22 @@ import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
 import { BodyComplexWithTracing } from "../bodyComplexWithTracing";
 import {
-  BasicGetValidResponse,
-  Basic as BasicModel,
-  BasicGetInvalidResponse,
-  BasicGetEmptyResponse,
-  BasicGetNullResponse,
-  BasicGetNotProvidedResponse
+  BasicopGetValidResponse,
+  Basic,
+  BasicopGetInvalidResponse,
+  BasicopGetEmptyResponse,
+  BasicopGetNullResponse,
+  BasicopGetNotProvidedResponse
 } from "../models";
 
 /**
- * Class representing a Basic.
+ * Class representing a Basicop.
  */
-export class Basic {
+export class Basicop {
   private readonly client: BodyComplexWithTracing;
 
   /**
-   * Initialize a new instance of the class Basic class.
+   * Initialize a new instance of the class Basicop class.
    * @param client Reference to the service client
    */
   constructor(client: BodyComplexWithTracing) {
@@ -41,7 +41,7 @@ export class Basic {
    */
   async getValid(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetValidResponse> {
+  ): Promise<BasicopGetValidResponse> {
     const { span, updatedOptions } = createSpan(
       "BodyComplexWithTracing-getValid",
       coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -54,7 +54,7 @@ export class Basic {
         operationArguments,
         getValidOperationSpec
       );
-      return result as BasicGetValidResponse;
+      return result as BasicopGetValidResponse;
     } catch (error) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -72,7 +72,7 @@ export class Basic {
    * @param options The options parameters.
    */
   async putValid(
-    complexBody: BasicModel,
+    complexBody: Basic,
     options?: coreHttp.OperationOptions
   ): Promise<coreHttp.RestResponse> {
     const { span, updatedOptions } = createSpan(
@@ -106,7 +106,7 @@ export class Basic {
    */
   async getInvalid(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetInvalidResponse> {
+  ): Promise<BasicopGetInvalidResponse> {
     const { span, updatedOptions } = createSpan(
       "BodyComplexWithTracing-getInvalid",
       coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -119,7 +119,7 @@ export class Basic {
         operationArguments,
         getInvalidOperationSpec
       );
-      return result as BasicGetInvalidResponse;
+      return result as BasicopGetInvalidResponse;
     } catch (error) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -137,7 +137,7 @@ export class Basic {
    */
   async getEmpty(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetEmptyResponse> {
+  ): Promise<BasicopGetEmptyResponse> {
     const { span, updatedOptions } = createSpan(
       "BodyComplexWithTracing-getEmpty",
       coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -150,7 +150,7 @@ export class Basic {
         operationArguments,
         getEmptyOperationSpec
       );
-      return result as BasicGetEmptyResponse;
+      return result as BasicopGetEmptyResponse;
     } catch (error) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -168,7 +168,7 @@ export class Basic {
    */
   async getNull(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetNullResponse> {
+  ): Promise<BasicopGetNullResponse> {
     const { span, updatedOptions } = createSpan(
       "BodyComplexWithTracing-getNull",
       coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -181,7 +181,7 @@ export class Basic {
         operationArguments,
         getNullOperationSpec
       );
-      return result as BasicGetNullResponse;
+      return result as BasicopGetNullResponse;
     } catch (error) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,
@@ -199,7 +199,7 @@ export class Basic {
    */
   async getNotProvided(
     options?: coreHttp.OperationOptions
-  ): Promise<BasicGetNotProvidedResponse> {
+  ): Promise<BasicopGetNotProvidedResponse> {
     const { span, updatedOptions } = createSpan(
       "BodyComplexWithTracing-getNotProvided",
       coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -212,7 +212,7 @@ export class Basic {
         operationArguments,
         getNotProvidedOperationSpec
       );
-      return result as BasicGetNotProvidedResponse;
+      return result as BasicopGetNotProvidedResponse;
     } catch (error) {
       span.setStatus({
         code: CanonicalCode.UNKNOWN,

--- a/test/integration/generated/bodyComplexWithTracing/src/operations/index.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/operations/index.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export * from "./basic";
+export * from "./basicop";
 export * from "./primitive";
 export * from "./array";
 export * from "./dictionary";

--- a/test/integration/generated/bodyDate/rollup.config.js
+++ b/test/integration/generated/bodyDate/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDateClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-date.js",
     format: "umd",
     name: "BodyDate",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDate/src/index.ts
+++ b/test/integration/generated/bodyDate/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyDateClient } from "./bodyDateClient";
 export { BodyDateClientContext } from "./bodyDateClientContext";

--- a/test/integration/generated/bodyDateTime/rollup.config.js
+++ b/test/integration/generated/bodyDateTime/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDateTimeClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-datetime.js",
     format: "umd",
     name: "BodyDatetime",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDateTime/src/index.ts
+++ b/test/integration/generated/bodyDateTime/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyDateTimeClient } from "./bodyDateTimeClient";
 export { BodyDateTimeClientContext } from "./bodyDateTimeClientContext";

--- a/test/integration/generated/bodyDateTimeRfc1123/rollup.config.js
+++ b/test/integration/generated/bodyDateTimeRfc1123/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDateTimeRfc1123Client.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-datetime-rfc1123.js",
     format: "umd",
     name: "BodyDatetimeRfc1123",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDateTimeRfc1123/src/index.ts
+++ b/test/integration/generated/bodyDateTimeRfc1123/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyDateTimeRfc1123Client } from "./bodyDateTimeRfc1123Client";
 export { BodyDateTimeRfc1123ClientContext } from "./bodyDateTimeRfc1123ClientContext";

--- a/test/integration/generated/bodyDictionary/rollup.config.js
+++ b/test/integration/generated/bodyDictionary/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDictionaryClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-dictionary.js",
     format: "umd",
     name: "BodyDictionary",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDictionary/src/index.ts
+++ b/test/integration/generated/bodyDictionary/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyDictionaryClient } from "./bodyDictionaryClient";
 export { BodyDictionaryClientContext } from "./bodyDictionaryClientContext";

--- a/test/integration/generated/bodyDuration/rollup.config.js
+++ b/test/integration/generated/bodyDuration/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDurationClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-duration.js",
     format: "umd",
     name: "BodyDuration",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDuration/src/index.ts
+++ b/test/integration/generated/bodyDuration/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyDurationClient } from "./bodyDurationClient";
 export { BodyDurationClientContext } from "./bodyDurationClientContext";

--- a/test/integration/generated/bodyFile/rollup.config.js
+++ b/test/integration/generated/bodyFile/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyFileClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-file.js",
     format: "umd",
     name: "BodyFile",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyFile/src/index.ts
+++ b/test/integration/generated/bodyFile/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyFileClient } from "./bodyFileClient";
 export { BodyFileClientContext } from "./bodyFileClientContext";

--- a/test/integration/generated/bodyFormData/rollup.config.js
+++ b/test/integration/generated/bodyFormData/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyFormDataClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-formdata.js",
     format: "umd",
     name: "BodyFormdata",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyFormData/src/index.ts
+++ b/test/integration/generated/bodyFormData/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyFormDataClient } from "./bodyFormDataClient";
 export { BodyFormDataClientContext } from "./bodyFormDataClientContext";

--- a/test/integration/generated/bodyInteger/rollup.config.js
+++ b/test/integration/generated/bodyInteger/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyIntegerClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-integer.js",
     format: "umd",
     name: "BodyInteger",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyInteger/src/index.ts
+++ b/test/integration/generated/bodyInteger/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyIntegerClient } from "./bodyIntegerClient";
 export { BodyIntegerClientContext } from "./bodyIntegerClientContext";

--- a/test/integration/generated/bodyNumber/rollup.config.js
+++ b/test/integration/generated/bodyNumber/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyNumberClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-number.js",
     format: "umd",
     name: "BodyNumber",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyNumber/src/index.ts
+++ b/test/integration/generated/bodyNumber/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyNumberClient } from "./bodyNumberClient";
 export { BodyNumberClientContext } from "./bodyNumberClientContext";

--- a/test/integration/generated/bodyString/rollup.config.js
+++ b/test/integration/generated/bodyString/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyStringClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-string.js",
     format: "umd",
     name: "BodyString",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyString/src/index.ts
+++ b/test/integration/generated/bodyString/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyStringClient } from "./bodyStringClient";
 export { BodyStringClientContext } from "./bodyStringClientContext";

--- a/test/integration/generated/bodyTime/rollup.config.js
+++ b/test/integration/generated/bodyTime/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyTimeClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-time.js",
     format: "umd",
     name: "BodyTime",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyTime/src/index.ts
+++ b/test/integration/generated/bodyTime/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { BodyTimeClient } from "./bodyTimeClient";
 export { BodyTimeClientContext } from "./bodyTimeClientContext";

--- a/test/integration/generated/customUrl/rollup.config.js
+++ b/test/integration/generated/customUrl/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/customUrlClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/custom-url.js",
     format: "umd",
     name: "CustomUrl",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/customUrl/src/index.ts
+++ b/test/integration/generated/customUrl/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { CustomUrlClient } from "./customUrlClient";
 export { CustomUrlClientContext } from "./customUrlClientContext";

--- a/test/integration/generated/customUrlMoreOptions/rollup.config.js
+++ b/test/integration/generated/customUrlMoreOptions/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/customUrlMoreOptionsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/custom-url-MoreOptions.js",
     format: "umd",
     name: "CustomUrlMoreOptions",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/customUrlMoreOptions/src/index.ts
+++ b/test/integration/generated/customUrlMoreOptions/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { CustomUrlMoreOptionsClient } from "./customUrlMoreOptionsClient";
 export { CustomUrlMoreOptionsClientContext } from "./customUrlMoreOptionsClientContext";

--- a/test/integration/generated/customUrlPaging/rollup.config.js
+++ b/test/integration/generated/customUrlPaging/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/customUrlPagingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/custom-url-paging.js",
     format: "umd",
     name: "CustomUrlPaging",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/customUrlPaging/src/index.ts
+++ b/test/integration/generated/customUrlPaging/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 /// <reference lib="esnext.asynciterable" />
+export * from "./operations";
 export * from "./models";
 export { CustomUrlPagingClient } from "./customUrlPagingClient";
 export { CustomUrlPagingClientContext } from "./customUrlPagingClientContext";

--- a/test/integration/generated/extensibleEnums/rollup.config.js
+++ b/test/integration/generated/extensibleEnums/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/extensibleEnumsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/extensible-enums.js",
     format: "umd",
     name: "ExtensibleEnums",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/extensibleEnums/src/extensibleEnumsClient.ts
+++ b/test/integration/generated/extensibleEnums/src/extensibleEnumsClient.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { Pet } from "./operations";
+import { Petop } from "./operations";
 import { ExtensibleEnumsClientContext } from "./extensibleEnumsClientContext";
 import { ExtensibleEnumsClientOptionalParams } from "./models";
 
@@ -17,8 +17,8 @@ export class ExtensibleEnumsClient extends ExtensibleEnumsClientContext {
    */
   constructor(options?: ExtensibleEnumsClientOptionalParams) {
     super(options);
-    this.pet = new Pet(this);
+    this.petop = new Petop(this);
   }
 
-  pet: Pet;
+  petop: Petop;
 }

--- a/test/integration/generated/extensibleEnums/src/index.ts
+++ b/test/integration/generated/extensibleEnums/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { ExtensibleEnumsClient } from "./extensibleEnumsClient";
 export { ExtensibleEnumsClientContext } from "./extensibleEnumsClientContext";

--- a/test/integration/generated/extensibleEnums/src/models/index.ts
+++ b/test/integration/generated/extensibleEnums/src/models/index.ts
@@ -80,7 +80,7 @@ export type IntEnum = string;
 /**
  * Contains response data for the getByPetId operation.
  */
-export type PetGetByPetIdResponse = Pet & {
+export type PetopGetByPetIdResponse = Pet & {
   /**
    * The underlying HTTP response.
    */
@@ -100,7 +100,7 @@ export type PetGetByPetIdResponse = Pet & {
 /**
  * Optional parameters.
  */
-export interface PetAddPetOptionalParams extends coreHttp.OperationOptions {
+export interface PetopAddPetOptionalParams extends coreHttp.OperationOptions {
   /**
    * pet param
    */
@@ -110,7 +110,7 @@ export interface PetAddPetOptionalParams extends coreHttp.OperationOptions {
 /**
  * Contains response data for the addPet operation.
  */
-export type PetAddPetResponse = Pet & {
+export type PetopAddPetResponse = Pet & {
   /**
    * The underlying HTTP response.
    */

--- a/test/integration/generated/extensibleEnums/src/operations/index.ts
+++ b/test/integration/generated/extensibleEnums/src/operations/index.ts
@@ -6,4 +6,4 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export * from "./pet";
+export * from "./petop";

--- a/test/integration/generated/extensibleEnums/src/operations/petop.ts
+++ b/test/integration/generated/extensibleEnums/src/operations/petop.ts
@@ -11,19 +11,19 @@ import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
 import { ExtensibleEnumsClient } from "../extensibleEnumsClient";
 import {
-  PetGetByPetIdResponse,
-  PetAddPetOptionalParams,
-  PetAddPetResponse
+  PetopGetByPetIdResponse,
+  PetopAddPetOptionalParams,
+  PetopAddPetResponse
 } from "../models";
 
 /**
- * Class representing a Pet.
+ * Class representing a Petop.
  */
-export class Pet {
+export class Petop {
   private readonly client: ExtensibleEnumsClient;
 
   /**
-   * Initialize a new instance of the class Pet class.
+   * Initialize a new instance of the class Petop class.
    * @param client Reference to the service client
    */
   constructor(client: ExtensibleEnumsClient) {
@@ -38,7 +38,7 @@ export class Pet {
   getByPetId(
     petId: string,
     options?: coreHttp.OperationOptions
-  ): Promise<PetGetByPetIdResponse> {
+  ): Promise<PetopGetByPetIdResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       petId,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -46,21 +46,21 @@ export class Pet {
     return this.client.sendOperationRequest(
       operationArguments,
       getByPetIdOperationSpec
-    ) as Promise<PetGetByPetIdResponse>;
+    ) as Promise<PetopGetByPetIdResponse>;
   }
 
   /**
    * add pet
    * @param options The options parameters.
    */
-  addPet(options?: PetAddPetOptionalParams): Promise<PetAddPetResponse> {
+  addPet(options?: PetopAddPetOptionalParams): Promise<PetopAddPetResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
     };
     return this.client.sendOperationRequest(
       operationArguments,
       addPetOperationSpec
-    ) as Promise<PetAddPetResponse>;
+    ) as Promise<PetopAddPetResponse>;
   }
 }
 // Operation Specifications

--- a/test/integration/generated/header/rollup.config.js
+++ b/test/integration/generated/header/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/headerClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/header.js",
     format: "umd",
     name: "Header",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/header/src/index.ts
+++ b/test/integration/generated/header/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { HeaderClient } from "./headerClient";
 export { HeaderClientContext } from "./headerClientContext";

--- a/test/integration/generated/httpInfrastructure/rollup.config.js
+++ b/test/integration/generated/httpInfrastructure/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/httpInfrastructureClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/httpInfrastructure.js",
     format: "umd",
     name: "HttpInfrastructure",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/httpInfrastructure/src/index.ts
+++ b/test/integration/generated/httpInfrastructure/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { HttpInfrastructureClient } from "./httpInfrastructureClient";
 export { HttpInfrastructureClientContext } from "./httpInfrastructureClientContext";

--- a/test/integration/generated/licenseHeader/rollup.config.js
+++ b/test/integration/generated/licenseHeader/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/licenseHeaderClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/license-header.js",
     format: "umd",
     name: "LicenseHeader",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/lro/rollup.config.js
+++ b/test/integration/generated/lro/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/lROClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/lro.js",
     format: "umd",
     name: "Lro",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/lro/src/index.ts
+++ b/test/integration/generated/lro/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { LROClient } from "./lROClient";
 export { LROClientContext } from "./lROClientContext";

--- a/test/integration/generated/lroParametrizedEndpoints/rollup.config.js
+++ b/test/integration/generated/lroParametrizedEndpoints/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/lroParametrizedEndpointsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/lro-parameterized-endpoints.js",
     format: "umd",
     name: "LroParameterizedEndpoints",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypes/rollup.config.js
+++ b/test/integration/generated/mediaTypes/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-service.js",
     format: "umd",
     name: "MediaTypesService",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypesV3/rollup.config.js
+++ b/test/integration/generated/mediaTypesV3/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesV3Client.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-v3-client.js",
     format: "umd",
     name: "MediaTypesV3Client",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypesV3/src/index.ts
+++ b/test/integration/generated/mediaTypesV3/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { MediaTypesV3Client } from "./mediaTypesV3Client";
 export { MediaTypesV3ClientContext } from "./mediaTypesV3ClientContext";

--- a/test/integration/generated/mediaTypesV3Lro/rollup.config.js
+++ b/test/integration/generated/mediaTypesV3Lro/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesV3LROClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-v3-lro-client.js",
     format: "umd",
     name: "MediaTypesV3LroClient",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypesWithTracing/rollup.config.js
+++ b/test/integration/generated/mediaTypesWithTracing/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesWithTracingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-service-tracing.js",
     format: "umd",
     name: "MediaTypesServiceTracing",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/modelFlattening/rollup.config.js
+++ b/test/integration/generated/modelFlattening/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/modelFlatteningClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/model-flattening.js",
     format: "umd",
     name: "ModelFlattening",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/multipleInheritance/rollup.config.js
+++ b/test/integration/generated/multipleInheritance/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/multipleInheritanceClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/multiple-inheritance.js",
     format: "umd",
     name: "MultipleInheritance",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/noLicenseHeader/rollup.config.js
+++ b/test/integration/generated/noLicenseHeader/rollup.config.js
@@ -7,15 +7,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/noLicenseHeaderClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/nolicense-header.js",
     format: "umd",
     name: "NolicenseHeader",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/noMappers/rollup.config.js
+++ b/test/integration/generated/noMappers/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/noMappersClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/no-mappers.js",
     format: "umd",
     name: "NoMappers",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/nonStringEnum/rollup.config.js
+++ b/test/integration/generated/nonStringEnum/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/nonStringEnumClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/non-string-num.js",
     format: "umd",
     name: "NonStringNum",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/nonStringEnum/src/index.ts
+++ b/test/integration/generated/nonStringEnum/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { NonStringEnumClient } from "./nonStringEnumClient";
 export { NonStringEnumClientContext } from "./nonStringEnumClientContext";

--- a/test/integration/generated/objectType/rollup.config.js
+++ b/test/integration/generated/objectType/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/objectTypeClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/object-type.js",
     format: "umd",
     name: "ObjectType",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/odataDiscriminator/rollup.config.js
+++ b/test/integration/generated/odataDiscriminator/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/oDataDiscriminatorClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/odata-discriminator.js",
     format: "umd",
     name: "OdataDiscriminator",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/paging/rollup.config.js
+++ b/test/integration/generated/paging/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/pagingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/paging-service.js",
     format: "umd",
     name: "PagingService",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/paging/src/index.ts
+++ b/test/integration/generated/paging/src/index.ts
@@ -7,6 +7,7 @@
  */
 
 /// <reference lib="esnext.asynciterable" />
+export * from "./operations";
 export * from "./models";
 export { PagingClient } from "./pagingClient";
 export { PagingClientContext } from "./pagingClientContext";

--- a/test/integration/generated/pagingNoIterators/rollup.config.js
+++ b/test/integration/generated/pagingNoIterators/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/pagingNoIteratorsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/paging-no-iterators.js",
     format: "umd",
     name: "PagingNoIterators",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/pagingNoIterators/src/index.ts
+++ b/test/integration/generated/pagingNoIterators/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { PagingNoIteratorsClient } from "./pagingNoIteratorsClient";
 export { PagingNoIteratorsClientContext } from "./pagingNoIteratorsClientContext";

--- a/test/integration/generated/regexConstraint/rollup.config.js
+++ b/test/integration/generated/regexConstraint/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/regexConstraint.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/regex-constraint.js",
     format: "umd",
     name: "RegexConstraint",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/report/rollup.config.js
+++ b/test/integration/generated/report/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/reportClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/zzzReport.js",
     format: "umd",
     name: "ZzzReport",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/requiredOptional/rollup.config.js
+++ b/test/integration/generated/requiredOptional/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/requiredOptionalClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/required-optional.js",
     format: "umd",
     name: "RequiredOptional",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/requiredOptional/src/index.ts
+++ b/test/integration/generated/requiredOptional/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { RequiredOptionalClient } from "./requiredOptionalClient";
 export { RequiredOptionalClientContext } from "./requiredOptionalClientContext";

--- a/test/integration/generated/subscriptionIdApiVersion/rollup.config.js
+++ b/test/integration/generated/subscriptionIdApiVersion/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/subscriptionIdApiVersionClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/subscriptionid-apiversion.js",
     format: "umd",
     name: "SubscriptionidApiversion",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/subscriptionIdApiVersion/src/index.ts
+++ b/test/integration/generated/subscriptionIdApiVersion/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { SubscriptionIdApiVersionClient } from "./subscriptionIdApiVersionClient";
 export { SubscriptionIdApiVersionClientContext } from "./subscriptionIdApiVersionClientContext";

--- a/test/integration/generated/url/rollup.config.js
+++ b/test/integration/generated/url/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/urlClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/url.js",
     format: "umd",
     name: "Url",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/url/src/index.ts
+++ b/test/integration/generated/url/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { UrlClient } from "./urlClient";
 export { UrlClientContext } from "./urlClientContext";

--- a/test/integration/generated/url2/rollup.config.js
+++ b/test/integration/generated/url2/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/urlClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/url.js",
     format: "umd",
     name: "Url",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/url2/src/index.ts
+++ b/test/integration/generated/url2/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { UrlClient } from "./urlClient";
 export { UrlClientContext } from "./urlClientContext";

--- a/test/integration/generated/urlMulti/rollup.config.js
+++ b/test/integration/generated/urlMulti/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/urlMultiClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/url-multi.js",
     format: "umd",
     name: "UrlMulti",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/urlMulti/src/index.ts
+++ b/test/integration/generated/urlMulti/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { UrlMultiClient } from "./urlMultiClient";
 export { UrlMultiClientContext } from "./urlMultiClientContext";

--- a/test/integration/generated/uuid/rollup.config.js
+++ b/test/integration/generated/uuid/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/uuidClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/uuid.js",
     format: "umd",
     name: "Uuid",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/uuid/src/index.ts
+++ b/test/integration/generated/uuid/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { UuidClient } from "./uuidClient";
 export { UuidClientContext } from "./uuidClientContext";

--- a/test/integration/generated/validation/rollup.config.js
+++ b/test/integration/generated/validation/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/validationClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/validation.js",
     format: "umd",
     name: "Validation",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/xmlservice/rollup.config.js
+++ b/test/integration/generated/xmlservice/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/xmlServiceClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/xml-service.js",
     format: "umd",
     name: "XmlService",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/xmlservice/src/index.ts
+++ b/test/integration/generated/xmlservice/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { XmlServiceClient } from "./xmlServiceClient";
 export { XmlServiceClientContext } from "./xmlServiceClientContext";

--- a/test/integration/generated/xmsErrorResponses/rollup.config.js
+++ b/test/integration/generated/xmsErrorResponses/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/xmsErrorResponsesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/xms-error-responses.js",
     format: "umd",
     name: "XmsErrorResponses",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/xmsErrorResponses/src/index.ts
+++ b/test/integration/generated/xmsErrorResponses/src/index.ts
@@ -6,6 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
+export * from "./operations";
 export * from "./models";
 export { XmsErrorResponsesClient } from "./xmsErrorResponsesClient";
 export { XmsErrorResponsesClientContext } from "./xmsErrorResponsesClientContext";

--- a/test/integration/generated/xmsErrorResponses/src/models/index.ts
+++ b/test/integration/generated/xmsErrorResponses/src/models/index.ts
@@ -76,7 +76,7 @@ export type PetHungryOrThirstyError = PetSadError & {
 /**
  * Contains response data for the getPetById operation.
  */
-export type PetGetPetByIdResponse = Pet & {
+export type PetopGetPetByIdResponse = Pet & {
   /**
    * The underlying HTTP response.
    */
@@ -96,7 +96,7 @@ export type PetGetPetByIdResponse = Pet & {
 /**
  * Contains response data for the doSomething operation.
  */
-export type PetDoSomethingResponse = PetAction & {
+export type PetopDoSomethingResponse = PetAction & {
   /**
    * The underlying HTTP response.
    */
@@ -112,6 +112,17 @@ export type PetDoSomethingResponse = PetAction & {
     parsedBody: PetAction;
   };
 };
+
+/**
+ * Optional parameters.
+ */
+export interface PetopHasModelsParamOptionalParams
+  extends coreHttp.OperationOptions {
+  /**
+   * Make sure model deserialization doesn't conflict with this param name, which has input name 'models'. Use client default value in call
+   */
+  models?: string;
+}
 
 /**
  * Optional parameters.

--- a/test/integration/generated/xmsErrorResponses/src/models/parameters.ts
+++ b/test/integration/generated/xmsErrorResponses/src/models/parameters.ts
@@ -6,7 +6,11 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { OperationParameter, OperationURLParameter } from "@azure/core-http";
+import {
+  OperationParameter,
+  OperationURLParameter,
+  OperationQueryParameter
+} from "@azure/core-http";
 
 export const accept: OperationParameter = {
   parameterPath: "accept",
@@ -48,6 +52,16 @@ export const whatAction: OperationURLParameter = {
   mapper: {
     serializedName: "whatAction",
     required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const models: OperationQueryParameter = {
+  parameterPath: ["options", "models"],
+  mapper: {
+    serializedName: "models",
     type: {
       name: "String"
     }

--- a/test/integration/generated/xmsErrorResponses/src/operations/index.ts
+++ b/test/integration/generated/xmsErrorResponses/src/operations/index.ts
@@ -6,4 +6,4 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export * from "./pet";
+export * from "./petop";

--- a/test/integration/generated/xmsErrorResponses/src/operations/petop.ts
+++ b/test/integration/generated/xmsErrorResponses/src/operations/petop.ts
@@ -10,16 +10,20 @@ import * as coreHttp from "@azure/core-http";
 import * as Mappers from "../models/mappers";
 import * as Parameters from "../models/parameters";
 import { XmsErrorResponsesClient } from "../xmsErrorResponsesClient";
-import { PetGetPetByIdResponse, PetDoSomethingResponse } from "../models";
+import {
+  PetopGetPetByIdResponse,
+  PetopDoSomethingResponse,
+  PetopHasModelsParamOptionalParams
+} from "../models";
 
 /**
- * Class representing a Pet.
+ * Class representing a Petop.
  */
-export class Pet {
+export class Petop {
   private readonly client: XmsErrorResponsesClient;
 
   /**
-   * Initialize a new instance of the class Pet class.
+   * Initialize a new instance of the class Petop class.
    * @param client Reference to the service client
    */
   constructor(client: XmsErrorResponsesClient) {
@@ -34,7 +38,7 @@ export class Pet {
   getPetById(
     petId: string,
     options?: coreHttp.OperationOptions
-  ): Promise<PetGetPetByIdResponse> {
+  ): Promise<PetopGetPetByIdResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       petId,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -42,7 +46,7 @@ export class Pet {
     return this.client.sendOperationRequest(
       operationArguments,
       getPetByIdOperationSpec
-    ) as Promise<PetGetPetByIdResponse>;
+    ) as Promise<PetopGetPetByIdResponse>;
   }
 
   /**
@@ -53,7 +57,7 @@ export class Pet {
   doSomething(
     whatAction: string,
     options?: coreHttp.OperationOptions
-  ): Promise<PetDoSomethingResponse> {
+  ): Promise<PetopDoSomethingResponse> {
     const operationArguments: coreHttp.OperationArguments = {
       whatAction,
       options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
@@ -61,7 +65,24 @@ export class Pet {
     return this.client.sendOperationRequest(
       operationArguments,
       doSomethingOperationSpec
-    ) as Promise<PetDoSomethingResponse>;
+    ) as Promise<PetopDoSomethingResponse>;
+  }
+
+  /**
+   * Ensure you can correctly deserialize the returned PetActionError and deserialization doesn't
+   * conflict with the input param name 'models'
+   * @param options The options parameters.
+   */
+  hasModelsParam(
+    options?: PetopHasModelsParamOptionalParams
+  ): Promise<coreHttp.RestResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      hasModelsParamOperationSpec
+    ) as Promise<coreHttp.RestResponse>;
   }
 }
 // Operation Specifications
@@ -110,6 +131,24 @@ const doSomethingOperationSpec: coreHttp.OperationSpec = {
     }
   },
   urlParameters: [Parameters.$host, Parameters.whatAction],
+  headerParameters: [Parameters.accept],
+  serializer
+};
+const hasModelsParamOperationSpec: coreHttp.OperationSpec = {
+  path: "/errorStatusCodes/Pets/hasModelsParam",
+  httpMethod: "POST",
+  responses: {
+    200: {},
+    500: {
+      bodyMapper: Mappers.PetActionError,
+      isError: true
+    },
+    default: {
+      bodyMapper: Mappers.PetActionError
+    }
+  },
+  queryParameters: [Parameters.models],
+  urlParameters: [Parameters.$host],
   headerParameters: [Parameters.accept],
   serializer
 };

--- a/test/integration/generated/xmsErrorResponses/src/xmsErrorResponsesClient.ts
+++ b/test/integration/generated/xmsErrorResponses/src/xmsErrorResponsesClient.ts
@@ -6,7 +6,7 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-import { Pet } from "./operations";
+import { Petop } from "./operations";
 import { XmsErrorResponsesClientContext } from "./xmsErrorResponsesClientContext";
 import { XmsErrorResponsesClientOptionalParams } from "./models";
 
@@ -17,8 +17,8 @@ export class XmsErrorResponsesClient extends XmsErrorResponsesClientContext {
    */
   constructor(options?: XmsErrorResponsesClientOptionalParams) {
     super(options);
-    this.pet = new Pet(this);
+    this.petop = new Petop(this);
   }
 
-  pet: Pet;
+  petop: Petop;
 }

--- a/test/integration/swaggers/body-complex.json
+++ b/test/integration/swaggers/body-complex.json
@@ -1,0 +1,1779 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "AutoRest Complex Test Service",
+    "description": "Test Infrastructure for AutoRest",
+    "version": "2016-02-29"
+  },
+  "host": "localhost:3000",
+  "schemes": [
+    "http"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/complex/basic/valid": {
+      "get": {
+        "operationId": "basicop_getValid",
+        "description": "Get complex type {id: 2, name: 'abc', color: 'YELLOW'}",
+        "responses": {
+          "200": {
+            "description": "Get complex type {id: 2, name: 'abc', color: 'YELLOW'}",
+            "schema": {
+              "$ref": "#/definitions/basic"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "basicop_putValid",
+        "description": "Please put {id: 2, name: 'abc', color: 'Magenta'}",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put {id: 2, name: 'abc', color: 'Magenta'}",
+            "schema": {
+              "$ref": "#/definitions/basic"
+            },
+            "required": true
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/basic/invalid": {
+      "get": {
+        "operationId": "basicop_getInvalid",
+        "description": "Get a basic complex type that is invalid for the local strong type",
+        "responses": {
+          "200": {
+            "description": "Get complex types with basic property",
+            "schema": {
+              "$ref": "#/definitions/basic"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/basic/empty": {
+      "get": {
+        "operationId": "basicop_getEmpty",
+        "description": "Get a basic complex type that is empty",
+        "responses": {
+          "200": {
+            "description": "Get complex types with basic property",
+            "schema": {
+              "$ref": "#/definitions/basic"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/basic/null": {
+      "get": {
+        "operationId": "basicop_getNull",
+        "description": "Get a basic complex type whose properties are null",
+        "responses": {
+          "200": {
+            "description": "Get complex types with basic property",
+            "schema": {
+              "$ref": "#/definitions/basic"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/basic/notprovided": {
+      "get": {
+        "operationId": "basicop_getNotProvided",
+        "description": "Get a basic complex type while the server doesn't provide a response payload",
+        "responses": {
+          "200": {
+            "description": "Get complex types with basic property",
+            "schema": {
+              "$ref": "#/definitions/basic"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/integer": {
+      "get": {
+        "operationId": "primitive_getInt",
+        "description": "Get complex types with integer properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/int-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putInt",
+        "description": "Put complex types with integer properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put -1 and 2",
+            "schema": {
+              "$ref": "#/definitions/int-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/long": {
+      "get": {
+        "operationId": "primitive_getLong",
+        "description": "Get complex types with long properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/long-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putLong",
+        "description": "Put complex types with long properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put 1099511627775 and -999511627788",
+            "schema": {
+              "$ref": "#/definitions/long-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/float": {
+      "get": {
+        "operationId": "primitive_getFloat",
+        "description": "Get complex types with float properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/float-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putFloat",
+        "description": "Put complex types with float properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put 1.05 and -0.003",
+            "schema": {
+              "$ref": "#/definitions/float-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/double": {
+      "get": {
+        "operationId": "primitive_getDouble",
+        "description": "Get complex types with double properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/double-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putDouble",
+        "description": "Put complex types with double properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005",
+            "schema": {
+              "$ref": "#/definitions/double-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/bool": {
+      "get": {
+        "operationId": "primitive_getBool",
+        "description": "Get complex types with bool properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/boolean-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putBool",
+        "description": "Put complex types with bool properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put true and false",
+            "schema": {
+              "$ref": "#/definitions/boolean-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/string": {
+      "get": {
+        "operationId": "primitive_getString",
+        "description": "Get complex types with string properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/string-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putString",
+        "description": "Put complex types with string properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put 'goodrequest', '', and null",
+            "schema": {
+              "$ref": "#/definitions/string-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/date": {
+      "get": {
+        "operationId": "primitive_getDate",
+        "description": "Get complex types with date properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/date-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putDate",
+        "description": "Put complex types with date properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put '0001-01-01' and '2016-02-29'",
+            "schema": {
+              "$ref": "#/definitions/date-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/datetime": {
+      "get": {
+        "operationId": "primitive_getDateTime",
+        "description": "Get complex types with datetime properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/datetime-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putDateTime",
+        "description": "Put complex types with datetime properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00'",
+            "schema": {
+              "$ref": "#/definitions/datetime-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/datetimerfc1123": {
+      "get": {
+        "operationId": "primitive_getDateTimeRfc1123",
+        "description": "Get complex types with datetimeRfc1123 properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/datetimerfc1123-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putDateTimeRfc1123",
+        "description": "Put complex types with datetimeRfc1123 properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT'",
+            "schema": {
+              "$ref": "#/definitions/datetimerfc1123-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/duration": {
+      "get": {
+        "operationId": "primitive_getDuration",
+        "description": "Get complex types with duration properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/duration-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putDuration",
+        "description": "Put complex types with duration properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put 'P123DT22H14M12.011S'",
+            "schema": {
+              "$ref": "#/definitions/duration-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/primitive/byte": {
+      "get": {
+        "operationId": "primitive_getByte",
+        "description": "Get complex types with byte properties",
+        "responses": {
+          "200": {
+            "description": "Get complex types with primitive property",
+            "schema": {
+              "$ref": "#/definitions/byte-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "primitive_putByte",
+        "description": "Put complex types with byte properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6)",
+            "schema": {
+              "$ref": "#/definitions/byte-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/array/valid": {
+      "get": {
+        "operationId": "array_getValid",
+        "description": "Get complex types with array property",
+        "responses": {
+          "200": {
+            "description": "Complex object with array property",
+            "schema": {
+              "$ref": "#/definitions/array-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "array_putValid",
+        "description": "Put complex types with array property",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put an array with 4 items: \"1, 2, 3, 4\", \"\", null, \"&S#$(*Y\", \"The quick brown fox jumps over the lazy dog\"",
+            "schema": {
+              "$ref": "#/definitions/array-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/array/empty": {
+      "get": {
+        "operationId": "array_getEmpty",
+        "description": "Get complex types with array property which is empty",
+        "responses": {
+          "200": {
+            "description": "Complex object with array property",
+            "schema": {
+              "$ref": "#/definitions/array-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "array_putEmpty",
+        "description": "Put complex types with array property which is empty",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put an empty array",
+            "schema": {
+              "$ref": "#/definitions/array-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/array/notprovided": {
+      "get": {
+        "operationId": "array_getNotProvided",
+        "description": "Get complex types with array property while server doesn't provide a response payload",
+        "responses": {
+          "200": {
+            "description": "Complex object with array property",
+            "schema": {
+              "$ref": "#/definitions/array-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/dictionary/typed/valid": {
+      "get": {
+        "operationId": "dictionary_getValid",
+        "description": "Get complex types with dictionary property",
+        "responses": {
+          "200": {
+            "description": "Complex object with dictionary property",
+            "schema": {
+              "$ref": "#/definitions/dictionary-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dictionary_putValid",
+        "description": "Put complex types with dictionary property",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put a dictionary with 5 key-value pairs: \"txt\":\"notepad\", \"bmp\":\"mspaint\", \"xls\":\"excel\", \"exe\":\"\", \"\":null",
+            "schema": {
+              "$ref": "#/definitions/dictionary-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/dictionary/typed/empty": {
+      "get": {
+        "operationId": "dictionary_getEmpty",
+        "description": "Get complex types with dictionary property which is empty",
+        "responses": {
+          "200": {
+            "description": "Complex object with dictionary property",
+            "schema": {
+              "$ref": "#/definitions/dictionary-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "dictionary_putEmpty",
+        "description": "Put complex types with dictionary property which is empty",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put an empty dictionary",
+            "schema": {
+              "$ref": "#/definitions/dictionary-wrapper"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/dictionary/typed/null": {
+      "get": {
+        "operationId": "dictionary_getNull",
+        "description": "Get complex types with dictionary property which is null",
+        "responses": {
+          "200": {
+            "description": "Complex object with dictionary property",
+            "schema": {
+              "$ref": "#/definitions/dictionary-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/dictionary/typed/notprovided": {
+      "get": {
+        "operationId": "dictionary_getNotProvided",
+        "description": "Get complex types with dictionary property while server doesn't provide a response payload",
+        "responses": {
+          "200": {
+            "description": "Complex object with dictionary property",
+            "schema": {
+              "$ref": "#/definitions/dictionary-wrapper"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/inheritance/valid": {
+      "get": {
+        "operationId": "inheritance_getValid",
+        "description": "Get complex types that extend others",
+        "responses": {
+          "200": {
+            "description": "Complex object that extends cat and pet",
+            "schema": {
+              "$ref": "#/definitions/siamese"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "inheritance_putValid",
+        "description": "Put complex types that extend others",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put a siamese with id=2, name=\"Siameee\", color=green, breed=persion, which hates 2 dogs, the 1st one named \"Potato\" with id=1 and food=\"tomato\", and the 2nd one named \"Tomato\" with id=-1 and food=\"french fries\".",
+            "schema": {
+              "$ref": "#/definitions/siamese"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/valid": {
+      "get": {
+        "operationId": "polymorphism_getValid",
+        "description": "Get complex types that are polymorphic",
+        "responses": {
+          "200": {
+            "description": "Returns an object like this: {\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1.0,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'length':20.0,\n            'species':'predator',\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'length':10.0,\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n          },\n          {\n            'fishtype': 'goblin',\n            'age': 1,\n            'birthday': '2015-08-08T00:00:00Z',\n            'length': 30.0,\n            'species': 'scary',\n            'jawsize': 5\n          }\n        ]\n      };",
+            "schema": {
+              "$ref": "#/definitions/Fish"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "polymorphism_putValid",
+        "description": "Put complex types that are polymorphic",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put a salmon that looks like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1.0,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'length':20.0,\n            'species':'predator',\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'length':10.0,\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n          },\n          {\n            'fishtype': 'goblin',\n            'age': 1,\n            'birthday': '2015-08-08T00:00:00Z',\n            'length': 30.0,\n            'species': 'scary',\n            'jawsize': 5\n          }\n        ]\n      };",
+            "schema": {
+              "$ref": "#/definitions/Fish"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/dotsyntax": {
+      "get": {
+        "operationId": "polymorphism_getDotSyntax",
+        "description": "Get complex types that are polymorphic, JSON key contains a dot",
+        "responses": {
+          "200": {
+            "description": "Returns an object like where JSON key of discriminator contains a dot",
+            "schema": {
+              "$ref": "#/definitions/DotFish"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/composedWithDiscriminator": {
+      "get": {
+        "operationId": "polymorphism_getComposedWithDiscriminator",
+        "description": "Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.",
+        "responses": {
+          "200": {
+            "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects with discriminator specified",
+            "schema": {
+              "$ref": "#/definitions/DotFishMarket"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/composedWithoutDiscriminator": {
+      "get": {
+        "operationId": "polymorphism_getComposedWithoutDiscriminator",
+        "description": "Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.",
+        "responses": {
+          "200": {
+            "description": "Returns an object that composes a scalar polymorphic object and array of polymorphic objects without discriminator specified",
+            "schema": {
+              "$ref": "#/definitions/DotFishMarket"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/complicated": {
+      "get": {
+        "operationId": "polymorphism_getComplicated",
+        "description": "Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/salmon"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "polymorphism_putComplicated",
+        "description": "Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/salmon"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/missingdiscriminator": {
+      "put": {
+        "operationId": "polymorphism_putMissingDiscriminator",
+        "description": "Put complex types that are polymorphic, omitting the discriminator",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/salmon"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns a salmon",
+            "schema": {
+              "$ref": "#/definitions/salmon"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphism/missingrequired/invalid": {
+      "put": {
+        "operationId": "polymorphism_putValidMissingRequired",
+        "description": "Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:\n{\n    \"fishtype\": \"sawshark\",\n    \"species\": \"snaggle toothed\",\n    \"length\": 18.5,\n    \"age\": 2,\n    \"birthday\": \"2013-06-01T01:00:00Z\",\n    \"location\": \"alaska\",\n    \"picture\": base64(FF FF FF FF FE),\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"birthday\": \"2012-01-05T01:00:00Z\",\n            \"length\": 20,\n            \"age\": 6\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"picture\": base64(FF FF FF FF FE),\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
+            "schema": {
+              "$ref": "#/definitions/Fish"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/polymorphicrecursive/valid": {
+      "get": {
+        "operationId": "polymorphicrecursive_getValid",
+        "description": "Get complex types that are polymorphic and have recursive references",
+        "responses": {
+          "200": {
+            "description": "Complex object that extends cat and pet, returns a Salmon like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'species':'predator',\n            'length':20,\n            'siblings':[\n                {\n                    'fishtype':'Salmon',\n                    'location':'atlantic',\n                    'iswild':true,\n                    'species':'coho',\n                    'length':2,\n                    'siblings':[\n                      {\n                        'fishtype':'Shark',\n                        'age':6,\n                        'birthday': '2012-01-05T01:00:00Z',\n                        'species':'predator',\n                        'length':20\n                      },\n                      {\n                        'fishtype':'Sawshark',\n                        'age':105,\n                        'birthday': '1900-01-05T01:00:00Z',\n                        'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                        'species':'dangerous',\n                        'length':10\n                      }\n                    ]\n                },\n                {\n                    'fishtype':'Sawshark',\n                    'age':105,\n                    'birthday': '1900-01-05T01:00:00Z',\n                    'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n                    'species':'dangerous',\n                    'length':10,\n                    'siblings':[]\n                }\n            ]\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n            'length':10,'siblings':[]\n          }\n        ]\n    };",
+            "schema": {
+              "$ref": "#/definitions/Fish"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "polymorphicrecursive_putValid",
+        "description": "Put complex types that are polymorphic and have recursive references",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "description": "Please put a salmon that looks like this:\n{\n    \"fishtype\": \"salmon\",\n    \"species\": \"king\",\n    \"length\": 1,\n    \"age\": 1,\n    \"location\": \"alaska\",\n    \"iswild\": true,\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"length\": 20,\n            \"age\": 6,\n            \"siblings\": [\n                {\n                    \"fishtype\": \"salmon\",\n                    \"species\": \"coho\",\n                    \"length\": 2,\n                    \"age\": 2,\n                    \"location\": \"atlantic\",\n                    \"iswild\": true,\n                    \"siblings\": [\n                        {\n                            \"fishtype\": \"shark\",\n                            \"species\": \"predator\",\n                            \"length\": 20,\n                            \"age\": 6\n                        },\n                        {\n                            \"fishtype\": \"sawshark\",\n                            \"species\": \"dangerous\",\n                            \"length\": 10,\n                            \"age\": 105\n                        }\n                    ]\n                },\n                {\n                    \"fishtype\": \"sawshark\",\n                    \"species\": \"dangerous\",\n                    \"length\": 10,\n                    \"age\": 105\n                }\n            ]\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}",
+            "schema": {
+              "$ref": "#/definitions/Fish"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/readonlyproperty/valid": {
+      "get": {
+        "operationId": "readonlyproperty_getValid",
+        "description": "Get complex types that have readonly properties",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/readonly-obj"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "readonlyproperty_putValid",
+        "description": "Put complex types that have readonly properties",
+        "parameters": [
+          {
+            "name": "complexBody",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/readonly-obj"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Empty Response"
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/complex/flatten/valid": {
+      "get": {
+        "operationId": "flattencomplex_getValid",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/MyBaseType"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "type":  "object",
+      "properties": {
+        "status": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    },
+    "basic": {
+      "type":  "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Basic Id",
+          "x-nullable": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Name property with a very long description that does not fit on a single line and a line break."
+        },
+        "color": {
+          "type": "string",
+          "enum": [ "cyan", "Magenta", "YELLOW", "blacK" ],
+          "x-ms-enum": {
+            "name": "CMYKColors",
+            "modelAsString": true
+          }
+        }
+      }
+    },
+    "pet": {
+      "type":  "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "cat": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "color": {
+          "type": "string"
+        },
+        "hates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/dog"
+          }
+        }
+      }
+    },
+    "siamese": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/cat"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "breed": {
+          "type": "string"
+        }
+      }
+    },
+    "dog": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/pet"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "food": {
+          "type": "string"
+        }
+      }
+    },
+    "DotFish": {
+      "type":  "object",
+      "discriminator": "fish.type",
+      "required": [ "fish.type" ],
+      "properties": {
+        "fish.type": {
+          "type": "string"
+        },
+        "species": {
+          "type": "string"
+        }
+      }
+    },
+    "DotSalmon": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/DotFish"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "iswild": {
+          "type": "boolean"
+        }
+      }
+    },
+    "DotFishMarket": {
+      "properties": {
+        "sampleSalmon": {
+          "$ref": "#/definitions/DotSalmon"
+        },
+        "salmons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DotSalmon"
+          }
+        },
+        "sampleFish": {
+          "$ref": "#/definitions/DotFish"
+        },
+        "fishes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DotFish"
+          }
+        }
+      }
+    },
+    "Fish": {
+      "type":  "object",
+      "discriminator": "fishtype",
+      "required": [ "fishtype", "length" ],
+      "properties": {
+        "fishtype": {
+          "type": "string"
+        },
+        "species": {
+          "type": "string"
+        },
+        "length": {
+          "type": "number",
+          "format": "float"
+        },
+        "siblings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Fish"
+          }
+        }
+      }
+    },
+    "salmon": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Fish"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "location": {
+          "type": "string"
+        },
+        "iswild": {
+          "type": "boolean"
+        }
+      }
+    },
+    "smart_salmon": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/salmon"
+        }
+      ],
+      "properties": {
+        "college_degree": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "shark": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Fish"
+        }
+      ],
+      "type":  "object",
+      "required": [ "birthday" ],
+      "properties": {
+        "age": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "birthday": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "sawshark": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/shark"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "picture": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "goblinshark": {
+      "x-ms-discriminator-value": "goblin",
+      "allOf": [
+        {
+          "$ref": "#/definitions/shark"
+        }
+      ],
+      "type":  "object",
+      "properties": {
+        "jawsize": {
+          "type": "integer"
+        },
+        "color": {
+          "type": "string",
+          "description": "Colors possible",
+          "enum": [
+            "pink",
+            "gray",
+            "brown",
+            "RED",
+            "red"
+          ],
+          "x-ms-enum": {
+            "name": "GoblinSharkColor",
+            "modelAsString": true,
+            "values": [{
+              "value": "pink"
+            },{
+              "value": "gray"
+            },{
+              "value": "brown"
+            },{
+              "value": "RED",
+              "description": "Uppercase RED",
+              "name": "upperRed"
+            },{
+              "value": "red",
+              "description": "Lowercase RED",
+              "name": "lowerRed"
+            }]
+          },
+          "default": "gray"
+        }
+      }
+    },
+    "cookiecuttershark": {
+      "type":  "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/shark"
+        }
+      ]
+    },
+    "int-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field1": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "field2": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "long-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field1": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "field2": {
+          "type": "integer",
+          "format": "int64"
+        }
+      }
+    },
+    "float-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field1": {
+          "type": "number",
+          "format": "float"
+        },
+        "field2": {
+          "type": "number",
+          "format": "float"
+        }
+      }
+    },
+    "double-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field1": {
+          "type": "number",
+          "format": "double"
+        },
+        "field_56_zeros_after_the_dot_and_negative_zero_before_dot_and_this_is_a_long_field_name_on_purpose": {
+          "type": "number",
+          "format": "double"
+        }
+      }
+    },
+    "boolean-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field_true": {
+          "type": "boolean"
+        },
+        "field_false": {
+          "type": "boolean"
+        }
+      }
+    },
+    "string-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field": {
+          "type": "string"
+        },
+        "empty": {
+          "type": "string"
+        },
+        "null": {
+          "type": "string"
+        }
+      }
+    },
+    "date-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "format": "date"
+        },
+        "leap": {
+          "type": "string",
+          "format": "date"
+        }
+      }
+    },
+    "datetime-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "now": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "datetimerfc1123-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "format": "date-time-rfc1123"
+        },
+        "now": {
+          "type": "string",
+          "format": "date-time-rfc1123"
+        }
+      }
+    },
+    "duration-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "format": "duration"
+        }
+      }
+    },
+    "byte-wrapper": {
+      "type":  "object",
+      "properties": {
+        "field": {
+          "type": "string",
+          "format": "byte"
+        }
+      }
+    },
+    "array-wrapper": {
+      "type":  "object",
+      "properties": {
+        "array": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "dictionary-wrapper": {
+      "type":  "object",
+      "properties": {
+        "defaultProgram": {
+          "type":  "object",
+          "x-nullable": true,
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "readonly-obj": {
+      "type":  "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "readOnly": true
+        },
+        "size": {
+          "type": "integer",
+          "format": "int32"
+        }
+      }
+    },
+    "MyKind": {
+      "type": "string",
+      "enum": [
+        "Kind1"
+      ],
+      "x-ms-enum": {
+        "name": "MyKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Kind1"
+          }
+        ]
+      }
+    },
+    "MyBaseHelperType": {
+      "type": "object",
+      "properties": {
+        "propBH1": {
+          "type": "string"
+        }
+      }
+    },
+    "MyBaseType": {
+      "type": "object",
+      "discriminator": "kind",
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/MyKind"
+        },
+        "propB1": {
+          "type": "string"
+        },
+        "helper": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/MyBaseHelperType"
+        }
+      },
+      "required": [
+        "kind"
+      ]
+    },
+    "MyDerivedType": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "#/definitions/MyBaseType"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "propD1": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "x-ms-discriminator-value": "Kind1"
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "description": "API ID.",
+      "required": true,
+      "type": "string",
+      "enum": [ "2016-02-29" ]
+    }
+  }
+}

--- a/test/integration/swaggers/extensible-enums-swagger.json
+++ b/test/integration/swaggers/extensible-enums-swagger.json
@@ -1,0 +1,138 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "2016-07-07",
+    "title": "PetStore Inc",
+    "description": "PetStore"
+  },
+  "host": "localhost:3000",
+  "schemes": ["http"],
+  "paths": {
+    "/extensibleenums/pet/{petId}": {
+      "get": {
+        "operationId": "Petop_GetByPetId",
+        "description": "get pet by id",
+        "x-ms-examples": {
+          "Petop_GetByPetId": {
+            "$ref": "./examples/Pet_GetByPetId.json"
+          }
+        },
+        "parameters": [
+          {
+            "$ref": "#/parameters/petid"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "produces": ["application/json"],
+        "consumes": ["application/json"]
+      }
+    },
+    "/extensibleenums/pet/addPet": {
+      "post": {
+        "operationId": "Petop_AddPet",
+        "description": "add pet",
+        "x-ms-examples": {
+          "Petop_AddPet": {
+            "$ref": "./examples/Pet_AddPet.json"
+          }
+        },
+        "parameters": [
+          {
+            "name": "petParam",
+            "description": "pet param",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          }
+        },
+        "produces": ["application/json"],
+        "consumes": ["application/json"]
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "name",
+          "type": "string"
+        },
+        "DaysOfWeek": {
+          "type": "string",
+          "description": "Type of Pet",
+          "enum": [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+            "Sunday"
+          ],
+          "x-ms-enum": {
+            "name": "DaysOfWeekExtensibleEnum",
+            "modelAsString": true
+          },
+          "default": "Friday"
+        },
+        "IntEnum": {
+          "type": "string",
+          "description": "",
+          "enum": ["1", "2", "3"],
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "IntEnum",
+            "values": [
+              {
+                "value": "1",
+                "description": "one",
+                "name": "1",
+                "allowedValues": ["1.1", "1.2", "1.3"]
+              },
+              {
+                "value": "2",
+                "description": "two",
+                "name": "2",
+                "allowedValues": ["2.1", "2.2"]
+              },
+              {
+                "value": "3",
+                "description": "three",
+                "name": "3",
+                "allowedValues": ["3.1", "3.3"]
+              }
+            ]
+          }
+        }
+      },
+      "required": ["IntEnum"]
+    }
+  },
+  "parameters": {
+    "petid": {
+      "name": "petId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Pet id",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/test/integration/swaggers/xms-error-responses.json
+++ b/test/integration/swaggers/xms-error-responses.json
@@ -1,0 +1,257 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "0.0.0",
+    "title": "XMS Error Response Extensions",
+    "description": "XMS Error Response Extensions"
+  },
+  "host": "localhost",
+  "schemes": ["http"],
+  "produces": ["application/json"],
+  "consumes": ["application/json"],
+  "paths": {
+    "/errorStatusCodes/Pets/{petId}/GetPet": {
+      "get": {
+        "operationId": "Petop_GetPetById",
+        "description": "Gets pets by id.",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "pet id"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "202": {
+            "description": "something something dark side"
+          },
+          "404": {
+            "description": "Not found",
+            "schema": {
+              "$ref": "#/definitions/NotFoundErrorBase"
+            },
+            "x-ms-error-response": true
+          },
+          "400": {
+            "description": "Bad request",
+            "schema": {
+              "type": "string"
+            },
+            "x-ms-error-response": true
+          },
+          "501": {
+            "description": "Some unexpected error",
+            "schema": {
+              "type": "integer"
+            },
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "default stuff"
+          }
+        }
+      }
+    },
+    "/errorStatusCodes/Pets/doSomething/{whatAction}": {
+      "post": {
+        "operationId": "Petop_DoSomething",
+        "description": "Asks pet to do something",
+        "parameters": [
+          {
+            "name": "whatAction",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "what action the pet should do"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "action performed",
+            "schema": {
+              "$ref": "#/definitions/PetAction"
+            }
+          },
+          "500": {
+            "description": "something bad happened",
+            "schema": {
+              "$ref": "#/definitions/PetActionError"
+            },
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "default stuff",
+            "schema": {
+              "$ref": "#/definitions/PetActionError"
+            }
+          }
+        }
+      }
+    },
+    "/errorStatusCodes/Pets/hasModelsParam": {
+      "post": {
+        "operationId": "Petop_HasModelsParam",
+        "description": "Ensure you can correctly deserialize the returned PetActionError and deserialization doesn't conflict with the input param name 'models'",
+        "parameters": [
+          {
+            "name": "models",
+            "in": "query",
+            "type": "string",
+            "x-ms-client-default": "value1",
+            "description": "Make sure model deserialization doesn't conflict with this param name, which has input name 'models'. Use client default value in call"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK. We will be returning an error though"
+          },
+          "500": {
+            "description": "Will return error. Make sure the error can be correctly deserialized",
+            "schema": {
+              "$ref": "#/definitions/PetActionError"
+            },
+            "x-ms-error-response": true
+          },
+          "default": {
+            "description": "Default",
+            "schema": {
+              "$ref": "#/definitions/PetActionError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Pet": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Animal"
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "readOnly": true,
+          "description": "Gets the Pet by id."
+        }
+      }
+    },
+    "NotFoundErrorBase": {
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "whatNotFound": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BaseError"
+        }
+      ],
+      "required": ["whatNotFound"],
+      "discriminator": "whatNotFound"
+    },
+    "BaseError": {
+      "properties": {
+        "someBaseProp": {
+          "type": "string"
+        }
+      }
+    },
+    "LinkNotFound": {
+      "properties": {
+        "whatSubAddress": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NotFoundErrorBase"
+        }
+      ],
+      "x-ms-discriminator-value": "InvalidResourceLink"
+    },
+    "AnimalNotFound": {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NotFoundErrorBase"
+        }
+      ]
+    },
+    "Animal": {
+      "properties": {
+        "aniType": {
+          "type": "string"
+        }
+      }
+    },
+    "PetAction": {
+      "properties": {
+        "actionResponse": {
+          "type": "string",
+          "description": "action feedback"
+        }
+      }
+    },
+    "PetActionError": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PetAction"
+        }
+      ],
+      "properties": {
+        "errorType": {
+          "type": "string"
+        },
+        "errorMessage": {
+          "type": "string",
+          "description": "the error message"
+        }
+      },
+      "required": ["errorType"],
+      "discriminator": "errorType"
+    },
+    "PetSadError": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PetActionError"
+        }
+      ],
+      "properties": {
+        "reason": {
+          "type": "string",
+          "description": "why is the pet sad"
+        }
+      }
+    },
+    "PetHungryOrThirstyError": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PetSadError"
+        }
+      ],
+      "properties": {
+        "hungryOrThirsty": {
+          "type": "string",
+          "description": "is the pet hungry or thirsty or both"
+        }
+      }
+    }
+  }
+}

--- a/test/integration/xmsErrorResponses.spec.ts
+++ b/test/integration/xmsErrorResponses.spec.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import {
   AnimalNotFound,
   LinkNotFound,
-  PetGetPetByIdResponse,
+  PetopGetPetByIdResponse,
   PetHungryOrThirstyError,
   PetSadError,
   XmsErrorResponsesClient
@@ -21,7 +21,7 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
 
   it("should get an animal not found error", async () => {
     try {
-      const response: any = await client.pet.getPetById("coyoteUgly");
+      const response: any = await client.petop.getPetById("coyoteUgly");
       assert.fail();
     } catch (ex) {
       const expected: AnimalNotFound = {
@@ -36,10 +36,10 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
   });
 
   it("should get an animal without error", async () => {
-    const response: PetGetPetByIdResponse = await client.pet.getPetById(
+    const response: PetopGetPetByIdResponse = await client.petop.getPetById(
       "tommy"
     );
-    const expected: Partial<PetGetPetByIdResponse> = {
+    const expected: Partial<PetopGetPetByIdResponse> = {
       name: "Tommy Tomson",
       aniType: "Dog"
     };
@@ -49,7 +49,7 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
 
   it("should get an animal hungry/thirsty error", async () => {
     try {
-      const response: any = await client.pet.doSomething("fetch");
+      const response: any = await client.petop.doSomething("fetch");
       assert.fail();
     } catch (ex) {
       const expected: PetHungryOrThirstyError = {
@@ -67,7 +67,7 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
 
   it("should get an animal sad error", async () => {
     try {
-      const response: any = await client.pet.doSomething("jump");
+      const response: any = await client.petop.doSomething("jump");
       assert.fail();
     } catch (ex) {
       const expected: PetSadError = {
@@ -84,7 +84,7 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
 
   it("should get a link found error", async () => {
     try {
-      const response: any = await client.pet.getPetById("weirdAlYankovic");
+      const response: any = await client.petop.getPetById("weirdAlYankovic");
       assert.fail();
     } catch (ex) {
       const expected: LinkNotFound = {
@@ -100,7 +100,7 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
 
   it("should get an unexpected int error", async () => {
     try {
-      const response: any = await client.pet.getPetById("alien123");
+      const response: any = await client.petop.getPetById("alien123");
       assert.fail();
     } catch (ex) {
       assert.deepEqual(JSON.parse(ex.message), 123);
@@ -110,7 +110,7 @@ describe("Integration tests for XmsErrorResponsesClient", () => {
 
   it("should get an bad requested string error", async () => {
     try {
-      const response: any = await client.pet.getPetById("ringo");
+      const response: any = await client.petop.getPetById("ringo");
       assert.fail();
     } catch (ex) {
       assert.deepEqual(JSON.parse(ex.message), "ringo is missing");

--- a/test/utils/test-swagger-gen.ts
+++ b/test/utils/test-swagger-gen.ts
@@ -74,13 +74,13 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true
   },
   bodyComplex: {
-    swagger: "body-complex.json",
+    swagger: "test/integration/swaggers/body-complex.json",
     clientName: "BodyComplexClient",
     packageName: "body-complex",
     licenseHeader: true
   },
   bodyComplexWithTracing: {
-    swagger: "body-complex.json",
+    swagger: "test/integration/swaggers/body-complex.json",
     clientName: "bodyComplexWithTracing",
     packageName: "body-complex-tracing",
     licenseHeader: true,
@@ -344,13 +344,13 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true
   },
   extensibleEnums: {
-    swagger: "extensible-enums-swagger.json",
+    swagger: "test/integration/swaggers/extensible-enums-swagger.json",
     clientName: "ExtensibleEnumsClient",
     packageName: "extensible-enums",
     licenseHeader: true
   },
   xmsErrorResponses: {
-    swagger: "xms-error-responses.json",
+    swagger: "test/integration/swaggers/xms-error-responses.json",
     clientName: "XmsErrorResponsesClient",
     packageName: "xms-error-responses",
     licenseHeader: true


### PR DESCRIPTION
This PR fixes the following issues:

1. **[Remove reference to "@azure/core-arm" ](https://github.com/Azure/autorest.typescript/issues/807)**
We have already deprecated @azure/core-arm package and deleted the source code from our repositories. But, the new generator references this package in the rollup config file. So, this PR removes that reference. 

2. **[Export Operations in the v6 generator](https://github.com/Azure/autorest.typescript/issues/808)**
In the generated SDK's src/index.ts file, we are not exporting the operations which is not correct. We need to export it. This PR adds code changes to add an export line for the operations in the src/index.ts file. 

But, while fixing this code, I encountered different issue. In some of the swagger files, the operation group name conflicts with the model name. That has to be fixed. There are 2 options:

1. I can change it in the autorest.testserver. But, I think that is not required. The reason is, to the best of my knowledge, this affects only TS SDK. So, we don't want to change it in the common place. 

2. I can copy the file locally (to this repo) and modify it. The only problem is we are losing the advantage of the common place for all test files. But, I think it is ok since we have only 3 such files. 

(Note: This problem did not occur in the old generated as the models is exported with '<XYZ>models'. Also, the operation group have suffix 'operations' added. So, there will not be any conflict.)

@joheredi Please review and approve.

@ramya-rao-a FYI.....