### PR TITLE
Fix Names specifically overridden in Configuration Files

### DIFF
--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -30,7 +30,7 @@ npm install ${packageDetails.name}
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -137,6 +137,9 @@ export function normalizeName(
   nameType: NameType,
   shouldGuard?: boolean
 ): string {
+  if (name.startsWith("$DO_NOT_NORMALIZE$")) {
+    return name.replace("$DO_NOT_NORMALIZE$", "");
+  }
   const casingConvention = getCasingConvention(nameType);
   const sanitizedName = sanitizeName(name);
   const parts = getNameParts(sanitizedName);

--- a/test/integration/generated/additionalProperties/README.md
+++ b/test/integration/generated/additionalProperties/README.md
@@ -17,7 +17,7 @@ npm install additional-properties
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/appconfiguration/README.md
+++ b/test/integration/generated/appconfiguration/README.md
@@ -17,7 +17,7 @@ npm install appconfiguration
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/appconfigurationexport/README.md
+++ b/test/integration/generated/appconfigurationexport/README.md
@@ -17,7 +17,7 @@ npm install appconfiguration
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/arrayConstraints/README.md
+++ b/test/integration/generated/arrayConstraints/README.md
@@ -17,7 +17,7 @@ npm install array-constraints-client
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/azureParameterGrouping/README.md
+++ b/test/integration/generated/azureParameterGrouping/README.md
@@ -17,7 +17,7 @@ npm install azure-parameter-grouping
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/azureReport/README.md
+++ b/test/integration/generated/azureReport/README.md
@@ -17,7 +17,7 @@ npm install zzzAzureReport
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/azureSpecialProperties/README.md
+++ b/test/integration/generated/azureSpecialProperties/README.md
@@ -17,7 +17,7 @@ npm install azure-special-properties
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyArray/README.md
+++ b/test/integration/generated/bodyArray/README.md
@@ -17,7 +17,7 @@ npm install body-array
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyBoolean/README.md
+++ b/test/integration/generated/bodyBoolean/README.md
@@ -17,7 +17,7 @@ npm install body-boolean
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyBooleanQuirks/README.md
+++ b/test/integration/generated/bodyBooleanQuirks/README.md
@@ -17,7 +17,7 @@ npm install body-boolean-quirks
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyByte/README.md
+++ b/test/integration/generated/bodyByte/README.md
@@ -17,7 +17,7 @@ npm install body-byte
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyComplex/README.md
+++ b/test/integration/generated/bodyComplex/README.md
@@ -17,7 +17,7 @@ npm install body-complex
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyComplexWithTracing/README.md
+++ b/test/integration/generated/bodyComplexWithTracing/README.md
@@ -17,7 +17,7 @@ npm install body-complex-tracing
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyDate/README.md
+++ b/test/integration/generated/bodyDate/README.md
@@ -17,7 +17,7 @@ npm install body-date
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyDateTime/README.md
+++ b/test/integration/generated/bodyDateTime/README.md
@@ -17,7 +17,7 @@ npm install body-datetime
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyDateTimeRfc1123/README.md
+++ b/test/integration/generated/bodyDateTimeRfc1123/README.md
@@ -17,7 +17,7 @@ npm install body-datetime-rfc1123
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyDictionary/README.md
+++ b/test/integration/generated/bodyDictionary/README.md
@@ -17,7 +17,7 @@ npm install body-dictionary
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyDuration/README.md
+++ b/test/integration/generated/bodyDuration/README.md
@@ -17,7 +17,7 @@ npm install body-duration
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyFile/README.md
+++ b/test/integration/generated/bodyFile/README.md
@@ -17,7 +17,7 @@ npm install body-file
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyFormData/README.md
+++ b/test/integration/generated/bodyFormData/README.md
@@ -17,7 +17,7 @@ npm install body-formdata
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyInteger/README.md
+++ b/test/integration/generated/bodyInteger/README.md
@@ -17,7 +17,7 @@ npm install body-integer
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyNumber/README.md
+++ b/test/integration/generated/bodyNumber/README.md
@@ -17,7 +17,7 @@ npm install body-number
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyString/README.md
+++ b/test/integration/generated/bodyString/README.md
@@ -17,7 +17,7 @@ npm install body-string
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/bodyTime/README.md
+++ b/test/integration/generated/bodyTime/README.md
@@ -17,7 +17,7 @@ npm install body-time
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/customUrl/README.md
+++ b/test/integration/generated/customUrl/README.md
@@ -17,7 +17,7 @@ npm install custom-url
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/customUrlMoreOptions/README.md
+++ b/test/integration/generated/customUrlMoreOptions/README.md
@@ -17,7 +17,7 @@ npm install custom-url-MoreOptions
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/customUrlPaging/README.md
+++ b/test/integration/generated/customUrlPaging/README.md
@@ -17,7 +17,7 @@ npm install custom-url-paging
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/extensibleEnums/README.md
+++ b/test/integration/generated/extensibleEnums/README.md
@@ -17,7 +17,7 @@ npm install extensible-enums
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/header/README.md
+++ b/test/integration/generated/header/README.md
@@ -17,7 +17,7 @@ npm install header
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/httpInfrastructure/README.md
+++ b/test/integration/generated/httpInfrastructure/README.md
@@ -17,7 +17,7 @@ npm install httpInfrastructure
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/licenseHeader/README.md
+++ b/test/integration/generated/licenseHeader/README.md
@@ -17,7 +17,7 @@ npm install license-header
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/lro/README.md
+++ b/test/integration/generated/lro/README.md
@@ -17,7 +17,7 @@ npm install lro
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/lroParametrizedEndpoints/README.md
+++ b/test/integration/generated/lroParametrizedEndpoints/README.md
@@ -17,7 +17,7 @@ npm install lro-parameterized-endpoints
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/mapperrequired/README.md
+++ b/test/integration/generated/mapperrequired/README.md
@@ -17,7 +17,7 @@ npm install mapperrequired
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/mediaTypes/README.md
+++ b/test/integration/generated/mediaTypes/README.md
@@ -17,7 +17,7 @@ npm install media-types-service
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/mediaTypesV3/README.md
+++ b/test/integration/generated/mediaTypesV3/README.md
@@ -17,7 +17,7 @@ npm install media-types-v3-client
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/mediaTypesV3Lro/README.md
+++ b/test/integration/generated/mediaTypesV3Lro/README.md
@@ -17,7 +17,7 @@ npm install media-types-v3-lro-client
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/mediaTypesWithTracing/README.md
+++ b/test/integration/generated/mediaTypesWithTracing/README.md
@@ -17,7 +17,7 @@ npm install media-types-service-tracing
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/modelFlattening/README.md
+++ b/test/integration/generated/modelFlattening/README.md
@@ -17,7 +17,7 @@ npm install model-flattening
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/multipleInheritance/README.md
+++ b/test/integration/generated/multipleInheritance/README.md
@@ -17,7 +17,7 @@ npm install multiple-inheritance
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/nameChecker/src/index.ts
+++ b/test/integration/generated/nameChecker/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./models";
+export { SearchClient } from "./searchClient";
+export { SearchClientContext } from "./searchClientContext";

--- a/test/integration/generated/nameChecker/src/models/index.ts
+++ b/test/integration/generated/nameChecker/src/models/index.ts
@@ -1,0 +1,567 @@
+import * as coreHttp from "@azure/core-http";
+
+/** Describes an error condition for the Azure Cognitive Search API. */
+export interface SearchError {
+  /**
+   * One of a server-defined set of error codes.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly code?: string;
+  /**
+   * A human-readable representation of the error.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly message: string;
+  /**
+   * An array of details about specific errors that led to this reported error.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly details?: SearchError[];
+}
+
+/** Response containing search results from an index. */
+export interface SearchDocumentsResult {
+  /**
+   * The total count of results found by the search operation, or null if the count was not requested. If present, the count may be greater than the number of results in this response. This can happen if you use the $top or $skip parameters, or if Azure Cognitive Search can't return all the requested documents in a single Search response.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly count?: number;
+  /**
+   * A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not specified in the request.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly coverage?: number;
+  /**
+   * The facet query results for the search operation, organized as a collection of buckets for each faceted field; null if the query did not include any facet expressions.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly facets?: { [propertyName: string]: FacetResult[] };
+  /**
+   * Continuation JSON payload returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this JSON along with @odata.nextLink to formulate another POST Search request to get the next part of the search response.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly nextPageParameters?: SearchRequest;
+  /**
+   * The sequence of results returned by the query.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly results: SearchResult[];
+  /**
+   * Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search response. Make sure to use the same verb (GET or POST) as the request that produced this response.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly nextLink?: string;
+}
+
+/** A single bucket of a facet query result. Reports the number of documents with a field value falling within a particular range or having a particular value or interval. */
+export interface FacetResult {
+  /** Describes unknown properties. The value of an unknown property can be of "any" type. */
+  [property: string]: any;
+  /**
+   * The approximate count of documents falling within the bucket described by this facet.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly count?: number;
+}
+
+/** Parameters for filtering, sorting, faceting, paging, and other search query behaviors. */
+export interface SearchRequest {
+  /** A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation. */
+  includeTotalResultCount?: boolean;
+  /** The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs. */
+  facets?: string[];
+  /** The OData $filter expression to apply to the search query. */
+  filter?: string;
+  /** The comma-separated list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting. */
+  highlightFields?: string;
+  /** A string tag that is appended to hit highlights. Must be set with highlightPreTag. Default is &lt;/em&gt;. */
+  highlightPostTag?: string;
+  /** A string tag that is prepended to hit highlights. Must be set with highlightPostTag. Default is &lt;em&gt;. */
+  highlightPreTag?: string;
+  /** A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100. */
+  minimumCoverage?: number;
+  /** The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. */
+  orderBy?: string;
+  /** A value that specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax. */
+  queryType?: QueryType;
+  /** A value that specifies whether we want to calculate scoring statistics (such as document frequency) globally for more consistent scoring, or locally, for lower latency. The default is 'local'. Use 'global' to aggregate scoring statistics globally before scoring. Using global scoring statistics can increase latency of search queries. */
+  scoringStatistics?: ScoringStatistics;
+  /** A value to be used to create a sticky session, which can help getting more consistent results. As long as the same sessionId is used, a best-effort attempt will be made to target the same replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the load balancing of the requests across replicas and adversely affect the performance of the search service. The value used as sessionId cannot start with a '_' character. */
+  sessionId?: string;
+  /** The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name-values. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be "mylocation--122.2,44.8" (without the quotes). */
+  scoringParameters?: string[];
+  /** The name of a scoring profile to evaluate match scores for matching documents in order to sort the results. */
+  scoringProfile?: string;
+  /** A full-text search query expression; Use "*" or omit this parameter to match all documents. */
+  searchText?: string;
+  /** The comma-separated list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter. */
+  searchFields?: string;
+  /** A value that specifies whether any or all of the search terms must be matched in order to count the document as a match. */
+  searchMode?: SearchMode;
+  /** The comma-separated list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included. */
+  select?: string;
+  /** The number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use skip due to this limitation, consider using orderby on a totally-ordered key and filter with a range query instead. */
+  skip?: number;
+  /** The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results. */
+  top?: number;
+}
+
+/** Contains a document found by a search query, plus associated metadata. */
+export interface SearchResult {
+  /** Describes unknown properties. The value of an unknown property can be of "any" type. */
+  [property: string]: any;
+  /**
+   * The relevance score of the document compared to other documents returned by the query.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly _score: number;
+  /**
+   * Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly _highlights?: { [propertyName: string]: string[] };
+}
+
+/** Response containing suggestion query results from an index. */
+export interface SuggestDocumentsResult {
+  /**
+   * The sequence of results returned by the query.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly results: SuggestResult[];
+  /**
+   * A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not set in the request.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly coverage?: number;
+}
+
+/** A result containing a document found by a suggestion query, plus associated metadata. */
+export interface SuggestResult {
+  /** Describes unknown properties. The value of an unknown property can be of "any" type. */
+  [property: string]: any;
+  /**
+   * The text of the suggestion result.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly _text: string;
+}
+
+/** Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors. */
+export interface SuggestRequest {
+  /** An OData expression that filters the documents considered for suggestions. */
+  filter?: string;
+  /** A value indicating whether to use fuzzy matching for the suggestion query. Default is false. When set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources. */
+  useFuzzyMatching?: boolean;
+  /** A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting of suggestions is disabled. */
+  highlightPostTag?: string;
+  /** A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting of suggestions is disabled. */
+  highlightPreTag?: string;
+  /** A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestion query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. */
+  minimumCoverage?: number;
+  /** The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. */
+  orderBy?: string;
+  /** The search text to use to suggest documents. Must be at least 1 character, and no more than 100 characters. */
+  searchText: string;
+  /** The comma-separated list of field names to search for the specified search text. Target fields must be included in the specified suggester. */
+  searchFields?: string;
+  /** The comma-separated list of fields to retrieve. If unspecified, only the key field will be included in the results. */
+  select?: string;
+  /** The name of the suggester as specified in the suggesters collection that's part of the index definition. */
+  suggesterName: string;
+  /** The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5. */
+  top?: number;
+}
+
+/** Contains a batch of document write actions to send to the index. */
+export interface IndexBatch {
+  /** The actions in the batch. */
+  actions: IndexAction[];
+}
+
+/** Represents an index action that operates on a document. */
+export interface IndexAction {
+  /** Describes unknown properties. The value of an unknown property can be of "any" type. */
+  [property: string]: any;
+  /** The operation to perform on a document in an indexing batch. */
+  __actionType: IndexActionType;
+}
+
+/** Response containing the status of operations for all documents in the indexing request. */
+export interface IndexDocumentsResult {
+  /**
+   * The list of status information for each document in the indexing request.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly results: IndexingResult[];
+}
+
+/** Status of an indexing operation for a single document. */
+export interface IndexingResult {
+  /**
+   * The key of a document that was in the indexing request.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly key: string;
+  /**
+   * The error message explaining why the indexing operation failed for the document identified by the key; null if indexing succeeded.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly errorMessage?: string;
+  /**
+   * A value indicating whether the indexing operation succeeded for the document identified by the key.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly succeeded: boolean;
+  /**
+   * The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly statusCode: number;
+}
+
+/** The result of Autocomplete query. */
+export interface AutocompleteResult {
+  /**
+   * A value indicating the percentage of the index that was considered by the autocomplete request, or null if minimumCoverage was not specified in the request.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly coverage?: number;
+  /**
+   * The list of returned Autocompleted items.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly results: AutocompleteItem[];
+}
+
+/** The result of Autocomplete requests. */
+export interface AutocompleteItem {
+  /**
+   * The completed term.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly text: string;
+  /**
+   * The query along with the completed term.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly queryPlusText: string;
+}
+
+/** Parameters for fuzzy matching, and other autocomplete query behaviors. */
+export interface AutocompleteRequest {
+  /** The search text on which to base autocomplete results. */
+  searchText: string;
+  /** Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms. */
+  autocompleteMode?: AutocompleteMode;
+  /** An OData expression that filters the documents used to produce completed terms for the Autocomplete result. */
+  filter?: string;
+  /** A value indicating whether to use fuzzy matching for the autocomplete query. Default is false. When set to true, the query will autocomplete terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources. */
+  useFuzzyMatching?: boolean;
+  /** A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting is disabled. */
+  highlightPostTag?: string;
+  /** A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting is disabled. */
+  highlightPreTag?: string;
+  /** A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. */
+  minimumCoverage?: number;
+  /** The comma-separated list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester. */
+  searchFields?: string;
+  /** The name of the suggester as specified in the suggesters collection that's part of the index definition. */
+  suggesterName: string;
+  /** The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5. */
+  top?: number;
+}
+
+/** Parameter group */
+export interface RequestOptions {
+  /** The tracking ID sent with the request to help with debugging. */
+  xMsClientRequestId?: string;
+}
+
+/** Parameter group */
+export interface SearchOptions {
+  /** A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation. */
+  includeTotalResultCount?: boolean;
+  /** The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs. */
+  facets?: string[];
+  /** The OData $filter expression to apply to the search query. */
+  filter?: string;
+  /** The list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting. */
+  highlightFields?: string[];
+  /** A string tag that is appended to hit highlights. Must be set with highlightPreTag. Default is &lt;/em&gt;. */
+  highlightPostTag?: string;
+  /** A string tag that is prepended to hit highlights. Must be set with highlightPostTag. Default is &lt;em&gt;. */
+  highlightPreTag?: string;
+  /** A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100. */
+  minimumCoverage?: number;
+  /** The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. */
+  orderBy?: string[];
+  /** A value that specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax. */
+  queryType?: QueryType;
+  /** The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name-values. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be "mylocation--122.2,44.8" (without the quotes). */
+  scoringParameters?: string[];
+  /** The name of a scoring profile to evaluate match scores for matching documents in order to sort the results. */
+  scoringProfile?: string;
+  /** The list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter. */
+  searchFields?: string[];
+  /** A value that specifies whether any or all of the search terms must be matched in order to count the document as a match. */
+  searchMode?: SearchMode;
+  /** A value that specifies whether we want to calculate scoring statistics (such as document frequency) globally for more consistent scoring, or locally, for lower latency. */
+  scoringStatistics?: ScoringStatistics;
+  /** A value to be used to create a sticky session, which can help to get more consistent results. As long as the same sessionId is used, a best-effort attempt will be made to target the same replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the load balancing of the requests across replicas and adversely affect the performance of the search service. The value used as sessionId cannot start with a '_' character. */
+  sessionId?: string;
+  /** The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included. */
+  select?: string[];
+  /** The number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use $skip due to this limitation, consider using $orderby on a totally-ordered key and $filter with a range query instead. */
+  skip?: number;
+  /** The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results. */
+  top?: number;
+}
+
+/** Parameter group */
+export interface SuggestOptions {
+  /** An OData expression that filters the documents considered for suggestions. */
+  filter?: string;
+  /** A value indicating whether to use fuzzy matching for the suggestions query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestions queries are slower and consume more resources. */
+  useFuzzyMatching?: boolean;
+  /** A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting of suggestions is disabled. */
+  highlightPostTag?: string;
+  /** A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting of suggestions is disabled. */
+  highlightPreTag?: string;
+  /** A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestions query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. */
+  minimumCoverage?: number;
+  /** The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses. */
+  orderBy?: string[];
+  /** The list of field names to search for the specified search text. Target fields must be included in the specified suggester. */
+  searchFields?: string[];
+  /** The list of fields to retrieve. If unspecified, only the key field will be included in the results. */
+  select?: string[];
+  /** The number of suggestions to retrieve. The value must be a number between 1 and 100. The default is 5. */
+  top?: number;
+}
+
+/** Parameter group */
+export interface AutocompleteOptions {
+  /** Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms. */
+  autocompleteMode?: AutocompleteMode;
+  /** An OData expression that filters the documents used to produce completed terms for the Autocomplete result. */
+  filter?: string;
+  /** A value indicating whether to use fuzzy matching for the autocomplete query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources. */
+  useFuzzyMatching?: boolean;
+  /** A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting is disabled. */
+  highlightPostTag?: string;
+  /** A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting is disabled. */
+  highlightPreTag?: string;
+  /** A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80. */
+  minimumCoverage?: number;
+  /** The list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester. */
+  searchFields?: string[];
+  /** The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5. */
+  top?: number;
+}
+
+/** Defines values for QueryType. */
+export type QueryType = "simple" | "full";
+/** Defines values for SearchMode. */
+export type SearchMode = "any" | "all";
+/** Defines values for ScoringStatistics. */
+export type ScoringStatistics = "local" | "global";
+/** Defines values for IndexActionType. */
+export type IndexActionType = "upload" | "merge" | "mergeOrUpload" | "delete";
+/** Defines values for AutocompleteMode. */
+export type AutocompleteMode = "oneTerm" | "twoTerms" | "oneTermWithContext";
+
+/** Optional parameters. */
+export interface DocumentsCountOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+}
+
+/** Contains response data for the count operation. */
+export type DocumentsCountResponse = {
+  /** The parsed response body. */
+  body: number;
+
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: number;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsSearchGetOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+  /** Parameter group */
+  searchOptions?: SearchOptions;
+  /** A full-text search query expression; Use "*" or omit this parameter to match all documents. */
+  searchText?: string;
+}
+
+/** Contains response data for the searchGet operation. */
+export type DocumentsSearchGetResponse = SearchDocumentsResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: SearchDocumentsResult;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsSearchPostOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+}
+
+/** Contains response data for the searchPost operation. */
+export type DocumentsSearchPostResponse = SearchDocumentsResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: SearchDocumentsResult;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsGetOptionalParams extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+  /** List of field names to retrieve for the document; Any field not retrieved will be missing from the returned document. */
+  selectedFields?: string[];
+}
+
+/** Contains response data for the get operation. */
+export type DocumentsGetResponse = {
+  /** The parsed response body. */
+  body: any;
+
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: any;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsSuggestGetOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+  /** Parameter group */
+  suggestOptions?: SuggestOptions;
+}
+
+/** Contains response data for the suggestGet operation. */
+export type DocumentsSuggestGetResponse = SuggestDocumentsResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: SuggestDocumentsResult;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsSuggestPostOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+}
+
+/** Contains response data for the suggestPost operation. */
+export type DocumentsSuggestPostResponse = SuggestDocumentsResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: SuggestDocumentsResult;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsIndexOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+}
+
+/** Contains response data for the index operation. */
+export type DocumentsIndexResponse = IndexDocumentsResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: IndexDocumentsResult;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsAutocompleteGetOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+  /** Parameter group */
+  autocompleteOptions?: AutocompleteOptions;
+}
+
+/** Contains response data for the autocompleteGet operation. */
+export type DocumentsAutocompleteGetResponse = AutocompleteResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: AutocompleteResult;
+  };
+};
+
+/** Optional parameters. */
+export interface DocumentsAutocompletePostOptionalParams
+  extends coreHttp.OperationOptions {
+  /** Parameter group */
+  requestOptionsParam?: RequestOptions;
+}
+
+/** Contains response data for the autocompletePost operation. */
+export type DocumentsAutocompletePostResponse = AutocompleteResult & {
+  /** The underlying HTTP response. */
+  _response: coreHttp.HttpResponse & {
+    /** The response body as text (string format) */
+    bodyAsText: string;
+
+    /** The response body as parsed JSON or XML */
+    parsedBody: AutocompleteResult;
+  };
+};
+
+/** Optional parameters. */
+export interface SearchClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /** Api Version */
+  apiVersion?: string;
+  /** Overrides client endpoint. */
+  endpoint?: string;
+}

--- a/test/integration/generated/nameChecker/src/models/mappers.ts
+++ b/test/integration/generated/nameChecker/src/models/mappers.ts
@@ -1,0 +1,638 @@
+import * as coreHttp from "@azure/core-http";
+
+export const SearchError: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SearchError",
+    modelProperties: {
+      code: {
+        serializedName: "code",
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      },
+      message: {
+        serializedName: "message",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      },
+      details: {
+        serializedName: "details",
+        readOnly: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "SearchError"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const SearchDocumentsResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SearchDocumentsResult",
+    modelProperties: {
+      count: {
+        serializedName: "@odata\\.count",
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      },
+      coverage: {
+        serializedName: "@search\\.coverage",
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      },
+      facets: {
+        serializedName: "@search\\.facets",
+        readOnly: true,
+        type: {
+          name: "Dictionary",
+          value: {
+            type: {
+              name: "Sequence",
+              element: { type: { name: "Composite", className: "FacetResult" } }
+            }
+          }
+        }
+      },
+      nextPageParameters: {
+        serializedName: "@search\\.nextPageParameters",
+        type: {
+          name: "Composite",
+          className: "SearchRequest"
+        }
+      },
+      results: {
+        serializedName: "value",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "SearchResult"
+            }
+          }
+        }
+      },
+      nextLink: {
+        serializedName: "@odata\\.nextLink",
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const FacetResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "FacetResult",
+    additionalProperties: { type: { name: "Object" } },
+    modelProperties: {
+      count: {
+        serializedName: "count",
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const SearchRequest: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SearchRequest",
+    modelProperties: {
+      includeTotalResultCount: {
+        serializedName: "count",
+        type: {
+          name: "Boolean"
+        }
+      },
+      facets: {
+        serializedName: "facets",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      },
+      filter: {
+        serializedName: "filter",
+        type: {
+          name: "String"
+        }
+      },
+      highlightFields: {
+        serializedName: "highlight",
+        type: {
+          name: "String"
+        }
+      },
+      highlightPostTag: {
+        serializedName: "highlightPostTag",
+        type: {
+          name: "String"
+        }
+      },
+      highlightPreTag: {
+        serializedName: "highlightPreTag",
+        type: {
+          name: "String"
+        }
+      },
+      minimumCoverage: {
+        serializedName: "minimumCoverage",
+        type: {
+          name: "Number"
+        }
+      },
+      orderBy: {
+        serializedName: "orderby",
+        type: {
+          name: "String"
+        }
+      },
+      queryType: {
+        serializedName: "queryType",
+        type: {
+          name: "Enum",
+          allowedValues: ["simple", "full"]
+        }
+      },
+      scoringStatistics: {
+        serializedName: "scoringStatistics",
+        type: {
+          name: "Enum",
+          allowedValues: ["local", "global"]
+        }
+      },
+      sessionId: {
+        serializedName: "sessionId",
+        type: {
+          name: "String"
+        }
+      },
+      scoringParameters: {
+        serializedName: "scoringParameters",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      },
+      scoringProfile: {
+        serializedName: "scoringProfile",
+        type: {
+          name: "String"
+        }
+      },
+      searchText: {
+        serializedName: "search",
+        type: {
+          name: "String"
+        }
+      },
+      searchFields: {
+        serializedName: "searchFields",
+        type: {
+          name: "String"
+        }
+      },
+      searchMode: {
+        serializedName: "searchMode",
+        type: {
+          name: "Enum",
+          allowedValues: ["any", "all"]
+        }
+      },
+      select: {
+        serializedName: "select",
+        type: {
+          name: "String"
+        }
+      },
+      skip: {
+        serializedName: "skip",
+        type: {
+          name: "Number"
+        }
+      },
+      top: {
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const SearchResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SearchResult",
+    additionalProperties: { type: { name: "Object" } },
+    modelProperties: {
+      _score: {
+        serializedName: "@search\\.score",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      },
+      _highlights: {
+        serializedName: "@search\\.highlights",
+        readOnly: true,
+        type: {
+          name: "Dictionary",
+          value: {
+            type: { name: "Sequence", element: { type: { name: "String" } } }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const SuggestDocumentsResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SuggestDocumentsResult",
+    modelProperties: {
+      results: {
+        serializedName: "value",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "SuggestResult"
+            }
+          }
+        }
+      },
+      coverage: {
+        serializedName: "@search\\.coverage",
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const SuggestResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SuggestResult",
+    additionalProperties: { type: { name: "Object" } },
+    modelProperties: {
+      _text: {
+        serializedName: "@search\\.text",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const SuggestRequest: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "SuggestRequest",
+    modelProperties: {
+      filter: {
+        serializedName: "filter",
+        type: {
+          name: "String"
+        }
+      },
+      useFuzzyMatching: {
+        serializedName: "fuzzy",
+        type: {
+          name: "Boolean"
+        }
+      },
+      highlightPostTag: {
+        serializedName: "highlightPostTag",
+        type: {
+          name: "String"
+        }
+      },
+      highlightPreTag: {
+        serializedName: "highlightPreTag",
+        type: {
+          name: "String"
+        }
+      },
+      minimumCoverage: {
+        serializedName: "minimumCoverage",
+        type: {
+          name: "Number"
+        }
+      },
+      orderBy: {
+        serializedName: "orderby",
+        type: {
+          name: "String"
+        }
+      },
+      searchText: {
+        serializedName: "search",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      searchFields: {
+        serializedName: "searchFields",
+        type: {
+          name: "String"
+        }
+      },
+      select: {
+        serializedName: "select",
+        type: {
+          name: "String"
+        }
+      },
+      suggesterName: {
+        serializedName: "suggesterName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      top: {
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const IndexBatch: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "IndexBatch",
+    modelProperties: {
+      actions: {
+        serializedName: "value",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "IndexAction"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const IndexAction: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "IndexAction",
+    additionalProperties: { type: { name: "Object" } },
+    modelProperties: {
+      __actionType: {
+        serializedName: "@search\\.action",
+        required: true,
+        type: {
+          name: "Enum",
+          allowedValues: ["upload", "merge", "mergeOrUpload", "delete"]
+        }
+      }
+    }
+  }
+};
+
+export const IndexDocumentsResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "IndexDocumentsResult",
+    modelProperties: {
+      results: {
+        serializedName: "value",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "IndexingResult"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const IndexingResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "IndexingResult",
+    modelProperties: {
+      key: {
+        serializedName: "key",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      },
+      errorMessage: {
+        serializedName: "errorMessage",
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      },
+      succeeded: {
+        serializedName: "status",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Boolean"
+        }
+      },
+      statusCode: {
+        serializedName: "statusCode",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};
+
+export const AutocompleteResult: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "AutocompleteResult",
+    modelProperties: {
+      coverage: {
+        serializedName: "@search\\.coverage",
+        readOnly: true,
+        type: {
+          name: "Number"
+        }
+      },
+      results: {
+        serializedName: "value",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "AutocompleteItem"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const AutocompleteItem: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "AutocompleteItem",
+    modelProperties: {
+      text: {
+        serializedName: "text",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      },
+      queryPlusText: {
+        serializedName: "queryPlusText",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const AutocompleteRequest: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "AutocompleteRequest",
+    modelProperties: {
+      searchText: {
+        serializedName: "search",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      autocompleteMode: {
+        serializedName: "autocompleteMode",
+        type: {
+          name: "Enum",
+          allowedValues: ["oneTerm", "twoTerms", "oneTermWithContext"]
+        }
+      },
+      filter: {
+        serializedName: "filter",
+        type: {
+          name: "String"
+        }
+      },
+      useFuzzyMatching: {
+        serializedName: "fuzzy",
+        type: {
+          name: "Boolean"
+        }
+      },
+      highlightPostTag: {
+        serializedName: "highlightPostTag",
+        type: {
+          name: "String"
+        }
+      },
+      highlightPreTag: {
+        serializedName: "highlightPreTag",
+        type: {
+          name: "String"
+        }
+      },
+      minimumCoverage: {
+        serializedName: "minimumCoverage",
+        type: {
+          name: "Number"
+        }
+      },
+      searchFields: {
+        serializedName: "searchFields",
+        type: {
+          name: "String"
+        }
+      },
+      suggesterName: {
+        serializedName: "suggesterName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      top: {
+        serializedName: "top",
+        type: {
+          name: "Number"
+        }
+      }
+    }
+  }
+};

--- a/test/integration/generated/nameChecker/src/models/parameters.ts
+++ b/test/integration/generated/nameChecker/src/models/parameters.ts
@@ -1,0 +1,574 @@
+import {
+  OperationParameter,
+  OperationURLParameter,
+  OperationQueryParameter,
+  QueryCollectionFormat
+} from "@azure/core-http";
+import {
+  SearchRequest as SearchRequestMapper,
+  SuggestRequest as SuggestRequestMapper,
+  IndexBatch as IndexBatchMapper,
+  AutocompleteRequest as AutocompleteRequestMapper
+} from "../models/mappers";
+
+export const accept: OperationParameter = {
+  parameterPath: "accept",
+  mapper: {
+    defaultValue: "application/json",
+    isConstant: true,
+    serializedName: "Accept",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const endpoint: OperationURLParameter = {
+  parameterPath: "endpoint",
+  mapper: {
+    serializedName: "endpoint",
+    required: true,
+    type: {
+      name: "String"
+    }
+  },
+  skipEncoding: true
+};
+
+export const indexName: OperationURLParameter = {
+  parameterPath: "indexName",
+  mapper: {
+    serializedName: "indexName",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const xMsClientRequestId: OperationParameter = {
+  parameterPath: ["options", "requestOptionsParam", "xMsClientRequestId"],
+  mapper: {
+    serializedName: "x-ms-client-request-id",
+    type: {
+      name: "Uuid"
+    }
+  }
+};
+
+export const apiVersion: OperationQueryParameter = {
+  parameterPath: "apiVersion",
+  mapper: {
+    defaultValue: "2020-06-30-Preview",
+    isConstant: true,
+    serializedName: "api-version",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const searchText: OperationQueryParameter = {
+  parameterPath: ["options", "searchText"],
+  mapper: {
+    serializedName: "search",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const includeTotalResultCount: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "includeTotalResultCount"],
+  mapper: {
+    serializedName: "$count",
+    type: {
+      name: "Boolean"
+    }
+  }
+};
+
+export const facets: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "facets"],
+  mapper: {
+    serializedName: "facet",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Multi
+};
+
+export const filter: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "filter"],
+  mapper: {
+    serializedName: "$filter",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const highlightFields: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "highlightFields"],
+  mapper: {
+    serializedName: "highlight",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const highlightPostTag: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "highlightPostTag"],
+  mapper: {
+    serializedName: "highlightPostTag",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const highlightPreTag: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "highlightPreTag"],
+  mapper: {
+    serializedName: "highlightPreTag",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const minimumCoverage: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "minimumCoverage"],
+  mapper: {
+    serializedName: "minimumCoverage",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const orderBy: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "orderBy"],
+  mapper: {
+    serializedName: "$orderby",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const queryType: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "queryType"],
+  mapper: {
+    serializedName: "queryType",
+    type: {
+      name: "Enum",
+      allowedValues: ["simple", "full"]
+    }
+  }
+};
+
+export const scoringParameters: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "scoringParameters"],
+  mapper: {
+    serializedName: "scoringParameter",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Multi
+};
+
+export const scoringProfile: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "scoringProfile"],
+  mapper: {
+    serializedName: "scoringProfile",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const searchFields: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "searchFields"],
+  mapper: {
+    serializedName: "searchFields",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const searchMode: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "searchMode"],
+  mapper: {
+    serializedName: "searchMode",
+    type: {
+      name: "Enum",
+      allowedValues: ["any", "all"]
+    }
+  }
+};
+
+export const scoringStatistics: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "scoringStatistics"],
+  mapper: {
+    serializedName: "scoringStatistics",
+    type: {
+      name: "Enum",
+      allowedValues: ["local", "global"]
+    }
+  }
+};
+
+export const sessionId: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "sessionId"],
+  mapper: {
+    serializedName: "sessionId",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const select: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "select"],
+  mapper: {
+    serializedName: "$select",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const skip: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "skip"],
+  mapper: {
+    serializedName: "$skip",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const top: OperationQueryParameter = {
+  parameterPath: ["options", "searchOptions", "top"],
+  mapper: {
+    serializedName: "$top",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const contentType: OperationParameter = {
+  parameterPath: ["options", "contentType"],
+  mapper: {
+    defaultValue: "application/json",
+    isConstant: true,
+    serializedName: "Content-Type",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const searchRequest: OperationParameter = {
+  parameterPath: "searchRequest",
+  mapper: SearchRequestMapper
+};
+
+export const key: OperationURLParameter = {
+  parameterPath: "key",
+  mapper: {
+    serializedName: "key",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const selectedFields: OperationQueryParameter = {
+  parameterPath: ["options", "selectedFields"],
+  mapper: {
+    serializedName: "$select",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const search$DONotNormalize$Text: OperationQueryParameter = {
+  parameterPath: "search$DONotNormalize$Text",
+  mapper: {
+    serializedName: "search",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const suggesterName: OperationQueryParameter = {
+  parameterPath: "suggesterName",
+  mapper: {
+    serializedName: "suggesterName",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const filter1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "filter"],
+  mapper: {
+    serializedName: "$filter",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const useFuzzyMatching: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "useFuzzyMatching"],
+  mapper: {
+    serializedName: "fuzzy",
+    type: {
+      name: "Boolean"
+    }
+  }
+};
+
+export const highlightPostTag1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "highlightPostTag"],
+  mapper: {
+    serializedName: "highlightPostTag",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const highlightPreTag1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "highlightPreTag"],
+  mapper: {
+    serializedName: "highlightPreTag",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const minimumCoverage1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "minimumCoverage"],
+  mapper: {
+    serializedName: "minimumCoverage",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const orderBy1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "orderBy"],
+  mapper: {
+    serializedName: "$orderby",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const searchFields1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "searchFields"],
+  mapper: {
+    serializedName: "searchFields",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const select1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "select"],
+  mapper: {
+    serializedName: "$select",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const top1: OperationQueryParameter = {
+  parameterPath: ["options", "suggestOptions", "top"],
+  mapper: {
+    serializedName: "$top",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const suggestRequest: OperationParameter = {
+  parameterPath: "suggestRequest",
+  mapper: SuggestRequestMapper
+};
+
+export const batch: OperationParameter = {
+  parameterPath: "batch",
+  mapper: IndexBatchMapper
+};
+
+export const autocompleteMode: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "autocompleteMode"],
+  mapper: {
+    serializedName: "autocompleteMode",
+    type: {
+      name: "Enum",
+      allowedValues: ["oneTerm", "twoTerms", "oneTermWithContext"]
+    }
+  }
+};
+
+export const filter2: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "filter"],
+  mapper: {
+    serializedName: "$filter",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const useFuzzyMatching1: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "useFuzzyMatching"],
+  mapper: {
+    serializedName: "fuzzy",
+    type: {
+      name: "Boolean"
+    }
+  }
+};
+
+export const highlightPostTag2: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "highlightPostTag"],
+  mapper: {
+    serializedName: "highlightPostTag",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const highlightPreTag2: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "highlightPreTag"],
+  mapper: {
+    serializedName: "highlightPreTag",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const minimumCoverage2: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "minimumCoverage"],
+  mapper: {
+    serializedName: "minimumCoverage",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const searchFields2: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "searchFields"],
+  mapper: {
+    serializedName: "searchFields",
+    type: {
+      name: "Sequence",
+      element: {
+        type: {
+          name: "String"
+        }
+      }
+    }
+  },
+  collectionFormat: QueryCollectionFormat.Csv
+};
+
+export const top2: OperationQueryParameter = {
+  parameterPath: ["options", "autocompleteOptions", "top"],
+  mapper: {
+    serializedName: "$top",
+    type: {
+      name: "Number"
+    }
+  }
+};
+
+export const autocompleteRequest: OperationParameter = {
+  parameterPath: "autocompleteRequest",
+  mapper: AutocompleteRequestMapper
+};

--- a/test/integration/generated/nameChecker/src/operations/documents.ts
+++ b/test/integration/generated/nameChecker/src/operations/documents.ts
@@ -1,0 +1,435 @@
+import * as coreHttp from "@azure/core-http";
+import * as Mappers from "../models/mappers";
+import * as Parameters from "../models/parameters";
+import { SearchClient } from "../searchClient";
+import {
+  DocumentsCountOptionalParams,
+  DocumentsCountResponse,
+  DocumentsSearchGetOptionalParams,
+  DocumentsSearchGetResponse,
+  SearchRequest,
+  DocumentsSearchPostOptionalParams,
+  DocumentsSearchPostResponse,
+  DocumentsGetOptionalParams,
+  DocumentsGetResponse,
+  DocumentsSuggestGetOptionalParams,
+  DocumentsSuggestGetResponse,
+  SuggestRequest,
+  DocumentsSuggestPostOptionalParams,
+  DocumentsSuggestPostResponse,
+  IndexBatch,
+  DocumentsIndexOptionalParams,
+  DocumentsIndexResponse,
+  DocumentsAutocompleteGetOptionalParams,
+  DocumentsAutocompleteGetResponse,
+  AutocompleteRequest,
+  DocumentsAutocompletePostOptionalParams,
+  DocumentsAutocompletePostResponse
+} from "../models";
+
+/** Class representing a Documents. */
+export class Documents {
+  private readonly client: SearchClient;
+
+  /**
+   * Initialize a new instance of the class Documents class.
+   * @param client Reference to the service client
+   */
+  constructor(client: SearchClient) {
+    this.client = client;
+  }
+
+  /**
+   * Queries the number of documents in the index.
+   * @param options The options parameters.
+   */
+  count(
+    options?: DocumentsCountOptionalParams
+  ): Promise<DocumentsCountResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      countOperationSpec
+    ) as Promise<DocumentsCountResponse>;
+  }
+
+  /**
+   * Searches for documents in the index.
+   * @param options The options parameters.
+   */
+  searchGet(
+    options?: DocumentsSearchGetOptionalParams
+  ): Promise<DocumentsSearchGetResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      searchGetOperationSpec
+    ) as Promise<DocumentsSearchGetResponse>;
+  }
+
+  /**
+   * Searches for documents in the index.
+   * @param searchRequest The definition of the Search request.
+   * @param options The options parameters.
+   */
+  searchPost(
+    searchRequest: SearchRequest,
+    options?: DocumentsSearchPostOptionalParams
+  ): Promise<DocumentsSearchPostResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      searchRequest,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      searchPostOperationSpec
+    ) as Promise<DocumentsSearchPostResponse>;
+  }
+
+  /**
+   * Retrieves a document from the index.
+   * @param key The key of the document to retrieve.
+   * @param options The options parameters.
+   */
+  get(
+    key: string,
+    options?: DocumentsGetOptionalParams
+  ): Promise<DocumentsGetResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      key,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      getOperationSpec
+    ) as Promise<DocumentsGetResponse>;
+  }
+
+  /**
+   * Suggests documents in the index that match the given partial query text.
+   * @param suggesterName The name of the suggester as specified in the suggesters collection that's part
+   *                      of the index definition.
+   * @param search$DONotNormalize$Text The search text to use to suggest documents. Must be at least 1
+   *                                   character, and no more than 100 characters.
+   * @param options The options parameters.
+   */
+  suggestGet(
+    suggesterName: string,
+    search$DONotNormalize$Text: string,
+    options?: DocumentsSuggestGetOptionalParams
+  ): Promise<DocumentsSuggestGetResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      suggesterName,
+      search$DONotNormalize$Text,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      suggestGetOperationSpec
+    ) as Promise<DocumentsSuggestGetResponse>;
+  }
+
+  /**
+   * Suggests documents in the index that match the given partial query text.
+   * @param suggestRequest The Suggest request.
+   * @param options The options parameters.
+   */
+  suggestPost(
+    suggestRequest: SuggestRequest,
+    options?: DocumentsSuggestPostOptionalParams
+  ): Promise<DocumentsSuggestPostResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      suggestRequest,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      suggestPostOperationSpec
+    ) as Promise<DocumentsSuggestPostResponse>;
+  }
+
+  /**
+   * Sends a batch of document write actions to the index.
+   * @param batch The batch of index actions.
+   * @param options The options parameters.
+   */
+  index(
+    batch: IndexBatch,
+    options?: DocumentsIndexOptionalParams
+  ): Promise<DocumentsIndexResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      batch,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      indexOperationSpec
+    ) as Promise<DocumentsIndexResponse>;
+  }
+
+  /**
+   * Autocompletes incomplete query terms based on input text and matching terms in the index.
+   * @param suggesterName The name of the suggester as specified in the suggesters collection that's part
+   *                      of the index definition.
+   * @param search$DONotNormalize$Text The incomplete term which should be auto-completed.
+   * @param options The options parameters.
+   */
+  autocompleteGet(
+    suggesterName: string,
+    search$DONotNormalize$Text: string,
+    options?: DocumentsAutocompleteGetOptionalParams
+  ): Promise<DocumentsAutocompleteGetResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      suggesterName,
+      search$DONotNormalize$Text,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      autocompleteGetOperationSpec
+    ) as Promise<DocumentsAutocompleteGetResponse>;
+  }
+
+  /**
+   * Autocompletes incomplete query terms based on input text and matching terms in the index.
+   * @param autocompleteRequest The definition of the Autocomplete request.
+   * @param options The options parameters.
+   */
+  autocompletePost(
+    autocompleteRequest: AutocompleteRequest,
+    options?: DocumentsAutocompletePostOptionalParams
+  ): Promise<DocumentsAutocompletePostResponse> {
+    const operationArguments: coreHttp.OperationArguments = {
+      autocompleteRequest,
+      options: coreHttp.operationOptionsToRequestOptionsBase(options || {})
+    };
+    return this.client.sendOperationRequest(
+      operationArguments,
+      autocompletePostOperationSpec
+    ) as Promise<DocumentsAutocompletePostResponse>;
+  }
+}
+// Operation Specifications
+const serializer = new coreHttp.Serializer(Mappers, /* isXml */ false);
+
+const countOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/$count",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: { type: { name: "Number" } }
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [Parameters.accept, Parameters.xMsClientRequestId],
+  serializer
+};
+const searchGetOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: Mappers.SearchDocumentsResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  queryParameters: [
+    Parameters.apiVersion,
+    Parameters.searchText,
+    Parameters.includeTotalResultCount,
+    Parameters.facets,
+    Parameters.filter,
+    Parameters.highlightFields,
+    Parameters.highlightPostTag,
+    Parameters.highlightPreTag,
+    Parameters.minimumCoverage,
+    Parameters.orderBy,
+    Parameters.queryType,
+    Parameters.scoringParameters,
+    Parameters.scoringProfile,
+    Parameters.searchFields,
+    Parameters.searchMode,
+    Parameters.scoringStatistics,
+    Parameters.sessionId,
+    Parameters.select,
+    Parameters.skip,
+    Parameters.top
+  ],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [Parameters.accept, Parameters.xMsClientRequestId],
+  serializer
+};
+const searchPostOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/search.post.search",
+  httpMethod: "POST",
+  responses: {
+    200: {
+      bodyMapper: Mappers.SearchDocumentsResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  requestBody: Parameters.searchRequest,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [
+    Parameters.accept,
+    Parameters.xMsClientRequestId,
+    Parameters.contentType
+  ],
+  mediaType: "json",
+  serializer
+};
+const getOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs('{key}')",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: { type: { name: "any" } }
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  queryParameters: [Parameters.apiVersion, Parameters.selectedFields],
+  urlParameters: [Parameters.endpoint, Parameters.indexName, Parameters.key],
+  headerParameters: [Parameters.accept, Parameters.xMsClientRequestId],
+  serializer
+};
+const suggestGetOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/search.suggest",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: Mappers.SuggestDocumentsResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  queryParameters: [
+    Parameters.apiVersion,
+    Parameters.search$DONotNormalize$Text,
+    Parameters.suggesterName,
+    Parameters.filter1,
+    Parameters.useFuzzyMatching,
+    Parameters.highlightPostTag1,
+    Parameters.highlightPreTag1,
+    Parameters.minimumCoverage1,
+    Parameters.orderBy1,
+    Parameters.searchFields1,
+    Parameters.select1,
+    Parameters.top1
+  ],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [Parameters.accept, Parameters.xMsClientRequestId],
+  serializer
+};
+const suggestPostOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/search.post.suggest",
+  httpMethod: "POST",
+  responses: {
+    200: {
+      bodyMapper: Mappers.SuggestDocumentsResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  requestBody: Parameters.suggestRequest,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [
+    Parameters.accept,
+    Parameters.xMsClientRequestId,
+    Parameters.contentType
+  ],
+  mediaType: "json",
+  serializer
+};
+const indexOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/search.index",
+  httpMethod: "POST",
+  responses: {
+    200: {
+      bodyMapper: Mappers.IndexDocumentsResult
+    },
+    207: {
+      bodyMapper: Mappers.IndexDocumentsResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  requestBody: Parameters.batch,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [
+    Parameters.accept,
+    Parameters.xMsClientRequestId,
+    Parameters.contentType
+  ],
+  mediaType: "json",
+  serializer
+};
+const autocompleteGetOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/search.autocomplete",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: Mappers.AutocompleteResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  queryParameters: [
+    Parameters.apiVersion,
+    Parameters.search$DONotNormalize$Text,
+    Parameters.suggesterName,
+    Parameters.autocompleteMode,
+    Parameters.filter2,
+    Parameters.useFuzzyMatching1,
+    Parameters.highlightPostTag2,
+    Parameters.highlightPreTag2,
+    Parameters.minimumCoverage2,
+    Parameters.searchFields2,
+    Parameters.top2
+  ],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [Parameters.accept, Parameters.xMsClientRequestId],
+  serializer
+};
+const autocompletePostOperationSpec: coreHttp.OperationSpec = {
+  path: "/docs/search.post.autocomplete",
+  httpMethod: "POST",
+  responses: {
+    200: {
+      bodyMapper: Mappers.AutocompleteResult
+    },
+    default: {
+      bodyMapper: Mappers.SearchError
+    }
+  },
+  requestBody: Parameters.autocompleteRequest,
+  queryParameters: [Parameters.apiVersion],
+  urlParameters: [Parameters.endpoint, Parameters.indexName],
+  headerParameters: [
+    Parameters.accept,
+    Parameters.xMsClientRequestId,
+    Parameters.contentType
+  ],
+  mediaType: "json",
+  serializer
+};

--- a/test/integration/generated/nameChecker/src/operations/index.ts
+++ b/test/integration/generated/nameChecker/src/operations/index.ts
@@ -1,0 +1,1 @@
+export * from "./documents";

--- a/test/integration/generated/nameChecker/src/searchClient.ts
+++ b/test/integration/generated/nameChecker/src/searchClient.ts
@@ -1,0 +1,22 @@
+import { Documents } from "./operations";
+import { SearchClientContext } from "./searchClientContext";
+import { SearchClientOptionalParams } from "./models";
+
+export class SearchClient extends SearchClientContext {
+  /**
+   * Initializes a new instance of the SearchClient class.
+   * @param endpoint The endpoint URL of the search service.
+   * @param indexName The name of the index.
+   * @param options The parameter options
+   */
+  constructor(
+    endpoint: string,
+    indexName: string,
+    options?: SearchClientOptionalParams
+  ) {
+    super(endpoint, indexName, options);
+    this.documents = new Documents(this);
+  }
+
+  documents: Documents;
+}

--- a/test/integration/generated/nameChecker/src/searchClientContext.ts
+++ b/test/integration/generated/nameChecker/src/searchClientContext.ts
@@ -1,0 +1,53 @@
+import * as coreHttp from "@azure/core-http";
+import { SearchClientOptionalParams } from "./models";
+
+const packageName = "@azure/search-documents";
+const packageVersion = "1.0.0-preview1";
+
+export class SearchClientContext extends coreHttp.ServiceClient {
+  endpoint: string;
+  indexName: string;
+  apiVersion: string;
+
+  /**
+   * Initializes a new instance of the SearchClientContext class.
+   * @param endpoint The endpoint URL of the search service.
+   * @param indexName The name of the index.
+   * @param options The parameter options
+   */
+  constructor(
+    endpoint: string,
+    indexName: string,
+    options?: SearchClientOptionalParams
+  ) {
+    if (endpoint === undefined) {
+      throw new Error("'endpoint' cannot be null");
+    }
+    if (indexName === undefined) {
+      throw new Error("'indexName' cannot be null");
+    }
+
+    // Initializing default values for options
+    if (!options) {
+      options = {};
+    }
+
+    if (!options.userAgent) {
+      const defaultUserAgent = coreHttp.getDefaultUserAgentValue();
+      options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
+    }
+
+    super(undefined, options);
+
+    this.requestContentType = "application/json; charset=utf-8";
+
+    this.baseUri = options.endpoint || "{endpoint}/indexes('{indexName}')";
+
+    // Parameter assignments
+    this.endpoint = endpoint;
+    this.indexName = indexName;
+
+    // Assigning values to Constant parameters
+    this.apiVersion = options.apiVersion || "2020-06-30-Preview";
+  }
+}

--- a/test/integration/generated/noLicenseHeader/README.md
+++ b/test/integration/generated/noLicenseHeader/README.md
@@ -17,7 +17,7 @@ npm install nolicense-header
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/noMappers/README.md
+++ b/test/integration/generated/noMappers/README.md
@@ -17,7 +17,7 @@ npm install no-mappers
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/nonStringEnum/README.md
+++ b/test/integration/generated/nonStringEnum/README.md
@@ -17,7 +17,7 @@ npm install non-string-num
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/objectType/README.md
+++ b/test/integration/generated/objectType/README.md
@@ -17,7 +17,7 @@ npm install object-type
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/odataDiscriminator/README.md
+++ b/test/integration/generated/odataDiscriminator/README.md
@@ -17,7 +17,7 @@ npm install odata-discriminator
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/paging/README.md
+++ b/test/integration/generated/paging/README.md
@@ -17,7 +17,7 @@ npm install paging-service
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/pagingNoIterators/README.md
+++ b/test/integration/generated/pagingNoIterators/README.md
@@ -17,7 +17,7 @@ npm install paging-no-iterators
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/readmeFileChecker/README.md
+++ b/test/integration/generated/readmeFileChecker/README.md
@@ -17,7 +17,7 @@ npm install @azure/keyvault-secrets
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/regexConstraint/README.md
+++ b/test/integration/generated/regexConstraint/README.md
@@ -17,7 +17,7 @@ npm install regex-constraint
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/report/README.md
+++ b/test/integration/generated/report/README.md
@@ -17,7 +17,7 @@ npm install zzzReport
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/requiredOptional/README.md
+++ b/test/integration/generated/requiredOptional/README.md
@@ -17,7 +17,7 @@ npm install required-optional
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/subscriptionIdApiVersion/README.md
+++ b/test/integration/generated/subscriptionIdApiVersion/README.md
@@ -17,7 +17,7 @@ npm install subscriptionid-apiversion
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/url/README.md
+++ b/test/integration/generated/url/README.md
@@ -17,7 +17,7 @@ npm install url
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/url2/README.md
+++ b/test/integration/generated/url2/README.md
@@ -17,7 +17,7 @@ npm install url
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/urlMulti/README.md
+++ b/test/integration/generated/urlMulti/README.md
@@ -17,7 +17,7 @@ npm install url-multi
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/uuid/README.md
+++ b/test/integration/generated/uuid/README.md
@@ -17,7 +17,7 @@ npm install uuid
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/validation/README.md
+++ b/test/integration/generated/validation/README.md
@@ -17,7 +17,7 @@ npm install validation
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/xmlservice/README.md
+++ b/test/integration/generated/xmlservice/README.md
@@ -17,7 +17,7 @@ npm install xml-service
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/generated/xmsErrorResponses/README.md
+++ b/test/integration/generated/xmsErrorResponses/README.md
@@ -17,7 +17,7 @@ npm install xms-error-responses
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/integration/nameChecker.spec.ts
+++ b/test/integration/nameChecker.spec.ts
@@ -1,0 +1,53 @@
+import { SearchClient } from "./generated/nameChecker/src";
+import { assert } from "chai";
+import * as fs from "fs";
+
+describe("Integration tests for NameChecker", () => {
+  let client: SearchClient;
+
+  it("should create a client successfully", async () => {
+    client = new SearchClient("sampleEndPoint", "sampleIndexName");
+    assert.notEqual(client, null);
+  });
+
+  it("should check for naming overrides in models index file", async () => {
+    const content: string = fs.readFileSync(
+      "./test/integration/generated/nameChecker/src/models/index.ts",
+      "utf-8"
+    );
+
+    let containsHidden = content.includes("readonly _score: number;");
+
+    assert.equal(
+      containsHidden,
+      true,
+      "Expected _score naming override missing"
+    );
+
+    containsHidden = content.includes(
+      "readonly _highlights?: { [propertyName: string]: string[] };"
+    );
+
+    assert.equal(
+      containsHidden,
+      true,
+      "Expected _highlights naming override missing"
+    );
+
+    containsHidden = content.includes("__actionType: IndexActionType;");
+
+    assert.equal(
+      containsHidden,
+      true,
+      "Expected __actionType naming override missing"
+    );
+
+    containsHidden = content.includes("readonly _text: string;");
+
+    assert.equal(
+      containsHidden,
+      true,
+      "Expected _text naming override missing"
+    );
+  });
+});

--- a/test/integration/readmeFileChecker.spec.ts
+++ b/test/integration/readmeFileChecker.spec.ts
@@ -1,7 +1,7 @@
 import { KeyVaultClient } from "./generated/readmeFileChecker/src/";
 import { assert } from "chai";
 
-describe("Integration tests for AppCOnfiguration", () => {
+describe("Integration tests for AppConfiguration", () => {
   let client: KeyVaultClient;
 
   it("should create a client successfully", async () => {

--- a/test/integration/swaggers/Data.md
+++ b/test/integration/swaggers/Data.md
@@ -59,31 +59,31 @@ directive:
   - from: swagger-document
     where: $.definitions.AutocompleteItem.properties
     transform: >
-      $["text"]["x-ms-client-name"] = "SDKCustomT$e$x$t";
-      $["queryPlusText"]["x-ms-client-name"] = "SDKCustomq$u$e$r$y$P$l$u$s$T$e$x$t";
+      $["text"]["x-ms-client-name"] = "SDKCustomT^e^x^t";
+      $["queryPlusText"]["x-ms-client-name"] = "SDKCustomq^u^e^r^y^P^l^u^s^T^e^x^t";
   - from: swagger-document
     where: $.definitions.AutocompleteRequest.properties
     transform: >
-      $["search"]["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+      $["search"]["x-ms-client-name"] = "SDKCustomS^e^a^r^c^h^T^e^x^t";
   - from: swagger-document
     where: $.definitions.SearchRequest.properties
     transform: >
-      $["search"]["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+      $["search"]["x-ms-client-name"] = "SDKCustomS^e^a^r^c^h^T^e^x^t";
   - from: swagger-document
     where: $.definitions.SuggestRequest.properties
     transform: >
-      $["search"]["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+      $["search"]["x-ms-client-name"] = "SDKCustomS^e^a^r^c^h^T^e^x^t";
   - from: swagger-document
     where: $.paths["/docs"].get.parameters[0]
     transform: >
-      $["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+      $["x-ms-client-name"] = "SDKCustomS^e^a^r^c^h^T^e^x^t";
 
 modelerfour:
   naming:
     override:
-      SDKCustomT$e$x$t: text
-      SDKCustomq$u$e$r$y$P$l$u$s$T$e$x$t: queryPlusText
-      SDKCustomS$e$a$r$c$h$T$e$x$t: searchText
+      SDKCustomT^e^x^t: text
+      SDKCustomq^u^e^r^y^P^l^u^s^T^e^x^t: queryPlusText
+      SDKCustomS^e^a^r^c^h^T^e^x^t: searchText
 ```
 
 ```yaml

--- a/test/integration/swaggers/Data.md
+++ b/test/integration/swaggers/Data.md
@@ -1,0 +1,111 @@
+# Azure Cognitive Search TypeScript Protocol Layer
+
+> see https://aka.ms/autorest
+
+## Configuration
+
+```yaml
+package-name: "@azure/search-documents"
+generate-metadata: false
+license-header: MICROSOFT_MIT_NO_VERSION
+input-file: ./searchindex.json
+add-credentials: false
+title: SearchClient
+```
+
+## Customizations for Track 2 Generator
+
+See the [AutoRest samples](https://github.com/Azure/autorest/tree/master/Samples/3b-custom-transformations)
+for more about how we're customizing things.
+
+### Remove duplicate header parameter
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.paths..post
+    transform: >
+      const newParameters = [];
+      for (let param of $.parameters) {
+        if (param["$ref"] !== "#/parameters/ClientRequestIdParameter") {
+          newParameters.push(param);
+        }
+      }
+      $.parameters = newParameters;
+  - from: swagger-document
+    where: $.paths..get
+    transform: >
+      const newParameters = [];
+      for (let param of $.parameters) {
+        if (param["$ref"] !== "#/parameters/ClientRequestIdParameter") {
+          newParameters.push(param);
+        }
+      }
+      $.parameters = newParameters;
+```
+
+### Give a less-common name for actionType
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.IndexAction
+    transform: >
+      $.required = ['@search.action'];
+```
+
+```yaml
+directive:
+  - from: swagger-document
+    where: $.definitions.AutocompleteItem.properties
+    transform: >
+      $["text"]["x-ms-client-name"] = "SDKCustomT$e$x$t";
+      $["queryPlusText"]["x-ms-client-name"] = "SDKCustomq$u$e$r$y$P$l$u$s$T$e$x$t";
+  - from: swagger-document
+    where: $.definitions.AutocompleteRequest.properties
+    transform: >
+      $["search"]["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+  - from: swagger-document
+    where: $.definitions.SearchRequest.properties
+    transform: >
+      $["search"]["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+  - from: swagger-document
+    where: $.definitions.SuggestRequest.properties
+    transform: >
+      $["search"]["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+  - from: swagger-document
+    where: $.paths["/docs"].get.parameters[0]
+    transform: >
+      $["x-ms-client-name"] = "SDKCustomS$e$a$r$c$h$T$e$x$t";
+
+modelerfour:
+  naming:
+    override:
+      SDKCustomT$e$x$t: text
+      SDKCustomq$u$e$r$y$P$l$u$s$T$e$x$t: queryPlusText
+      SDKCustomS$e$a$r$c$h$T$e$x$t: searchText
+```
+
+```yaml
+modelerfour:
+  naming:
+    override:
+      ActionType: $DO_NOT_NORMALIZE$__actionType
+```
+
+```yaml
+modelerfour:
+  naming:
+    override:
+      text: $DO_NOT_NORMALIZE$_text
+```
+
+### Change score to \_score & highlights to \_highlights in SuggestResult
+
+```yaml
+modelerfour:
+  naming:
+    override:
+      Score: $DO_NOT_NORMALIZE$_score
+      Highlights: $DO_NOT_NORMALIZE$_highlights
+```

--- a/test/integration/swaggers/searchindex.json
+++ b/test/integration/swaggers/searchindex.json
@@ -1,0 +1,1537 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "SearchIndexClient",
+    "description": "Client that can be used to query an index and upload, merge, or delete documents.",
+    "version": "2020-06-30-Preview",
+    "x-ms-code-generation-settings": {
+      "useDateTimeOffset": true,
+      "syncMethods": "None"
+    }
+  },
+  "x-ms-parameterized-host": {
+    "hostTemplate": "{endpoint}/indexes('{indexName}')",
+    "useSchemePrefix": false,
+    "parameters": [
+      {
+        "$ref": "#/parameters/EndpointParameter"
+      },
+      {
+        "$ref": "#/parameters/IndexNameParameter"
+      }
+    ]
+  },
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "paths": {
+    "/docs/$count": {
+      "get": {
+        "tags": ["Documents"],
+        "operationId": "Documents_Count",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/Count-Documents"
+        },
+        "x-ms-examples": {
+          "SearchIndexCountDocuments": {
+            "$ref": "./examples/SearchIndexCountDocuments.json"
+          }
+        },
+        "description": "Queries the number of documents in the index.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs": {
+      "get": {
+        "tags": ["Documents"],
+        "operationId": "Documents_SearchGet",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/Search-Documents"
+        },
+        "x-ms-examples": {
+          "SearchIndexSearchDocumentsGet": {
+            "$ref": "./examples/SearchIndexSearchDocumentsGet.json"
+          }
+        },
+        "description": "Searches for documents in the index.",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "type": "string",
+            "description": "A full-text search query expression; Use \"*\" or omit this parameter to match all documents.",
+            "x-ms-client-name": "SearchText"
+          },
+          {
+            "name": "$count",
+            "in": "query",
+            "type": "boolean",
+            "description": "A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation.",
+            "x-nullable": false,
+            "x-ms-client-name": "IncludeTotalResultCount",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "facet",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "description": "The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs.",
+            "x-ms-client-name": "Facets",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "type": "string",
+            "description": "The OData $filter expression to apply to the search query.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "highlight",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting.",
+            "x-ms-client-name": "HighlightFields",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "highlightPostTag",
+            "in": "query",
+            "type": "string",
+            "description": "A string tag that is appended to hit highlights. Must be set with highlightPreTag. Default is &lt;/em&gt;.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "highlightPreTag",
+            "in": "query",
+            "type": "string",
+            "description": "A string tag that is prepended to hit highlights. Must be set with highlightPostTag. Default is &lt;em&gt;.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "minimumCoverage",
+            "in": "query",
+            "type": "number",
+            "format": "double",
+            "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, and desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no OrderBy is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses.",
+            "x-ms-client-name": "OrderBy",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "queryType",
+            "in": "query",
+            "type": "string",
+            "enum": ["simple", "full"],
+            "x-ms-enum": {
+              "name": "QueryType",
+              "modelAsString": false,
+              "values": [
+                {
+                  "value": "simple",
+                  "name": "Simple",
+                  "description": "Uses the simple query syntax for searches. Search text is interpreted using a simple query language that allows for symbols such as +, * and \"\". Queries are evaluated across all searchable fields by default, unless the searchFields parameter is specified."
+                },
+                {
+                  "value": "full",
+                  "name": "Full",
+                  "description": "Uses the full Lucene query syntax for searches. Search text is interpreted using the Lucene query language which allows field-specific and weighted searches, as well as other advanced features."
+                }
+              ]
+            },
+            "x-nullable": false,
+            "description": "A value that specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "scoringParameter",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "collectionFormat": "multi",
+            "x-ms-client-name": "ScoringParameters",
+            "description": "The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name-values. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be \"mylocation--122.2,44.8\" (without the quotes).",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "scoringProfile",
+            "in": "query",
+            "type": "string",
+            "description": "The name of a scoring profile to evaluate match scores for matching documents in order to sort the results.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "searchFields",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "searchMode",
+            "in": "query",
+            "type": "string",
+            "enum": ["any", "all"],
+            "x-ms-enum": {
+              "name": "SearchMode",
+              "modelAsString": false,
+              "values": [
+                {
+                  "value": "any",
+                  "name": "Any",
+                  "description": "Any of the search terms must be matched in order to count the document as a match."
+                },
+                {
+                  "value": "all",
+                  "name": "All",
+                  "description": "All of the search terms must be matched in order to count the document as a match."
+                }
+              ]
+            },
+            "x-nullable": false,
+            "description": "A value that specifies whether any or all of the search terms must be matched in order to count the document as a match.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "scoringStatistics",
+            "in": "query",
+            "type": "string",
+            "enum": ["local", "global"],
+            "x-ms-enum": {
+              "name": "ScoringStatistics",
+              "modelAsString": false,
+              "values": [
+                {
+                  "value": "local",
+                  "name": "Local",
+                  "description": "The scoring statistics will be calculated locally for lower latency."
+                },
+                {
+                  "value": "global",
+                  "name": "Global",
+                  "description": "The scoring statistics will be calculated globally for more consistent scoring."
+                }
+              ]
+            },
+            "x-nullable": false,
+            "description": "A value that specifies whether we want to calculate scoring statistics (such as document frequency) globally for more consistent scoring, or locally, for lower latency.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "sessionId",
+            "in": "query",
+            "type": "string",
+            "description": "A value to be used to create a sticky session, which can help to get more consistent results. As long as the same sessionId is used, a best-effort attempt will be made to target the same replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the load balancing of the requests across replicas and adversely affect the performance of the search service. The value used as sessionId cannot start with a '_' character.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "$skip",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use $skip due to this limitation, consider using $orderby on a totally-ordered key and $filter with a range query instead.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results.",
+            "x-ms-parameter-grouping": {
+              "name": "SearchOptions"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing documents that match the search criteria.",
+            "schema": {
+              "$ref": "#/definitions/SearchDocumentsResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs/search.post.search": {
+      "post": {
+        "tags": ["Documents"],
+        "operationId": "Documents_SearchPost",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/Search-Documents"
+        },
+        "x-ms-examples": {
+          "SearchIndexSearchDocumentsPost": {
+            "$ref": "./examples/SearchIndexSearchDocumentsPost.json"
+          }
+        },
+        "description": "Searches for documents in the index.",
+        "parameters": [
+          {
+            "name": "searchRequest",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/SearchRequest",
+              "description": "The Search request."
+            },
+            "description": "The definition of the Search request."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing documents that match the search criteria.",
+            "schema": {
+              "$ref": "#/definitions/SearchDocumentsResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs('{key}')": {
+      "get": {
+        "tags": ["Documents"],
+        "operationId": "Documents_Get",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/lookup-document"
+        },
+        "x-ms-examples": {
+          "SearchIndexGetDocument": {
+            "$ref": "./examples/SearchIndexGetDocument.json"
+          }
+        },
+        "description": "Retrieves a document from the index.",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "description": "The key of the document to retrieve.",
+            "type": "string"
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of field names to retrieve for the document; Any field not retrieved will be missing from the returned document.",
+            "x-ms-client-name": "SelectedFields"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response containing the requested document.",
+            "schema": {
+              "type": "object"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs/search.suggest": {
+      "get": {
+        "tags": ["Documents"],
+        "operationId": "Documents_SuggestGet",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/suggestions"
+        },
+        "x-ms-examples": {
+          "SearchIndexSuggestDocumentsGet": {
+            "$ref": "./examples/SearchIndexSuggestDocumentsGet.json"
+          }
+        },
+        "description": "Suggests documents in the index that match the given partial query text.",
+        "parameters": [
+          {
+            "name": "search",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The search text to use to suggest documents. Must be at least 1 character, and no more than 100 characters.",
+            "x-ms-client-name": "SearchText"
+          },
+          {
+            "name": "suggesterName",
+            "in": "query",
+            "required": true,
+            "type": "string",
+            "description": "The name of the suggester as specified in the suggesters collection that's part of the index definition."
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "type": "string",
+            "description": "An OData expression that filters the documents considered for suggestions.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "fuzzy",
+            "in": "query",
+            "type": "boolean",
+            "description": "A value indicating whether to use fuzzy matching for the suggestions query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestions queries are slower and consume more resources.",
+            "x-ms-client-name": "UseFuzzyMatching",
+            "x-nullable": false,
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "highlightPostTag",
+            "in": "query",
+            "type": "string",
+            "description": "A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting of suggestions is disabled.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "highlightPreTag",
+            "in": "query",
+            "type": "string",
+            "description": "A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting of suggestions is disabled.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "minimumCoverage",
+            "in": "query",
+            "type": "number",
+            "format": "double",
+            "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestions query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "$orderby",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "x-ms-client-name": "OrderBy",
+            "description": "The list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "searchFields",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of field names to search for the specified search text. Target fields must be included in the specified suggester.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "$select",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of fields to retrieve. If unspecified, only the key field will be included in the results.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of suggestions to retrieve. The value must be a number between 1 and 100. The default is 5.",
+            "x-ms-parameter-grouping": {
+              "name": "SuggestOptions"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing suggested documents that match the partial input.",
+            "schema": {
+              "$ref": "#/definitions/SuggestDocumentsResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs/search.post.suggest": {
+      "post": {
+        "tags": ["Documents"],
+        "operationId": "Documents_SuggestPost",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/suggestions"
+        },
+        "x-ms-examples": {
+          "SearchIndexSuggestDocumentsPost": {
+            "$ref": "./examples/SearchIndexSuggestDocumentsPost.json"
+          }
+        },
+        "description": "Suggests documents in the index that match the given partial query text.",
+        "parameters": [
+          {
+            "name": "suggestRequest",
+            "in": "body",
+            "required": true,
+            "description": "The Suggest request.",
+            "schema": {
+              "$ref": "#/definitions/SuggestRequest"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing suggested documents that match the partial input.",
+            "schema": {
+              "$ref": "#/definitions/SuggestDocumentsResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs/search.index": {
+      "post": {
+        "tags": ["Documents"],
+        "operationId": "Documents_Index",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/addupdate-or-delete-documents"
+        },
+        "x-ms-examples": {
+          "SearchIndexIndexDocuments": {
+            "$ref": "./examples/SearchIndexIndexDocuments.json"
+          }
+        },
+        "description": "Sends a batch of document write actions to the index.",
+        "parameters": [
+          {
+            "name": "batch",
+            "in": "body",
+            "description": "The batch of index actions.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/IndexBatch"
+            }
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing the status of operations for all actions in the batch.",
+            "schema": {
+              "$ref": "#/definitions/IndexDocumentsResult"
+            }
+          },
+          "207": {
+            "description": "Response containing the status of operations for all actions in the batch.",
+            "schema": {
+              "$ref": "#/definitions/IndexDocumentsResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs/search.autocomplete": {
+      "get": {
+        "tags": ["Documents"],
+        "operationId": "Documents_AutocompleteGet",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/autocomplete"
+        },
+        "x-ms-examples": {
+          "SearchIndexAutocompleteDocumentsGet": {
+            "$ref": "./examples/SearchIndexAutocompleteDocumentsGet.json"
+          }
+        },
+        "description": "Autocompletes incomplete query terms based on input text and matching terms in the index.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "The incomplete term which should be auto-completed.",
+            "x-ms-client-name": "SearchText"
+          },
+          {
+            "name": "suggesterName",
+            "in": "query",
+            "type": "string",
+            "required": true,
+            "description": "The name of the suggester as specified in the suggesters collection that's part of the index definition."
+          },
+          {
+            "name": "autocompleteMode",
+            "in": "query",
+            "type": "string",
+            "x-nullable": false,
+            "enum": ["oneTerm", "twoTerms", "oneTermWithContext"],
+            "x-ms-enum": {
+              "name": "AutocompleteMode",
+              "modelAsString": false,
+              "values": [
+                {
+                  "value": "oneTerm",
+                  "name": "OneTerm",
+                  "description": "Only one term is suggested. If the query has two terms, only the last term is completed. For example, if the input is 'washington medic', the suggested terms could include 'medicaid', 'medicare', and 'medicine'."
+                },
+                {
+                  "value": "twoTerms",
+                  "name": "TwoTerms",
+                  "description": "Matching two-term phrases in the index will be suggested. For example, if the input is 'medic', the suggested terms could include 'medicare coverage' and 'medical assistant'."
+                },
+                {
+                  "value": "oneTermWithContext",
+                  "name": "OneTermWithContext",
+                  "description": "Completes the last term in a query with two or more terms, where the last two terms are a phrase that exists in the index. For example, if the input is 'washington medic', the suggested terms could include 'washington medicaid' and 'washington medical'."
+                }
+              ]
+            },
+            "description": "Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "$filter",
+            "in": "query",
+            "type": "string",
+            "description": "An OData expression that filters the documents used to produce completed terms for the Autocomplete result.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "fuzzy",
+            "in": "query",
+            "type": "boolean",
+            "description": "A value indicating whether to use fuzzy matching for the autocomplete query. Default is false. When set to true, the query will find terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources.",
+            "x-ms-client-name": "UseFuzzyMatching",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "highlightPostTag",
+            "in": "query",
+            "type": "string",
+            "description": "A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting is disabled.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "highlightPreTag",
+            "in": "query",
+            "type": "string",
+            "description": "A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting is disabled.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "minimumCoverage",
+            "in": "query",
+            "type": "number",
+            "format": "double",
+            "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "searchFields",
+            "in": "query",
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          },
+          {
+            "name": "$top",
+            "in": "query",
+            "type": "integer",
+            "format": "int32",
+            "description": "The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5.",
+            "x-ms-parameter-grouping": {
+              "name": "AutocompleteOptions"
+            }
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing suggested query terms that complete the partial input.",
+            "schema": {
+              "$ref": "#/definitions/AutocompleteResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    },
+    "/docs/search.post.autocomplete": {
+      "post": {
+        "tags": ["Documents"],
+        "operationId": "Documents_AutocompletePost",
+        "externalDocs": {
+          "url": "https://docs.microsoft.com/rest/api/searchservice/autocomplete"
+        },
+        "x-ms-examples": {
+          "SearchIndexAutocompleteDocumentsPost": {
+            "$ref": "./examples/SearchIndexAutocompleteDocumentsPost.json"
+          }
+        },
+        "description": "Autocompletes incomplete query terms based on input text and matching terms in the index.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ClientRequestIdParameter"
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "name": "autocompleteRequest",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/AutocompleteRequest"
+            },
+            "description": "The definition of the Autocomplete request."
+          }
+        ],
+        "x-ms-request-id": "request-id",
+        "responses": {
+          "200": {
+            "description": "Response containing suggested query terms that complete the partial input.",
+            "schema": {
+              "$ref": "#/definitions/AutocompleteResult"
+            }
+          },
+          "default": {
+            "description": "Error response.",
+            "schema": {
+              "$ref": "#/definitions/SearchError"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "SuggestDocumentsResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SuggestResult"
+          },
+          "readOnly": true,
+          "x-ms-client-name": "Results",
+          "description": "The sequence of results returned by the query."
+        },
+        "@search.coverage": {
+          "type": "number",
+          "readOnly": true,
+          "format": "double",
+          "x-ms-client-name": "Coverage",
+          "description": "A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not set in the request."
+        }
+      },
+      "required": ["value"],
+      "description": "Response containing suggestion query results from an index."
+    },
+    "SuggestResult": {
+      "properties": {
+        "@search.text": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The text of the suggestion result.",
+          "x-ms-client-name": "Text"
+        }
+      },
+      "required": ["@search.text"],
+      "additionalProperties": true,
+      "description": "A result containing a document found by a suggestion query, plus associated metadata."
+    },
+    "FacetResult": {
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int64",
+          "readOnly": true,
+          "description": "The approximate count of documents falling within the bucket described by this facet."
+        }
+      },
+      "additionalProperties": true,
+      "description": "A single bucket of a facet query result. Reports the number of documents with a field value falling within a particular range or having a particular value or interval."
+    },
+    "SearchDocumentsResult": {
+      "properties": {
+        "@odata.count": {
+          "type": "integer",
+          "format": "int64",
+          "readOnly": true,
+          "x-ms-client-name": "Count",
+          "description": "The total count of results found by the search operation, or null if the count was not requested. If present, the count may be greater than the number of results in this response. This can happen if you use the $top or $skip parameters, or if Azure Cognitive Search can't return all the requested documents in a single Search response."
+        },
+        "@search.coverage": {
+          "type": "number",
+          "format": "double",
+          "readOnly": true,
+          "x-ms-client-name": "Coverage",
+          "description": "A value indicating the percentage of the index that was included in the query, or null if minimumCoverage was not specified in the request."
+        },
+        "@search.facets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/FacetResult"
+            }
+          },
+          "readOnly": true,
+          "x-ms-client-name": "Facets",
+          "description": "The facet query results for the search operation, organized as a collection of buckets for each faceted field; null if the query did not include any facet expressions."
+        },
+        "@search.nextPageParameters": {
+          "$ref": "#/definitions/SearchRequest",
+          "readOnly": true,
+          "x-ms-client-name": "NextPageParameters",
+          "description": "Continuation JSON payload returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this JSON along with @odata.nextLink to formulate another POST Search request to get the next part of the search response."
+        },
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SearchResult"
+          },
+          "readOnly": true,
+          "x-ms-client-name": "Results",
+          "description": "The sequence of results returned by the query."
+        },
+        "@odata.nextLink": {
+          "type": "string",
+          "readOnly": true,
+          "x-ms-client-name": "NextLink",
+          "description": "Continuation URL returned when Azure Cognitive Search can't return all the requested results in a single Search response. You can use this URL to formulate another GET or POST Search request to get the next part of the search response. Make sure to use the same verb (GET or POST) as the request that produced this response."
+        }
+      },
+      "required": ["value"],
+      "description": "Response containing search results from an index."
+    },
+    "SearchResult": {
+      "properties": {
+        "@search.score": {
+          "type": "number",
+          "format": "double",
+          "readOnly": true,
+          "x-ms-client-name": "Score",
+          "x-nullable": false,
+          "description": "The relevance score of the document compared to other documents returned by the query."
+        },
+        "@search.highlights": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "readOnly": true,
+          "x-ms-client-name": "Highlights",
+          "description": "Text fragments from the document that indicate the matching search terms, organized by each applicable field; null if hit highlighting was not enabled for the query."
+        }
+      },
+      "required": ["@search.score"],
+      "additionalProperties": true,
+      "description": "Contains a document found by a search query, plus associated metadata."
+    },
+    "IndexBatch": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/IndexAction"
+          },
+          "description": "The actions in the batch.",
+          "x-ms-client-name": "Actions"
+        }
+      },
+      "required": ["value"],
+      "description": "Contains a batch of document write actions to send to the index."
+    },
+    "IndexAction": {
+      "properties": {
+        "@search.action": {
+          "type": "string",
+          "enum": ["upload", "merge", "mergeOrUpload", "delete"],
+          "x-ms-enum": {
+            "name": "IndexActionType",
+            "modelAsString": false,
+            "values": [
+              {
+                "value": "upload",
+                "name": "Upload",
+                "description": "Inserts the document into the index if it is new and updates it if it exists. All fields are replaced in the update case."
+              },
+              {
+                "value": "merge",
+                "name": "Merge",
+                "description": "Merges the specified field values with an existing document. If the document does not exist, the merge will fail. Any field you specify in a merge will replace the existing field in the document. This also applies to collections of primitive and complex types."
+              },
+              {
+                "value": "mergeOrUpload",
+                "name": "MergeOrUpload",
+                "description": "Behaves like merge if a document with the given key already exists in the index. If the document does not exist, it behaves like upload with a new document."
+              },
+              {
+                "value": "delete",
+                "name": "Delete",
+                "description": "Removes the specified document from the index. Any field you specify in a delete operation other than the key field will be ignored. If you want to remove an individual field from a document, use merge instead and set the field explicitly to null."
+              }
+            ]
+          },
+          "x-ms-client-name": "ActionType",
+          "x-nullable": false,
+          "description": "The operation to perform on a document in an indexing batch."
+        }
+      },
+      "additionalProperties": true,
+      "description": "Represents an index action that operates on a document."
+    },
+    "IndexingResult": {
+      "properties": {
+        "key": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The key of a document that was in the indexing request."
+        },
+        "errorMessage": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The error message explaining why the indexing operation failed for the document identified by the key; null if indexing succeeded."
+        },
+        "status": {
+          "x-ms-client-name": "Succeeded",
+          "type": "boolean",
+          "x-nullable": false,
+          "readOnly": true,
+          "description": "A value indicating whether the indexing operation succeeded for the document identified by the key."
+        },
+        "statusCode": {
+          "type": "integer",
+          "format": "int32",
+          "x-nullable": false,
+          "readOnly": true,
+          "description": "The status code of the indexing operation. Possible values include: 200 for a successful update or delete, 201 for successful document creation, 400 for a malformed input document, 404 for document not found, 409 for a version conflict, 422 when the index is temporarily unavailable, or 503 for when the service is too busy."
+        }
+      },
+      "required": ["key", "status", "statusCode"],
+      "description": "Status of an indexing operation for a single document."
+    },
+    "IndexDocumentsResult": {
+      "properties": {
+        "value": {
+          "x-ms-client-name": "Results",
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/IndexingResult"
+          },
+          "description": "The list of status information for each document in the indexing request."
+        }
+      },
+      "required": ["value"],
+      "description": "Response containing the status of operations for all documents in the indexing request."
+    },
+    "SearchMode": {
+      "type": "string",
+      "enum": ["any", "all"],
+      "x-ms-enum": {
+        "name": "SearchMode",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": "any",
+            "name": "Any",
+            "description": "Any of the search terms must be matched in order to count the document as a match."
+          },
+          {
+            "value": "all",
+            "name": "All",
+            "description": "All of the search terms must be matched in order to count the document as a match."
+          }
+        ]
+      },
+      "description": "Specifies whether any or all of the search terms must be matched in order to count the document as a match."
+    },
+    "QueryType": {
+      "type": "string",
+      "enum": ["simple", "full"],
+      "x-ms-enum": {
+        "name": "QueryType",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": "simple",
+            "name": "Simple",
+            "description": "Uses the simple query syntax for searches. Search text is interpreted using a simple query language that allows for symbols such as +, * and \"\". Queries are evaluated across all searchable fields by default, unless the searchFields parameter is specified."
+          },
+          {
+            "value": "full",
+            "name": "Full",
+            "description": "Uses the full Lucene query syntax for searches. Search text is interpreted using the Lucene query language which allows field-specific and weighted searches, as well as other advanced features."
+          }
+        ]
+      },
+      "description": "Specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax."
+    },
+    "ScoringStatistics": {
+      "type": "string",
+      "enum": ["local", "global"],
+      "x-ms-enum": {
+        "name": "ScoringStatistics",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": "local",
+            "name": "Local",
+            "description": "The scoring statistics will be calculated locally for lower latency."
+          },
+          {
+            "value": "global",
+            "name": "Global",
+            "description": "The scoring statistics will be calculated globally for more consistent scoring."
+          }
+        ]
+      },
+      "description": "A value that specifies whether we want to calculate scoring statistics (such as document frequency) globally for more consistent scoring, or locally, for lower latency. The default is 'local'. Use 'global' to aggregate scoring statistics globally before scoring. Using global scoring statistics can increase latency of search queries."
+    },
+    "AutocompleteMode": {
+      "type": "string",
+      "enum": ["oneTerm", "twoTerms", "oneTermWithContext"],
+      "x-ms-enum": {
+        "name": "AutocompleteMode",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": "oneTerm",
+            "name": "OneTerm",
+            "description": "Only one term is suggested. If the query has two terms, only the last term is completed. For example, if the input is 'washington medic', the suggested terms could include 'medicaid', 'medicare', and 'medicine'."
+          },
+          {
+            "value": "twoTerms",
+            "name": "TwoTerms",
+            "description": "Matching two-term phrases in the index will be suggested. For example, if the input is 'medic', the suggested terms could include 'medicare coverage' and 'medical assistant'."
+          },
+          {
+            "value": "oneTermWithContext",
+            "name": "OneTermWithContext",
+            "description": "Completes the last term in a query with two or more terms, where the last two terms are a phrase that exists in the index. For example, if the input is 'washington medic', the suggested terms could include 'washington medicaid' and 'washington medical'."
+          }
+        ]
+      },
+      "description": "Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context in producing autocomplete terms."
+    },
+    "SearchRequest": {
+      "properties": {
+        "count": {
+          "type": "boolean",
+          "description": "A value that specifies whether to fetch the total count of results. Default is false. Setting this value to true may have a performance impact. Note that the count returned is an approximation.",
+          "x-ms-client-name": "IncludeTotalResultCount"
+        },
+        "facets": {
+          "externalDocs": {
+            "url": "https://docs.microsoft.com/rest/api/searchservice/Search-Documents"
+          },
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of facet expressions to apply to the search query. Each facet expression contains a field name, optionally followed by a comma-separated list of name:value pairs."
+        },
+        "filter": {
+          "externalDocs": {
+            "url": "https://docs.microsoft.com/rest/api/searchservice/OData-Expression-Syntax-for-Azure-Search"
+          },
+          "type": "string",
+          "description": "The OData $filter expression to apply to the search query."
+        },
+        "highlight": {
+          "type": "string",
+          "description": "The comma-separated list of field names to use for hit highlights. Only searchable fields can be used for hit highlighting.",
+          "x-ms-client-name": "HighlightFields"
+        },
+        "highlightPostTag": {
+          "type": "string",
+          "description": "A string tag that is appended to hit highlights. Must be set with highlightPreTag. Default is &lt;/em&gt;."
+        },
+        "highlightPreTag": {
+          "type": "string",
+          "description": "A string tag that is prepended to hit highlights. Must be set with highlightPostTag. Default is &lt;em&gt;."
+        },
+        "minimumCoverage": {
+          "type": "number",
+          "format": "double",
+          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a search query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 100."
+        },
+        "orderby": {
+          "x-ms-client-name": "OrderBy",
+          "type": "string",
+          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses."
+        },
+        "queryType": {
+          "$ref": "#/definitions/QueryType",
+          "description": "A value that specifies the syntax of the search query. The default is 'simple'. Use 'full' if your query uses the Lucene query syntax."
+        },
+        "scoringStatistics": {
+          "$ref": "#/definitions/ScoringStatistics",
+          "description": "A value that specifies whether we want to calculate scoring statistics (such as document frequency) globally for more consistent scoring, or locally, for lower latency. The default is 'local'. Use 'global' to aggregate scoring statistics globally before scoring. Using global scoring statistics can increase latency of search queries."
+        },
+        "sessionId": {
+          "type": "string",
+          "description": "A value to be used to create a sticky session, which can help getting more consistent results. As long as the same sessionId is used, a best-effort attempt will be made to target the same replica set. Be wary that reusing the same sessionID values repeatedly can interfere with the load balancing of the requests across replicas and adversely affect the performance of the search service. The value used as sessionId cannot start with a '_' character."
+        },
+        "scoringParameters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The list of parameter values to be used in scoring functions (for example, referencePointParameter) using the format name-values. For example, if the scoring profile defines a function with a parameter called 'mylocation' the parameter string would be \"mylocation--122.2,44.8\" (without the quotes)."
+        },
+        "scoringProfile": {
+          "type": "string",
+          "description": "The name of a scoring profile to evaluate match scores for matching documents in order to sort the results."
+        },
+        "search": {
+          "type": "string",
+          "description": "A full-text search query expression; Use \"*\" or omit this parameter to match all documents.",
+          "x-ms-client-name": "SearchText"
+        },
+        "searchFields": {
+          "type": "string",
+          "description": "The comma-separated list of field names to which to scope the full-text search. When using fielded search (fieldName:searchExpression) in a full Lucene query, the field names of each fielded search expression take precedence over any field names listed in this parameter."
+        },
+        "searchMode": {
+          "$ref": "#/definitions/SearchMode",
+          "description": "A value that specifies whether any or all of the search terms must be matched in order to count the document as a match."
+        },
+        "select": {
+          "type": "string",
+          "description": "The comma-separated list of fields to retrieve. If unspecified, all fields marked as retrievable in the schema are included."
+        },
+        "skip": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of search results to skip. This value cannot be greater than 100,000. If you need to scan documents in sequence, but cannot use skip due to this limitation, consider using orderby on a totally-ordered key and filter with a range query instead."
+        },
+        "top": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of search results to retrieve. This can be used in conjunction with $skip to implement client-side paging of search results. If results are truncated due to server-side paging, the response will include a continuation token that can be used to issue another Search request for the next page of results."
+        }
+      },
+      "description": "Parameters for filtering, sorting, faceting, paging, and other search query behaviors."
+    },
+    "SuggestRequest": {
+      "properties": {
+        "filter": {
+          "externalDocs": {
+            "url": "https://docs.microsoft.com/rest/api/searchservice/OData-Expression-Syntax-for-Azure-Search"
+          },
+          "type": "string",
+          "description": "An OData expression that filters the documents considered for suggestions."
+        },
+        "fuzzy": {
+          "type": "boolean",
+          "description": "A value indicating whether to use fuzzy matching for the suggestion query. Default is false. When set to true, the query will find suggestions even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy suggestion searches are slower and consume more resources.",
+          "x-ms-client-name": "UseFuzzyMatching"
+        },
+        "highlightPostTag": {
+          "type": "string",
+          "description": "A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting of suggestions is disabled."
+        },
+        "highlightPreTag": {
+          "type": "string",
+          "description": "A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting of suggestions is disabled."
+        },
+        "minimumCoverage": {
+          "type": "number",
+          "format": "double",
+          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by a suggestion query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
+        },
+        "orderby": {
+          "x-ms-client-name": "OrderBy",
+          "type": "string",
+          "description": "The comma-separated list of OData $orderby expressions by which to sort the results. Each expression can be either a field name or a call to either the geo.distance() or the search.score() functions. Each expression can be followed by asc to indicate ascending, or desc to indicate descending. The default is ascending order. Ties will be broken by the match scores of documents. If no $orderby is specified, the default sort order is descending by document match score. There can be at most 32 $orderby clauses."
+        },
+        "search": {
+          "type": "string",
+          "description": "The search text to use to suggest documents. Must be at least 1 character, and no more than 100 characters.",
+          "x-ms-client-name": "SearchText"
+        },
+        "searchFields": {
+          "type": "string",
+          "description": "The comma-separated list of field names to search for the specified search text. Target fields must be included in the specified suggester."
+        },
+        "select": {
+          "type": "string",
+          "description": "The comma-separated list of fields to retrieve. If unspecified, only the key field will be included in the results."
+        },
+        "suggesterName": {
+          "type": "string",
+          "description": "The name of the suggester as specified in the suggesters collection that's part of the index definition."
+        },
+        "top": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of suggestions to retrieve. This must be a value between 1 and 100. The default is 5."
+        }
+      },
+      "required": ["search", "suggesterName"],
+      "description": "Parameters for filtering, sorting, fuzzy matching, and other suggestions query behaviors."
+    },
+    "AutocompleteRequest": {
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "The search text on which to base autocomplete results.",
+          "x-ms-client-name": "SearchText"
+        },
+        "autocompleteMode": {
+          "$ref": "#/definitions/AutocompleteMode",
+          "description": "Specifies the mode for Autocomplete. The default is 'oneTerm'. Use 'twoTerms' to get shingles and 'oneTermWithContext' to use the current context while producing auto-completed terms."
+        },
+        "filter": {
+          "externalDocs": {
+            "url": "https://docs.microsoft.com/rest/api/searchservice/OData-Expression-Syntax-for-Azure-Search"
+          },
+          "type": "string",
+          "description": "An OData expression that filters the documents used to produce completed terms for the Autocomplete result."
+        },
+        "fuzzy": {
+          "type": "boolean",
+          "description": "A value indicating whether to use fuzzy matching for the autocomplete query. Default is false. When set to true, the query will autocomplete terms even if there's a substituted or missing character in the search text. While this provides a better experience in some scenarios, it comes at a performance cost as fuzzy autocomplete queries are slower and consume more resources.",
+          "x-ms-client-name": "UseFuzzyMatching"
+        },
+        "highlightPostTag": {
+          "type": "string",
+          "description": "A string tag that is appended to hit highlights. Must be set with highlightPreTag. If omitted, hit highlighting is disabled."
+        },
+        "highlightPreTag": {
+          "type": "string",
+          "description": "A string tag that is prepended to hit highlights. Must be set with highlightPostTag. If omitted, hit highlighting is disabled."
+        },
+        "minimumCoverage": {
+          "type": "number",
+          "format": "double",
+          "description": "A number between 0 and 100 indicating the percentage of the index that must be covered by an autocomplete query in order for the query to be reported as a success. This parameter can be useful for ensuring search availability even for services with only one replica. The default is 80."
+        },
+        "searchFields": {
+          "type": "string",
+          "description": "The comma-separated list of field names to consider when querying for auto-completed terms. Target fields must be included in the specified suggester."
+        },
+        "suggesterName": {
+          "type": "string",
+          "description": "The name of the suggester as specified in the suggesters collection that's part of the index definition."
+        },
+        "top": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of auto-completed terms to retrieve. This must be a value between 1 and 100. The default is 5."
+        }
+      },
+      "required": ["search", "suggesterName"],
+      "description": "Parameters for fuzzy matching, and other autocomplete query behaviors."
+    },
+    "AutocompleteResult": {
+      "properties": {
+        "@search.coverage": {
+          "type": "number",
+          "format": "double",
+          "readOnly": true,
+          "x-ms-client-name": "Coverage",
+          "description": "A value indicating the percentage of the index that was considered by the autocomplete request, or null if minimumCoverage was not specified in the request."
+        },
+        "value": {
+          "type": "array",
+          "readOnly": true,
+          "items": {
+            "$ref": "#/definitions/AutocompleteItem"
+          },
+          "description": "The list of returned Autocompleted items.",
+          "x-ms-client-name": "Results"
+        }
+      },
+      "required": ["value"],
+      "description": "The result of Autocomplete query."
+    },
+    "AutocompleteItem": {
+      "properties": {
+        "text": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The completed term."
+        },
+        "queryPlusText": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The query along with the completed term."
+        }
+      },
+      "required": ["text", "queryPlusText"],
+      "description": "The result of Autocomplete requests."
+    },
+    "SearchError": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "readOnly": true,
+          "description": "One of a server-defined set of error codes."
+        },
+        "message": {
+          "type": "string",
+          "readOnly": true,
+          "description": "A human-readable representation of the error."
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SearchError"
+          },
+          "readOnly": true,
+          "description": "An array of details about specific errors that led to this reported error."
+        }
+      },
+      "required": ["message"],
+      "description": "Describes an error condition for the Azure Cognitive Search API."
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    },
+    "ClientRequestIdParameter": {
+      "name": "x-ms-client-request-id",
+      "in": "header",
+      "required": false,
+      "type": "string",
+      "format": "uuid",
+      "description": "The tracking ID sent with the request to help with debugging.",
+      "x-ms-client-request-id": true,
+      "x-ms-parameter-grouping": {
+        "name": "request-options"
+      },
+      "x-ms-parameter-location": "method"
+    },
+    "EndpointParameter": {
+      "name": "endpoint",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-skip-url-encoding": true,
+      "description": "The endpoint URL of the search service.",
+      "x-ms-parameter-location": "client"
+    },
+    "IndexNameParameter": {
+      "name": "indexName",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "x-ms-skip-url-encoding": false,
+      "description": "The name of the index.",
+      "x-ms-parameter-location": "client"
+    }
+  }
+}

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/README.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/README.md
@@ -17,7 +17,7 @@ npm install arm-package-deploymentscripts-2019-10-preview
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-features-2015-12/README.md
+++ b/test/smoke/generated/arm-package-features-2015-12/README.md
@@ -17,7 +17,7 @@ npm install arm-package-features-2015-12
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-links-2016-09/README.md
+++ b/test/smoke/generated/arm-package-links-2016-09/README.md
@@ -17,7 +17,7 @@ npm install arm-package-links-2016-09
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-locks-2016-09/README.md
+++ b/test/smoke/generated/arm-package-locks-2016-09/README.md
@@ -17,7 +17,7 @@ npm install arm-package-locks-2016-09
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/README.md
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/README.md
@@ -17,7 +17,7 @@ npm install arm-package-managedapplications-2018-06
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-policy-2019-09/README.md
+++ b/test/smoke/generated/arm-package-policy-2019-09/README.md
@@ -17,7 +17,7 @@ npm install arm-package-policy-2019-09
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-resources-2019-08/README.md
+++ b/test/smoke/generated/arm-package-resources-2019-08/README.md
@@ -17,7 +17,7 @@ npm install arm-package-resources-2019-08
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/README.md
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/README.md
@@ -17,7 +17,7 @@ npm install arm-package-subscriptions-2019-06
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/compute-resource-manager/README.md
+++ b/test/smoke/generated/compute-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install compute-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/cosmos-db-resource-manager/README.md
+++ b/test/smoke/generated/cosmos-db-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install cosmos-db-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/graphrbac-data-plane/README.md
+++ b/test/smoke/generated/graphrbac-data-plane/README.md
@@ -17,7 +17,7 @@ npm install graphrbac-data-plane
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/keyvault-resource-manager/README.md
+++ b/test/smoke/generated/keyvault-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install keyvault-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/monitor-data-plane/README.md
+++ b/test/smoke/generated/monitor-data-plane/README.md
@@ -17,7 +17,7 @@ npm install monitor-data-plane
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/msi-resource-manager/README.md
+++ b/test/smoke/generated/msi-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install msi-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/network-resource-manager/README.md
+++ b/test/smoke/generated/network-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install network-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/sql-resource-manager/README.md
+++ b/test/smoke/generated/sql-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install sql-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/storage-resource-manager/README.md
+++ b/test/smoke/generated/storage-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install storage-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/smoke/generated/web-resource-manager/README.md
+++ b/test/smoke/generated/web-resource-manager/README.md
@@ -17,7 +17,7 @@ npm install web-resource-manager
 
 #### Sample code
 
