### PR TITLE
Fix polymorphic skip normalization

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -741,14 +741,19 @@ function withDiscriminator(
     return properties;
   }
 
+  // Store the discriminated properties to later calculate the set of properties without discriminator
+  const discriminatedPropertiesNames: string[] = [];
   const discProps = keys(discriminatorValues).map<PropertySignatureStructure>(
     key => {
-      const name = normalizeName(key, NameType.Property);
+      // Remove enclosing quotes from the key to get the real property name
+      const propertyName = key.replace(/(^")|("$)/g, "");
+      const name = normalizeName(propertyName, NameType.Property);
+      discriminatedPropertiesNames.push(name);
       return {
         docs: [
           `Polymorphic discriminator, which specifies the different types this object can be`
         ],
-        name,
+        name: `"${name}"`,
         type: discriminatorValues[key].map(disc => `"${disc}"`).join(" | "),
         kind: StructureKind.PropertySignature
       };
@@ -756,7 +761,7 @@ function withDiscriminator(
   );
 
   const propertiesWithoutDiscriminator = properties.filter(
-    p => !discProps.some(dp => dp.name === p.name)
+    p => !discriminatedPropertiesNames.some(dp => dp === p.name)
   );
 
   return [...discProps, ...propertiesWithoutDiscriminator];

--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -707,7 +707,7 @@ function getProperties(
   return properties
     .filter(property => !property.isDiscriminator)
     .map<PropertySignatureStructure>(property => ({
-      name: property.name,
+      name: `"${property.name}"`,
       hasQuestionToken: !property.required,
       isReadonly: property.readOnly,
       type: getTypename(property),
@@ -741,14 +741,11 @@ function withDiscriminator(
     return properties;
   }
 
-  // Store the discriminated properties to later calculate the set of properties without discriminator
-  const discriminatedPropertiesNames: string[] = [];
   const discProps = keys(discriminatorValues).map<PropertySignatureStructure>(
     key => {
       // Remove enclosing quotes from the key to get the real property name
       const propertyName = key.replace(/(^")|("$)/g, "");
       const name = normalizeName(propertyName, NameType.Property);
-      discriminatedPropertiesNames.push(name);
       return {
         docs: [
           `Polymorphic discriminator, which specifies the different types this object can be`
@@ -761,7 +758,7 @@ function withDiscriminator(
   );
 
   const propertiesWithoutDiscriminator = properties.filter(
-    p => !discriminatedPropertiesNames.some(dp => dp === p.name)
+    p => !discProps.some(dp => dp.name === p.name)
   );
 
   return [...discProps, ...propertiesWithoutDiscriminator];

--- a/test/integration/generated/polymorphicSkipNormalize/src/generated/index.ts
+++ b/test/integration/generated/polymorphicSkipNormalize/src/generated/index.ts
@@ -1,0 +1,3 @@
+export * from "./models";
+export { MediaServicesClient } from "./mediaServicesClient";
+export { MediaServicesClientContext } from "./mediaServicesClientContext";

--- a/test/integration/generated/polymorphicSkipNormalize/src/generated/mediaServicesClient.ts
+++ b/test/integration/generated/polymorphicSkipNormalize/src/generated/mediaServicesClient.ts
@@ -1,0 +1,12 @@
+import { MediaServicesClientContext } from "./mediaServicesClientContext";
+import { MediaServicesClientOptionalParams } from "./models";
+
+export class MediaServicesClient extends MediaServicesClientContext {
+  /**
+   * Initializes a new instance of the MediaServicesClient class.
+   * @param options The parameter options
+   */
+  constructor(options?: MediaServicesClientOptionalParams) {
+    super(options);
+  }
+}

--- a/test/integration/generated/polymorphicSkipNormalize/src/generated/mediaServicesClientContext.ts
+++ b/test/integration/generated/polymorphicSkipNormalize/src/generated/mediaServicesClientContext.ts
@@ -1,0 +1,29 @@
+import * as coreHttp from "@azure/core-http";
+import { MediaServicesClientOptionalParams } from "./models";
+
+const packageName = "@azure/media-services";
+const packageVersion = "1.0.0-preview1";
+
+export class MediaServicesClientContext extends coreHttp.ServiceClient {
+  /**
+   * Initializes a new instance of the MediaServicesClientContext class.
+   * @param options The parameter options
+   */
+  constructor(options?: MediaServicesClientOptionalParams) {
+    // Initializing default values for options
+    if (!options) {
+      options = {};
+    }
+
+    if (!options.userAgent) {
+      const defaultUserAgent = coreHttp.getDefaultUserAgentValue();
+      options.userAgent = `${packageName}/${packageVersion} ${defaultUserAgent}`;
+    }
+
+    super(undefined, options);
+
+    this.requestContentType = "application/json; charset=utf-8";
+
+    this.baseUri = options.endpoint;
+  }
+}

--- a/test/integration/generated/polymorphicSkipNormalize/src/generated/models/index.ts
+++ b/test/integration/generated/polymorphicSkipNormalize/src/generated/models/index.ts
@@ -1,0 +1,768 @@
+import * as coreHttp from "@azure/core-http";
+
+export type MethodRequestUnion =
+  | MethodRequest
+  | MediaGraphTopologySetRequest
+  | MediaGraphTopologySetRequestBody
+  | MediaGraphInstanceSetRequest
+  | MediaGraphInstanceSetRequestBody
+  | ItemNonSetRequestBaseUnion
+  | MediaGraphTopologyListRequest
+  | MediaGraphInstanceListRequest;
+export type MediaGraphSourceUnion =
+  | MediaGraphSource
+  | MediaGraphRtspSource
+  | MediaGraphIoTHubMessageSource;
+export type MediaGraphProcessorUnion =
+  | MediaGraphProcessor
+  | MediaGraphMotionDetectionProcessor
+  | MediaGraphExtensionProcessorBaseUnion
+  | MediaGraphSignalGateProcessor;
+export type MediaGraphSinkUnion =
+  | MediaGraphSink
+  | MediaGraphIoTHubMessageSink
+  | MediaGraphFileSink
+  | MediaGraphAssetSink;
+export type MediaGraphEndpointUnion =
+  | MediaGraphEndpoint
+  | MediaGraphUnsecuredEndpoint
+  | MediaGraphTlsEndpoint;
+export type MediaGraphCredentialsUnion =
+  | MediaGraphCredentials
+  | MediaGraphUsernamePasswordCredentials
+  | MediaGraphHttpHeaderCredentials;
+export type MediaGraphCertificateSourceUnion =
+  | MediaGraphCertificateSource
+  | MediaGraphPemCertificateList;
+export type MediaGraphImageFormatUnion =
+  | MediaGraphImageFormat
+  | MediaGraphImageFormatRaw
+  | MediaGraphImageFormatJpeg
+  | MediaGraphImageFormatBmp
+  | MediaGraphImageFormatPng;
+export type ItemNonSetRequestBaseUnion =
+  | ItemNonSetRequestBase
+  | MediaGraphTopologyGetRequest
+  | MediaGraphTopologyDeleteRequest
+  | MediaGraphInstanceGetRequest
+  | MediaGraphInstanceActivateRequest
+  | MediaGraphInstanceDeActivateRequest
+  | MediaGraphInstanceDeleteRequest;
+export type MediaGraphExtensionProcessorBaseUnion =
+  | MediaGraphExtensionProcessorBase
+  | MediaGraphCognitiveServicesVisionExtension
+  | MediaGraphGrpcExtension
+  | MediaGraphHttpExtension;
+
+/** Base Class for Method Requests. */
+export interface MethodRequest {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName:
+    | "GraphTopologySet"
+    | "MediaGraphTopologySetRequestBody"
+    | "GraphInstanceSet"
+    | "MediaGraphInstanceSetRequestBody"
+    | "ItemNonSetRequestBase"
+    | "GraphTopologyList"
+    | "GraphTopologyGet"
+    | "GraphTopologyDelete"
+    | "GraphInstanceList"
+    | "GraphInstanceGet"
+    | "GraphInstanceActivate"
+    | "GraphInstanceDeactivate"
+    | "GraphInstanceDelete";
+  /** api version */
+  apiVersion?: "2.0";
+}
+
+/** The definition of a media graph topology. */
+export interface MediaGraphTopology {
+  /** The identifier for the media graph topology. */
+  name: string;
+  /** The system data for a resource. This is used by both topologies and instances. */
+  systemData?: MediaGraphSystemData;
+  /** A description of the properties of a media graph topology. */
+  properties?: MediaGraphTopologyProperties;
+}
+
+/** The system data for a resource. This is used by both topologies and instances. */
+export interface MediaGraphSystemData {
+  /** The timestamp of resource creation (UTC). */
+  createdAt?: Date;
+  /** The timestamp of resource last modification (UTC). */
+  lastModifiedAt?: Date;
+}
+
+/** A description of the properties of a media graph topology. */
+export interface MediaGraphTopologyProperties {
+  /** A description of a media graph topology. It is recommended to use this to describe the expected use of the topology. */
+  description?: string;
+  /** The list of parameters defined in the topology. The value for these parameters are supplied by instances of this topology. */
+  parameters?: MediaGraphParameterDeclaration[];
+  /** The list of source nodes in this topology. */
+  sources?: MediaGraphSourceUnion[];
+  /** The list of processor nodes in this topology. */
+  processors?: MediaGraphProcessorUnion[];
+  /** The list of sink nodes in this topology. */
+  sinks?: MediaGraphSinkUnion[];
+}
+
+/** The declaration of a parameter in the media graph topology. A media graph topology can be authored with parameters. Then, during graph instance creation, the value for those parameters can be specified. This allows the same graph topology to be used as a blueprint for multiple graph instances with different values for the parameters. */
+export interface MediaGraphParameterDeclaration {
+  /** The name of the parameter. */
+  name: string;
+  /** The type of the parameter. */
+  type: MediaGraphParameterType;
+  /** Description of the parameter. */
+  description?: string;
+  /** The default value for the parameter to be used if the media graph instance does not specify a value. */
+  default?: string;
+}
+
+/** A source node in a media graph. */
+export interface MediaGraphSource {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type":
+    | "#Microsoft.Media.MediaGraphRtspSource"
+    | "#Microsoft.Media.MediaGraphIoTHubMessageSource";
+  /** The name to be used for this source node. */
+  name: string;
+}
+
+/** A node that represents the desired processing of media in a graph. Takes media and/or events as inputs, and emits media and/or event as output. */
+export interface MediaGraphProcessor {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type":
+    | "#Microsoft.Media.MediaGraphMotionDetectionProcessor"
+    | "#Microsoft.Media.MediaGraphExtensionProcessorBase"
+    | "#Microsoft.Media.MediaGraphCognitiveServicesVisionExtension"
+    | "#Microsoft.Media.MediaGraphGrpcExtension"
+    | "#Microsoft.Media.MediaGraphHttpExtension"
+    | "#Microsoft.Media.MediaGraphSignalGateProcessor";
+  /** The name for this processor node. */
+  name: string;
+  /** An array of the names of the other nodes in the media graph, the outputs of which are used as input for this processor node. */
+  inputs: MediaGraphNodeInput[];
+}
+
+/** Represents the input to any node in a media graph. */
+export interface MediaGraphNodeInput {
+  /** The name of another node in the media graph, the output of which is used as input to this node. */
+  nodeName: string;
+  /** Allows for the selection of particular streams from another node. */
+  outputSelectors?: MediaGraphOutputSelector[];
+}
+
+/** Allows for the selection of particular streams from another node. */
+export interface MediaGraphOutputSelector {
+  /** The stream property to compare with. */
+  property?: MediaGraphOutputSelectorProperty;
+  /** The operator to compare streams by. */
+  operator?: MediaGraphOutputSelectorOperator;
+  /** Value to compare against. */
+  value?: string;
+}
+
+/** Enables a media graph to write media data to a destination outside of the Live Video Analytics IoT Edge module. */
+export interface MediaGraphSink {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type":
+    | "#Microsoft.Media.MediaGraphIoTHubMessageSink"
+    | "#Microsoft.Media.MediaGraphFileSink"
+    | "#Microsoft.Media.MediaGraphAssetSink";
+  /** The name to be used for the media graph sink. */
+  name: string;
+  /** An array of the names of the other nodes in the media graph, the outputs of which are used as input for this sink node. */
+  inputs: MediaGraphNodeInput[];
+}
+
+/** Represents an instance of a media graph. */
+export interface MediaGraphInstance {
+  /** The identifier for the media graph instance. */
+  name: string;
+  /** The system data for a resource. This is used by both topologies and instances. */
+  systemData?: MediaGraphSystemData;
+  /** Properties of a media graph instance. */
+  properties?: MediaGraphInstanceProperties;
+}
+
+/** Properties of a media graph instance. */
+export interface MediaGraphInstanceProperties {
+  /** An optional description for the instance. */
+  description?: string;
+  /** The name of the media graph topology that this instance will run. A topology with this name should already have been set in the Edge module. */
+  topologyName?: string;
+  /** List of one or more graph instance parameters. */
+  parameters?: MediaGraphParameterDefinition[];
+  /** Allowed states for a graph instance. */
+  state?: MediaGraphInstanceState;
+}
+
+/** A key-value pair. A media graph topology allows certain values to be parameterized. When an instance is created, the parameters are supplied with arguments specific to that instance. This allows the same graph topology to be used as a blueprint for multiple graph instances with different values for the parameters. */
+export interface MediaGraphParameterDefinition {
+  /** The name of the parameter defined in the media graph topology. */
+  name: string;
+  /** The value to supply for the named parameter defined in the media graph topology. */
+  value: string;
+}
+
+/** Base class for endpoints. */
+export interface MediaGraphEndpoint {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type":
+    | "#Microsoft.Media.MediaGraphUnsecuredEndpoint"
+    | "#Microsoft.Media.MediaGraphTlsEndpoint";
+  /** Polymorphic credentials to be presented to the endpoint. */
+  credentials?: MediaGraphCredentialsUnion;
+  /** Url for the endpoint. */
+  url: string;
+}
+
+/** Credentials to present during authentication. */
+export interface MediaGraphCredentials {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type":
+    | "#Microsoft.Media.MediaGraphUsernamePasswordCredentials"
+    | "#Microsoft.Media.MediaGraphHttpHeaderCredentials";
+}
+
+/** Base class for certificate sources. */
+export interface MediaGraphCertificateSource {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphPemCertificateList";
+}
+
+/** Options for controlling the authentication of TLS endpoints. */
+export interface MediaGraphTlsValidationOptions {
+  /** Boolean value ignoring the host name (common name) during validation. */
+  ignoreHostname?: string;
+  /** Boolean value ignoring the integrity of the certificate chain at the current time. */
+  ignoreSignature?: string;
+}
+
+/** Describes the properties of an image frame. */
+export interface MediaGraphImage {
+  /** The scaling mode for the image. */
+  scale?: MediaGraphImageScale;
+  /** Encoding settings for an image. */
+  format?: MediaGraphImageFormatUnion;
+}
+
+/** The scaling mode for the image. */
+export interface MediaGraphImageScale {
+  /** Describes the modes for scaling an input video frame into an image, before it is sent to an inference engine. */
+  mode?: MediaGraphImageScaleMode;
+  /** The desired output width of the image. */
+  width?: string;
+  /** The desired output height of the image. */
+  height?: string;
+}
+
+/** Encoding settings for an image. */
+export interface MediaGraphImageFormat {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type":
+    | "#Microsoft.Media.MediaGraphImageFormatRaw"
+    | "#Microsoft.Media.MediaGraphImageFormatJpeg"
+    | "#Microsoft.Media.MediaGraphImageFormatBmp"
+    | "#Microsoft.Media.MediaGraphImageFormatPng";
+}
+
+/** Describes the properties of a sample. */
+export interface MediaGraphSamplingOptions {
+  /** If true, limits the samples submitted to the extension to only samples which have associated inference(s) */
+  skipSamplesWithoutAnnotation?: string;
+  /** Maximum rate of samples submitted to the extension */
+  maximumSamplesPerSecond?: string;
+}
+
+/** Describes how media should be transferred to the inference engine. */
+export interface MediaGraphGrpcExtensionDataTransfer {
+  /** The size of the buffer for all in-flight frames in mebibytes if mode is SharedMemory. Should not be specified otherwise. */
+  sharedMemorySizeMiB?: string;
+  /** How frame data should be transmitted to the inference engine. */
+  mode: MediaGraphGrpcExtensionDataTransferMode;
+}
+
+/** Represents the MediaGraphTopologySetRequest. */
+export type MediaGraphTopologySetRequest = MethodRequest & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphTopologySet";
+  /** The definition of a media graph topology. */
+  graph: MediaGraphTopology;
+};
+
+/** Represents the MediaGraphTopologySetRequest body. */
+export type MediaGraphTopologySetRequestBody = MethodRequest &
+  MediaGraphTopology & {
+    /** Polymorphic discriminator, which specifies the different types this object can be */
+    methodName: "MediaGraphTopologySetRequestBody";
+  };
+
+/** Represents the MediaGraphInstanceSetRequest. */
+export type MediaGraphInstanceSetRequest = MethodRequest & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphInstanceSet";
+  /** Represents an instance of a media graph. */
+  instance: MediaGraphInstance;
+};
+
+/** Represents the MediaGraphInstanceSetRequest body. */
+export type MediaGraphInstanceSetRequestBody = MethodRequest &
+  MediaGraphInstance & {
+    /** Polymorphic discriminator, which specifies the different types this object can be */
+    methodName: "MediaGraphInstanceSetRequestBody";
+  };
+
+export type ItemNonSetRequestBase = MethodRequest & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "ItemNonSetRequestBase";
+  /** method name */
+  name: string;
+};
+
+/** Represents the MediaGraphTopologyListRequest. */
+export type MediaGraphTopologyListRequest = MethodRequest & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphTopologyList";
+};
+
+/** Represents the MediaGraphInstanceListRequest. */
+export type MediaGraphInstanceListRequest = MethodRequest & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphInstanceList";
+};
+
+/** Enables a media graph to capture media from a RTSP server. */
+export type MediaGraphRtspSource = MediaGraphSource & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphRtspSource";
+  /** Underlying RTSP transport. This is used to enable or disable HTTP tunneling. */
+  transport?: MediaGraphRtspTransport;
+  /** RTSP endpoint of the stream that is being connected to. */
+  endpoint: MediaGraphEndpointUnion;
+};
+
+/** Enables a media graph to receive messages via routes declared in the IoT Edge deployment manifest. */
+export type MediaGraphIoTHubMessageSource = MediaGraphSource & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphIoTHubMessageSource";
+  /** Name of the input path where messages can be routed to (via routes declared in the IoT Edge deployment manifest). */
+  hubInputName?: string;
+};
+
+/** A node that accepts raw video as input, and detects if there are moving objects present. If so, then it emits an event, and allows frames where motion was detected to pass through. Other frames are blocked/dropped. */
+export type MediaGraphMotionDetectionProcessor = MediaGraphProcessor & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphMotionDetectionProcessor";
+  /** Enumeration that specifies the sensitivity of the motion detection processor. */
+  sensitivity?: MediaGraphMotionDetectionSensitivity;
+  /** Indicates whether the processor should detect and output the regions, within the video frame, where motion was detected. Default is true. */
+  outputMotionRegion?: boolean;
+  /** Event aggregation window duration, or 0 for no aggregation. */
+  eventAggregationWindow?: string;
+};
+
+/** Processor that allows for extensions outside of the Live Video Analytics Edge module to be integrated into the graph. It is the base class for various different kinds of extension processor types. */
+export type MediaGraphExtensionProcessorBase = MediaGraphProcessor & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphExtensionProcessorBase";
+  /** Endpoint to which this processor should connect. */
+  endpoint: MediaGraphEndpointUnion;
+  /** Describes the parameters of the image that is sent as input to the endpoint. */
+  image: MediaGraphImage;
+  /** Describes the sampling options to be applied when forwarding samples to the extension. */
+  samplingOptions?: MediaGraphSamplingOptions;
+};
+
+/** A signal gate determines when to block (gate) incoming media, and when to allow it through. It gathers input events over the activationEvaluationWindow, and determines whether to open or close the gate. */
+export type MediaGraphSignalGateProcessor = MediaGraphProcessor & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphSignalGateProcessor";
+  /** The period of time over which the gate gathers input events before evaluating them. */
+  activationEvaluationWindow?: string;
+  /** Signal offset once the gate is activated (can be negative). It is an offset between the time the event is received, and the timestamp of the first media sample (eg. video frame) that is allowed through by the gate. */
+  activationSignalOffset?: string;
+  /** The minimum period for which the gate remains open in the absence of subsequent triggers (events). */
+  minimumActivationTime?: string;
+  /** The maximum period for which the gate remains open in the presence of subsequent events. */
+  maximumActivationTime?: string;
+};
+
+/** Enables a media graph to publish messages that can be delivered via routes declared in the IoT Edge deployment manifest. */
+export type MediaGraphIoTHubMessageSink = MediaGraphSink & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphIoTHubMessageSink";
+  /** Name of the output path to which the media graph will publish message. These messages can then be delivered to desired destinations by declaring routes referencing the output path in the IoT Edge deployment manifest. */
+  hubOutputName: string;
+};
+
+/** Enables a media graph to write/store media (video and audio) to a file on the Edge device. */
+export type MediaGraphFileSink = MediaGraphSink & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphFileSink";
+  /** Absolute directory for all outputs to the Edge device from this sink. */
+  baseDirectoryPath: string;
+  /** File name pattern for creating new files on the Edge device. The pattern must include at least one system variable. See the documentation for available variables and additional examples. */
+  fileNamePattern: string;
+  /** Maximum amount of disk space that can be used for storing files from this sink. */
+  maximumSizeMiB: string;
+};
+
+/** Enables a media graph to record media to an Azure Media Services asset for subsequent playback. */
+export type MediaGraphAssetSink = MediaGraphSink & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphAssetSink";
+  /** A name pattern when creating new assets. The pattern must include at least one system variable. See the documentation for available variables and additional examples. */
+  assetNamePattern: string;
+  /** When writing media to an asset, wait until at least this duration of media has been accumulated on the Edge. Expressed in increments of 30 seconds, with a minimum of 30 seconds and a recommended maximum of 5 minutes. */
+  segmentLength?: string;
+  /** Path to a local file system directory for temporary caching of media before writing to an Asset. Used when the Edge device is temporarily disconnected from Azure. */
+  localMediaCachePath: string;
+  /** Maximum amount of disk space that can be used for temporary caching of media. */
+  localMediaCacheMaximumSizeMiB: string;
+};
+
+/** An endpoint that the media graph can connect to, with no encryption in transit. */
+export type MediaGraphUnsecuredEndpoint = MediaGraphEndpoint & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphUnsecuredEndpoint";
+};
+
+/** A TLS endpoint for media graph external connections. */
+export type MediaGraphTlsEndpoint = MediaGraphEndpoint & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphTlsEndpoint";
+  /** Trusted certificates when authenticating a TLS connection. Null designates that Azure Media Service's source of trust should be used. */
+  trustedCertificates?: MediaGraphCertificateSourceUnion;
+  /** Validation options to use when authenticating a TLS connection. By default, strict validation is used. */
+  validationOptions?: MediaGraphTlsValidationOptions;
+};
+
+/** Username/password credential pair. */
+export type MediaGraphUsernamePasswordCredentials = MediaGraphCredentials & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphUsernamePasswordCredentials";
+  /** Username for a username/password pair. */
+  username: string;
+  /** Password for a username/password pair. Please use a parameter so that the actual value is not returned on PUT or GET requests. */
+  password: string;
+};
+
+/** Http header service credentials. */
+export type MediaGraphHttpHeaderCredentials = MediaGraphCredentials & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphHttpHeaderCredentials";
+  /** HTTP header name. */
+  headerName: string;
+  /** HTTP header value. Please use a parameter so that the actual value is not returned on PUT or GET requests. */
+  headerValue: string;
+};
+
+/** A list of PEM formatted certificates. */
+export type MediaGraphPemCertificateList = MediaGraphCertificateSource & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphPemCertificateList";
+  /** PEM formatted public certificates one per entry. */
+  certificates: string[];
+};
+
+/** Encoding settings for raw images. */
+export type MediaGraphImageFormatRaw = MediaGraphImageFormat & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphImageFormatRaw";
+  /** The pixel format that will be used to encode images. */
+  pixelFormat: MediaGraphImageFormatRawPixelFormat;
+};
+
+/** Encoding settings for Jpeg images. */
+export type MediaGraphImageFormatJpeg = MediaGraphImageFormat & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphImageFormatJpeg";
+  /** The image quality. Value must be between 0 to 100 (best quality). */
+  quality?: string;
+};
+
+/** Encoding settings for Bmp images. */
+export type MediaGraphImageFormatBmp = MediaGraphImageFormat & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphImageFormatBmp";
+};
+
+/** Encoding settings for Png images. */
+export type MediaGraphImageFormatPng = MediaGraphImageFormat & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphImageFormatPng";
+};
+
+/** Represents the MediaGraphTopologyGetRequest. */
+export type MediaGraphTopologyGetRequest = ItemNonSetRequestBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphTopologyGet";
+};
+
+/** Represents the MediaGraphTopologyDeleteRequest. */
+export type MediaGraphTopologyDeleteRequest = ItemNonSetRequestBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphTopologyDelete";
+};
+
+/** Represents the MediaGraphInstanceGetRequest. */
+export type MediaGraphInstanceGetRequest = ItemNonSetRequestBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphInstanceGet";
+};
+
+/** Represents the MediaGraphInstanceActivateRequest. */
+export type MediaGraphInstanceActivateRequest = ItemNonSetRequestBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphInstanceActivate";
+};
+
+/** Represents the MediaGraphInstanceDeactivateRequest. */
+export type MediaGraphInstanceDeActivateRequest = ItemNonSetRequestBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphInstanceDeactivate";
+};
+
+/** Represents the MediaGraphInstanceDeleteRequest. */
+export type MediaGraphInstanceDeleteRequest = ItemNonSetRequestBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  methodName: "GraphInstanceDelete";
+};
+
+/** A processor that allows the media graph to send video frames to a Cognitive Services Vision extension. Inference results are relayed to downstream nodes. */
+export type MediaGraphCognitiveServicesVisionExtension = MediaGraphExtensionProcessorBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphCognitiveServicesVisionExtension";
+};
+
+/** A processor that allows the media graph to send video frames to an external inference container over a gRPC connection. This can be done using shared memory (for high frame rates), or over the network. Inference results are relayed to downstream nodes. */
+export type MediaGraphGrpcExtension = MediaGraphExtensionProcessorBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphGrpcExtension";
+  /** How media should be transferred to the inference engine. */
+  dataTransfer: MediaGraphGrpcExtensionDataTransfer;
+  /** Optional configuration to pass to the gRPC extension. */
+  extensionConfiguration?: string;
+};
+
+/** A processor that allows the media graph to send video frames (mostly at low frame rates e.g. <5 fps) to an external inference container over an HTTP-based RESTful API. Inference results are relayed to downstream nodes. */
+export type MediaGraphHttpExtension = MediaGraphExtensionProcessorBase & {
+  /** Polymorphic discriminator, which specifies the different types this object can be */
+  "@type": "#Microsoft.Media.MediaGraphHttpExtension";
+};
+
+/** Known values of {@link MediaGraphParameterType} that the service accepts. */
+export const enum KnownMediaGraphParameterType {
+  /** A string parameter value. */
+  String = "String",
+  /** A string to hold sensitive information as parameter value. */
+  SecretString = "SecretString",
+  /** A 32-bit signed integer as parameter value. */
+  Int = "Int",
+  /** A 64-bit double-precision floating point type as parameter value. */
+  Double = "Double",
+  /** A boolean value that is either true or false. */
+  Bool = "Bool"
+}
+
+/**
+ * Defines values for MediaGraphParameterType. \
+ * {@link KnownMediaGraphParameterType} can be used interchangeably with MediaGraphParameterType,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **String**: A string parameter value. \
+ * **SecretString**: A string to hold sensitive information as parameter value. \
+ * **Int**: A 32-bit signed integer as parameter value. \
+ * **Double**: A 64-bit double-precision floating point type as parameter value. \
+ * **Bool**: A boolean value that is either true or false.
+ */
+export type MediaGraphParameterType = string;
+
+/** Known values of {@link MediaGraphOutputSelectorProperty} that the service accepts. */
+export const enum KnownMediaGraphOutputSelectorProperty {
+  /** The stream's MIME type or subtype. */
+  MediaType = "mediaType"
+}
+
+/**
+ * Defines values for MediaGraphOutputSelectorProperty. \
+ * {@link KnownMediaGraphOutputSelectorProperty} can be used interchangeably with MediaGraphOutputSelectorProperty,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **mediaType**: The stream's MIME type or subtype.
+ */
+export type MediaGraphOutputSelectorProperty = string;
+
+/** Known values of {@link MediaGraphOutputSelectorOperator} that the service accepts. */
+export const enum KnownMediaGraphOutputSelectorOperator {
+  /** A media type is the same type or a subtype. */
+  Is = "is",
+  /** A media type is not the same type or a subtype. */
+  IsNot = "isNot"
+}
+
+/**
+ * Defines values for MediaGraphOutputSelectorOperator. \
+ * {@link KnownMediaGraphOutputSelectorOperator} can be used interchangeably with MediaGraphOutputSelectorOperator,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **is**: A media type is the same type or a subtype. \
+ * **isNot**: A media type is not the same type or a subtype.
+ */
+export type MediaGraphOutputSelectorOperator = string;
+
+/** Known values of {@link MediaGraphInstanceState} that the service accepts. */
+export const enum KnownMediaGraphInstanceState {
+  /** The media graph instance is idle and not processing media. */
+  Inactive = "Inactive",
+  /** The media graph instance is transitioning into the active state. */
+  Activating = "Activating",
+  /** The media graph instance is active and processing media. */
+  Active = "Active",
+  /** The media graph instance is transitioning into the inactive state. */
+  Deactivating = "Deactivating"
+}
+
+/**
+ * Defines values for MediaGraphInstanceState. \
+ * {@link KnownMediaGraphInstanceState} can be used interchangeably with MediaGraphInstanceState,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Inactive**: The media graph instance is idle and not processing media. \
+ * **Activating**: The media graph instance is transitioning into the active state. \
+ * **Active**: The media graph instance is active and processing media. \
+ * **Deactivating**: The media graph instance is transitioning into the inactive state.
+ */
+export type MediaGraphInstanceState = string;
+
+/** Known values of {@link MediaGraphRtspTransport} that the service accepts. */
+export const enum KnownMediaGraphRtspTransport {
+  /** HTTP/HTTPS transport. This should be used when HTTP tunneling is desired. */
+  Http = "Http",
+  /** TCP transport. This should be used when HTTP tunneling is NOT desired. */
+  Tcp = "Tcp"
+}
+
+/**
+ * Defines values for MediaGraphRtspTransport. \
+ * {@link KnownMediaGraphRtspTransport} can be used interchangeably with MediaGraphRtspTransport,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Http**: HTTP\/HTTPS transport. This should be used when HTTP tunneling is desired. \
+ * **Tcp**: TCP transport. This should be used when HTTP tunneling is NOT desired.
+ */
+export type MediaGraphRtspTransport = string;
+
+/** Known values of {@link MediaGraphMotionDetectionSensitivity} that the service accepts. */
+export const enum KnownMediaGraphMotionDetectionSensitivity {
+  /** Low Sensitivity. */
+  Low = "Low",
+  /** Medium Sensitivity. */
+  Medium = "Medium",
+  /** High Sensitivity. */
+  High = "High"
+}
+
+/**
+ * Defines values for MediaGraphMotionDetectionSensitivity. \
+ * {@link KnownMediaGraphMotionDetectionSensitivity} can be used interchangeably with MediaGraphMotionDetectionSensitivity,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Low**: Low Sensitivity. \
+ * **Medium**: Medium Sensitivity. \
+ * **High**: High Sensitivity.
+ */
+export type MediaGraphMotionDetectionSensitivity = string;
+
+/** Known values of {@link MediaGraphImageScaleMode} that the service accepts. */
+export const enum KnownMediaGraphImageScaleMode {
+  /** Use the same aspect ratio as the input frame. */
+  PreserveAspectRatio = "PreserveAspectRatio",
+  /** Center pad the input frame to match the given dimensions. */
+  Pad = "Pad",
+  /** Stretch input frame to match given dimensions. */
+  Stretch = "Stretch"
+}
+
+/**
+ * Defines values for MediaGraphImageScaleMode. \
+ * {@link KnownMediaGraphImageScaleMode} can be used interchangeably with MediaGraphImageScaleMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **PreserveAspectRatio**: Use the same aspect ratio as the input frame. \
+ * **Pad**: Center pad the input frame to match the given dimensions. \
+ * **Stretch**: Stretch input frame to match given dimensions.
+ */
+export type MediaGraphImageScaleMode = string;
+
+/** Known values of {@link MediaGraphGrpcExtensionDataTransferMode} that the service accepts. */
+export const enum KnownMediaGraphGrpcExtensionDataTransferMode {
+  /** Frames are transferred embedded into the gRPC messages. */
+  Embedded = "Embedded",
+  /** Frames are transferred through shared memory. */
+  SharedMemory = "SharedMemory"
+}
+
+/**
+ * Defines values for MediaGraphGrpcExtensionDataTransferMode. \
+ * {@link KnownMediaGraphGrpcExtensionDataTransferMode} can be used interchangeably with MediaGraphGrpcExtensionDataTransferMode,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Embedded**: Frames are transferred embedded into the gRPC messages. \
+ * **SharedMemory**: Frames are transferred through shared memory.
+ */
+export type MediaGraphGrpcExtensionDataTransferMode = string;
+
+/** Known values of {@link MediaGraphImageFormatRawPixelFormat} that the service accepts. */
+export const enum KnownMediaGraphImageFormatRawPixelFormat {
+  /** Planar YUV 4:2:0, 12bpp, (1 Cr and Cb sample per 2x2 Y samples). */
+  Yuv420P = "Yuv420p",
+  /** Packed RGB 5:6:5, 16bpp, (msb)   5R 6G 5B(lsb), big-endian. */
+  Rgb565Be = "Rgb565be",
+  /** Packed RGB 5:6:5, 16bpp, (msb)   5R 6G 5B(lsb), little-endian. */
+  Rgb565Le = "Rgb565le",
+  /** Packed RGB 5:5:5, 16bpp, (msb)1X 5R 5G 5B(lsb), big-endian , X=unused/undefined. */
+  Rgb555Be = "Rgb555be",
+  /** Packed RGB 5:5:5, 16bpp, (msb)1X 5R 5G 5B(lsb), little-endian, X=unused/undefined. */
+  Rgb555Le = "Rgb555le",
+  /** Packed RGB 8:8:8, 24bpp, RGBRGB. */
+  Rgb24 = "Rgb24",
+  /** Packed RGB 8:8:8, 24bpp, BGRBGR. */
+  Bgr24 = "Bgr24",
+  /** Packed ARGB 8:8:8:8, 32bpp, ARGBARGB. */
+  Argb = "Argb",
+  /** Packed RGBA 8:8:8:8, 32bpp, RGBARGBA. */
+  Rgba = "Rgba",
+  /** Packed ABGR 8:8:8:8, 32bpp, ABGRABGR. */
+  Abgr = "Abgr",
+  /** Packed BGRA 8:8:8:8, 32bpp, BGRABGRA. */
+  Bgra = "Bgra"
+}
+
+/**
+ * Defines values for MediaGraphImageFormatRawPixelFormat. \
+ * {@link KnownMediaGraphImageFormatRawPixelFormat} can be used interchangeably with MediaGraphImageFormatRawPixelFormat,
+ *  this enum contains the known values that the service supports.
+ * ### Know values supported by the service
+ * **Yuv420p**: Planar YUV 4:2:0, 12bpp, (1 Cr and Cb sample per 2x2 Y samples). \
+ * **Rgb565be**: Packed RGB 5:6:5, 16bpp, (msb)   5R 6G 5B(lsb), big-endian. \
+ * **Rgb565le**: Packed RGB 5:6:5, 16bpp, (msb)   5R 6G 5B(lsb), little-endian. \
+ * **Rgb555be**: Packed RGB 5:5:5, 16bpp, (msb)1X 5R 5G 5B(lsb), big-endian , X=unused\/undefined. \
+ * **Rgb555le**: Packed RGB 5:5:5, 16bpp, (msb)1X 5R 5G 5B(lsb), little-endian, X=unused\/undefined. \
+ * **Rgb24**: Packed RGB 8:8:8, 24bpp, RGBRGB. \
+ * **Bgr24**: Packed RGB 8:8:8, 24bpp, BGRBGR. \
+ * **Argb**: Packed ARGB 8:8:8:8, 32bpp, ARGBARGB. \
+ * **Rgba**: Packed RGBA 8:8:8:8, 32bpp, RGBARGBA. \
+ * **Abgr**: Packed ABGR 8:8:8:8, 32bpp, ABGRABGR. \
+ * **Bgra**: Packed BGRA 8:8:8:8, 32bpp, BGRABGRA.
+ */
+export type MediaGraphImageFormatRawPixelFormat = string;
+
+/** Optional parameters. */
+export interface MediaServicesClientOptionalParams
+  extends coreHttp.ServiceClientOptions {
+  /** Overrides client endpoint. */
+  endpoint?: string;
+}

--- a/test/integration/generated/polymorphicSkipNormalize/src/generated/models/mappers.ts
+++ b/test/integration/generated/polymorphicSkipNormalize/src/generated/models/mappers.ts
@@ -1,0 +1,1380 @@
+import * as coreHttp from "@azure/core-http";
+
+export const MethodRequest: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MethodRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: {
+      serializedName: "methodName",
+      clientName: "methodName"
+    },
+    modelProperties: {
+      methodName: {
+        serializedName: "methodName",
+        required: true,
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      },
+      apiVersion: {
+        defaultValue: "2.0",
+        isConstant: true,
+        serializedName: "@apiVersion",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphTopology: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopology",
+    modelProperties: {
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      systemData: {
+        serializedName: "systemData",
+        type: {
+          name: "Composite",
+          className: "MediaGraphSystemData"
+        }
+      },
+      properties: {
+        serializedName: "properties",
+        type: {
+          name: "Composite",
+          className: "MediaGraphTopologyProperties"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphSystemData: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphSystemData",
+    modelProperties: {
+      createdAt: {
+        serializedName: "createdAt",
+        type: {
+          name: "DateTime"
+        }
+      },
+      lastModifiedAt: {
+        serializedName: "lastModifiedAt",
+        type: {
+          name: "DateTime"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphTopologyProperties: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopologyProperties",
+    modelProperties: {
+      description: {
+        serializedName: "description",
+        type: {
+          name: "String"
+        }
+      },
+      parameters: {
+        serializedName: "parameters",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphParameterDeclaration"
+            }
+          }
+        }
+      },
+      sources: {
+        serializedName: "sources",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphSource"
+            }
+          }
+        }
+      },
+      processors: {
+        serializedName: "processors",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphProcessor"
+            }
+          }
+        }
+      },
+      sinks: {
+        serializedName: "sinks",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphSink"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphParameterDeclaration: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphParameterDeclaration",
+    modelProperties: {
+      name: {
+        constraints: {
+          MaxLength: 64
+        },
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      type: {
+        serializedName: "type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      description: {
+        serializedName: "description",
+        type: {
+          name: "String"
+        }
+      },
+      default: {
+        serializedName: "default",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphSource: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphSource",
+    uberParent: "MediaGraphSource",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphProcessor: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphProcessor",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      inputs: {
+        serializedName: "inputs",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphNodeInput"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphNodeInput: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphNodeInput",
+    modelProperties: {
+      nodeName: {
+        serializedName: "nodeName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      outputSelectors: {
+        serializedName: "outputSelectors",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphOutputSelector"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphOutputSelector: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphOutputSelector",
+    modelProperties: {
+      property: {
+        serializedName: "property",
+        type: {
+          name: "String"
+        }
+      },
+      operator: {
+        serializedName: "operator",
+        type: {
+          name: "String"
+        }
+      },
+      value: {
+        serializedName: "value",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphSink: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphSink",
+    uberParent: "MediaGraphSink",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      inputs: {
+        serializedName: "inputs",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphNodeInput"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphInstance: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstance",
+    modelProperties: {
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      systemData: {
+        serializedName: "systemData",
+        type: {
+          name: "Composite",
+          className: "MediaGraphSystemData"
+        }
+      },
+      properties: {
+        serializedName: "properties",
+        type: {
+          name: "Composite",
+          className: "MediaGraphInstanceProperties"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphInstanceProperties: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceProperties",
+    modelProperties: {
+      description: {
+        serializedName: "description",
+        type: {
+          name: "String"
+        }
+      },
+      topologyName: {
+        serializedName: "topologyName",
+        type: {
+          name: "String"
+        }
+      },
+      parameters: {
+        serializedName: "parameters",
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "Composite",
+              className: "MediaGraphParameterDefinition"
+            }
+          }
+        }
+      },
+      state: {
+        serializedName: "state",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphParameterDefinition: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphParameterDefinition",
+    modelProperties: {
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      value: {
+        serializedName: "value",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphEndpoint: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphEndpoint",
+    uberParent: "MediaGraphEndpoint",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      credentials: {
+        serializedName: "credentials",
+        type: {
+          name: "Composite",
+          className: "MediaGraphCredentials"
+        }
+      },
+      url: {
+        serializedName: "url",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphCredentials: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphCredentials",
+    uberParent: "MediaGraphCredentials",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphCertificateSource: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphCertificateSource",
+    uberParent: "MediaGraphCertificateSource",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphTlsValidationOptions: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphTlsValidationOptions",
+    modelProperties: {
+      ignoreHostname: {
+        serializedName: "ignoreHostname",
+        type: {
+          name: "String"
+        }
+      },
+      ignoreSignature: {
+        serializedName: "ignoreSignature",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphImage: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphImage",
+    modelProperties: {
+      scale: {
+        serializedName: "scale",
+        type: {
+          name: "Composite",
+          className: "MediaGraphImageScale"
+        }
+      },
+      format: {
+        serializedName: "format",
+        type: {
+          name: "Composite",
+          className: "MediaGraphImageFormat"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphImageScale: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphImageScale",
+    modelProperties: {
+      mode: {
+        serializedName: "mode",
+        type: {
+          name: "String"
+        }
+      },
+      width: {
+        serializedName: "width",
+        type: {
+          name: "String"
+        }
+      },
+      height: {
+        serializedName: "height",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphImageFormat: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphImageFormat",
+  type: {
+    name: "Composite",
+    className: "MediaGraphImageFormat",
+    uberParent: "MediaGraphImageFormat",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      "@type": {
+        serializedName: "@type",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphSamplingOptions: coreHttp.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "MediaGraphSamplingOptions",
+    modelProperties: {
+      skipSamplesWithoutAnnotation: {
+        serializedName: "skipSamplesWithoutAnnotation",
+        type: {
+          name: "String"
+        }
+      },
+      maximumSamplesPerSecond: {
+        serializedName: "maximumSamplesPerSecond",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphGrpcExtensionDataTransfer: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphGrpcExtensionDataTransfer",
+  type: {
+    name: "Composite",
+    className: "MediaGraphGrpcExtensionDataTransfer",
+    modelProperties: {
+      sharedMemorySizeMiB: {
+        serializedName: "sharedMemorySizeMiB",
+        type: {
+          name: "String"
+        }
+      },
+      mode: {
+        serializedName: "mode",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphTopologySetRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphTopologySet",
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopologySetRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MethodRequest.type.modelProperties,
+      graph: {
+        serializedName: "graph",
+        type: {
+          name: "Composite",
+          className: "MediaGraphTopology"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphTopologySetRequestBody: coreHttp.CompositeMapper = {
+  serializedName: "MediaGraphTopologySetRequestBody",
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopologySetRequestBody",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MethodRequest.type.modelProperties,
+      ...MediaGraphTopology.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphInstanceSetRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphInstanceSet",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceSetRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MethodRequest.type.modelProperties,
+      instance: {
+        serializedName: "instance",
+        type: {
+          name: "Composite",
+          className: "MediaGraphInstance"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphInstanceSetRequestBody: coreHttp.CompositeMapper = {
+  serializedName: "MediaGraphInstanceSetRequestBody",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceSetRequestBody",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MethodRequest.type.modelProperties,
+      ...MediaGraphInstance.type.modelProperties
+    }
+  }
+};
+
+export const ItemNonSetRequestBase: coreHttp.CompositeMapper = {
+  serializedName: "ItemNonSetRequestBase",
+  type: {
+    name: "Composite",
+    className: "ItemNonSetRequestBase",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: {
+      serializedName: "methodName",
+      clientName: "methodName"
+    },
+    modelProperties: {
+      ...MethodRequest.type.modelProperties,
+      name: {
+        serializedName: "name",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphTopologyListRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphTopologyList",
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopologyListRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MethodRequest.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphInstanceListRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphInstanceList",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceListRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MethodRequest.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphRtspSource: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphRtspSource",
+  type: {
+    name: "Composite",
+    className: "MediaGraphRtspSource",
+    uberParent: "MediaGraphSource",
+    polymorphicDiscriminator: MediaGraphSource.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphSource.type.modelProperties,
+      transport: {
+        serializedName: "transport",
+        type: {
+          name: "String"
+        }
+      },
+      endpoint: {
+        serializedName: "endpoint",
+        type: {
+          name: "Composite",
+          className: "MediaGraphEndpoint"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphIoTHubMessageSource: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphIoTHubMessageSource",
+  type: {
+    name: "Composite",
+    className: "MediaGraphIoTHubMessageSource",
+    uberParent: "MediaGraphSource",
+    polymorphicDiscriminator: MediaGraphSource.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphSource.type.modelProperties,
+      hubInputName: {
+        serializedName: "hubInputName",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphMotionDetectionProcessor: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphMotionDetectionProcessor",
+  type: {
+    name: "Composite",
+    className: "MediaGraphMotionDetectionProcessor",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: MediaGraphProcessor.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphProcessor.type.modelProperties,
+      sensitivity: {
+        serializedName: "sensitivity",
+        type: {
+          name: "String"
+        }
+      },
+      outputMotionRegion: {
+        serializedName: "outputMotionRegion",
+        type: {
+          name: "Boolean"
+        }
+      },
+      eventAggregationWindow: {
+        serializedName: "eventAggregationWindow",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphExtensionProcessorBase: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphExtensionProcessorBase",
+  type: {
+    name: "Composite",
+    className: "MediaGraphExtensionProcessorBase",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: {
+      serializedName: "@type",
+      clientName: "@type"
+    },
+    modelProperties: {
+      ...MediaGraphProcessor.type.modelProperties,
+      endpoint: {
+        serializedName: "endpoint",
+        type: {
+          name: "Composite",
+          className: "MediaGraphEndpoint"
+        }
+      },
+      image: {
+        serializedName: "image",
+        type: {
+          name: "Composite",
+          className: "MediaGraphImage"
+        }
+      },
+      samplingOptions: {
+        serializedName: "samplingOptions",
+        type: {
+          name: "Composite",
+          className: "MediaGraphSamplingOptions"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphSignalGateProcessor: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphSignalGateProcessor",
+  type: {
+    name: "Composite",
+    className: "MediaGraphSignalGateProcessor",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: MediaGraphProcessor.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphProcessor.type.modelProperties,
+      activationEvaluationWindow: {
+        serializedName: "activationEvaluationWindow",
+        type: {
+          name: "String"
+        }
+      },
+      activationSignalOffset: {
+        serializedName: "activationSignalOffset",
+        type: {
+          name: "String"
+        }
+      },
+      minimumActivationTime: {
+        serializedName: "minimumActivationTime",
+        type: {
+          name: "String"
+        }
+      },
+      maximumActivationTime: {
+        serializedName: "maximumActivationTime",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphIoTHubMessageSink: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphIoTHubMessageSink",
+  type: {
+    name: "Composite",
+    className: "MediaGraphIoTHubMessageSink",
+    uberParent: "MediaGraphSink",
+    polymorphicDiscriminator: MediaGraphSink.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphSink.type.modelProperties,
+      hubOutputName: {
+        serializedName: "hubOutputName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphFileSink: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphFileSink",
+  type: {
+    name: "Composite",
+    className: "MediaGraphFileSink",
+    uberParent: "MediaGraphSink",
+    polymorphicDiscriminator: MediaGraphSink.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphSink.type.modelProperties,
+      baseDirectoryPath: {
+        serializedName: "baseDirectoryPath",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      fileNamePattern: {
+        serializedName: "fileNamePattern",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      maximumSizeMiB: {
+        serializedName: "maximumSizeMiB",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphAssetSink: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphAssetSink",
+  type: {
+    name: "Composite",
+    className: "MediaGraphAssetSink",
+    uberParent: "MediaGraphSink",
+    polymorphicDiscriminator: MediaGraphSink.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphSink.type.modelProperties,
+      assetNamePattern: {
+        serializedName: "assetNamePattern",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      segmentLength: {
+        serializedName: "segmentLength",
+        type: {
+          name: "String"
+        }
+      },
+      localMediaCachePath: {
+        serializedName: "localMediaCachePath",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      localMediaCacheMaximumSizeMiB: {
+        serializedName: "localMediaCacheMaximumSizeMiB",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphUnsecuredEndpoint: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphUnsecuredEndpoint",
+  type: {
+    name: "Composite",
+    className: "MediaGraphUnsecuredEndpoint",
+    uberParent: "MediaGraphEndpoint",
+    polymorphicDiscriminator: MediaGraphEndpoint.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphEndpoint.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphTlsEndpoint: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphTlsEndpoint",
+  type: {
+    name: "Composite",
+    className: "MediaGraphTlsEndpoint",
+    uberParent: "MediaGraphEndpoint",
+    polymorphicDiscriminator: MediaGraphEndpoint.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphEndpoint.type.modelProperties,
+      trustedCertificates: {
+        serializedName: "trustedCertificates",
+        type: {
+          name: "Composite",
+          className: "MediaGraphCertificateSource"
+        }
+      },
+      validationOptions: {
+        serializedName: "validationOptions",
+        type: {
+          name: "Composite",
+          className: "MediaGraphTlsValidationOptions"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphUsernamePasswordCredentials: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphUsernamePasswordCredentials",
+  type: {
+    name: "Composite",
+    className: "MediaGraphUsernamePasswordCredentials",
+    uberParent: "MediaGraphCredentials",
+    polymorphicDiscriminator:
+      MediaGraphCredentials.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphCredentials.type.modelProperties,
+      username: {
+        serializedName: "username",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      password: {
+        serializedName: "password",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphHttpHeaderCredentials: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphHttpHeaderCredentials",
+  type: {
+    name: "Composite",
+    className: "MediaGraphHttpHeaderCredentials",
+    uberParent: "MediaGraphCredentials",
+    polymorphicDiscriminator:
+      MediaGraphCredentials.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphCredentials.type.modelProperties,
+      headerName: {
+        serializedName: "headerName",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      headerValue: {
+        serializedName: "headerValue",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphPemCertificateList: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphPemCertificateList",
+  type: {
+    name: "Composite",
+    className: "MediaGraphPemCertificateList",
+    uberParent: "MediaGraphCertificateSource",
+    polymorphicDiscriminator:
+      MediaGraphCertificateSource.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphCertificateSource.type.modelProperties,
+      certificates: {
+        serializedName: "certificates",
+        required: true,
+        type: {
+          name: "Sequence",
+          element: {
+            type: {
+              name: "String"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphImageFormatRaw: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphImageFormatRaw",
+  type: {
+    name: "Composite",
+    className: "MediaGraphImageFormatRaw",
+    uberParent: "MediaGraphImageFormat",
+    polymorphicDiscriminator:
+      MediaGraphImageFormat.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphImageFormat.type.modelProperties,
+      pixelFormat: {
+        serializedName: "pixelFormat",
+        required: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphImageFormatJpeg: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphImageFormatJpeg",
+  type: {
+    name: "Composite",
+    className: "MediaGraphImageFormatJpeg",
+    uberParent: "MediaGraphImageFormat",
+    polymorphicDiscriminator:
+      MediaGraphImageFormat.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphImageFormat.type.modelProperties,
+      quality: {
+        serializedName: "quality",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphImageFormatBmp: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphImageFormatBmp",
+  type: {
+    name: "Composite",
+    className: "MediaGraphImageFormatBmp",
+    uberParent: "MediaGraphImageFormat",
+    polymorphicDiscriminator:
+      MediaGraphImageFormat.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphImageFormat.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphImageFormatPng: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphImageFormatPng",
+  type: {
+    name: "Composite",
+    className: "MediaGraphImageFormatPng",
+    uberParent: "MediaGraphImageFormat",
+    polymorphicDiscriminator:
+      MediaGraphImageFormat.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphImageFormat.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphTopologyGetRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphTopologyGet",
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopologyGetRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...ItemNonSetRequestBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphTopologyDeleteRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphTopologyDelete",
+  type: {
+    name: "Composite",
+    className: "MediaGraphTopologyDeleteRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...ItemNonSetRequestBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphInstanceGetRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphInstanceGet",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceGetRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...ItemNonSetRequestBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphInstanceActivateRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphInstanceActivate",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceActivateRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...ItemNonSetRequestBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphInstanceDeActivateRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphInstanceDeactivate",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceDeActivateRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...ItemNonSetRequestBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphInstanceDeleteRequest: coreHttp.CompositeMapper = {
+  serializedName: "GraphInstanceDelete",
+  type: {
+    name: "Composite",
+    className: "MediaGraphInstanceDeleteRequest",
+    uberParent: "MethodRequest",
+    polymorphicDiscriminator: MethodRequest.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...ItemNonSetRequestBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphCognitiveServicesVisionExtension: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphCognitiveServicesVisionExtension",
+  type: {
+    name: "Composite",
+    className: "MediaGraphCognitiveServicesVisionExtension",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: MediaGraphProcessor.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphExtensionProcessorBase.type.modelProperties
+    }
+  }
+};
+
+export const MediaGraphGrpcExtension: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphGrpcExtension",
+  type: {
+    name: "Composite",
+    className: "MediaGraphGrpcExtension",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: MediaGraphProcessor.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphExtensionProcessorBase.type.modelProperties,
+      dataTransfer: {
+        serializedName: "dataTransfer",
+        type: {
+          name: "Composite",
+          className: "MediaGraphGrpcExtensionDataTransfer"
+        }
+      },
+      extensionConfiguration: {
+        serializedName: "extensionConfiguration",
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
+export const MediaGraphHttpExtension: coreHttp.CompositeMapper = {
+  serializedName: "#Microsoft.Media.MediaGraphHttpExtension",
+  type: {
+    name: "Composite",
+    className: "MediaGraphHttpExtension",
+    uberParent: "MediaGraphProcessor",
+    polymorphicDiscriminator: MediaGraphProcessor.type.polymorphicDiscriminator,
+    modelProperties: {
+      ...MediaGraphExtensionProcessorBase.type.modelProperties
+    }
+  }
+};
+
+export let discriminators = {
+  MethodRequest: MethodRequest,
+  MediaGraphSource: MediaGraphSource,
+  MediaGraphProcessor: MediaGraphProcessor,
+  MediaGraphSink: MediaGraphSink,
+  MediaGraphEndpoint: MediaGraphEndpoint,
+  MediaGraphCredentials: MediaGraphCredentials,
+  MediaGraphCertificateSource: MediaGraphCertificateSource,
+  MediaGraphImageFormat: MediaGraphImageFormat,
+  "MethodRequest.GraphTopologySet": MediaGraphTopologySetRequest,
+  "MethodRequest.MediaGraphTopologySetRequestBody": MediaGraphTopologySetRequestBody,
+  "MethodRequest.GraphInstanceSet": MediaGraphInstanceSetRequest,
+  "MethodRequest.MediaGraphInstanceSetRequestBody": MediaGraphInstanceSetRequestBody,
+  "MethodRequest.ItemNonSetRequestBase": ItemNonSetRequestBase,
+  "MethodRequest.GraphTopologyList": MediaGraphTopologyListRequest,
+  "MethodRequest.GraphInstanceList": MediaGraphInstanceListRequest,
+  "MediaGraphSource.#Microsoft.Media.MediaGraphRtspSource": MediaGraphRtspSource,
+  "MediaGraphSource.#Microsoft.Media.MediaGraphIoTHubMessageSource": MediaGraphIoTHubMessageSource,
+  "MediaGraphProcessor.#Microsoft.Media.MediaGraphMotionDetectionProcessor": MediaGraphMotionDetectionProcessor,
+  "MediaGraphProcessor.#Microsoft.Media.MediaGraphExtensionProcessorBase": MediaGraphExtensionProcessorBase,
+  "MediaGraphProcessor.#Microsoft.Media.MediaGraphSignalGateProcessor": MediaGraphSignalGateProcessor,
+  "MediaGraphSink.#Microsoft.Media.MediaGraphIoTHubMessageSink": MediaGraphIoTHubMessageSink,
+  "MediaGraphSink.#Microsoft.Media.MediaGraphFileSink": MediaGraphFileSink,
+  "MediaGraphSink.#Microsoft.Media.MediaGraphAssetSink": MediaGraphAssetSink,
+  "MediaGraphEndpoint.#Microsoft.Media.MediaGraphUnsecuredEndpoint": MediaGraphUnsecuredEndpoint,
+  "MediaGraphEndpoint.#Microsoft.Media.MediaGraphTlsEndpoint": MediaGraphTlsEndpoint,
+  "MediaGraphCredentials.#Microsoft.Media.MediaGraphUsernamePasswordCredentials": MediaGraphUsernamePasswordCredentials,
+  "MediaGraphCredentials.#Microsoft.Media.MediaGraphHttpHeaderCredentials": MediaGraphHttpHeaderCredentials,
+  "MediaGraphCertificateSource.#Microsoft.Media.MediaGraphPemCertificateList": MediaGraphPemCertificateList,
+  "MediaGraphImageFormat.#Microsoft.Media.MediaGraphImageFormatRaw": MediaGraphImageFormatRaw,
+  "MediaGraphImageFormat.#Microsoft.Media.MediaGraphImageFormatJpeg": MediaGraphImageFormatJpeg,
+  "MediaGraphImageFormat.#Microsoft.Media.MediaGraphImageFormatBmp": MediaGraphImageFormatBmp,
+  "MediaGraphImageFormat.#Microsoft.Media.MediaGraphImageFormatPng": MediaGraphImageFormatPng,
+  "MethodRequest.GraphTopologyGet": MediaGraphTopologyGetRequest,
+  "MethodRequest.GraphTopologyDelete": MediaGraphTopologyDeleteRequest,
+  "MethodRequest.GraphInstanceGet": MediaGraphInstanceGetRequest,
+  "MethodRequest.GraphInstanceActivate": MediaGraphInstanceActivateRequest,
+  "MethodRequest.GraphInstanceDeactivate": MediaGraphInstanceDeActivateRequest,
+  "MethodRequest.GraphInstanceDelete": MediaGraphInstanceDeleteRequest,
+  "MediaGraphProcessor.#Microsoft.Media.MediaGraphCognitiveServicesVisionExtension": MediaGraphCognitiveServicesVisionExtension,
+  "MediaGraphProcessor.#Microsoft.Media.MediaGraphGrpcExtension": MediaGraphGrpcExtension,
+  "MediaGraphProcessor.#Microsoft.Media.MediaGraphHttpExtension": MediaGraphHttpExtension
+};

--- a/test/integration/swaggers/MediaServices_polymorphic_skipNormalize.md
+++ b/test/integration/swaggers/MediaServices_polymorphic_skipNormalize.md
@@ -1,0 +1,23 @@
+# Azure Example TypeScript Protocol Layer
+
+> see https://aka.ms/autorest
+
+## Configuration
+
+```yaml
+package-name: "@azure/api-learn"
+title: GeneratedClient
+description: Example Client
+generate-metadata: false
+license-header: MICROSOFT_MIT_NO_VERSION
+output-folder: ../
+source-code-folder-path: ./src/generated
+input-file: https://github.com/Azure/azure-rest-api-specs/blob/a57e89f8c3e1215201694cc0d6e9a51842573df0/specification/mediaservices/data-plane/LiveVideoAnalytics.Edge/preview/2.0.0/LiveVideoAnalyticsSdkDefinitions.json
+add-credentials: false
+use-extension:
+  "@autorest/typescript": "~/projects/autorest.typescript"
+modelerfour:
+  naming:
+    override:
+      "@type": $DO_NOT_NORMALIZE$@type
+```

--- a/test/utils/test-swagger-gen.ts
+++ b/test/utils/test-swagger-gen.ts
@@ -397,6 +397,12 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     clientName: "SearchClient",
     packageName: "@azure/search-documents"
   },
+  polymorphicSkipNormalize: {
+    swaggerOrConfig:
+      "test/integration/swaggers/MediaServices_polymorphic_skipNormalize.md",
+    clientName: "MediaServicesClient",
+    packageName: "@azure/media-services"
+  },
   petstore: {
     swaggerOrConfig: "test/integration/swaggers/petstore.json",
     clientName: "PetStore",


### PR DESCRIPTION
We currently have the ability to tell the generator to skip property name normalization by setting an M4 name override like the following 

```yaml
modelerfour:
  naming:
    override:
      '@type': $DO_NOT_NORMALIZE$@type
```

However in some cases, such as the one in the example, when generating the object key is enclosed by quotes to make it a valid javascript property name. This was causing 2 issues

1. normalizeName wouldn't recognize the $DO_NOT_NORMALIZE$ token, as the overriden name would not start with $DO_NOT_NORMALIZE$ but "$DO_NOT_NORMALIZE$. So it normalized it anyway
2. When generating non-discriminated properties we are note wrapping the property name in quotes which while doesn't make any difference in the actual generated code it would make generation fail if the example above was used with a non-discriminated property since the following object is not valid in JS
```javascript
const foo = {
   @type: "someType"
}
```

So the fixes are:

1. Make sure to strip quotes at the beginning and end when normalizing discriminated property name. This is not an issue with normal properties because we use a "dictionary" to store discriminated props info which requires the property name to be enclosed with "". While in regular properties the name is stored in a string property so they are not enclosed by quotes.
2. Explicitly set quotes in the property name when generating both regular and discriminated-properties. Our codegen runs the generated code through prettier which removes un-needed quotes so this won't have any adverse side-effects