### PR TITLE
Add case in getMapperTypeFromSchema for SchemaType.Uuid

### DIFF
--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -28,6 +28,7 @@ import { getLanguageMetadata } from "../utils/languageHelpers";
 import { isNil } from "lodash";
 import { normalizeName, NameType } from "../utils/nameUtils";
 import { extractHeaders } from "../utils/extractHeaders";
+import { MapperTypes } from "../utils/valueHelpers";
 import { KnownMediaType } from "@azure-tools/codegen";
 import { ClientOptions } from "../models/clientDetails";
 import {
@@ -771,7 +772,9 @@ export function getMapperTypeFromSchema(type: SchemaType, format?: string) {
     case SchemaType.Object:
       return MapperType.Object;
     case SchemaType.Any:
-      return "any";
+      return MapperTypes.any;
+    case SchemaType.Uuid;
+      return MapperTypes.Uuid;
     default:
       throw new Error(`There is no known Mapper type for schema type ${type}`);
   }


### PR DESCRIPTION
Returns `MapperTypes.Uuid` (from `valueHelpers.ts` -> `MapperTypes` (note the plurality of this imported type differs from `@azure/core-http` -> `MapperType`
Also updates `SchemaType.Any` case to return `MapperTypes.any` instead of simply hard-coded `'any'`.

The lack of a valid return value from `getMapperTypeFromSchema` for `SchemaType.Uuid` was causing issues in my valid `swagger.json`
The full error was:
```
An error was encountered while handling a request: Error: There is no known Mapper type for schema type uuid
    at Object.getMapperTypeFromSchema (C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\mapperTransforms.js:524:19)
    at getSpecType (C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:127:43)
    at getMapperForSchema (C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:324:26)
    at transformOperationResponse (C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:181:15)
    at C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:234:56
    at Array.map (<anonymous>)
    at transformOperation (C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:234:40)
    at C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:275:85
    at Array.map (<anonymous>)
    at transformOperationGroup (C:\Users\mjohnst\.autorest\@autorest_typescript@6.0.0-dev.20201105.2\node_modules\@autorest\typescript\dist\src\transforms\operationTransforms.js:275:68)
FATAL: Error: There is no known Mapper type for schema type uuid
(node:28212) UnhandledPromiseRejectionWarning: Error: Plugin typescript reported failure.
    at C:\Users\mjohnst\.autorest\@autorest_core@3.0.6349\node_modules\@autorest\core\dist\lib\pipeline\plugins\external.js:27:19
    at async ScheduleNode (C:\Users\mjohnst\.autorest\@autorest_core@3.0.6349\node_modules\@autorest\core\dist\lib\pipeline\pipeline.js:314:33)
(node:28212) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 29)
(node:28212) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:28212) UnhandledPromiseRejectionWarning: Error: Plugin typescript reported failure.
    at C:\Users\mjohnst\.autorest\@autorest_core@3.0.6349\node_modules\@autorest\core\dist\lib\pipeline\plugins\external.js:27:19
    at async ScheduleNode (C:\Users\mjohnst\.autorest\@autorest_core@3.0.6349\node_modules\@autorest\core\dist\lib\pipeline\pipeline.js:314:33)
(node:28212) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 30)
  Error: Plugin typescript reported failure.
```

After this change, I validated locally that the Typescript code is successfully generated.