-Refer the sample code in the [azure-sdk-for-js-samples](https://github.com/Azure/azure-sdk-for-js-samples) repository.
+Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
 
 ## Related projects
 

--- a/test/utils/test-swagger-gen.ts
+++ b/test/utils/test-swagger-gen.ts
@@ -385,6 +385,11 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     swaggerOrConfig: "test/integration/swaggers/keyvaults-secrets.md",
     clientName: "KeyVaultClient",
     packageName: "@azure/keyvault-secrets"
+  },
+  nameChecker: {
+    swaggerOrConfig: "test/integration/swaggers/Data.md",
+    clientName: "SearchClient",
+    packageName: "@azure/search-documents"
   }
 };
 
@@ -432,7 +437,7 @@ const generateSwaggers = async (
     }
 
     let inputFileCommand: string = `${swaggerPath}`;
-    if (!swaggerPath.endsWith("md")) {
+    if (!swaggerPath.endsWith(".md")) {
       inputFileCommand = `--input-file=${inputFileCommand}`;
     }
 

--- a/tsconfig.browser-test.json
+++ b/tsconfig.browser-test.json
@@ -33,9 +33,11 @@
     "test/integration/generated/bodyFormData/*.ts",
     "test/integration/generated/appconfigurationexport/*.ts",
     "test/integration/generated/mapperrequired/*.ts",
+    "test/integration/generated/nameChecker/*.ts",
     "test/integration/licenseHeader.spec.ts",
     "test/integration/bodyFormData.spec.ts",
     "test/integration/appConfigurationExport.spec.ts",
-    "test/integration/mapperRequired.spec.ts"
+    "test/integration/mapperRequired.spec.ts",
+    "test/integration/nameChecker.spec.ts"
   ]
 }


### PR DESCRIPTION
This is to fix the naming issue related to search SDK - https://github.com/Azure/autorest.typescript/issues/840.