### PR TITLE
Improve the generated README.md to be close to Track 2's

### DIFF
--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -89,6 +89,8 @@ function createMetadata(
      * "Client".
      */
     title.match(/(.*) Client/)?.[1] ??
+    /** I noticed management-plane swaggers do not use spaces in their titles */
+    title.match(/(.*)Client/)?.[1] ??
     clientClassName.match(/(.*)Client/)?.[1] ??
     title.match(/(.*) Service/)?.[1] ??
     "Service";

--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -204,7 +204,7 @@ function writeKeyConcepts(metadata: Metadata): string {
 
 ### ${metadata.clientClassName}
 
-\`${metadata.clientClassName}\` is the primary interface for developers using the ${metadata.clientDescriptiveName} library. It provides asynchronous methods to access a specific use of ${metadata.serviceName}.`;
+\`${metadata.clientClassName}\` is the primary interface for developers using the ${metadata.clientDescriptiveName} library. Explore the methods on this client object to understand the different features of the ${metadata.serviceName} service that you can access.`;
 }
 
 function writeTroubleshooting(metadata: Metadata): string {
@@ -270,7 +270,9 @@ export function generateReadmeFile(
   const readmeFileContents = `
 # ${metadata.clientDescriptiveName} library for JavaScript
 
-This package contains an isomorphic SDK for ${metadata.clientDescriptiveName}.
+This package contains an isomorphic SDK (runs both in node.js and in browsers) for ${
+    metadata.clientDescriptiveName
+  }.
 ${addNewline(metadata.description)}
 ${addNewline(
   metadata.packageSourceURL && `[Source code](${metadata.packageSourceURL}) |`

--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -5,39 +5,296 @@ import { Project } from "ts-morph";
 import { PackageDetails } from "../../models/packageDetails";
 import { ClientDetails } from "../../models/clientDetails";
 
+/**
+ * Prefixes the input string with a white space.
+ * @param str - string to prefix with a space
+ * @returns a prefixed string with space if the input string is defined. Otherwise, returns an empty string.
+ */
+function addSpace(str?: string): string {
+  return str === undefined ? "" : " " + str;
+}
+
+/**
+ * Prefixes the input string with a newline if possible.
+ * @param str - string to prefix with a new line
+ * @param noWrite - whether to create the string
+ * @returns a string prefixed with a new line if the input string is defined and the noWrite flag is false. Otherwise, returns an empty string.
+ */
+function addNewline(str?: string, noWrite: boolean = false): string {
+  return !str || noWrite ? "" : "\n" + str;
+}
+
+/**
+ * Meta data information about the service, the package, and the client.
+ */
+interface Metadata {
+  /** The name of the service */
+  serviceName: string;
+  /** The name of the package */
+  clientPackageName: string;
+  /** The name of the client class */
+  clientClassName: string;
+  /** Whether the package being generated is for an Azure service */
+  azure: boolean;
+  /** The path to the package directory relative to the repository it lives in */
+  relativePackageSourcePath?: string;
+  /** The URL of the repository the package lives in */
+  repoURL?: string;
+  /** The URL to the package directory in the repository */
+  packageSourceURL?: string;
+  /** The URL to the package's samples */
+  samplesURL?: string;
+  /** A descriptive name for the client extracted from the swagger */
+  clientDescriptiveName?: string;
+  /** A description for the service extracted from the swagger */
+  description?: string;
+  /** The URL for impression */
+  impressionURL?: string;
+  /** The URL to the API reference */
+  apiRefURL?: string;
+  /** The URL to the package on npmjs.org */
+  packageNPMURL?: string;
+  /** The link to the contributing guide in the repository */
+  contributingGuideURL?: string;
+  /** The name of the project that lives in the repository */
+  projectName?: string;
+}
+
+/**
+ * Returns meta data information about the service, the package, and the client.
+ * @param clientDetails - the client details
+ * @param packageDetails - the package details
+ * @returns inferred metadata about the service, the package, and the client
+ */
+function createMetadata(
+  clientDetails: ClientDetails,
+  packageDetails: PackageDetails
+): Metadata {
+  const azureHuh = packageDetails.scopeName === "azure";
+  const repoURL = azureHuh
+    ? "https://github.com/Azure/azure-sdk-for-js"
+    : undefined;
+  const relativePackageSourcePath = clientDetails.options.azureOutputDirectory;
+  const packageSourceURL =
+    repoURL && `${repoURL}/tree/master/${relativePackageSourcePath}`;
+  const names = relativePackageSourcePath?.split("/").slice(1);
+  const packageParentDirectoryName = names?.[0];
+  const packageDirectoryName = names?.[1];
+  const clientClassName = clientDetails.name;
+  const clientPackageName = packageDetails.name;
+  const title = clientDetails.info?.title ?? clientClassName;
+  const serviceName =
+    /**
+     * It is a required convention in Azure swaggers for their titles to end with
+     * "Client".
+     */
+    title.match(/(.*) Client/)?.[1] ??
+    clientClassName.match(/(.*)Client/)?.[1] ??
+    title.match(/(.*) Service/)?.[1] ??
+    "Service";
+  return {
+    serviceName: serviceName,
+    clientPackageName: clientPackageName,
+    clientClassName: clientClassName,
+    azure: azureHuh,
+    relativePackageSourcePath: relativePackageSourcePath,
+    repoURL: repoURL,
+    packageSourceURL: packageSourceURL,
+    samplesURL: packageSourceURL && `${packageSourceURL}/samples`,
+    impressionURL: azureHuh
+      ? `https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2F${packageParentDirectoryName}%2F${packageDirectoryName}%2FREADME.png`
+      : undefined,
+    clientDescriptiveName: azureHuh
+      ? title.startsWith("Azure")
+        ? title
+        : `Azure ${title}`
+      : title,
+    description: clientDetails.info?.description,
+    apiRefURL: azureHuh
+      ? `https://docs.microsoft.com/javascript/api/${clientPackageName}`
+      : undefined,
+    packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}`,
+    contributingGuideURL: repoURL && `${repoURL}/blob/master/CONTRIBUTING.md`,
+    projectName: azureHuh ? "Microsoft Azure SDK for Javascript" : undefined
+  };
+}
+
+/**
+ * Creates the string for the "Getting Started" section in the README.md file.
+ * @param metadata metadata about the service, package, and the client.
+ * @returns the required getting started section in the readme file
+ */
+function writeGettingStarted(metadata: Metadata): string {
+  const text = `## Getting started
+
+### Currently supported environments
+
+- Node.js version 8.x.x or higher
+- Browser Javascript
+${addNewline(
+  `### Prerequisites
+
+- An [Azure subscription][azure_sub].`,
+  !metadata.azure
+)}
+
+### Install the \`${metadata.clientPackageName}\` package
+
+Install the${addSpace(
+    metadata.clientDescriptiveName
+  )} library for Javascript with \`npm\`:
+
+\`\`\`bash
+npm install ${metadata.clientPackageName}
+\`\`\`
+${addNewline(
+  `### Create and authenticate a \`${metadata.clientClassName}\`
+
+To create a client object to access the ${
+    metadata.serviceName
+  } API, you will need the \`endpoint\` of your ${
+    metadata.serviceName
+  } resource and a \`credential\`. The${addSpace(
+    metadata.clientDescriptiveName
+  )} can use Azure Active Directory credentials to authenticate.
+
+You can find the endpoint for your ${
+    metadata.serviceName
+  } resource in the [Azure Portal][azure_portal].
+
+#### Using an Azure Active Directory Credential
+
+Client API key authentication is used in most of the examples, but you can also authenticate with Azure Active Directory using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the \`@azure/identity\` package:
+
+\`\`\`bash
+npm install @azure/identity
+\`\`\`
+
+You will also need to register a new AAD application and grant access to ${
+    metadata.serviceName
+  } by assigning the suitable role to your service principal (note: roles such as \`"Owner"\` will not grant the necessary permissions).
+
+Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: \`AZURE_CLIENT_ID\`, \`AZURE_TENANT_ID\`, \`AZURE_CLIENT_SECRET\`.
+
+\`\`\`javascript
+const { ${metadata.clientClassName} } = require("${
+    metadata.clientPackageName
+  }");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+const client = new ${
+    metadata.clientClassName
+  }("<endpoint>", new DefaultAzureCredential());
+\`\`\``,
+  !metadata.azure
+)}
+`;
+  return addNewline(text);
+}
+
+/**
+ * Creates the string for the "Key Concepts" section in the README.md file.
+ * @param metadata metadata about the service, package, and the client.
+ * @returns the required key concepts section in the readme file
+ */
+function writeKeyConcepts(metadata: Metadata): string {
+  return `## Key concepts
+
+### ${metadata.clientClassName}
+
+\`${metadata.clientClassName}\` is the primary interface for developers using the ${metadata.clientDescriptiveName} library. It provides asynchronous methods to access a specific use of ${metadata.serviceName}.`;
+}
+
+function writeTroubleshooting(metadata: Metadata): string {
+  const text = `## Troubleshooting
+
+### Logging
+
+Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the \`AZURE_LOG_LEVEL\` environment variable to \`info\`. Alternatively, logging can be enabled at runtime by calling \`setLogLevel\` in the \`@azure/logger\`:
+
+\`\`\`javascript
+import { setLogLevel } from "@azure/logger";
+
+setLogLevel("info");
+\`\`\`
+
+For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](${metadata.repoURL}/tree/master/sdk/core/logger).`;
+  return addNewline(text, !metadata.azure);
+}
+
+/**
+ * Creates the string for the "Next Steps" section in the README.md file.
+ * @param metadata metadata about the service, package, and the client.
+ * @returns the required next steps section in the readme file
+ */
+function writeNextSteps(metadata: Metadata): string {
+  const text = `## Next steps
+
+Please take a look at the [samples](${metadata.samplesURL}) directory for detailed examples on how to use this library.`;
+  return addNewline(metadata.samplesURL && text);
+}
+
+/**
+ * Creates the string for the "Contributing" section in the README.md file.
+ * @param metadata metadata about the service, package, and the client.
+ * @returns the required contributing section in the readme file
+ */
+function writeContributing(metadata: Metadata): string {
+  const text = `## Contributing
+
+If you'd like to contribute to this library, please read the [contributing guide](${metadata.contributingGuideURL}) to learn more about how to build and test the code.`;
+  return addNewline(metadata.contributingGuideURL && text);
+}
+
+/**
+ * Creates the string for the "Related Projects" section in the README.md file.
+ * @param metadata metadata about the service, package, and the client.
+ * @returns the required related projects section in the readme file
+ */
+function writeRelatedProjects(metadata: Metadata): string {
+  const text = `## Related projects
+
+- [${metadata.projectName}](${metadata.repoURL})`;
+  return addNewline(metadata.projectName && text);
+}
+
 export function generateReadmeFile(
   clientDetails: ClientDetails,
   packageDetails: PackageDetails,
   project: Project
 ) {
+  const metadata = createMetadata(clientDetails, packageDetails);
+  const identityPackageURL = `${metadata.repoURL}/tree/master/sdk/identity/identity`;
   const readmeFileContents = `
-## Azure ${clientDetails.name} SDK for JavaScript
+# ${metadata.clientDescriptiveName} library for JavaScript
 
-This package contains an isomorphic SDK for ${clientDetails.name}.
-
-### Currently supported environments
-
-- Node.js version 8.x.x or higher
-- Browser JavaScript
-
-### How to Install
-
-\`\`\`bash
-npm install ${packageDetails.name}
-\`\`\`
-
-### How to use
-
-#### Sample code
-
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
-
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+This package contains an isomorphic SDK for ${metadata.clientDescriptiveName}.
+${addNewline(metadata.description)}
+${addNewline(
+  metadata.packageSourceURL && `[Source code](${metadata.packageSourceURL}) |`
+)}${addNewline(
+    metadata.packageNPMURL && `[Package (NPM)](${metadata.packageNPMURL}) |`
+  )}${addNewline(
+    metadata.apiRefURL &&
+      `[API reference documentation](${metadata.apiRefURL}) |`
+  )}${addNewline(metadata.samplesURL && `[Samples](${metadata.samplesURL})`)}
+${writeGettingStarted(metadata)}
+${writeKeyConcepts(metadata)}
+${writeTroubleshooting(metadata)}
+${writeNextSteps(metadata)}
+${writeContributing(metadata)}
+${writeRelatedProjects(metadata)}
+${addNewline(
+  metadata.impressionURL && `![Impressions](${metadata.impressionURL})`
+)}
+${addNewline(
+  `[azure_cli]: https://docs.microsoft.com/cli/azure
+[azure_sub]: https://azure.microsoft.com/free/
+[azure_portal]: https://portal.azure.com
+[azure_identity]: ${identityPackageURL}
+[defaultazurecredential]: ${identityPackageURL}#defaultazurecredential`,
+  !metadata.azure
+)}
 `;
 
   project.createSourceFile("README.md", readmeFileContents.trim(), {

--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -117,7 +117,7 @@ function createMetadata(
       : undefined,
     packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}`,
     contributingGuideURL: repoURL && `${repoURL}/blob/master/CONTRIBUTING.md`,
