### PR TITLE
Rename @azure-tools/autorest-extension-base dependency to new @autorest/extension-base pkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,48 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@autorest/extension-base": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@autorest/extension-base/-/extension-base-3.1.0.tgz",
+            "integrity": "sha512-LHSLvPDG0uoMsOmzh0wOtxHu0dvoTaqDRJkgJVAZFVz4VfLocXhFActkwQ31yoB0IO7phZnuvcG8NcvKObURAQ==",
+            "requires": {
+                "@azure-tools/codegen": "~2.5.0",
+                "js-yaml": "3.13.1",
+                "vscode-jsonrpc": "^3.5.0"
+            },
+            "dependencies": {
+                "@azure-tools/async-io": {
+                    "version": "3.0.253",
+                    "resolved": "https://registry.npmjs.org/@azure-tools/async-io/-/async-io-3.0.253.tgz",
+                    "integrity": "sha512-5Zo6Sr7ttnh6vaDhG1ESycJtOKzJCxo+bdJ68dmGgU/czm2HDptjKcVvenNuJNeWpvf0DmklXQDXZIkg11swzw==",
+                    "requires": {
+                        "@azure-tools/tasks": "~3.0.253",
+                        "proper-lockfile": "~2.0.1"
+                    }
+                },
+                "@azure-tools/codegen": {
+                    "version": "2.5.292",
+                    "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-2.5.292.tgz",
+                    "integrity": "sha512-UU9/OgJfd+br9C/M9R8k2r+pyWtanRfl/u865BvkX3yBbMLbDsj12QP/AcY3MoC40rHpWYUJVTBDB84X3zIiIw==",
+                    "requires": {
+                        "@azure-tools/async-io": "~3.0.253",
+                        "@azure-tools/linq": "~3.1.262",
+                        "js-yaml": "3.13.1",
+                        "semver": "^5.5.1"
+                    }
+                },
+                "@azure-tools/linq": {
+                    "version": "3.1.262",
+                    "resolved": "https://registry.npmjs.org/@azure-tools/linq/-/linq-3.1.262.tgz",
+                    "integrity": "sha512-7ctcSXYoGkTvWahsgnHh50D8+nT4hF6h+benQUKDQWdQHUFiV14QvLmGbPqux4Yp57OcX1NOwqKeA6JQDWsEuQ=="
+                },
+                "@azure-tools/tasks": {
+                    "version": "3.0.253",
+                    "resolved": "https://registry.npmjs.org/@azure-tools/tasks/-/tasks-3.0.253.tgz",
+                    "integrity": "sha512-ViYOxgal9iukwbebZUpj5hEnT6OjSLDFItqPXYfMkntm7BCM1OQbBVo49KMBqOyCu6o+M5EVC7KF8SldL3oGtg=="
+                }
+            }
+        },
         "@autorest/test-server": {
             "version": "3.0.27",
             "resolved": "https://registry.npmjs.org/@autorest/test-server/-/test-server-3.0.27.tgz",
@@ -27,16 +69,6 @@
                     "resolved": "https://registry.npmjs.org/@azure-tools/tasks/-/tasks-3.0.247.tgz",
                     "integrity": "sha512-H9p+of/QnEIcT0Ea2mSz2MSt4eaTPm86ZpipLRsJoizafUKWmbCoG00awQxPRoIN/9ebVmqFPJ2eb4exs6G6AA=="
                 }
-            }
-        },
-        "@azure-tools/autorest-extension-base": {
-            "version": "3.1.246",
-            "resolved": "https://registry.npmjs.org/@azure-tools/autorest-extension-base/-/autorest-extension-base-3.1.246.tgz",
-            "integrity": "sha512-o+O7AA/H7Hx02mv2XFTQJlo3NNzxjpkdnEGMqGu997EGznT3R1mtw/V+2VeGrKF99TsSWDhKW3bn4ru54+YB2Q==",
-            "requires": {
-                "@azure-tools/codegen": "~2.4.267",
-                "js-yaml": "3.13.1",
-                "vscode-jsonrpc": "^3.5.0"
             }
         },
         "@azure-tools/codegen": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "LICENSE"
     ],
     "dependencies": {
-        "@azure-tools/autorest-extension-base": "^3.1.246",
+        "@autorest/extension-base": "^3.1.0",
         "@azure-tools/codegen": "^2.4.267",
         "@azure-tools/codemodel": "^4.13.339",
         "@azure/core-http": "^1.2.1-alpha.20201203.2",

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import {
   AutoRestExtension,
   Host,
   startSession
-} from "@azure-tools/autorest-extension-base";
+} from "@autorest/extension-base";
 import { generateTypeScriptLibrary } from "./typescriptGenerator";
 import { CodeModel, codeModelSchema } from "@azure-tools/codemodel";
 

--- a/src/transforms/optionsTransforms.ts
+++ b/src/transforms/optionsTransforms.ts
@@ -1,4 +1,4 @@
-import { Channel, Host } from "@azure-tools/autorest-extension-base";
+import { Channel, Host } from "@autorest/extension-base";
 import { ClientOptions } from "../models/clientDetails";
 import { OperationGroupDetails } from "../models/operationDetails";
 import { KnownMediaType } from "@azure-tools/codegen";

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -19,7 +19,7 @@ import { transformOptions } from "./optionsTransforms";
 import { transformParameters } from "./parameterTransforms";
 import { transformObjects, transformObject } from "./objectTransforms";
 import { ObjectDetails } from "../models/modelDetails";
-import { Host } from "@azure-tools/autorest-extension-base";
+import { Host } from "@autorest/extension-base";
 import { transformBaseUrl } from "./urlTransforms";
 import { normalizeModelWithExtensions } from "./extensions";
 import { transformGroups } from "./groupTransforms";

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -4,7 +4,7 @@
 import * as prettier from "prettier";
 import { CodeModel } from "@azure-tools/codemodel";
 import { Project, IndentationText } from "ts-morph";
-import { Host } from "@azure-tools/autorest-extension-base";
+import { Host } from "@autorest/extension-base";
 import { PackageDetails } from "./models/packageDetails";
 import { transformCodeModel } from "./transforms/transforms";
 
@@ -76,8 +76,7 @@ export async function generateTypeScriptLibrary(
   const shouldGenerateLicense: boolean =
     (await host.GetValue("license-header")) || false;
 
-  const hideClients: boolean =
-    (await host.GetValue("hide-clients")) || false;
+  const hideClients: boolean = (await host.GetValue("hide-clients")) || false;
 
   // Skip metadata generation if `generate-metadata` is explicitly false
   if ((await host.GetValue("generate-metadata")) !== false) {

--- a/test/unit/transforms/optionsTransforms.spec.ts
+++ b/test/unit/transforms/optionsTransforms.spec.ts
@@ -1,4 +1,4 @@
-import { Channel, Host, Message } from "@azure-tools/autorest-extension-base";
+import { Channel, Host, Message } from "@autorest/extension-base";
 import { assert } from "chai";
 import { getCredentialScopes } from "../../../src/transforms/optionsTransforms";
 


### PR DESCRIPTION
This package was renamed when we moved it to the autorest monorepo