### PR TITLE
LRO throws when fails

### DIFF
--- a/src/lro/azureAsyncOperationStrategy.ts
+++ b/src/lro/azureAsyncOperationStrategy.ts
@@ -1,6 +1,5 @@
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -33,7 +32,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/src/lro/constants.ts
+++ b/src/lro/constants.ts
@@ -1,1 +1,3 @@
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/src/lro/locationStrategy.ts
+++ b/src/lro/locationStrategy.ts
@@ -1,4 +1,5 @@
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -7,7 +8,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/integration/generated/lro/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/integration/generated/lro/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/integration/generated/lro/src/lro/constants.ts
+++ b/test/integration/generated/lro/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/integration/generated/lro/src/lro/locationStrategy.ts
+++ b/test/integration/generated/lro/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/integration/generated/lro/src/lro/requestUtils.ts
+++ b/test/integration/generated/lro/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/integration/generated/lroParametrizedEndpoints/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/integration/generated/lroParametrizedEndpoints/src/lro/constants.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/integration/generated/lroParametrizedEndpoints/src/lro/locationStrategy.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/integration/generated/lroParametrizedEndpoints/src/lro/requestUtils.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/integration/generated/mediaTypesV3Lro/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/integration/generated/mediaTypesV3Lro/src/lro/constants.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/integration/generated/mediaTypesV3Lro/src/lro/locationStrategy.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/integration/generated/mediaTypesV3Lro/src/lro/requestUtils.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/integration/generated/paging/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/integration/generated/paging/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/integration/generated/paging/src/lro/constants.ts
+++ b/test/integration/generated/paging/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/integration/generated/paging/src/lro/locationStrategy.ts
+++ b/test/integration/generated/paging/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/integration/generated/paging/src/lro/requestUtils.ts
+++ b/test/integration/generated/paging/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/integration/generated/pagingNoIterators/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/integration/generated/pagingNoIterators/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/integration/generated/pagingNoIterators/src/lro/constants.ts
+++ b/test/integration/generated/pagingNoIterators/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/integration/generated/pagingNoIterators/src/lro/locationStrategy.ts
+++ b/test/integration/generated/pagingNoIterators/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/integration/generated/pagingNoIterators/src/lro/requestUtils.ts
+++ b/test/integration/generated/pagingNoIterators/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/integration/lro.spec.ts
+++ b/test/integration/lro.spec.ts
@@ -1,16 +1,10 @@
 import { LROClient, Product } from "./generated/lro/src";
 import { assert } from "chai";
 import {
-  HttpOperationResponse,
   InternalPipelineOptions,
   OperationOptions,
   RequestPolicyFactory
 } from "@azure/core-http";