-    projectName: azureHuh ? "Microsoft Azure SDK for Javascript" : undefined
+    projectName: azureHuh ? "Microsoft Azure SDK for JavaScript" : undefined
   };
 }
 
@@ -132,7 +132,7 @@ function writeGettingStarted(metadata: Metadata): string {
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser Javascript
+- Browser JavaScript
 ${addNewline(
   `### Prerequisites
 
@@ -144,7 +144,7 @@ ${addNewline(
 
 Install the${addSpace(
     metadata.clientDescriptiveName
-  )} library for Javascript with \`npm\`:
+  )} library for JavaScript with \`npm\`:
 
 \`\`\`bash
 npm install ${metadata.clientPackageName}

--- a/src/models/clientDetails.ts
+++ b/src/models/clientDetails.ts
@@ -8,6 +8,7 @@ import { ParameterDetails } from "./parameterDetails";
 import { ObjectDetails } from "./modelDetails";
 import { EndpointDetails } from "../transforms/urlTransforms";
 import { KnownMediaType } from "@azure-tools/codegen";
+import { Info } from "@autorest/codemodel";
 
 export interface ClientOptions {
   azureArm?: boolean;
@@ -16,6 +17,7 @@ export interface ClientOptions {
   mediaTypes?: Set<KnownMediaType>;
   hasPaging?: boolean;
   credentialScopes?: string[];
+  azureOutputDirectory?: string;
 }
 
 export interface TracingInfo {
@@ -26,7 +28,7 @@ export interface TracingInfo {
 export interface ClientDetails {
   name: string;
   className: string;
-  description?: string;
+  info?: Info;
   sourceFileName: string;
   objects: ObjectDetails[];
   mappers: Mapper[];

--- a/src/transforms/optionsTransforms.ts
+++ b/src/transforms/optionsTransforms.ts
@@ -17,16 +17,18 @@ export async function transformOptions(
     (await host.GetValue("disable-async-iterators")) === true;
   const credentialScopes = await getCredentialScopes(host);
 
-  const outputDirectoryPath: string = await host.GetValue("outputFolderUri");
-  const outputDirectoryRelativePath: string = outputDirectoryPath
-    .replace(/\/$/, "")
+  const outputDirectoryPath: string | null = await host.GetValue(
+    "outputFolderUri"
+  );
+  const outputDirectoryRelativePath: string | undefined = outputDirectoryPath
+    ?.replace(/\/$/, "")
     .split("/")
     .slice(-3)
     .join("/");
 
   return {
     azureOutputDirectory:
-      outputDirectoryRelativePath.substr(0, 3) === "sdk"
+      outputDirectoryRelativePath?.substr(0, 3) === "sdk"
         ? outputDirectoryRelativePath
         : undefined,
     addCredentials,

--- a/src/transforms/optionsTransforms.ts
+++ b/src/transforms/optionsTransforms.ts
@@ -17,7 +17,18 @@ export async function transformOptions(
     (await host.GetValue("disable-async-iterators")) === true;
   const credentialScopes = await getCredentialScopes(host);
 
+  const outputDirectoryPath: string = await host.GetValue("outputFolderUri");
+  const outputDirectoryRelativePath: string = outputDirectoryPath
+    .replace(/\/$/, "")
+    .split("/")
+    .slice(-3)
+    .join("/");
+
   return {
+    azureOutputDirectory:
+      outputDirectoryRelativePath.substr(0, 3) === "sdk"
+        ? outputDirectoryRelativePath
+        : undefined,
     addCredentials,
     mediaTypes,
     disablePagingAsyncIterators,

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -117,7 +117,7 @@ export async function transformCodeModel(
   return {
     name: className,
     className,
-    description: codeModel.info.description,
+    info: codeModel.info,
     sourceFileName: normalizeName(className, NameType.File),
     objects: [...objects, ...groups],
     mappers,

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -70,7 +70,7 @@ export async function generateTypeScriptLibrary(
     name: packageName,
     scopeName: packageNameParts[2],
     nameWithoutScope: packageNameParts[3],
-    description: clientDetails.description,
+    description: clientDetails.info?.description,
     version: (await host.GetValue("package-version")) || "1.0.0"
   };
 

--- a/test/integration/generated/additionalProperties/README.md
+++ b/test/integration/generated/additionalProperties/README.md
@@ -1,27 +1,30 @@
-## Azure AdditionalPropertiesClient SDK for JavaScript
+# AdditionalPropertiesClient library for JavaScript
 
 This package contains an isomorphic SDK for AdditionalPropertiesClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/additional-properties) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `additional-properties` package
+
+Install the AdditionalPropertiesClient library for Javascript with `npm`:
 
 ```bash
 npm install additional-properties
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### AdditionalPropertiesClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`AdditionalPropertiesClient` is the primary interface for developers using the AdditionalPropertiesClient library. It provides asynchronous methods to access a specific use of AdditionalProperties.

--- a/test/integration/generated/appconfiguration/README.md
+++ b/test/integration/generated/appconfiguration/README.md
@@ -1,27 +1,29 @@
-## Azure AppConfigurationClient SDK for JavaScript
+# AppConfigurationClient library for JavaScript
 
 This package contains an isomorphic SDK for AppConfigurationClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/appconfiguration) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `appconfiguration` package
+
+Install the AppConfigurationClient library for Javascript with `npm`:
 
 ```bash
 npm install appconfiguration
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### AppConfigurationClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`AppConfigurationClient` is the primary interface for developers using the AppConfigurationClient library. It provides asynchronous methods to access a specific use of AppConfiguration.

--- a/test/integration/generated/appconfigurationexport/README.md
+++ b/test/integration/generated/appconfigurationexport/README.md
@@ -1,27 +1,29 @@
-## Azure AppConfigurationClient SDK for JavaScript
+# AppConfigurationClient library for JavaScript
 
 This package contains an isomorphic SDK for AppConfigurationClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/appconfiguration) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `appconfiguration` package
+
+Install the AppConfigurationClient library for Javascript with `npm`:
 
 ```bash
 npm install appconfiguration
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### AppConfigurationClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`AppConfigurationClient` is the primary interface for developers using the AppConfigurationClient library. It provides asynchronous methods to access a specific use of AppConfiguration.

--- a/test/integration/generated/arrayConstraints/README.md
+++ b/test/integration/generated/arrayConstraints/README.md
@@ -1,27 +1,29 @@
-## Azure ArrayConstraintsClient SDK for JavaScript
+# ArrayConstraintsClient library for JavaScript
 
 This package contains an isomorphic SDK for ArrayConstraintsClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/array-constraints-client) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `array-constraints-client` package
+
+Install the ArrayConstraintsClient library for Javascript with `npm`:
 
 ```bash
 npm install array-constraints-client
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ArrayConstraintsClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ArrayConstraintsClient` is the primary interface for developers using the ArrayConstraintsClient library. It provides asynchronous methods to access a specific use of ArrayConstraints.

--- a/test/integration/generated/azureParameterGrouping/README.md
+++ b/test/integration/generated/azureParameterGrouping/README.md
@@ -1,27 +1,30 @@
-## Azure AzureParameterGroupingClient SDK for JavaScript
+# AzureParameterGroupingClient library for JavaScript
 
 This package contains an isomorphic SDK for AzureParameterGroupingClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/azure-parameter-grouping) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `azure-parameter-grouping` package
