### PR TITLE
Use TypeScript v3.6.0 to be able to compile abort-controller

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9054,9 +9054,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.1.tgz",
-      "integrity": "sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==",
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "ts-node": "^7.0.1",
     "tslib": "^1.10.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.2.2",
+    "typescript": "^3.6.0",
     "underscore": "^1.8.3",
     "webpack": "~4.26.1",
     "webpack-cli": "~3.1.2",


### PR DESCRIPTION
Otherwise, we will get the error in this log when adding a dependency for core-auth: https://dev.azure.com/azure-public/azsdk/_build/results?buildId=10244&view=logs&j=499e71a5-ab92-5cb7-8e77-9c19c2280f63&t=331a722e-d89d-5d12-1500-1d0f556ecaa0

```
node_modules/@azure/abort-controller/types/src/AbortController.d.ts(73,9): error TS1086: An accessor cannot be declared in an ambient context.
node_modules/@azure/abort-controller/types/src/AbortSignal.d.ts(40,9): error TS1086: An accessor cannot be declared in an ambient context.
node_modules/@azure/abort-controller/types/src/AbortSignal.d.ts(46,16): error TS1086: An accessor cannot be declared in an ambient context.
```

core-auth depends on abort-controller and it is needed for the work on supporting TokenCredential in v4. For more information, see https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations.