### PR TITLE
Fix a race condition in unit tests

### DIFF
--- a/test/xml/xmlTests.ts
+++ b/test/xml/xmlTests.ts
@@ -24,8 +24,8 @@ describe('typescript', function () {
   describe('XML client', function () {
     it('should be able to abort a simple XML get', async function () {
       const controller = getAbortController();
-      const slideshowPromise = testClient.xml.getSimple({ abortSignal: controller.signal });
       controller.abort();
+      const slideshowPromise = testClient.xml.getSimple({ abortSignal: controller.signal });
       const err: msRest.RestError = await msAssert.throwsAsync(slideshowPromise);
       err.code.should.equal("REQUEST_ABORTED_ERROR");
     });


### PR DESCRIPTION
`gulp test` throws this error in tests when used with ms-rest-js from this [PR](https://github.com/Azure/ms-rest-js/pull/410): https://dev.azure.com/azure-public/azsdk/_build/results?buildId=10260&view=logs&j=86a3e3bd-71b3-5ac8-ea13-11866678232f&t=0ef955d0-98d6-55ad-9cce-da5a10715e64:
```
1) typescript
       XML client
         should be able to abort a simple XML get:

      AssertionError: expected 'REQUEST_SEND_ERROR' to equal 'REQUEST_ABORTED_ERROR'
      + expected - actual

      -REQUEST_SEND_ERROR
      +REQUEST_ABORTED_ERROR
      
      at Context.<anonymous> (test/xml/xmlTests.ts:30:23)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```

This PR fixes this race condition by asking the controller to abort before the request is sent.