+
+Install the AzureParameterGroupingClient library for Javascript with `npm`:
 
 ```bash
 npm install azure-parameter-grouping
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### AzureParameterGroupingClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`AzureParameterGroupingClient` is the primary interface for developers using the AzureParameterGroupingClient library. It provides asynchronous methods to access a specific use of AzureParameterGrouping.

--- a/test/integration/generated/azureReport/README.md
+++ b/test/integration/generated/azureReport/README.md
@@ -1,27 +1,30 @@
-## Azure ReportClient SDK for JavaScript
+# ReportClient library for JavaScript
 
 This package contains an isomorphic SDK for ReportClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/zzzAzureReport) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `zzzAzureReport` package
+
+Install the ReportClient library for Javascript with `npm`:
 
 ```bash
 npm install zzzAzureReport
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ReportClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ReportClient` is the primary interface for developers using the ReportClient library. It provides asynchronous methods to access a specific use of Report.

--- a/test/integration/generated/azureSpecialProperties/README.md
+++ b/test/integration/generated/azureSpecialProperties/README.md
@@ -1,27 +1,30 @@
-## Azure AzureSpecialPropertiesClient SDK for JavaScript
+# AzureSpecialPropertiesClient library for JavaScript
 
 This package contains an isomorphic SDK for AzureSpecialPropertiesClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/azure-special-properties) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `azure-special-properties` package
+
+Install the AzureSpecialPropertiesClient library for Javascript with `npm`:
 
 ```bash
 npm install azure-special-properties
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### AzureSpecialPropertiesClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`AzureSpecialPropertiesClient` is the primary interface for developers using the AzureSpecialPropertiesClient library. It provides asynchronous methods to access a specific use of AzureSpecialProperties.

--- a/test/integration/generated/bodyArray/README.md
+++ b/test/integration/generated/bodyArray/README.md
@@ -1,27 +1,30 @@
-## Azure BodyArrayClient SDK for JavaScript
+# BodyArrayClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyArrayClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/body-array) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-array` package
+
+Install the BodyArrayClient library for Javascript with `npm`:
 
 ```bash
 npm install body-array
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyArrayClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyArrayClient` is the primary interface for developers using the BodyArrayClient library. It provides asynchronous methods to access a specific use of BodyArray.

--- a/test/integration/generated/bodyBoolean/README.md
+++ b/test/integration/generated/bodyBoolean/README.md
@@ -1,27 +1,30 @@
-## Azure BodyBooleanClient SDK for JavaScript
+# BodyBooleanClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyBooleanClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-boolean) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-boolean` package
+
+Install the BodyBooleanClient library for Javascript with `npm`:
 
 ```bash
 npm install body-boolean
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyBooleanClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyBooleanClient` is the primary interface for developers using the BodyBooleanClient library. It provides asynchronous methods to access a specific use of BodyBoolean.

