### PR TITLE
Rename know to known in extensible enum header comment

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -489,7 +489,7 @@ function getExtensibleChoiceDescription(choice: UnionDetails) {
   return [
     `${choice.description} \\`,
     ...(hasEnum ? [enumLink] : []),
-    `### Know values supported by the service`,
+    `### Known values supported by the service`,
     valueDescriptions
   ].join(" \n");
 }

--- a/test/integration/generated/appconfiguration/src/models/index.ts
+++ b/test/integration/generated/appconfiguration/src/models/index.ts
@@ -208,7 +208,7 @@ export const enum KnownGet6ItemsItem {
  * Defines values for Get6ItemsItem. \
  * {@link KnownGet6ItemsItem} can be used interchangeably with Get6ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -236,7 +236,7 @@ export const enum KnownHead6ItemsItem {
  * Defines values for Head6ItemsItem. \
  * {@link KnownHead6ItemsItem} can be used interchangeably with Head6ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -264,7 +264,7 @@ export const enum KnownGet7ItemsItem {
  * Defines values for Get7ItemsItem. \
  * {@link KnownGet7ItemsItem} can be used interchangeably with Get7ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -292,7 +292,7 @@ export const enum KnownHead7ItemsItem {
  * Defines values for Head7ItemsItem. \
  * {@link KnownHead7ItemsItem} can be used interchangeably with Head7ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -320,7 +320,7 @@ export const enum KnownEnum4 {
  * Defines values for Enum4. \
  * {@link KnownEnum4} can be used interchangeably with Enum4,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -348,7 +348,7 @@ export const enum KnownEnum5 {
  * Defines values for Enum5. \
  * {@link KnownEnum5} can be used interchangeably with Enum5,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \

--- a/test/integration/generated/appconfigurationexport/src/models/index.ts
+++ b/test/integration/generated/appconfigurationexport/src/models/index.ts
@@ -208,7 +208,7 @@ export const enum KnownGet6ItemsItem {
  * Defines values for Get6ItemsItem. \
  * {@link KnownGet6ItemsItem} can be used interchangeably with Get6ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -236,7 +236,7 @@ export const enum KnownHead6ItemsItem {
  * Defines values for Head6ItemsItem. \
  * {@link KnownHead6ItemsItem} can be used interchangeably with Head6ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -264,7 +264,7 @@ export const enum KnownGet7ItemsItem {
  * Defines values for Get7ItemsItem. \
  * {@link KnownGet7ItemsItem} can be used interchangeably with Get7ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -292,7 +292,7 @@ export const enum KnownHead7ItemsItem {
  * Defines values for Head7ItemsItem. \
  * {@link KnownHead7ItemsItem} can be used interchangeably with Head7ItemsItem,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -320,7 +320,7 @@ export const enum KnownEnum4 {
  * Defines values for Enum4. \
  * {@link KnownEnum4} can be used interchangeably with Enum4,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \
@@ -348,7 +348,7 @@ export const enum KnownEnum5 {
  * Defines values for Enum5. \
  * {@link KnownEnum5} can be used interchangeably with Enum5,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **key** \
  * **label** \
  * **content_type** \

--- a/test/integration/generated/arrayConstraints/src/models/index.ts
+++ b/test/integration/generated/arrayConstraints/src/models/index.ts
@@ -23,7 +23,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/attestation/src/models/index.ts
+++ b/test/integration/generated/attestation/src/models/index.ts
@@ -42,7 +42,7 @@ export const enum KnownAttestationType {
  * Defines values for AttestationType. \
  * {@link KnownAttestationType} can be used interchangeably with AttestationType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **SgxEnclave**: Intel Software Guard eXtensions \
  * **OpenEnclave**: OpenEnclave extensions to SGX \
  * **Tpm**: Edge TPM Virtualization Based Security
@@ -61,7 +61,7 @@ export const enum KnownDataType {
  * Defines values for DataType. \
  * {@link KnownDataType} can be used interchangeably with DataType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Binary**: The contents of the field should be treated as binary and not interpreted by MAA. \
  * **JSON**: The contents of the field should be treated as a JSON object and may be further interpreted by MAA.
  */

--- a/test/integration/generated/bodyArray/src/models/index.ts
+++ b/test/integration/generated/bodyArray/src/models/index.ts
@@ -29,7 +29,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **foo1** \
  * **foo2** \
  * **foo3**
@@ -47,7 +47,7 @@ export const enum KnownEnum1 {
  * Defines values for Enum1. \
  * {@link KnownEnum1} can be used interchangeably with Enum1,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **foo1** \
  * **foo2** \
  * **foo3**

--- a/test/integration/generated/bodyComplex/src/models/index.ts
+++ b/test/integration/generated/bodyComplex/src/models/index.ts
@@ -214,7 +214,7 @@ export const enum KnownCMYKColors {
  * Defines values for CMYKColors. \
  * {@link KnownCMYKColors} can be used interchangeably with CMYKColors,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **cyan** \
  * **Magenta** \
  * **YELLOW** \
@@ -231,7 +231,7 @@ export const enum KnownMyKind {
  * Defines values for MyKind. \
  * {@link KnownMyKind} can be used interchangeably with MyKind,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Kind1**
  */
 export type MyKind = string;
@@ -251,7 +251,7 @@ export const enum KnownGoblinSharkColor {
  * Defines values for GoblinSharkColor. \
  * {@link KnownGoblinSharkColor} can be used interchangeably with GoblinSharkColor,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **pink** \
  * **gray** \
  * **brown** \

--- a/test/integration/generated/bodyComplexWithTracing/src/models/index.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/models/index.ts
@@ -214,7 +214,7 @@ export const enum KnownCMYKColors {
  * Defines values for CMYKColors. \
  * {@link KnownCMYKColors} can be used interchangeably with CMYKColors,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **cyan** \
  * **Magenta** \
  * **YELLOW** \
@@ -231,7 +231,7 @@ export const enum KnownMyKind {
  * Defines values for MyKind. \
  * {@link KnownMyKind} can be used interchangeably with MyKind,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Kind1**
  */
 export type MyKind = string;
@@ -251,7 +251,7 @@ export const enum KnownGoblinSharkColor {
  * Defines values for GoblinSharkColor. \
  * {@link KnownGoblinSharkColor} can be used interchangeably with GoblinSharkColor,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **pink** \
  * **gray** \
  * **brown** \

--- a/test/integration/generated/extensibleEnums/src/models/index.ts
+++ b/test/integration/generated/extensibleEnums/src/models/index.ts
@@ -31,7 +31,7 @@ export const enum KnownDaysOfWeekExtensibleEnum {
  * Defines values for DaysOfWeekExtensibleEnum. \
  * {@link KnownDaysOfWeekExtensibleEnum} can be used interchangeably with DaysOfWeekExtensibleEnum,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Monday** \
  * **Tuesday** \
  * **Wednesday** \
@@ -56,7 +56,7 @@ export const enum KnownIntEnum {
  * Defines values for IntEnum. \
  * {@link KnownIntEnum} can be used interchangeably with IntEnum,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **1**: This is a really long comment to see what wrapping looks like. This comment is really long and it should wrap for readability. Please wrap. This should wrap. \
  * **2**: two \
  * **3**: three

--- a/test/integration/generated/licenseHeader/src/models/index.ts
+++ b/test/integration/generated/licenseHeader/src/models/index.ts
@@ -18,7 +18,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/lro/src/models/index.ts
+++ b/test/integration/generated/lro/src/models/index.ts
@@ -563,7 +563,7 @@ export const enum KnownProductPropertiesProvisioningStateValues {
  * Defines values for ProductPropertiesProvisioningStateValues. \
  * {@link KnownProductPropertiesProvisioningStateValues} can be used interchangeably with ProductPropertiesProvisioningStateValues,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Succeeded** \
  * **Failed** \
  * **canceled** \
@@ -597,7 +597,7 @@ export const enum KnownSubProductPropertiesProvisioningStateValues {
  * Defines values for SubProductPropertiesProvisioningStateValues. \
  * {@link KnownSubProductPropertiesProvisioningStateValues} can be used interchangeably with SubProductPropertiesProvisioningStateValues,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Succeeded** \
  * **Failed** \
  * **canceled** \
@@ -631,7 +631,7 @@ export const enum KnownOperationResultStatus {
  * Defines values for OperationResultStatus. \
  * {@link KnownOperationResultStatus} can be used interchangeably with OperationResultStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Succeeded** \
  * **Failed** \
  * **canceled** \

--- a/test/integration/generated/modelFlattening/src/models/index.ts
+++ b/test/integration/generated/modelFlattening/src/models/index.ts
@@ -134,7 +134,7 @@ export const enum KnownFlattenedProductPropertiesProvisioningStateValues {
  * Defines values for FlattenedProductPropertiesProvisioningStateValues. \
  * {@link KnownFlattenedProductPropertiesProvisioningStateValues} can be used interchangeably with FlattenedProductPropertiesProvisioningStateValues,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Succeeded** \
  * **Failed** \
  * **canceled** \

--- a/test/integration/generated/noLicenseHeader/src/models/index.ts
+++ b/test/integration/generated/noLicenseHeader/src/models/index.ts
@@ -10,7 +10,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/noMappers/src/models/index.ts
+++ b/test/integration/generated/noMappers/src/models/index.ts
@@ -18,7 +18,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/noOperation/src/models/index.ts
+++ b/test/integration/generated/noOperation/src/models/index.ts
@@ -23,7 +23,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/nonStringEnum/src/models/index.ts
+++ b/test/integration/generated/nonStringEnum/src/models/index.ts
@@ -21,7 +21,7 @@ export const enum KnownIntEnum {
  * Defines values for IntEnum. \
  * {@link KnownIntEnum} can be used interchangeably with IntEnum,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **200** \
  * **403** \
  * **405** \
@@ -43,7 +43,7 @@ export const enum KnownFloatEnum {
  * Defines values for FloatEnum. \
  * {@link KnownFloatEnum} can be used interchangeably with FloatEnum,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **200.4** \
  * **403.4** \
  * **405.3** \

--- a/test/integration/generated/odataDiscriminator/src/models/index.ts
+++ b/test/integration/generated/odataDiscriminator/src/models/index.ts
@@ -73,7 +73,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/operationgroupclash/src/models/index.ts
+++ b/test/integration/generated/operationgroupclash/src/models/index.ts
@@ -20,7 +20,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/optionalnull/src/models/index.ts
+++ b/test/integration/generated/optionalnull/src/models/index.ts
@@ -32,7 +32,7 @@ export const enum KnownEnum0 {
  * Defines values for Enum0. \
  * {@link KnownEnum0} can be used interchangeably with Enum0,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **one** \
  * **two**
  */

--- a/test/integration/generated/paging/src/models/index.ts
+++ b/test/integration/generated/paging/src/models/index.ts
@@ -103,7 +103,7 @@ export const enum KnownOperationResultStatus {
  * Defines values for OperationResultStatus. \
  * {@link KnownOperationResultStatus} can be used interchangeably with OperationResultStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Succeeded** \
  * **Failed** \
  * **canceled** \

--- a/test/integration/generated/pagingNoIterators/src/models/index.ts
+++ b/test/integration/generated/pagingNoIterators/src/models/index.ts
@@ -103,7 +103,7 @@ export const enum KnownOperationResultStatus {
  * Defines values for OperationResultStatus. \
  * {@link KnownOperationResultStatus} can be used interchangeably with OperationResultStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Succeeded** \
  * **Failed** \
  * **canceled** \

--- a/test/integration/generated/petstore/src/models/index.ts
+++ b/test/integration/generated/petstore/src/models/index.ts
@@ -71,7 +71,7 @@ export const enum KnownPetStatus {
  * Defines values for PetStatus. \
  * {@link KnownPetStatus} can be used interchangeably with PetStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **available** \
  * **pending** \
  * **sold**
@@ -89,7 +89,7 @@ export const enum KnownOrderStatus {
  * Defines values for OrderStatus. \
  * {@link KnownOrderStatus} can be used interchangeably with OrderStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **placed** \
  * **approved** \
  * **delivered**

--- a/test/integration/generated/polymorphicSkipNormalize/src/generated/models/index.ts
+++ b/test/integration/generated/polymorphicSkipNormalize/src/generated/models/index.ts
@@ -571,7 +571,7 @@ export const enum KnownMediaGraphParameterType {
  * Defines values for MediaGraphParameterType. \
  * {@link KnownMediaGraphParameterType} can be used interchangeably with MediaGraphParameterType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **String**: A string parameter value. \
  * **SecretString**: A string to hold sensitive information as parameter value. \
  * **Int**: A 32-bit signed integer as parameter value. \
@@ -590,7 +590,7 @@ export const enum KnownMediaGraphOutputSelectorProperty {
  * Defines values for MediaGraphOutputSelectorProperty. \
  * {@link KnownMediaGraphOutputSelectorProperty} can be used interchangeably with MediaGraphOutputSelectorProperty,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **mediaType**: The stream's MIME type or subtype.
  */
 export type MediaGraphOutputSelectorProperty = string;
@@ -607,7 +607,7 @@ export const enum KnownMediaGraphOutputSelectorOperator {
  * Defines values for MediaGraphOutputSelectorOperator. \
  * {@link KnownMediaGraphOutputSelectorOperator} can be used interchangeably with MediaGraphOutputSelectorOperator,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **is**: A media type is the same type or a subtype. \
  * **isNot**: A media type is not the same type or a subtype.
  */
@@ -629,7 +629,7 @@ export const enum KnownMediaGraphInstanceState {
  * Defines values for MediaGraphInstanceState. \
  * {@link KnownMediaGraphInstanceState} can be used interchangeably with MediaGraphInstanceState,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Inactive**: The media graph instance is idle and not processing media. \
  * **Activating**: The media graph instance is transitioning into the active state. \
  * **Active**: The media graph instance is active and processing media. \
@@ -649,7 +649,7 @@ export const enum KnownMediaGraphRtspTransport {
  * Defines values for MediaGraphRtspTransport. \
  * {@link KnownMediaGraphRtspTransport} can be used interchangeably with MediaGraphRtspTransport,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Http**: HTTP\/HTTPS transport. This should be used when HTTP tunneling is desired. \
  * **Tcp**: TCP transport. This should be used when HTTP tunneling is NOT desired.
  */
@@ -669,7 +669,7 @@ export const enum KnownMediaGraphMotionDetectionSensitivity {
  * Defines values for MediaGraphMotionDetectionSensitivity. \
  * {@link KnownMediaGraphMotionDetectionSensitivity} can be used interchangeably with MediaGraphMotionDetectionSensitivity,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Low**: Low Sensitivity. \
  * **Medium**: Medium Sensitivity. \
  * **High**: High Sensitivity.
@@ -690,7 +690,7 @@ export const enum KnownMediaGraphImageScaleMode {
  * Defines values for MediaGraphImageScaleMode. \
  * {@link KnownMediaGraphImageScaleMode} can be used interchangeably with MediaGraphImageScaleMode,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **PreserveAspectRatio**: Use the same aspect ratio as the input frame. \
  * **Pad**: Center pad the input frame to match the given dimensions. \
  * **Stretch**: Stretch input frame to match given dimensions.
@@ -709,7 +709,7 @@ export const enum KnownMediaGraphGrpcExtensionDataTransferMode {
  * Defines values for MediaGraphGrpcExtensionDataTransferMode. \
  * {@link KnownMediaGraphGrpcExtensionDataTransferMode} can be used interchangeably with MediaGraphGrpcExtensionDataTransferMode,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Embedded**: Frames are transferred embedded into the gRPC messages. \
  * **SharedMemory**: Frames are transferred through shared memory.
  */
@@ -745,7 +745,7 @@ export const enum KnownMediaGraphImageFormatRawPixelFormat {
  * Defines values for MediaGraphImageFormatRawPixelFormat. \
  * {@link KnownMediaGraphImageFormatRawPixelFormat} can be used interchangeably with MediaGraphImageFormatRawPixelFormat,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Yuv420p**: Planar YUV 4:2:0, 12bpp, (1 Cr and Cb sample per 2x2 Y samples). \
  * **Rgb565be**: Packed RGB 5:6:5, 16bpp, (msb)   5R 6G 5B(lsb), big-endian. \
  * **Rgb565le**: Packed RGB 5:6:5, 16bpp, (msb)   5R 6G 5B(lsb), little-endian. \

--- a/test/integration/generated/readmeFileChecker/src/models/index.ts
+++ b/test/integration/generated/readmeFileChecker/src/models/index.ts
@@ -216,7 +216,7 @@ export const enum KnownApiVersion72Preview {
  * Defines values for ApiVersion72Preview. \
  * {@link KnownApiVersion72Preview} can be used interchangeably with ApiVersion72Preview,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **7.2-preview**: Api Version '7.2-preview'
  */
 export type ApiVersion72Preview = string;
@@ -243,7 +243,7 @@ export const enum KnownDeletionRecoveryLevel {
  * Defines values for DeletionRecoveryLevel. \
  * {@link KnownDeletionRecoveryLevel} can be used interchangeably with DeletionRecoveryLevel,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Purgeable**: Denotes a vault state in which deletion is an irreversible operation, without the possibility for recovery. This level corresponds to no protection being available against a Delete operation; the data is irretrievably lost upon accepting a Delete operation at the entity level or higher (vault, resource group, subscription etc.) \
  * **Recoverable+Purgeable**: Denotes a vault state in which deletion is recoverable, and which also permits immediate and permanent deletion (i.e. purge). This level guarantees the recoverability of the deleted entity during the retention interval (90 days), unless a Purge operation is requested, or the subscription is cancelled. System wil permanently delete it after 90 days, if not recovered \
  * **Recoverable**: Denotes a vault state in which deletion is recoverable without the possibility for immediate and permanent deletion (i.e. purge). This level guarantees the recoverability of the deleted entity during the retention interval(90 days) and while the subscription is still available. System wil permanently delete it after 90 days, if not recovered \

--- a/test/integration/generated/storageblob/src/models/index.ts
+++ b/test/integration/generated/storageblob/src/models/index.ts
@@ -674,7 +674,7 @@ export const enum KnownAccessTier {
  * Defines values for AccessTier. \
  * {@link KnownAccessTier} can be used interchangeably with AccessTier,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **P4** \
  * **P6** \
  * **P10** \
@@ -702,7 +702,7 @@ export const enum KnownArchiveStatus {
  * Defines values for ArchiveStatus. \
  * {@link KnownArchiveStatus} can be used interchangeably with ArchiveStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **rehydrate-pending-to-hot** \
  * **rehydrate-pending-to-cool**
  */
@@ -718,7 +718,7 @@ export const enum KnownRehydratePriority {
  * Defines values for RehydratePriority. \
  * {@link KnownRehydratePriority} can be used interchangeably with RehydratePriority,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **High** \
  * **Standard**
  */
@@ -734,7 +734,7 @@ export const enum KnownPublicAccessType {
  * Defines values for PublicAccessType. \
  * {@link KnownPublicAccessType} can be used interchangeably with PublicAccessType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **container** \
  * **blob**
  */
@@ -751,7 +751,7 @@ export const enum KnownGeoReplicationStatusType {
  * Defines values for GeoReplicationStatusType. \
  * {@link KnownGeoReplicationStatusType} can be used interchangeably with GeoReplicationStatusType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **live** \
  * **bootstrap** \
  * **unavailable**
@@ -878,7 +878,7 @@ export const enum KnownStorageErrorCode {
  * Defines values for StorageErrorCode. \
  * {@link KnownStorageErrorCode} can be used interchangeably with StorageErrorCode,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **AccountAlreadyExists** \
  * **AccountBeingCreated** \
  * **AccountIsDisabled** \
@@ -1013,7 +1013,7 @@ export const enum KnownPremiumPageBlobAccessTier {
  * Defines values for PremiumPageBlobAccessTier. \
  * {@link KnownPremiumPageBlobAccessTier} can be used interchangeably with PremiumPageBlobAccessTier,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **P4** \
  * **P6** \
  * **P10** \
@@ -1040,7 +1040,7 @@ export const enum KnownBlobExpiryOptions {
  * Defines values for BlobExpiryOptions. \
  * {@link KnownBlobExpiryOptions} can be used interchangeably with BlobExpiryOptions,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **NeverExpire** \
  * **RelativeToCreation** \
  * **RelativeToNow** \

--- a/test/integration/generated/textanalytics/src/models/index.ts
+++ b/test/integration/generated/textanalytics/src/models/index.ts
@@ -600,7 +600,7 @@ export const enum KnownStringIndexType {
  * Defines values for StringIndexType. \
  * {@link KnownStringIndexType} can be used interchangeably with StringIndexType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **TextElements_v8**: Returned offset and length values will correspond to TextElements (Graphemes and Grapheme clusters) confirming to the Unicode 8.0.0 standard. Use this option if your application is written in .Net Framework or .Net Core and you will be using StringInfo. \
  * **UnicodeCodePoint**: Returned offset and length values will correspond to Unicode code points. Use this option if your application is written in a language that support Unicode, for example Python. \
  * **Utf16CodeUnit**: Returned offset and length values will correspond to UTF-16 code units. Use this option if your application is written in a language that support Unicode, for example Java, JavaScript.
@@ -617,7 +617,7 @@ export const enum KnownPiiTaskParametersDomain {
  * Defines values for PiiTaskParametersDomain. \
  * {@link KnownPiiTaskParametersDomain} can be used interchangeably with PiiTaskParametersDomain,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **phi** \
  * **none**
  */
@@ -804,7 +804,7 @@ export const enum KnownPiiCategory {
  * Defines values for PiiCategory. \
  * {@link KnownPiiCategory} can be used interchangeably with PiiCategory,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **ABARoutingNumber** \
  * **ARNationalIdentityNumber** \
  * **AUBankAccountNumber** \
@@ -998,7 +998,7 @@ export const enum KnownInnerErrorCodeValue {
  * Defines values for InnerErrorCodeValue. \
  * {@link KnownInnerErrorCodeValue} can be used interchangeably with InnerErrorCodeValue,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **InvalidParameterValue** \
  * **InvalidRequestBodyFormat** \
  * **EmptyRequest** \
@@ -1021,7 +1021,7 @@ export const enum KnownWarningCode {
  * Defines values for WarningCode. \
  * {@link KnownWarningCode} can be used interchangeably with WarningCode,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **LongWordsInDocument** \
  * **DocumentTruncated**
  */
@@ -1056,7 +1056,7 @@ export const enum KnownRelationType {
  * Defines values for RelationType. \
  * {@link KnownRelationType} can be used interchangeably with RelationType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **Abbreviation** \
  * **DirectionOfBodyStructure** \
  * **DirectionOfCondition** \

--- a/test/integration/generated/xmlservice/src/models/index.ts
+++ b/test/integration/generated/xmlservice/src/models/index.ts
@@ -285,7 +285,7 @@ export const enum KnownPublicAccessType {
  * Defines values for PublicAccessType. \
  * {@link KnownPublicAccessType} can be used interchangeably with PublicAccessType,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **container** \
  * **blob**
  */
@@ -309,7 +309,7 @@ export const enum KnownAccessTier {
  * Defines values for AccessTier. \
  * {@link KnownAccessTier} can be used interchangeably with AccessTier,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **P4** \
  * **P6** \
  * **P10** \
@@ -333,7 +333,7 @@ export const enum KnownArchiveStatus {
  * Defines values for ArchiveStatus. \
  * {@link KnownArchiveStatus} can be used interchangeably with ArchiveStatus,
  *  this enum contains the known values that the service supports.
- * ### Know values supported by the service
+ * ### Known values supported by the service
  * **rehydrate-pending-to-hot** \
  * **rehydrate-pending-to-cool**
  */


### PR DESCRIPTION
This pull request renamed the generated header comment for extensible enums

Before: `Know values supported by the service`
After: `Known values supported by the service`

It's a tiny change, but I feel like `Know values` isn't grammatically correct - if there's a reason it's set that way
feel free to let me know!