### PR TITLE
Upgrade Autorest dependency in package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2500,9 +2500,9 @@
             "dev": true
         },
         "autorest": {
-            "version": "3.0.6187",
-            "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.0.6187.tgz",
-            "integrity": "sha512-Xk27qVfsAbmp95Kx+Wwr7LiKlwsoFtcixu46sEaXCRr9zS+lZJDO50uZLXa2ZIE8/z9accpNt3HTdv/9DHk7yg=="
+            "version": "3.0.6339",
+            "resolved": "https://registry.npmjs.org/autorest/-/autorest-3.0.6339.tgz",
+            "integrity": "sha512-OCCmAxi5gUnh7yPho5A4n8kDrnp5uz4DdFrqwMmp/bU5DVByIdVwrWERlB7EnCFqQ9jz86oZtsjy91B07+zLnw=="
         },
         "available-typed-arrays": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "@azure/logger": "^1.0.0",
         "@opentelemetry/api": "^0.10.2",
         "@types/lodash": "^4.14.149",
-        "autorest": "^3.0.6187",
+        "autorest": "^3.0.6339",
         "lodash": "^4.17.15",
         "prettier": "^1.19.1",
         "source-map-support": "^0.5.16",


### PR DESCRIPTION
This PR is to fix the issue https://github.com/Azure/autorest.typescript/issues/869. 

The issue happens only with a previous version of autorest. Once you upgrade the version, this issue will be resolved. 

@joheredi Please review and approve.

@ramya-rao-a FYI......