--- a/test/integration/generated/bodyBooleanQuirks/README.md
+++ b/test/integration/generated/bodyBooleanQuirks/README.md
@@ -1,27 +1,30 @@
-## Azure BodyBooleanQuirksClient SDK for JavaScript
+# BodyBooleanQuirksClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyBooleanQuirksClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-boolean-quirks) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-boolean-quirks` package
+
+Install the BodyBooleanQuirksClient library for Javascript with `npm`:
 
 ```bash
 npm install body-boolean-quirks
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyBooleanQuirksClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyBooleanQuirksClient` is the primary interface for developers using the BodyBooleanQuirksClient library. It provides asynchronous methods to access a specific use of BodyBooleanQuirks.

--- a/test/integration/generated/bodyByte/README.md
+++ b/test/integration/generated/bodyByte/README.md
@@ -1,27 +1,30 @@
-## Azure BodyByteClient SDK for JavaScript
+# BodyByteClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyByteClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/body-byte) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-byte` package
+
+Install the BodyByteClient library for Javascript with `npm`:
 
 ```bash
 npm install body-byte
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyByteClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyByteClient` is the primary interface for developers using the BodyByteClient library. It provides asynchronous methods to access a specific use of BodyByte.

--- a/test/integration/generated/bodyComplex/README.md
+++ b/test/integration/generated/bodyComplex/README.md
@@ -1,27 +1,30 @@
-## Azure BodyComplexClient SDK for JavaScript
+# BodyComplexClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyComplexClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-complex) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-complex` package
+
+Install the BodyComplexClient library for Javascript with `npm`:
 
 ```bash
 npm install body-complex
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyComplexClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyComplexClient` is the primary interface for developers using the BodyComplexClient library. It provides asynchronous methods to access a specific use of BodyComplex.

--- a/test/integration/generated/bodyComplexWithTracing/README.md
+++ b/test/integration/generated/bodyComplexWithTracing/README.md
@@ -1,27 +1,30 @@
-## Azure BodyComplexWithTracing SDK for JavaScript
+# bodyComplexWithTracing library for JavaScript
 
-This package contains an isomorphic SDK for BodyComplexWithTracing.
+This package contains an isomorphic SDK for bodyComplexWithTracing.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-complex-tracing) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-complex-tracing` package
+
+Install the bodyComplexWithTracing library for Javascript with `npm`:
 
 ```bash
 npm install body-complex-tracing
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyComplexWithTracing
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyComplexWithTracing` is the primary interface for developers using the bodyComplexWithTracing library. It provides asynchronous methods to access a specific use of Service.

--- a/test/integration/generated/bodyDate/README.md
+++ b/test/integration/generated/bodyDate/README.md
@@ -1,27 +1,30 @@
-## Azure BodyDateClient SDK for JavaScript
+# BodyDateClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyDateClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-date) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-date` package
+
+Install the BodyDateClient library for Javascript with `npm`:
 
 ```bash
 npm install body-date
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyDateClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyDateClient` is the primary interface for developers using the BodyDateClient library. It provides asynchronous methods to access a specific use of BodyDate.

--- a/test/integration/generated/bodyDateTime/README.md
+++ b/test/integration/generated/bodyDateTime/README.md
@@ -1,27 +1,30 @@
-## Azure BodyDateTimeClient SDK for JavaScript
+# BodyDateTimeClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyDateTimeClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-datetime) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-datetime` package
+
+Install the BodyDateTimeClient library for Javascript with `npm`:
 
 ```bash
 npm install body-datetime
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyDateTimeClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyDateTimeClient` is the primary interface for developers using the BodyDateTimeClient library. It provides asynchronous methods to access a specific use of BodyDateTime.

--- a/test/integration/generated/bodyDateTimeRfc1123/README.md
+++ b/test/integration/generated/bodyDateTimeRfc1123/README.md
@@ -1,27 +1,30 @@
-## Azure BodyDateTimeRfc1123Client SDK for JavaScript
+# BodyDateTimeRfc1123Client library for JavaScript
 
 This package contains an isomorphic SDK for BodyDateTimeRfc1123Client.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-datetime-rfc1123) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-datetime-rfc1123` package
+
+Install the BodyDateTimeRfc1123Client library for Javascript with `npm`:
 
 ```bash
 npm install body-datetime-rfc1123
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyDateTimeRfc1123Client
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyDateTimeRfc1123Client` is the primary interface for developers using the BodyDateTimeRfc1123Client library. It provides asynchronous methods to access a specific use of BodyDateTimeRfc1123.

--- a/test/integration/generated/bodyDictionary/README.md
+++ b/test/integration/generated/bodyDictionary/README.md
@@ -1,27 +1,30 @@
-## Azure BodyDictionaryClient SDK for JavaScript
+# BodyDictionaryClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyDictionaryClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/body-dictionary) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-dictionary` package
+
+Install the BodyDictionaryClient library for Javascript with `npm`:
 
 ```bash
 npm install body-dictionary
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyDictionaryClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyDictionaryClient` is the primary interface for developers using the BodyDictionaryClient library. It provides asynchronous methods to access a specific use of BodyDictionary.

--- a/test/integration/generated/bodyDuration/README.md
+++ b/test/integration/generated/bodyDuration/README.md
@@ -1,27 +1,30 @@
-## Azure BodyDurationClient SDK for JavaScript
+# BodyDurationClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyDurationClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-duration) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-duration` package
+
+Install the BodyDurationClient library for Javascript with `npm`:
 
 ```bash
 npm install body-duration
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyDurationClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyDurationClient` is the primary interface for developers using the BodyDurationClient library. It provides asynchronous methods to access a specific use of BodyDuration.

--- a/test/integration/generated/bodyFile/README.md
+++ b/test/integration/generated/bodyFile/README.md
@@ -1,27 +1,30 @@
-## Azure BodyFileClient SDK for JavaScript
+# BodyFileClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyFileClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/body-file) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-file` package
+
+Install the BodyFileClient library for Javascript with `npm`:
 
 ```bash
 npm install body-file
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyFileClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyFileClient` is the primary interface for developers using the BodyFileClient library. It provides asynchronous methods to access a specific use of BodyFile.

--- a/test/integration/generated/bodyFormData/README.md
+++ b/test/integration/generated/bodyFormData/README.md
@@ -1,27 +1,30 @@
-## Azure BodyFormDataClient SDK for JavaScript
+# BodyFormDataClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyFormDataClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/body-formdata) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-formdata` package
+
+Install the BodyFormDataClient library for Javascript with `npm`:
 
 ```bash
 npm install body-formdata
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyFormDataClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyFormDataClient` is the primary interface for developers using the BodyFormDataClient library. It provides asynchronous methods to access a specific use of BodyFormData.

--- a/test/integration/generated/bodyInteger/README.md
+++ b/test/integration/generated/bodyInteger/README.md
@@ -1,27 +1,30 @@
-## Azure BodyIntegerClient SDK for JavaScript
+# BodyIntegerClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyIntegerClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-integer) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-integer` package
+
+Install the BodyIntegerClient library for Javascript with `npm`:
 
 ```bash
 npm install body-integer
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyIntegerClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyIntegerClient` is the primary interface for developers using the BodyIntegerClient library. It provides asynchronous methods to access a specific use of BodyInteger.

--- a/test/integration/generated/bodyNumber/README.md
+++ b/test/integration/generated/bodyNumber/README.md
@@ -1,27 +1,30 @@
-## Azure BodyNumberClient SDK for JavaScript
+# BodyNumberClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyNumberClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-number) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-number` package
+
+Install the BodyNumberClient library for Javascript with `npm`:
 
 ```bash
 npm install body-number
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyNumberClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyNumberClient` is the primary interface for developers using the BodyNumberClient library. It provides asynchronous methods to access a specific use of BodyNumber.

--- a/test/integration/generated/bodyString/README.md
+++ b/test/integration/generated/bodyString/README.md
@@ -1,27 +1,30 @@
-## Azure BodyStringClient SDK for JavaScript
+# BodyStringClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyStringClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/body-string) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-string` package
+
+Install the BodyStringClient library for Javascript with `npm`:
 
 ```bash
 npm install body-string
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyStringClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyStringClient` is the primary interface for developers using the BodyStringClient library. It provides asynchronous methods to access a specific use of BodyString.

--- a/test/integration/generated/bodyTime/README.md
+++ b/test/integration/generated/bodyTime/README.md
@@ -1,27 +1,30 @@
-## Azure BodyTimeClient SDK for JavaScript
+# BodyTimeClient library for JavaScript
 
 This package contains an isomorphic SDK for BodyTimeClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/body-time) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `body-time` package
+
+Install the BodyTimeClient library for Javascript with `npm`:
 
 ```bash
 npm install body-time
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### BodyTimeClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`BodyTimeClient` is the primary interface for developers using the BodyTimeClient library. It provides asynchronous methods to access a specific use of BodyTime.

--- a/test/integration/generated/customUrl/README.md
+++ b/test/integration/generated/customUrl/README.md
@@ -1,27 +1,30 @@
-## Azure CustomUrlClient SDK for JavaScript
+# CustomUrlClient library for JavaScript
 
 This package contains an isomorphic SDK for CustomUrlClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/custom-url) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `custom-url` package
+
+Install the CustomUrlClient library for Javascript with `npm`:
 
 ```bash
 npm install custom-url
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### CustomUrlClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`CustomUrlClient` is the primary interface for developers using the CustomUrlClient library. It provides asynchronous methods to access a specific use of CustomUrl.

--- a/test/integration/generated/customUrlMoreOptions/README.md
+++ b/test/integration/generated/customUrlMoreOptions/README.md
@@ -1,27 +1,30 @@
-## Azure CustomUrlMoreOptionsClient SDK for JavaScript
+# CustomUrlMoreOptionsClient library for JavaScript
 
 This package contains an isomorphic SDK for CustomUrlMoreOptionsClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/custom-url-MoreOptions) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `custom-url-MoreOptions` package
+
+Install the CustomUrlMoreOptionsClient library for Javascript with `npm`:
 
 ```bash
 npm install custom-url-MoreOptions
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### CustomUrlMoreOptionsClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`CustomUrlMoreOptionsClient` is the primary interface for developers using the CustomUrlMoreOptionsClient library. It provides asynchronous methods to access a specific use of CustomUrlMoreOptions.

--- a/test/integration/generated/customUrlPaging/README.md
+++ b/test/integration/generated/customUrlPaging/README.md
@@ -1,27 +1,30 @@
-## Azure CustomUrlPagingClient SDK for JavaScript
+# CustomUrlPagingClient library for JavaScript
 
 This package contains an isomorphic SDK for CustomUrlPagingClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/custom-url-paging) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `custom-url-paging` package
+
+Install the CustomUrlPagingClient library for Javascript with `npm`:
 
 ```bash
 npm install custom-url-paging
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### CustomUrlPagingClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`CustomUrlPagingClient` is the primary interface for developers using the CustomUrlPagingClient library. It provides asynchronous methods to access a specific use of CustomUrlPaging.

--- a/test/integration/generated/extensibleEnums/README.md
+++ b/test/integration/generated/extensibleEnums/README.md
@@ -1,27 +1,30 @@
-## Azure ExtensibleEnumsClient SDK for JavaScript
+# ExtensibleEnumsClient library for JavaScript
 
 This package contains an isomorphic SDK for ExtensibleEnumsClient.
+
+PetStore
+
+[Package (NPM)](https://www.npmjs.com/package/extensible-enums) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `extensible-enums` package
+
+Install the ExtensibleEnumsClient library for Javascript with `npm`:
 
 ```bash
 npm install extensible-enums
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ExtensibleEnumsClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ExtensibleEnumsClient` is the primary interface for developers using the ExtensibleEnumsClient library. It provides asynchronous methods to access a specific use of ExtensibleEnums.

--- a/test/integration/generated/header/README.md
+++ b/test/integration/generated/header/README.md
@@ -1,27 +1,30 @@
-## Azure HeaderClient SDK for JavaScript
+# HeaderClient library for JavaScript
 
 This package contains an isomorphic SDK for HeaderClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/header) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `header` package
+
+Install the HeaderClient library for Javascript with `npm`:
 
 ```bash
 npm install header
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### HeaderClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`HeaderClient` is the primary interface for developers using the HeaderClient library. It provides asynchronous methods to access a specific use of Header.

--- a/test/integration/generated/httpInfrastructure/README.md
+++ b/test/integration/generated/httpInfrastructure/README.md
@@ -1,27 +1,30 @@
-## Azure HttpInfrastructureClient SDK for JavaScript
+# HttpInfrastructureClient library for JavaScript
 
 This package contains an isomorphic SDK for HttpInfrastructureClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/httpInfrastructure) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `httpInfrastructure` package
+
+Install the HttpInfrastructureClient library for Javascript with `npm`:
 
 ```bash
 npm install httpInfrastructure
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### HttpInfrastructureClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`HttpInfrastructureClient` is the primary interface for developers using the HttpInfrastructureClient library. It provides asynchronous methods to access a specific use of HttpInfrastructure.

--- a/test/integration/generated/licenseHeader/README.md
+++ b/test/integration/generated/licenseHeader/README.md
@@ -1,27 +1,29 @@
-## Azure LicenseHeaderClient SDK for JavaScript
+# LicenseHeaderClient library for JavaScript
 
 This package contains an isomorphic SDK for LicenseHeaderClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/license-header) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `license-header` package
+
+Install the LicenseHeaderClient library for Javascript with `npm`:
 
 ```bash
 npm install license-header
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### LicenseHeaderClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`LicenseHeaderClient` is the primary interface for developers using the LicenseHeaderClient library. It provides asynchronous methods to access a specific use of LicenseHeader.

--- a/test/integration/generated/lro/README.md
+++ b/test/integration/generated/lro/README.md
@@ -1,27 +1,30 @@
-## Azure LROClient SDK for JavaScript
+# LROClient library for JavaScript
 
 This package contains an isomorphic SDK for LROClient.
+
+Long-running Operation for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/lro) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `lro` package
+
+Install the LROClient library for Javascript with `npm`:
 
 ```bash
 npm install lro
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### LROClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`LROClient` is the primary interface for developers using the LROClient library. It provides asynchronous methods to access a specific use of LRO.

--- a/test/integration/generated/lroParametrizedEndpoints/README.md
+++ b/test/integration/generated/lroParametrizedEndpoints/README.md
@@ -1,27 +1,30 @@
-## Azure LroParametrizedEndpointsClient SDK for JavaScript
+# LroParametrizedEndpointsClient library for JavaScript
 
 This package contains an isomorphic SDK for LroParametrizedEndpointsClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/lro-parameterized-endpoints) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `lro-parameterized-endpoints` package
+
+Install the LroParametrizedEndpointsClient library for Javascript with `npm`:
 
 ```bash
 npm install lro-parameterized-endpoints
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### LroParametrizedEndpointsClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`LroParametrizedEndpointsClient` is the primary interface for developers using the LroParametrizedEndpointsClient library. It provides asynchronous methods to access a specific use of LroParametrizedEndpoints.

--- a/test/integration/generated/mapperrequired/README.md
+++ b/test/integration/generated/mapperrequired/README.md
@@ -1,27 +1,30 @@
-## Azure MapperRequiredClient SDK for JavaScript
+# MapperRequiredClient library for JavaScript
 
 This package contains an isomorphic SDK for MapperRequiredClient.
+
+The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
+
+[Package (NPM)](https://www.npmjs.com/package/mapperrequired) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `mapperrequired` package
+
+Install the MapperRequiredClient library for Javascript with `npm`:
 
 ```bash
 npm install mapperrequired
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### MapperRequiredClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`MapperRequiredClient` is the primary interface for developers using the MapperRequiredClient library. It provides asynchronous methods to access a specific use of MapperRequired.