-
-function getLROStatusFromBody(result: HttpOperationResponse): string {
-  const { status } = result.parsedBody || {};
-  return status;
-}
 
 const LROOptions = {
   updateIntervalInMs: 0
@@ -138,11 +132,12 @@ describe("LROs", () => {
       const poller = await client.lROs.beginPut200Acceptedcanceled200(
         LROOptions
       );
-
-      const result = await poller.pollUntilDone();
-      assert.deepEqual(result.provisioningState, "Canceled");
-      assert.deepEqual(result.id, "100");
-      assert.deepEqual(result.name, "foo");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Provisioning state: canceled");
+      }
     });
 
     it("should handle put200UpdatingSucceeded204", async () => {
@@ -157,10 +152,12 @@ describe("LROs", () => {
 
     it("should handle put201CreatingFailed200", async () => {
       const poller = await client.lROs.beginPut201CreatingFailed200(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(result.id, "100");
-      assert.equal(result.name, "foo");
-      assert.equal(result.provisioningState, "Failed");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Provisioning state: failed");
+      }
     });
   });
 
@@ -173,14 +170,22 @@ describe("LROs", () => {
 
     it("should handle post202NoRetry204", async () => {
       const poller = await client.lROs.beginPost202NoRetry204(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(result._response.status, 204);
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation failed");
+      }
     });
 
     it("should handle deleteNoHeaderInRetry", async () => {
       const poller = await client.lROs.beginDeleteNoHeaderInRetry(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(result._response.status, 204);
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation failed");
+      }
     });
 
     it("should handle put202Retry200", async () => {
@@ -219,8 +224,12 @@ describe("LROs", () => {
 
     it("should handle delete202NoRetry204", async () => {
       const poller = await client.lROs.beginDelete202NoRetry204(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(result._response.status, 204);
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation failed");
+      }
     });
 
     it("should handle deleteProvisioning202Accepted200Succeeded", async () => {
@@ -319,14 +328,22 @@ describe("LROs", () => {
       const poller = await client.lROs.beginDeleteAsyncRetrycanceled(
         LROOptions
       );
-      const result = await poller.pollUntilDone();
-      assert.equal(getLROStatusFromBody(result._response), "Canceled");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation status: canceled");
+      }
     });
 
     it("should handle DeleteAsyncRetryFailed", async () => {
       const poller = await client.lROs.beginDeleteAsyncRetryFailed(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(getLROStatusFromBody(result._response), "Failed");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation status: failed");
+      }
     });
 
     it("should handle putAsyncRetrySucceeded", async () => {
@@ -357,8 +374,12 @@ describe("LROs", () => {
 
     it("should handle putAsyncRetryFailed", async () => {
       const poller = await client.lROs.beginPutAsyncRetryFailed(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(getLROStatusFromBody(result._response), "Failed");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation status: failed");
+      }
     });
 
     it("should handle putAsyncNonResource", async () => {
@@ -388,8 +409,12 @@ describe("LROs", () => {
 
     it("should handle putAsyncNoRetrycanceled", async () => {
       const poller = await client.lROs.beginPutAsyncNoRetrycanceled(LROOptions);
-      const result = await poller.pollUntilDone();
-      assert.equal(getLROStatusFromBody(result._response), "Canceled");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation status: canceled");
+      }
     });
 
     it("should handle putAsyncSubResource", async () => {
@@ -421,8 +446,12 @@ describe("LROs", () => {
         ...LROOptions,
         product
       });
-      const result = await poller.pollUntilDone();
-      assert.deepEqual(getLROStatusFromBody(result._response), "Failed");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation status: failed");
+      }
     });
 
     it("should handle postAsyncRetrySucceeded", async () => {
@@ -439,8 +468,12 @@ describe("LROs", () => {
         ...LROOptions,
         product
       });
-      const result = await poller.pollUntilDone();
-      assert.deepInclude(getLROStatusFromBody(result._response), "Canceled");
+      try {
+        await poller.pollUntilDone();
+        throw new Error("should have thrown instead");
+      } catch (e) {
+        assert.equal(e.message, "Operation status: canceled");
+      }
     });
   });
 });

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/constants.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/requestUtils.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/constants.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/requestUtils.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/arm-package-resources-2019-08/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/arm-package-resources-2019-08/src/lro/constants.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/arm-package-resources-2019-08/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/arm-package-resources-2019-08/src/lro/requestUtils.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/compute-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/compute-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/compute-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/compute-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/compute-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/compute-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/compute-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/compute-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/cosmos-db-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/cosmos-db-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/cosmos-db-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/cosmos-db-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/keyvault-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/keyvault-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/keyvault-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/keyvault-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/network-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/network-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/network-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/network-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/network-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/network-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/network-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/network-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/sql-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/sql-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/sql-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/sql-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/sql-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/sql-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/sql-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/sql-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/storage-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/storage-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/storage-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/storage-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/storage-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/storage-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/storage-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/storage-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {

--- a/test/smoke/generated/web-resource-manager/src/lro/azureAsyncOperationStrategy.ts
+++ b/test/smoke/generated/web-resource-manager/src/lro/azureAsyncOperationStrategy.ts
@@ -7,8 +7,7 @@
  */
 
 import { BaseResult, FinalStateVia, LROResult } from "./models";
-import { terminalStates } from "./constants";
-import { getResponseStatus } from "./requestUtils";
+import { getResponseStatus, isAzureAsyncPollingDone } from "./requestUtils";
 
 export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>,
@@ -41,7 +40,7 @@ export function createAzureAsyncOperationStrategy<TResult extends BaseResult>(
     const status = getResponseStatus(response);
     const result = {
       result: response,
-      done: terminalStates.includes(status)
+      done: isAzureAsyncPollingDone(response)
     };
     if (status === "succeeded" && resourceLocation !== undefined) {
       return sendFinalRequest(result);

--- a/test/smoke/generated/web-resource-manager/src/lro/constants.ts
+++ b/test/smoke/generated/web-resource-manager/src/lro/constants.ts
@@ -6,4 +6,6 @@
  * Changes may cause incorrect behavior and will be lost if the code is regenerated.
  */
 
-export const terminalStates = ["succeeded", "failed", "canceled", "cancelled"];
+export const successStates = ["succeeded"];
+export const failureStates = ["failed", "canceled", "cancelled"];
+export const terminalStates = successStates.concat(failureStates);

--- a/test/smoke/generated/web-resource-manager/src/lro/locationStrategy.ts
+++ b/test/smoke/generated/web-resource-manager/src/lro/locationStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import { BaseResult, LROResult } from "./models";
+import { isLocationPollingDone } from "./requestUtils";
 
 export function createLocationStrategy<TResult extends BaseResult>(
   pollOnce: (pollingURL: string) => Promise<TResult>
@@ -15,7 +16,7 @@ export function createLocationStrategy<TResult extends BaseResult>(
     const result = await pollOnce(pollingURL);
     return {
       result: result,
-      done: result._response.status !== 202
+      done: isLocationPollingDone(result)
     };
   };
 }

--- a/test/smoke/generated/web-resource-manager/src/lro/requestUtils.ts
+++ b/test/smoke/generated/web-resource-manager/src/lro/requestUtils.ts
@@ -13,7 +13,7 @@ import {
   OperationResponse,
   OperationSpec
 } from "@azure/core-http";
-import { terminalStates } from "./constants";
+import { failureStates, successStates, terminalStates } from "./constants";
 import { BaseResult, LROConfig, LROMode, SendOperationFn } from "./models";
 
 /**
@@ -284,7 +284,29 @@ export function inferLROMode(
 }
 
 export function isBodyPollingDone(rawResponse: unknown) {
-  return terminalStates.includes(getProvisioningState(rawResponse));
+  const state = getProvisioningState(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Provisioning state: ${state}`);
+  }
+  return successStates.includes(state);
+}
+
+export function isLocationPollingDone<TResult extends BaseResult>(
+  rawResponse: TResult
+) {
+  const code = rawResponse._response.status;
+  if (![202, 200].includes(code)) {
+    throw new Error(`Operation failed`);
+  }
+  return code !== 202;
+}
+
+export function isAzureAsyncPollingDone(rawResponse: unknown) {
+  const state = getResponseStatus(rawResponse);
+  if (failureStates.includes(state)) {
+    throw new Error(`Operation status: ${state}`);
+  }
+  return successStates.includes(state);
 }
 
 export function getSpecPath(spec: OperationSpec): string {


### PR DESCRIPTION
According to the code gen crew, LROs in other languages throw when fail. This PR implements the same behavior in JS. Fixes https://github.com/Azure/autorest.typescript/issues/936