### PR TITLE
Remove core-arm in rollup file

### DIFF
--- a/src/generators/static/rollupConfigFileGenerator.ts
+++ b/src/generators/static/rollupConfigFileGenerator.ts
@@ -36,8 +36,7 @@ export function generateRollupConfig(
   const rollupConfig = `{
     input: "./esm/${clientDetails.sourceFileName}.js",
     external: [
-      "@azure/core-http",
-      "@azure/core-arm"
+      "@azure/core-http"
     ],
     output: {
       file: "./dist/${packageDetails.nameWithoutScope}.js",
@@ -45,8 +44,7 @@ export function generateRollupConfig(
       name: "${browserNameSpace}",
       sourcemap: true,
       globals: {
-        "@azure/core-http": "coreHttp",
-        "@azure/core-arm": "coreArm"
+        "@azure/core-http": "coreHttp"
       },
       banner: \`/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/additionalProperties/rollup.config.js
+++ b/test/integration/generated/additionalProperties/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/additionalPropertiesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/additional-properties.js",
     format: "umd",
     name: "AdditionalProperties",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/arrayConstraints/rollup.config.js
+++ b/test/integration/generated/arrayConstraints/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/arrayConstraintsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/array-constraints-client.js",
     format: "umd",
     name: "ArrayConstraintsClient",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureParameterGrouping/rollup.config.js
+++ b/test/integration/generated/azureParameterGrouping/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/azureParameterGroupingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/azure-parameter-grouping.js",
     format: "umd",
     name: "AzureParameterGrouping",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureReport/rollup.config.js
+++ b/test/integration/generated/azureReport/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/reportClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/zzzAzureReport.js",
     format: "umd",
     name: "ZzzAzureReport",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/azureSpecialProperties/rollup.config.js
+++ b/test/integration/generated/azureSpecialProperties/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/azureSpecialPropertiesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/azure-special-properties.js",
     format: "umd",
     name: "AzureSpecialProperties",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyArray/rollup.config.js
+++ b/test/integration/generated/bodyArray/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyArrayClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-array.js",
     format: "umd",
     name: "BodyArray",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyBoolean/rollup.config.js
+++ b/test/integration/generated/bodyBoolean/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyBooleanClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-boolean.js",
     format: "umd",
     name: "BodyBoolean",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyBooleanQuirks/rollup.config.js
+++ b/test/integration/generated/bodyBooleanQuirks/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyBooleanQuirksClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-boolean-quirks.js",
     format: "umd",
     name: "BodyBooleanQuirks",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyByte/rollup.config.js
+++ b/test/integration/generated/bodyByte/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyByteClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-byte.js",
     format: "umd",
     name: "BodyByte",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyComplex/rollup.config.js
+++ b/test/integration/generated/bodyComplex/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyComplexClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-complex.js",
     format: "umd",
     name: "BodyComplex",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyComplexWithTracing/rollup.config.js
+++ b/test/integration/generated/bodyComplexWithTracing/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyComplexWithTracing.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-complex-tracing.js",
     format: "umd",
     name: "BodyComplexTracing",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDate/rollup.config.js
+++ b/test/integration/generated/bodyDate/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDateClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-date.js",
     format: "umd",
     name: "BodyDate",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDateTime/rollup.config.js
+++ b/test/integration/generated/bodyDateTime/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDateTimeClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-datetime.js",
     format: "umd",
     name: "BodyDatetime",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDateTimeRfc1123/rollup.config.js
+++ b/test/integration/generated/bodyDateTimeRfc1123/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDateTimeRfc1123Client.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-datetime-rfc1123.js",
     format: "umd",
     name: "BodyDatetimeRfc1123",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDictionary/rollup.config.js
+++ b/test/integration/generated/bodyDictionary/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDictionaryClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-dictionary.js",
     format: "umd",
     name: "BodyDictionary",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyDuration/rollup.config.js
+++ b/test/integration/generated/bodyDuration/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyDurationClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-duration.js",
     format: "umd",
     name: "BodyDuration",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyFile/rollup.config.js
+++ b/test/integration/generated/bodyFile/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyFileClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-file.js",
     format: "umd",
     name: "BodyFile",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyFormData/rollup.config.js
+++ b/test/integration/generated/bodyFormData/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyFormDataClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-formdata.js",
     format: "umd",
     name: "BodyFormdata",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyInteger/rollup.config.js
+++ b/test/integration/generated/bodyInteger/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyIntegerClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-integer.js",
     format: "umd",
     name: "BodyInteger",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyNumber/rollup.config.js
+++ b/test/integration/generated/bodyNumber/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyNumberClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-number.js",
     format: "umd",
     name: "BodyNumber",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyString/rollup.config.js
+++ b/test/integration/generated/bodyString/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyStringClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-string.js",
     format: "umd",
     name: "BodyString",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/bodyTime/rollup.config.js
+++ b/test/integration/generated/bodyTime/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/bodyTimeClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/body-time.js",
     format: "umd",
     name: "BodyTime",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/customUrl/rollup.config.js
+++ b/test/integration/generated/customUrl/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/customUrlClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/custom-url.js",
     format: "umd",
     name: "CustomUrl",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/customUrlMoreOptions/rollup.config.js
+++ b/test/integration/generated/customUrlMoreOptions/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/customUrlMoreOptionsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/custom-url-MoreOptions.js",
     format: "umd",
     name: "CustomUrlMoreOptions",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/customUrlPaging/rollup.config.js
+++ b/test/integration/generated/customUrlPaging/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/customUrlPagingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/custom-url-paging.js",
     format: "umd",
     name: "CustomUrlPaging",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/extensibleEnums/rollup.config.js
+++ b/test/integration/generated/extensibleEnums/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/extensibleEnumsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/extensible-enums.js",
     format: "umd",
     name: "ExtensibleEnums",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/header/rollup.config.js
+++ b/test/integration/generated/header/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/headerClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/header.js",
     format: "umd",
     name: "Header",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/httpInfrastructure/rollup.config.js
+++ b/test/integration/generated/httpInfrastructure/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/httpInfrastructureClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/httpInfrastructure.js",
     format: "umd",
     name: "HttpInfrastructure",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/licenseHeader/rollup.config.js
+++ b/test/integration/generated/licenseHeader/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/licenseHeaderClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/license-header.js",
     format: "umd",
     name: "LicenseHeader",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/lro/rollup.config.js
+++ b/test/integration/generated/lro/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/lROClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/lro.js",
     format: "umd",
     name: "Lro",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/lroParametrizedEndpoints/rollup.config.js
+++ b/test/integration/generated/lroParametrizedEndpoints/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/lroParametrizedEndpointsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/lro-parameterized-endpoints.js",
     format: "umd",
     name: "LroParameterizedEndpoints",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypes/rollup.config.js
+++ b/test/integration/generated/mediaTypes/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-service.js",
     format: "umd",
     name: "MediaTypesService",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypesV3/rollup.config.js
+++ b/test/integration/generated/mediaTypesV3/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesV3Client.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-v3-client.js",
     format: "umd",
     name: "MediaTypesV3Client",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypesV3Lro/rollup.config.js
+++ b/test/integration/generated/mediaTypesV3Lro/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesV3LROClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-v3-lro-client.js",
     format: "umd",
     name: "MediaTypesV3LroClient",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/mediaTypesWithTracing/rollup.config.js
+++ b/test/integration/generated/mediaTypesWithTracing/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/mediaTypesWithTracingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/media-types-service-tracing.js",
     format: "umd",
     name: "MediaTypesServiceTracing",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/modelFlattening/rollup.config.js
+++ b/test/integration/generated/modelFlattening/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/modelFlatteningClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/model-flattening.js",
     format: "umd",
     name: "ModelFlattening",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/multipleInheritance/rollup.config.js
+++ b/test/integration/generated/multipleInheritance/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/multipleInheritanceClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/multiple-inheritance.js",
     format: "umd",
     name: "MultipleInheritance",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/noLicenseHeader/rollup.config.js
+++ b/test/integration/generated/noLicenseHeader/rollup.config.js
@@ -7,15 +7,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/noLicenseHeaderClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/nolicense-header.js",
     format: "umd",
     name: "NolicenseHeader",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/noMappers/rollup.config.js
+++ b/test/integration/generated/noMappers/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/noMappersClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/no-mappers.js",
     format: "umd",
     name: "NoMappers",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/nonStringEnum/rollup.config.js
+++ b/test/integration/generated/nonStringEnum/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/nonStringEnumClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/non-string-num.js",
     format: "umd",
     name: "NonStringNum",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/objectType/rollup.config.js
+++ b/test/integration/generated/objectType/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/objectTypeClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/object-type.js",
     format: "umd",
     name: "ObjectType",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/odataDiscriminator/rollup.config.js
+++ b/test/integration/generated/odataDiscriminator/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/oDataDiscriminatorClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/odata-discriminator.js",
     format: "umd",
     name: "OdataDiscriminator",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/paging/rollup.config.js
+++ b/test/integration/generated/paging/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/pagingClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/paging-service.js",
     format: "umd",
     name: "PagingService",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/pagingNoIterators/rollup.config.js
+++ b/test/integration/generated/pagingNoIterators/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/pagingNoIteratorsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/paging-no-iterators.js",
     format: "umd",
     name: "PagingNoIterators",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/regexConstraint/rollup.config.js
+++ b/test/integration/generated/regexConstraint/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/regexConstraint.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/regex-constraint.js",
     format: "umd",
     name: "RegexConstraint",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/report/rollup.config.js
+++ b/test/integration/generated/report/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/reportClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/zzzReport.js",
     format: "umd",
     name: "ZzzReport",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/requiredOptional/rollup.config.js
+++ b/test/integration/generated/requiredOptional/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/requiredOptionalClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/required-optional.js",
     format: "umd",
     name: "RequiredOptional",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/subscriptionIdApiVersion/rollup.config.js
+++ b/test/integration/generated/subscriptionIdApiVersion/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/subscriptionIdApiVersionClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/subscriptionid-apiversion.js",
     format: "umd",
     name: "SubscriptionidApiversion",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/url/rollup.config.js
+++ b/test/integration/generated/url/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/urlClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/url.js",
     format: "umd",
     name: "Url",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/url2/rollup.config.js
+++ b/test/integration/generated/url2/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/urlClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/url.js",
     format: "umd",
     name: "Url",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/urlMulti/rollup.config.js
+++ b/test/integration/generated/urlMulti/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/urlMultiClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/url-multi.js",
     format: "umd",
     name: "UrlMulti",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/uuid/rollup.config.js
+++ b/test/integration/generated/uuid/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/uuidClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/uuid.js",
     format: "umd",
     name: "Uuid",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/validation/rollup.config.js
+++ b/test/integration/generated/validation/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/validationClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/validation.js",
     format: "umd",
     name: "Validation",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/xmlservice/rollup.config.js
+++ b/test/integration/generated/xmlservice/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/xmlServiceClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/xml-service.js",
     format: "umd",
     name: "XmlService",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/integration/generated/xmsErrorResponses/rollup.config.js
+++ b/test/integration/generated/xmsErrorResponses/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/xmsErrorResponsesClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/xms-error-responses.js",
     format: "umd",
     name: "XmsErrorResponses",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/rollup.config.js
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/deploymentScriptsClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-deploymentscripts-2019-10-preview.js",
     format: "umd",
     name: "ArmPackageDeploymentscripts201910Preview",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-features-2015-12/rollup.config.js
+++ b/test/smoke/generated/arm-package-features-2015-12/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/featureClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-features-2015-12.js",
     format: "umd",
     name: "ArmPackageFeatures201512",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-links-2016-09/rollup.config.js
+++ b/test/smoke/generated/arm-package-links-2016-09/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/managementLinkClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-links-2016-09.js",
     format: "umd",
     name: "ArmPackageLinks201609",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-locks-2016-09/rollup.config.js
+++ b/test/smoke/generated/arm-package-locks-2016-09/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/managementLockClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-locks-2016-09.js",
     format: "umd",
     name: "ArmPackageLocks201609",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/rollup.config.js
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/applicationClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-managedapplications-2018-06.js",
     format: "umd",
     name: "ArmPackageManagedapplications201806",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-policy-2019-09/rollup.config.js
+++ b/test/smoke/generated/arm-package-policy-2019-09/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/policyClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-policy-2019-09.js",
     format: "umd",
     name: "ArmPackagePolicy201909",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-resources-2019-08/rollup.config.js
+++ b/test/smoke/generated/arm-package-resources-2019-08/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/resourceManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-resources-2019-08.js",
     format: "umd",
     name: "ArmPackageResources201908",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/rollup.config.js
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/subscriptionClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/arm-package-subscriptions-2019-06.js",
     format: "umd",
     name: "ArmPackageSubscriptions201906",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/compute-resource-manager/rollup.config.js
+++ b/test/smoke/generated/compute-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/computeManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/compute-resource-manager.js",
     format: "umd",
     name: "ComputeResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/cosmos-db-resource-manager/rollup.config.js
+++ b/test/smoke/generated/cosmos-db-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/cosmosDBManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/cosmos-db-resource-manager.js",
     format: "umd",
     name: "CosmosDbResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/graphrbac-data-plane/rollup.config.js
+++ b/test/smoke/generated/graphrbac-data-plane/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/graphRbacManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/graphrbac-data-plane.js",
     format: "umd",
     name: "GraphrbacDataPlane",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/keyvault-resource-manager/rollup.config.js
+++ b/test/smoke/generated/keyvault-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/keyVaultManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/keyvault-resource-manager.js",
     format: "umd",
     name: "KeyvaultResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/monitor-data-plane/rollup.config.js
+++ b/test/smoke/generated/monitor-data-plane/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/monitorClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/monitor-data-plane.js",
     format: "umd",
     name: "MonitorDataPlane",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/msi-resource-manager/rollup.config.js
+++ b/test/smoke/generated/msi-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/managedServiceIdentityClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/msi-resource-manager.js",
     format: "umd",
     name: "MsiResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/network-resource-manager/rollup.config.js
+++ b/test/smoke/generated/network-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/networkManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/network-resource-manager.js",
     format: "umd",
     name: "NetworkResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/sql-resource-manager/rollup.config.js
+++ b/test/smoke/generated/sql-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/sqlManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/sql-resource-manager.js",
     format: "umd",
     name: "SqlResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/storage-resource-manager/rollup.config.js
+++ b/test/smoke/generated/storage-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/storageManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/storage-resource-manager.js",
     format: "umd",
     name: "StorageResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.

--- a/test/smoke/generated/web-resource-manager/rollup.config.js
+++ b/test/smoke/generated/web-resource-manager/rollup.config.js
@@ -15,15 +15,14 @@ import sourcemaps from "rollup-plugin-sourcemaps";
  */
 const config = {
   input: "./esm/webSiteManagementClient.js",
-  external: ["@azure/core-http", "@azure/core-arm"],
+  external: ["@azure/core-http"],
   output: {
     file: "./dist/web-resource-manager.js",
     format: "umd",
     name: "WebResourceManager",
     sourcemap: true,
     globals: {
-      "@azure/core-http": "coreHttp",
-      "@azure/core-arm": "coreArm"
+      "@azure/core-http": "coreHttp"
     },
     banner: `/*
  * Copyright (c) Microsoft Corporation. All rights reserved.


### PR DESCRIPTION
This PR fixes the following issue:

1. **[Remove reference to "@azure/core-arm" ](https://github.com/Azure/autorest.typescript/issues/807)**
We have already deprecated @azure/core-arm package and deleted the source code from our repositories. But, the new generator references this package in the rollup config file. So, this PR removes that reference. 

@joheredi Please review and approve.

@ramya-rao-a FYI.... 