--- a/test/integration/generated/mediaTypes/README.md
+++ b/test/integration/generated/mediaTypes/README.md
@@ -1,27 +1,30 @@
-## Azure MediaTypesClient SDK for JavaScript
+# MediaTypesClient library for JavaScript
 
 This package contains an isomorphic SDK for MediaTypesClient.
+
+Play with produces/consumes and media-types in general.
+
+[Package (NPM)](https://www.npmjs.com/package/media-types-service) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `media-types-service` package
+
+Install the MediaTypesClient library for Javascript with `npm`:
 
 ```bash
 npm install media-types-service
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### MediaTypesClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`MediaTypesClient` is the primary interface for developers using the MediaTypesClient library. It provides asynchronous methods to access a specific use of MediaTypes.

--- a/test/integration/generated/mediaTypesV3/README.md
+++ b/test/integration/generated/mediaTypesV3/README.md
@@ -1,27 +1,29 @@
-## Azure MediaTypesV3Client SDK for JavaScript
+# MediaTypesV3Client library for JavaScript
 
 This package contains an isomorphic SDK for MediaTypesV3Client.
+
+
+[Package (NPM)](https://www.npmjs.com/package/media-types-v3-client) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `media-types-v3-client` package
+
+Install the MediaTypesV3Client library for Javascript with `npm`:
 
 ```bash
 npm install media-types-v3-client
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### MediaTypesV3Client
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`MediaTypesV3Client` is the primary interface for developers using the MediaTypesV3Client library. It provides asynchronous methods to access a specific use of MediaTypesV3.

--- a/test/integration/generated/mediaTypesV3Lro/README.md
+++ b/test/integration/generated/mediaTypesV3Lro/README.md
@@ -1,27 +1,29 @@
-## Azure MediaTypesV3LROClient SDK for JavaScript
+# MediaTypesV3LROClient library for JavaScript
 
 This package contains an isomorphic SDK for MediaTypesV3LROClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/media-types-v3-lro-client) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `media-types-v3-lro-client` package
+
+Install the MediaTypesV3LROClient library for Javascript with `npm`:
 
 ```bash
 npm install media-types-v3-lro-client
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### MediaTypesV3LROClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`MediaTypesV3LROClient` is the primary interface for developers using the MediaTypesV3LROClient library. It provides asynchronous methods to access a specific use of MediaTypesV3LRO.

--- a/test/integration/generated/mediaTypesWithTracing/README.md
+++ b/test/integration/generated/mediaTypesWithTracing/README.md
@@ -1,27 +1,30 @@
-## Azure MediaTypesWithTracingClient SDK for JavaScript
+# mediaTypesWithTracingClient library for JavaScript
 
-This package contains an isomorphic SDK for MediaTypesWithTracingClient.
+This package contains an isomorphic SDK for mediaTypesWithTracingClient.
+
+Play with produces/consumes and media-types in general.
+
+[Package (NPM)](https://www.npmjs.com/package/media-types-service-tracing) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `media-types-service-tracing` package
+
+Install the mediaTypesWithTracingClient library for Javascript with `npm`:
 
 ```bash
 npm install media-types-service-tracing
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### MediaTypesWithTracingClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`MediaTypesWithTracingClient` is the primary interface for developers using the mediaTypesWithTracingClient library. It provides asynchronous methods to access a specific use of MediaTypesWithTracing.

--- a/test/integration/generated/modelFlattening/README.md
+++ b/test/integration/generated/modelFlattening/README.md
@@ -1,27 +1,30 @@
-## Azure ModelFlatteningClient SDK for JavaScript
+# ModelFlatteningClient library for JavaScript
 
 This package contains an isomorphic SDK for ModelFlatteningClient.
+
+Resource Flattening for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/model-flattening) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `model-flattening` package
+
+Install the ModelFlatteningClient library for Javascript with `npm`:
 
 ```bash
 npm install model-flattening
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ModelFlatteningClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ModelFlatteningClient` is the primary interface for developers using the ModelFlatteningClient library. It provides asynchronous methods to access a specific use of ModelFlattening.

--- a/test/integration/generated/multipleInheritance/README.md
+++ b/test/integration/generated/multipleInheritance/README.md
@@ -1,27 +1,30 @@
-## Azure MultipleInheritanceClient SDK for JavaScript
+# MultipleInheritanceClient library for JavaScript
 
 This package contains an isomorphic SDK for MultipleInheritanceClient.
+
+Service client for multiinheritance client testing
+
+[Package (NPM)](https://www.npmjs.com/package/multiple-inheritance) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `multiple-inheritance` package
+
+Install the MultipleInheritanceClient library for Javascript with `npm`:
 
 ```bash
 npm install multiple-inheritance
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### MultipleInheritanceClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`MultipleInheritanceClient` is the primary interface for developers using the MultipleInheritanceClient library. It provides asynchronous methods to access a specific use of MultipleInheritance.

--- a/test/integration/generated/noLicenseHeader/README.md
+++ b/test/integration/generated/noLicenseHeader/README.md
@@ -1,27 +1,29 @@
-## Azure NoLicenseHeaderClient SDK for JavaScript
+# NoLicenseHeaderClient library for JavaScript
 
 This package contains an isomorphic SDK for NoLicenseHeaderClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/nolicense-header) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `nolicense-header` package
+
+Install the NoLicenseHeaderClient library for Javascript with `npm`:
 
 ```bash
 npm install nolicense-header
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### NoLicenseHeaderClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`NoLicenseHeaderClient` is the primary interface for developers using the NoLicenseHeaderClient library. It provides asynchronous methods to access a specific use of NoLicenseHeader.

--- a/test/integration/generated/noMappers/README.md
+++ b/test/integration/generated/noMappers/README.md
@@ -1,27 +1,29 @@
-## Azure NoMappersClient SDK for JavaScript
+# NoMappersClient library for JavaScript
 
 This package contains an isomorphic SDK for NoMappersClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/no-mappers) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `no-mappers` package
+
+Install the NoMappersClient library for Javascript with `npm`:
 
 ```bash
 npm install no-mappers
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### NoMappersClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`NoMappersClient` is the primary interface for developers using the NoMappersClient library. It provides asynchronous methods to access a specific use of NoMappers.

--- a/test/integration/generated/noOperation/README.md
+++ b/test/integration/generated/noOperation/README.md
@@ -1,27 +1,29 @@
-## Azure NoOperationsClient SDK for JavaScript
+# NoOperationsClient library for JavaScript
 
 This package contains an isomorphic SDK for NoOperationsClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/no-operation) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `no-operation` package
+
+Install the NoOperationsClient library for Javascript with `npm`:
 
 ```bash
 npm install no-operation
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### NoOperationsClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`NoOperationsClient` is the primary interface for developers using the NoOperationsClient library. It provides asynchronous methods to access a specific use of NoOperations.

--- a/test/integration/generated/nonStringEnum/README.md
+++ b/test/integration/generated/nonStringEnum/README.md
@@ -1,27 +1,30 @@
-## Azure NonStringEnumClient SDK for JavaScript
+# NonStringEnumClient library for JavaScript
 
 This package contains an isomorphic SDK for NonStringEnumClient.
