### PR TITLE
Fix the Smoke Test CI Failures in recent PRs

### DIFF
--- a/src/generators/static/tsConfigFileGenerator.ts
+++ b/src/generators/static/tsConfigFileGenerator.ts
@@ -19,7 +19,8 @@ const highLevelTsConfig = {
     lib: ["es6", "dom"],
     declaration: true,
     outDir: "./esm",
-    importHelpers: true
+    importHelpers: true,
+    skipLibCheck: true
   },
   include: ["./src/**/*.ts"],
   exclude: ["node_modules"]

--- a/test/integration/generated/additionalProperties/tsconfig.json
+++ b/test/integration/generated/additionalProperties/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/appconfiguration/tsconfig.json
+++ b/test/integration/generated/appconfiguration/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/appconfigurationexport/tsconfig.json
+++ b/test/integration/generated/appconfigurationexport/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/arrayConstraints/tsconfig.json
+++ b/test/integration/generated/arrayConstraints/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/attestation/tsconfig.json
+++ b/test/integration/generated/attestation/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/azureParameterGrouping/tsconfig.json
+++ b/test/integration/generated/azureParameterGrouping/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/azureReport/tsconfig.json
+++ b/test/integration/generated/azureReport/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/azureSpecialProperties/tsconfig.json
+++ b/test/integration/generated/azureSpecialProperties/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyArray/tsconfig.json
+++ b/test/integration/generated/bodyArray/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyBoolean/tsconfig.json
+++ b/test/integration/generated/bodyBoolean/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyBooleanQuirks/tsconfig.json
+++ b/test/integration/generated/bodyBooleanQuirks/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyByte/tsconfig.json
+++ b/test/integration/generated/bodyByte/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyComplex/tsconfig.json
+++ b/test/integration/generated/bodyComplex/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyComplexWithTracing/tsconfig.json
+++ b/test/integration/generated/bodyComplexWithTracing/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyDate/tsconfig.json
+++ b/test/integration/generated/bodyDate/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyDateTime/tsconfig.json
+++ b/test/integration/generated/bodyDateTime/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyDateTimeRfc1123/tsconfig.json
+++ b/test/integration/generated/bodyDateTimeRfc1123/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyDictionary/tsconfig.json
+++ b/test/integration/generated/bodyDictionary/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyDuration/tsconfig.json
+++ b/test/integration/generated/bodyDuration/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyFile/tsconfig.json
+++ b/test/integration/generated/bodyFile/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyFormData/tsconfig.json
+++ b/test/integration/generated/bodyFormData/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyInteger/tsconfig.json
+++ b/test/integration/generated/bodyInteger/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyNumber/tsconfig.json
+++ b/test/integration/generated/bodyNumber/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyString/tsconfig.json
+++ b/test/integration/generated/bodyString/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/bodyTime/tsconfig.json
+++ b/test/integration/generated/bodyTime/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/customUrl/tsconfig.json
+++ b/test/integration/generated/customUrl/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/customUrlMoreOptions/tsconfig.json
+++ b/test/integration/generated/customUrlMoreOptions/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/customUrlPaging/tsconfig.json
+++ b/test/integration/generated/customUrlPaging/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/extensibleEnums/tsconfig.json
+++ b/test/integration/generated/extensibleEnums/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/header/tsconfig.json
+++ b/test/integration/generated/header/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/headerprefix/tsconfig.json
+++ b/test/integration/generated/headerprefix/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/httpInfrastructure/tsconfig.json
+++ b/test/integration/generated/httpInfrastructure/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/licenseHeader/tsconfig.json
+++ b/test/integration/generated/licenseHeader/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/lro/tsconfig.json
+++ b/test/integration/generated/lro/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/lroParametrizedEndpoints/tsconfig.json
+++ b/test/integration/generated/lroParametrizedEndpoints/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/mapperrequired/tsconfig.json
+++ b/test/integration/generated/mapperrequired/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/mediaTypes/tsconfig.json
+++ b/test/integration/generated/mediaTypes/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/mediaTypesV3/tsconfig.json
+++ b/test/integration/generated/mediaTypesV3/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/mediaTypesV3Lro/tsconfig.json
+++ b/test/integration/generated/mediaTypesV3Lro/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/mediaTypesWithTracing/tsconfig.json
+++ b/test/integration/generated/mediaTypesWithTracing/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/modelFlattening/tsconfig.json
+++ b/test/integration/generated/modelFlattening/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/multipleInheritance/tsconfig.json
+++ b/test/integration/generated/multipleInheritance/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/nameChecker/tsconfig.json
+++ b/test/integration/generated/nameChecker/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/noLicenseHeader/tsconfig.json
+++ b/test/integration/generated/noLicenseHeader/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/noMappers/tsconfig.json
+++ b/test/integration/generated/noMappers/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/noOperation/tsconfig.json
+++ b/test/integration/generated/noOperation/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/nonStringEnum/tsconfig.json
+++ b/test/integration/generated/nonStringEnum/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/objectType/tsconfig.json
+++ b/test/integration/generated/objectType/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/odataDiscriminator/tsconfig.json
+++ b/test/integration/generated/odataDiscriminator/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/operationgroupclash/tsconfig.json
+++ b/test/integration/generated/operationgroupclash/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/optionalnull/tsconfig.json
+++ b/test/integration/generated/optionalnull/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/paging/tsconfig.json
+++ b/test/integration/generated/paging/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/pagingNoIterators/tsconfig.json
+++ b/test/integration/generated/pagingNoIterators/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/petstore/tsconfig.json
+++ b/test/integration/generated/petstore/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/readmeFileChecker/tsconfig.json
+++ b/test/integration/generated/readmeFileChecker/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/regexConstraint/tsconfig.json
+++ b/test/integration/generated/regexConstraint/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/report/tsconfig.json
+++ b/test/integration/generated/report/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/requiredOptional/tsconfig.json
+++ b/test/integration/generated/requiredOptional/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/storageblob/tsconfig.json
+++ b/test/integration/generated/storageblob/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/storagefileshare/tsconfig.json
+++ b/test/integration/generated/storagefileshare/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/subscriptionIdApiVersion/tsconfig.json
+++ b/test/integration/generated/subscriptionIdApiVersion/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/textanalytics/tsconfig.json
+++ b/test/integration/generated/textanalytics/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/url/tsconfig.json
+++ b/test/integration/generated/url/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/url2/tsconfig.json
+++ b/test/integration/generated/url2/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/urlMulti/tsconfig.json
+++ b/test/integration/generated/urlMulti/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/uuid/tsconfig.json
+++ b/test/integration/generated/uuid/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/validation/tsconfig.json
+++ b/test/integration/generated/validation/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/xmlservice/tsconfig.json
+++ b/test/integration/generated/xmlservice/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/integration/generated/xmsErrorResponses/tsconfig.json
+++ b/test/integration/generated/xmsErrorResponses/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/tsconfig.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-features-2015-12/tsconfig.json
+++ b/test/smoke/generated/arm-package-features-2015-12/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-links-2016-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-links-2016-09/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-locks-2016-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/tsconfig.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-policy-2019-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-resources-2019-08/tsconfig.json
+++ b/test/smoke/generated/arm-package-resources-2019-08/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/tsconfig.json
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/compute-resource-manager/tsconfig.json
+++ b/test/smoke/generated/compute-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/cosmos-db-resource-manager/tsconfig.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/graphrbac-data-plane/tsconfig.json
+++ b/test/smoke/generated/graphrbac-data-plane/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/keyvault-resource-manager/tsconfig.json
+++ b/test/smoke/generated/keyvault-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/monitor-data-plane/tsconfig.json
+++ b/test/smoke/generated/monitor-data-plane/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/msi-resource-manager/tsconfig.json
+++ b/test/smoke/generated/msi-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/network-resource-manager/tsconfig.json
+++ b/test/smoke/generated/network-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/sql-resource-manager/tsconfig.json
+++ b/test/smoke/generated/sql-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/storage-resource-manager/tsconfig.json
+++ b/test/smoke/generated/storage-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/test/smoke/generated/web-resource-manager/tsconfig.json
+++ b/test/smoke/generated/web-resource-manager/tsconfig.json
@@ -13,7 +13,8 @@
     "lib": ["es6", "dom"],
     "declaration": true,
     "outDir": "./esm",
-    "importHelpers": true
+    "importHelpers": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
In any recent PRs created against the autorest.typescript repository (main branch), you could see that the CI is failing for smoke tests. For example, you can check the PR: https://github.com/Azure/autorest.typescript/pull/1010. The code changes are in no way related to the smoke test failures. 

This CI failure could be resolved by setting the `skipLibCheck` to `true`. This PR does that.

@joheredi @deyaaeldeen Please review and approve. 