+
+Testing non-string enums.
+
+[Package (NPM)](https://www.npmjs.com/package/non-string-num) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `non-string-num` package
+
+Install the NonStringEnumClient library for Javascript with `npm`:
 
 ```bash
 npm install non-string-num
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### NonStringEnumClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`NonStringEnumClient` is the primary interface for developers using the NonStringEnumClient library. It provides asynchronous methods to access a specific use of NonStringEnum.

--- a/test/integration/generated/objectType/README.md
+++ b/test/integration/generated/objectType/README.md
@@ -1,27 +1,30 @@
-## Azure ObjectTypeClient SDK for JavaScript
+# ObjectTypeClient library for JavaScript
 
 This package contains an isomorphic SDK for ObjectTypeClient.
+
+Service client for testing basic type: object swaggers
+
+[Package (NPM)](https://www.npmjs.com/package/object-type) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `object-type` package
+
+Install the ObjectTypeClient library for Javascript with `npm`:
 
 ```bash
 npm install object-type
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ObjectTypeClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ObjectTypeClient` is the primary interface for developers using the ObjectTypeClient library. It provides asynchronous methods to access a specific use of ObjectType.

--- a/test/integration/generated/odataDiscriminator/README.md
+++ b/test/integration/generated/odataDiscriminator/README.md
@@ -1,27 +1,30 @@
-## Azure ODataDiscriminatorClient SDK for JavaScript
+# ODataDiscriminatorClient library for JavaScript
 
 This package contains an isomorphic SDK for ODataDiscriminatorClient.
+
+Client that can be used to manage and query indexes and documents, as well as manage other resources, on a search service.
+
+[Package (NPM)](https://www.npmjs.com/package/odata-discriminator) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `odata-discriminator` package
+
+Install the ODataDiscriminatorClient library for Javascript with `npm`:
 
 ```bash
 npm install odata-discriminator
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ODataDiscriminatorClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ODataDiscriminatorClient` is the primary interface for developers using the ODataDiscriminatorClient library. It provides asynchronous methods to access a specific use of ODataDiscriminator.

--- a/test/integration/generated/paging/README.md
+++ b/test/integration/generated/paging/README.md
@@ -1,27 +1,30 @@
-## Azure PagingClient SDK for JavaScript
+# PagingClient library for JavaScript
 
 This package contains an isomorphic SDK for PagingClient.
+
+Long-running Operation for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/paging-service) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `paging-service` package
+
+Install the PagingClient library for Javascript with `npm`:
 
 ```bash
 npm install paging-service
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### PagingClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`PagingClient` is the primary interface for developers using the PagingClient library. It provides asynchronous methods to access a specific use of Paging.

--- a/test/integration/generated/pagingNoIterators/README.md
+++ b/test/integration/generated/pagingNoIterators/README.md
@@ -1,27 +1,30 @@
-## Azure PagingNoIteratorsClient SDK for JavaScript
+# PagingNoIteratorsClient library for JavaScript
 
 This package contains an isomorphic SDK for PagingNoIteratorsClient.
+
+Long-running Operation for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/paging-no-iterators) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `paging-no-iterators` package
+
+Install the PagingNoIteratorsClient library for Javascript with `npm`:
 
 ```bash
 npm install paging-no-iterators
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### PagingNoIteratorsClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`PagingNoIteratorsClient` is the primary interface for developers using the PagingNoIteratorsClient library. It provides asynchronous methods to access a specific use of PagingNoIterators.

--- a/test/integration/generated/petstore/README.md
+++ b/test/integration/generated/petstore/README.md
@@ -1,27 +1,30 @@
-## Azure PetStore SDK for JavaScript
+# PetStore library for JavaScript
 
 This package contains an isomorphic SDK for PetStore.
+
+This is a sample server Petstore server.  You can find out more about Swagger at <a href="http://swagger.io">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample, you can use the api key "special-key" to test the authorization filters
+
+[Package (NPM)](https://www.npmjs.com/package/petstore) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `petstore` package
+
+Install the PetStore library for Javascript with `npm`:
 
 ```bash
 npm install petstore
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### PetStore
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`PetStore` is the primary interface for developers using the PetStore library. It provides asynchronous methods to access a specific use of Service.

--- a/test/integration/generated/readmeFileChecker/README.md
+++ b/test/integration/generated/readmeFileChecker/README.md
@@ -1,27 +1,94 @@
-## Azure KeyVaultClient SDK for JavaScript
+# Azure KeyVaultClient library for JavaScript
 
-This package contains an isomorphic SDK for KeyVaultClient.
+This package contains an isomorphic SDK for Azure KeyVaultClient.
+
+The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
+
+[Source code](https://github.com/Azure/azure-sdk-for-js/tree/master/undefined) |
+[Package (NPM)](https://www.npmjs.com/package/@azure/keyvault-secrets) |
+[API reference documentation](https://docs.microsoft.com/javascript/api/@azure/keyvault-secrets) |
+[Samples](https://github.com/Azure/azure-sdk-for-js/tree/master/undefined/samples)
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+### Prerequisites
+
+- An [Azure subscription][azure_sub].
+
+### Install the `@azure/keyvault-secrets` package
+
+Install the Azure KeyVaultClient library for Javascript with `npm`:
 
 ```bash
 npm install @azure/keyvault-secrets
 ```
 
-### How to use
+### Create and authenticate a `KeyVaultClient`
 
-#### Sample code
+To create a client object to access the KeyVault API, you will need the `endpoint` of your KeyVault resource and a `credential`. The Azure KeyVaultClient can use Azure Active Directory credentials to authenticate.
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+You can find the endpoint for your KeyVault resource in the [Azure Portal][azure_portal].
+
+#### Using an Azure Active Directory Credential
+
+Client API key authentication is used in most of the examples, but you can also authenticate with Azure Active Directory using the [Azure Identity library][azure_identity]. To use the [DefaultAzureCredential][defaultazurecredential] provider shown below, or other credential providers provided with the Azure SDK, please install the `@azure/identity` package:
+
+```bash
+npm install @azure/identity
+```
+
+You will also need to register a new AAD application and grant access to KeyVault by assigning the suitable role to your service principal (note: roles such as `"Owner"` will not grant the necessary permissions).
+
+Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`.
+
+```javascript
+const { KeyVaultClient } = require("@azure/keyvault-secrets");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+const client = new KeyVaultClient("<endpoint>", new DefaultAzureCredential());
+```
+
+## Key concepts
+
+### KeyVaultClient
+
+`KeyVaultClient` is the primary interface for developers using the Azure KeyVaultClient library. It provides asynchronous methods to access a specific use of KeyVault.
+
+## Troubleshooting
+
+### Logging
+
+Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
+
+```javascript
+import { setLogLevel } from "@azure/logger";
+
+setLogLevel("info");
+```
+
+For more detailed instructions on how to enable logs, you can look at the [@azure/logger package docs](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/core/logger).
+
+## Next steps
+
+Please take a look at the [samples](https://github.com/Azure/azure-sdk-for-js/tree/master/undefined/samples) directory for detailed examples on how to use this library.
+
+## Contributing
+
+If you'd like to contribute to this library, please read the [contributing guide](https://github.com/Azure/azure-sdk-for-js/blob/master/CONTRIBUTING.md) to learn more about how to build and test the code.
 
 ## Related projects
 
 - [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
 
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fundefined%2Fundefined%2FREADME.png)
 
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+[azure_cli]: https://docs.microsoft.com/cli/azure
+[azure_sub]: https://azure.microsoft.com/free/
+[azure_portal]: https://portal.azure.com
+[azure_identity]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity
+[defaultazurecredential]: https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/identity/identity#defaultazurecredential

--- a/test/integration/generated/regexConstraint/README.md
+++ b/test/integration/generated/regexConstraint/README.md
@@ -1,27 +1,29 @@
-## Azure RegexConstraint SDK for JavaScript
+# RegexConstraint library for JavaScript
 
 This package contains an isomorphic SDK for RegexConstraint.
+
+
+[Package (NPM)](https://www.npmjs.com/package/regex-constraint) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `regex-constraint` package
+
+Install the RegexConstraint library for Javascript with `npm`:
 
 ```bash
 npm install regex-constraint
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### RegexConstraint
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`RegexConstraint` is the primary interface for developers using the RegexConstraint library. It provides asynchronous methods to access a specific use of Service.

--- a/test/integration/generated/report/README.md
+++ b/test/integration/generated/report/README.md
@@ -1,27 +1,30 @@
-## Azure ReportClient SDK for JavaScript
+# ReportClient library for JavaScript
 
 This package contains an isomorphic SDK for ReportClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/zzzReport) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `zzzReport` package
+
+Install the ReportClient library for Javascript with `npm`:
 
 ```bash
 npm install zzzReport
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ReportClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ReportClient` is the primary interface for developers using the ReportClient library. It provides asynchronous methods to access a specific use of Report.

--- a/test/integration/generated/requiredOptional/README.md
+++ b/test/integration/generated/requiredOptional/README.md
@@ -1,27 +1,30 @@
-## Azure RequiredOptionalClient SDK for JavaScript
+# RequiredOptionalClient library for JavaScript
 
 This package contains an isomorphic SDK for RequiredOptionalClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/required-optional) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `required-optional` package
+
+Install the RequiredOptionalClient library for Javascript with `npm`:
 
 ```bash
 npm install required-optional
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### RequiredOptionalClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`RequiredOptionalClient` is the primary interface for developers using the RequiredOptionalClient library. It provides asynchronous methods to access a specific use of RequiredOptional.

--- a/test/integration/generated/subscriptionIdApiVersion/README.md
+++ b/test/integration/generated/subscriptionIdApiVersion/README.md
@@ -1,27 +1,30 @@
-## Azure SubscriptionIdApiVersionClient SDK for JavaScript
+# SubscriptionIdApiVersionClient library for JavaScript
 
 This package contains an isomorphic SDK for SubscriptionIdApiVersionClient.
+
+Some cool documentation.
+
+[Package (NPM)](https://www.npmjs.com/package/subscriptionid-apiversion) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `subscriptionid-apiversion` package
+
+Install the SubscriptionIdApiVersionClient library for Javascript with `npm`:
 
 ```bash
 npm install subscriptionid-apiversion
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### SubscriptionIdApiVersionClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`SubscriptionIdApiVersionClient` is the primary interface for developers using the SubscriptionIdApiVersionClient library. It provides asynchronous methods to access a specific use of SubscriptionIdApiVersion.

--- a/test/integration/generated/url/README.md
+++ b/test/integration/generated/url/README.md
@@ -1,27 +1,30 @@
-## Azure UrlClient SDK for JavaScript
+# UrlClient library for JavaScript
 
 This package contains an isomorphic SDK for UrlClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/url) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `url` package
+
+Install the UrlClient library for Javascript with `npm`:
 
 ```bash
 npm install url
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### UrlClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`UrlClient` is the primary interface for developers using the UrlClient library. It provides asynchronous methods to access a specific use of Url.

--- a/test/integration/generated/url2/README.md
+++ b/test/integration/generated/url2/README.md
@@ -1,27 +1,29 @@
-## Azure UrlClient SDK for JavaScript
+# UrlClient library for JavaScript
 
 This package contains an isomorphic SDK for UrlClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/url) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `url` package
+
+Install the UrlClient library for Javascript with `npm`:
 
 ```bash
 npm install url
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### UrlClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`UrlClient` is the primary interface for developers using the UrlClient library. It provides asynchronous methods to access a specific use of Url.

--- a/test/integration/generated/urlMulti/README.md
+++ b/test/integration/generated/urlMulti/README.md
@@ -1,27 +1,30 @@
-## Azure UrlMultiClient SDK for JavaScript
+# UrlMultiClient library for JavaScript
 
 This package contains an isomorphic SDK for UrlMultiClient.
+
+Test Infrastructure for AutoRest
+
+[Package (NPM)](https://www.npmjs.com/package/url-multi) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `url-multi` package
+
+Install the UrlMultiClient library for Javascript with `npm`:
 
 ```bash
 npm install url-multi
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### UrlMultiClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`UrlMultiClient` is the primary interface for developers using the UrlMultiClient library. It provides asynchronous methods to access a specific use of UrlMulti.

--- a/test/integration/generated/uuid/README.md
+++ b/test/integration/generated/uuid/README.md
@@ -1,27 +1,29 @@
-## Azure UuidClient SDK for JavaScript
+# UuidClient library for JavaScript
 
 This package contains an isomorphic SDK for UuidClient.
+
+
+[Package (NPM)](https://www.npmjs.com/package/uuid) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `uuid` package
+
+Install the UuidClient library for Javascript with `npm`:
 
 ```bash
 npm install uuid
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### UuidClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`UuidClient` is the primary interface for developers using the UuidClient library. It provides asynchronous methods to access a specific use of Uuid.

--- a/test/integration/generated/validation/README.md
+++ b/test/integration/generated/validation/README.md
@@ -1,27 +1,30 @@
-## Azure ValidationClient SDK for JavaScript
+# ValidationClient library for JavaScript
 
 This package contains an isomorphic SDK for ValidationClient.
+
+Test Infrastructure for AutoRest. No server backend exists for these tests.
+
+[Package (NPM)](https://www.npmjs.com/package/validation) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `validation` package
+
+Install the ValidationClient library for Javascript with `npm`:
 
 ```bash
 npm install validation
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### ValidationClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`ValidationClient` is the primary interface for developers using the ValidationClient library. It provides asynchronous methods to access a specific use of Validation.

--- a/test/integration/generated/xmlservice/README.md
+++ b/test/integration/generated/xmlservice/README.md
@@ -1,27 +1,30 @@
-## Azure XmlServiceClient SDK for JavaScript
+# XmlServiceClient library for JavaScript
 
 This package contains an isomorphic SDK for XmlServiceClient.
+
+Test Infrastructure for AutoRest Swagger BAT
+
+[Package (NPM)](https://www.npmjs.com/package/xml-service) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `xml-service` package
+
+Install the XmlServiceClient library for Javascript with `npm`:
 
 ```bash
 npm install xml-service
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### XmlServiceClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`XmlServiceClient` is the primary interface for developers using the XmlServiceClient library. It provides asynchronous methods to access a specific use of XmlService.

--- a/test/integration/generated/xmsErrorResponses/README.md
+++ b/test/integration/generated/xmsErrorResponses/README.md
@@ -1,27 +1,30 @@
-## Azure XmsErrorResponsesClient SDK for JavaScript
+# XmsErrorResponsesClient library for JavaScript
 
 This package contains an isomorphic SDK for XmsErrorResponsesClient.
+
+XMS Error Response Extensions
+
+[Package (NPM)](https://www.npmjs.com/package/xms-error-responses) |
+
+## Getting started
 
 ### Currently supported environments
 
 - Node.js version 8.x.x or higher
-- Browser JavaScript
+- Browser Javascript
 
-### How to Install
+
+### Install the `xms-error-responses` package
+
+Install the XmsErrorResponsesClient library for Javascript with `npm`:
 
 ```bash
 npm install xms-error-responses
 ```
 
-### How to use
 
-#### Sample code
+## Key concepts
 
-Refer the sample code in the [azure-sdk-for-js/samples](https://github.com/Azure/azure-sdk-for-js/tree/master/samples) folder.
+### XmsErrorResponsesClient
 
-## Related projects
-
-- [Microsoft Azure SDK for Javascript](https://github.com/Azure/azure-sdk-for-js)
-
-
-![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-js%2Fsdk%2Fcdn%2Farm-cdn%2FREADME.png)
+`XmsErrorResponsesClient` is the primary interface for developers using the XmsErrorResponsesClient library. It provides asynchronous methods to access a specific use of XmsErrorResponses.


### PR DESCRIPTION
This PR improves the generated README.md to be close to Track 2's ones. In particular:
- Generates required sections: `Getting Started`, `Key Concepts`, `Troubleshooting`, `Next Steps`, `Contributing`, and `Related Projects`.
- If the generation is not for an Azure package, Azure-specific information is omitted.

Example: https://github.com/Azure/azure-sdk-for-js/pull/14655
Related issue: https://github.com/Azure/azure-sdk-for-js/issues/14449
[Swagger](https://raw.githubusercontent.com/Azure/azure-rest-api-specs/d2982a8962885e8506b5ebc0b33cb8caf1dc7551/specification/cognitiveservices/data-plane/TextAnalytics/preview/v3.1-preview.4/TextAnalytics.json)

Fixes https://github.com/Azure/autorest.typescript/issues/594