### PR TITLE
Code to add skipLibCheck to tsconfig json

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ In addition to the [list of Autorest flags](https://github.com/Azure/autorest/bl
 | `--tracing-info`                | Controls specification of meta info attached to requests for tracing purposes                                                                                                                                                                                                                                                        |
 | `--disable-async-iterators`     | Does not generate async iterators needed for paging operations                                                                                                                                                                                                                                                                       |
 | `--allow-insecure-connection`   | Allow generated clients to make requests to HTTP endpoints                                                                                                                                                                                                                                                                           |
+| `--skip-lib-check`              | Sets `skipLibCheck` to `true` in the `tsconfig.json` file of the generated SDK.                                                                                                                                                                                                                                                      |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ In addition to the [list of Autorest flags](https://github.com/Azure/autorest/bl
 | `--tracing-info`                | Controls specification of meta info attached to requests for tracing purposes                                                                                                                                                                                                                                                        |
 | `--disable-async-iterators`     | Does not generate async iterators needed for paging operations                                                                                                                                                                                                                                                                       |
 | `--allow-insecure-connection`   | Allow generated clients to make requests to HTTP endpoints                                                                                                                                                                                                                                                                           |
-| `--skip-lib-check`              | Sets `skipLibCheck` to `true` in the `tsconfig.json` file of the generated SDK.                                                                                                                                                                                                                                                      |
+| `--skip-lib-check`              | Sets `skipLibCheck` to `true` in the `tsconfig.json` file of the generated SDK                                                                                                                                                                                                                                                      |
+
 
 ## Contributing
 

--- a/src/autorestSession.ts
+++ b/src/autorestSession.ts
@@ -24,6 +24,7 @@ export interface AutorestOptions {
   disablePagingAsyncIterators?: boolean;
   skipEnumValidation?: boolean;
   azureOutputDirectory?: string;
+  skipLibCheck?: boolean;
 }
 
 let host: Host;

--- a/src/generators/static/tsConfigFileGenerator.ts
+++ b/src/generators/static/tsConfigFileGenerator.ts
@@ -46,16 +46,23 @@ const restLevelTsConfig = {
 };
 
 export function generateTsConfig(project: Project) {
-  const { generateMetadata, restLevelClient } = getAutorestOptions();
+  const {
+    generateMetadata,
+    restLevelClient,
+    skipLibCheck
+  } = getAutorestOptions();
 
   if (!generateMetadata) {
     return;
   }
 
-  const tsConfigContents = restLevelClient
+  const tsConfigContents: any = restLevelClient
     ? restLevelTsConfig
     : highLevelTsConfig;
 
+  if (skipLibCheck) {
+    tsConfigContents.compilerOptions["skipLibCheck"] = true;
+  }
   project.createSourceFile("tsconfig.json", JSON.stringify(tsConfigContents), {
     overwrite: true
   });

--- a/src/utils/autorestOptions.ts
+++ b/src/utils/autorestOptions.ts
@@ -29,6 +29,7 @@ export async function extractAutorestOptions(): Promise<AutorestOptions> {
   const allowInsecureConnection = await getAllowInsecureConnection(host);
   const skipEnumValidation = await getSkipEnumValidation(host);
   const azureOutputDirectory = await getAzureOutputDirectoryPath(host);
+  const skipLibCheck = await getSkipLibCheck(host);
 
   return {
     azureArm,
@@ -49,7 +50,8 @@ export async function extractAutorestOptions(): Promise<AutorestOptions> {
     disablePagingAsyncIterators,
     skipEnumValidation,
     title,
-    azureOutputDirectory
+    azureOutputDirectory,
+    skipLibCheck
   };
 }
 
@@ -61,6 +63,10 @@ async function getSkipEnumValidation(host: Host): Promise<boolean> {
 
 async function getAllowInsecureConnection(host: Host): Promise<boolean> {
   return (await host.GetValue("allow-insecure-connection")) || false;
+}
+
+async function getSkipLibCheck(host: Host): Promise<boolean> {
+  return (await host.GetValue("skip-lib-check")) || false;
 }
 
 async function getIgnoreNullableOnOptional(host: Host): Promise<boolean> {

--- a/test/integration/generated/skiplibcheck/README.md
+++ b/test/integration/generated/skiplibcheck/README.md
@@ -1,0 +1,31 @@
+# SkipLibCheck client library for JavaScript
+
+This package contains an isomorphic SDK (runs both in Node.js and in browsers) for SkipLibCheck client.
+
+
+
+[Package (NPM)](https://www.npmjs.com/package/skip-lib-check) |
+
+## Getting started
+
+### Currently supported environments
+
+- Node.js version 10.x.x or higher
+- Browser JavaScript
+
+
+### Install the `skip-lib-check` package
+
+Install the SkipLibCheck client library for JavaScript with `npm`:
+
+```bash
+npm install skip-lib-check
+```
+
+
+## Key concepts
+
+### SkipLibCheckClient
+
+`SkipLibCheckClient` is the primary interface for developers using the SkipLibCheck client library. Explore the methods on this client object to understand the different features of the SkipLibCheck service that you can access.
+

--- a/test/integration/generated/skiplibcheck/api-extractor.json
+++ b/test/integration/generated/skiplibcheck/api-extractor.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
+  "mainEntryPointFilePath": "./esm/index.d.ts",
+  "docModel": { "enabled": true },
+  "apiReport": { "enabled": true, "reportFolder": "./review" },
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "",
+    "publicTrimmedFilePath": "./esm/index.d.ts"
+  },
+  "messages": {
+    "tsdocMessageReporting": { "default": { "logLevel": "none" } },
+    "extractorMessageReporting": {
+      "ae-missing-release-tag": { "logLevel": "none" },
+      "ae-unresolved-link": { "logLevel": "none" }
+    }
+  }
+}

--- a/test/integration/generated/skiplibcheck/package.json
+++ b/test/integration/generated/skiplibcheck/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "skip-lib-check",
+  "author": "Microsoft Corporation",
+  "description": "A generated SDK for SkipLibCheckClient.",
+  "version": "1.0.0-preview1",
+  "dependencies": {
+    "@azure/core-client": "^1.1.2",
+    "@azure/core-rest-pipeline": "1.0.0-beta.2",
+    "tslib": "^1.9.3"
+  },
+  "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
+  "license": "MIT",
+  "main": "./dist/index.js",
+  "module": "./esm/index.js",
+  "types": "./esm/index.d.ts",
+  "devDependencies": {
+    "@microsoft/api-extractor": "7.9.10",
+    "@rollup/plugin-commonjs": "11.0.2",
+    "@rollup/plugin-json": "^4.0.0",
+    "@rollup/plugin-multi-entry": "^3.0.0",
+    "@rollup/plugin-node-resolve": "^8.0.0",
+    "mkdirp": "^1.0.4",
+    "rollup": "^1.16.3",
+    "rollup-plugin-sourcemaps": "^0.4.2",
+    "rollup-plugin-node-resolve": "^3.4.0",
+    "typescript": "^3.1.1",
+    "uglify-js": "^3.4.9"
+  },
+  "homepage": "https://github.com/Azure/azure-sdk-for-js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Azure/azure-sdk-for-js.git"
+  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.js.map",
+    "dist/**/*.d.ts",
+    "dist/**/*.d.ts.map",
+    "esm/**/*.js",
+    "esm/**/*.js.map",
+    "esm/**/*.d.ts",
+    "esm/**/*.d.ts.map",
+    "src/**/*.ts",
+    "README.md",
+    "rollup.config.js",
+    "tsconfig.json",
+    "review/*"
+  ],
+  "scripts": {
+    "build": "tsc && rollup -c rollup.config.js && npm run minify && mkdirp ./review &&  npm run extract-api",
+    "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
+    "prepack": "npm install && npm run build",
+    "extract-api": "api-extractor run --local"
+  },
+  "sideEffects": false,
+  "autoPublish": true
+}

--- a/test/integration/generated/skiplibcheck/rollup.config.js
+++ b/test/integration/generated/skiplibcheck/rollup.config.js
@@ -1,0 +1,180 @@
+import nodeResolve from "@rollup/plugin-node-resolve";
+import cjs from "@rollup/plugin-commonjs";
+import sourcemaps from "rollup-plugin-sourcemaps";
+import multiEntry from "@rollup/plugin-multi-entry";
+import json from "@rollup/plugin-json";
+
+import nodeBuiltins from "builtin-modules";
+
+/**
+ * Gets the proper configuration needed for rollup's commonJS plugin for @opentelemetry/api.
+ *
+ * NOTE: this manual configuration is only needed because OpenTelemetry uses an
+ * __exportStar downleveled helper function to declare its exports which confuses
+ * rollup's automatic discovery mechanism.
+ *
+ * @returns an object reference that can be `...`'d into your cjs() configuration.
+ */
+export function openTelemetryCommonJs() {
+  const namedExports = {};
+
+  for (const key of [
+    "@opentelemetry/api",
+    "@azure/core-tracing/node_modules/@opentelemetry/api"
+  ]) {
+    namedExports[key] = [
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "SpanStatusCode",
+      "getSpanContext",
+      "setSpanContext"
+    ];
+  }
+
+  const releasedOpenTelemetryVersions = ["0.10.2", "1.0.0-rc.0"];
+
+  for (const version of releasedOpenTelemetryVersions) {
+    namedExports[
+      // working around a limitation in the rollup common.js plugin - it's not able to resolve these modules so the named exports listed above will not get applied. We have to drill down to the actual path.
+      `../../../common/temp/node_modules/.pnpm/@opentelemetry/api@${version}/node_modules/@opentelemetry/api/build/src/index.js`
+    ] = [
+      "SpanKind",
+      "TraceFlags",
+      "getSpan",
+      "setSpan",
+      "StatusCode",
+      "CanonicalCode",
+      "getSpanContext",
+      "setSpanContext"
+    ];
+  }
+
+  return namedExports;
+}
+
+// #region Warning Handler
+
+/**
+ * A function that can determine whether a rollupwarning should be ignored. If
+ * the function returns `true`, then the warning will not be displayed.
+ */
+
+function ignoreNiseSinonEvalWarnings(warning) {
+  return (
+    warning.code === "EVAL" &&
+    warning.id &&
+      (warning.id.includes("node_modules/nise") ||
+        warning.id.includes("node_modules/sinon")) === true
+  );
+}
+
+function ignoreChaiCircularDependencyWarnings(warning) {
+  return (
+    warning.code === "CIRCULAR_DEPENDENCY" &&
+    warning.importer && warning.importer.includes("node_modules/chai") === true
+  );
+}
+
+const warningInhibitors = [
+  ignoreChaiCircularDependencyWarnings,
+  ignoreNiseSinonEvalWarnings
+];
+
+/**
+ * Construct a warning handler for the shared rollup configuration
+ * that ignores certain warnings that are not relevant to testing.
+ */
+function makeOnWarnForTesting() {
+  return (warning, warn) => {
+    // If every inhibitor returns false (i.e. no inhibitors), then show the warning
+    if (warningInhibitors.every((inhib) => !inhib(warning))) {
+      warn(warning);
+    }
+  };
+}
+
+// #endregion
+
+function makeBrowserTestConfig() {
+  const config = {
+    input: {
+      include: ["dist-esm/test/**/*.spec.js"],
+      exclude: ["dist-esm/test/**/node/**"]
+    },
+    output: {
+      file: `dist-test/index.browser.js`,
+      format: "umd",
+      sourcemap: true
+    },
+    preserveSymlinks: false,
+    plugins: [
+      multiEntry({ exports: false }),
+      nodeResolve({
+        mainFields: ["module", "browser"]
+      }),
+      cjs({
+        namedExports: {
+          // Chai's strange internal architecture makes it impossible to statically
+          // analyze its exports.
+          chai: [
+            "version",
+            "use",
+            "util",
+            "config",
+            "expect",
+            "should",
+            "assert"
+          ],
+          ...openTelemetryCommonJs()
+        }
+      }),
+      json(),
+      sourcemaps()
+      //viz({ filename: "dist-test/browser-stats.html", sourcemap: true })
+    ],
+    onwarn: makeOnWarnForTesting(),
+    // Disable tree-shaking of test code.  In rollup-plugin-node-resolve@5.0.0,
+    // rollup started respecting the "sideEffects" field in package.json.  Since
+    // our package.json sets "sideEffects=false", this also applies to test
+    // code, which causes all tests to be removed by tree-shaking.
+    treeshake: false
+  };
+
+  return config;
+}
+
+const defaultConfigurationOptions = {
+  disableBrowserBundle: false
+};
+
+export function makeConfig(pkg, options) {
+  options = {
+    ...defaultConfigurationOptions,
+    ...(options || {})
+  };
+
+  const baseConfig = {
+    // Use the package's module field if it has one
+    input: pkg["module"] || "dist-esm/src/index.js",
+    external: [
+      ...nodeBuiltins,
+      ...Object.keys(pkg.dependencies),
+      ...Object.keys(pkg.devDependencies)
+    ],
+    output: { file: "dist/index.js", format: "cjs", sourcemap: true },
+    preserveSymlinks: false,
+    plugins: [sourcemaps(), nodeResolve(), cjs()]
+  };
+
+  const config = [baseConfig];
+
+  if (!options.disableBrowserBundle) {
+    config.push(makeBrowserTestConfig());
+  }
+
+  return config;
+}
+
+export default makeConfig(require("./package.json"));

--- a/test/integration/generated/skiplibcheck/src/index.ts
+++ b/test/integration/generated/skiplibcheck/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./models";
+export { SkipLibCheckClient } from "./skipLibCheckClient";
+export { SkipLibCheckClientContext } from "./skipLibCheckClientContext";

--- a/test/integration/generated/skiplibcheck/src/models/index.ts
+++ b/test/integration/generated/skiplibcheck/src/models/index.ts
@@ -1,0 +1,34 @@
+import * as coreClient from "@azure/core-client";
+
+/** Known values of {@link Enum0} that the service accepts. */
+export const enum KnownEnum0 {
+  One = "one",
+  Two = "two"
+}
+
+/**
+ * Defines values for Enum0. \
+ * {@link KnownEnum0} can be used interchangeably with Enum0,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **one** \
+ * **two**
+ */
+export type Enum0 = string;
+
+/** Optional parameters. */
+export interface SkipLibCheckClientApiV1ValueGetOptionalParams
+  extends coreClient.OperationOptions {}
+
+/** Contains response data for the apiV1ValueGet operation. */
+export type SkipLibCheckClientApiV1ValueGetResponse = {
+  /** The parsed response body. */
+  body: string;
+};
+
+/** Optional parameters. */
+export interface SkipLibCheckClientOptionalParams
+  extends coreClient.ServiceClientOptions {
+  /** Overrides client endpoint. */
+  endpoint?: string;
+}

--- a/test/integration/generated/skiplibcheck/src/models/parameters.ts
+++ b/test/integration/generated/skiplibcheck/src/models/parameters.ts
@@ -1,0 +1,36 @@
+import { OperationParameter, OperationURLParameter } from "@azure/core-client";
+
+export const accept: OperationParameter = {
+  parameterPath: "accept",
+  mapper: {
+    defaultValue: "application/json",
+    isConstant: true,
+    serializedName: "Accept",
+    type: {
+      name: "String"
+    }
+  }
+};
+
+export const $host: OperationURLParameter = {
+  parameterPath: "$host",
+  mapper: {
+    serializedName: "$host",
+    required: true,
+    type: {
+      name: "String"
+    }
+  },
+  skipEncoding: true
+};
+
+export const apiVersion: OperationParameter = {
+  parameterPath: "apiVersion",
+  mapper: {
+    serializedName: "api-version",
+    required: true,
+    type: {
+      name: "String"
+    }
+  }
+};

--- a/test/integration/generated/skiplibcheck/src/skipLibCheckClient.ts
+++ b/test/integration/generated/skiplibcheck/src/skipLibCheckClient.ts
@@ -1,0 +1,47 @@
+import * as coreClient from "@azure/core-client";
+import * as Parameters from "./models/parameters";
+import { SkipLibCheckClientContext } from "./skipLibCheckClientContext";
+import {
+  SkipLibCheckClientOptionalParams,
+  Enum0,
+  SkipLibCheckClientApiV1ValueGetOptionalParams,
+  SkipLibCheckClientApiV1ValueGetResponse
+} from "./models";
+
+export class SkipLibCheckClient extends SkipLibCheckClientContext {
+  /**
+   * Initializes a new instance of the SkipLibCheckClient class.
+   * @param $host server parameter
+   * @param apiVersion
+   * @param options The parameter options
+   */
+  constructor(
+    $host: string,
+    apiVersion: Enum0,
+    options?: SkipLibCheckClientOptionalParams
+  ) {
+    super($host, apiVersion, options);
+  }
+
+  /** @param options The options parameters. */
+  apiV1ValueGet(
+    options?: SkipLibCheckClientApiV1ValueGetOptionalParams
+  ): Promise<SkipLibCheckClientApiV1ValueGetResponse> {
+    return this.sendOperationRequest({ options }, apiV1ValueGetOperationSpec);
+  }
+}
+// Operation Specifications
+const serializer = coreClient.createSerializer({}, /* isXml */ false);
+
+const apiV1ValueGetOperationSpec: coreClient.OperationSpec = {
+  path: "/api/v1/value",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: { type: { name: "String" } }
+    }
+  },
+  urlParameters: [Parameters.$host],
+  headerParameters: [Parameters.accept, Parameters.apiVersion],
+  serializer
+};

--- a/test/integration/generated/skiplibcheck/src/skipLibCheckClientContext.ts
+++ b/test/integration/generated/skiplibcheck/src/skipLibCheckClientContext.ts
@@ -1,0 +1,44 @@
+import * as coreClient from "@azure/core-client";
+import { Enum0, SkipLibCheckClientOptionalParams } from "./models";
+
+export class SkipLibCheckClientContext extends coreClient.ServiceClient {
+  $host: string;
+  apiVersion: Enum0;
+
+  /**
+   * Initializes a new instance of the SkipLibCheckClientContext class.
+   * @param $host server parameter
+   * @param apiVersion
+   * @param options The parameter options
+   */
+  constructor(
+    $host: string,
+    apiVersion: Enum0,
+    options?: SkipLibCheckClientOptionalParams
+  ) {
+    if ($host === undefined) {
+      throw new Error("'$host' cannot be null");
+    }
+    if (apiVersion === undefined) {
+      throw new Error("'apiVersion' cannot be null");
+    }
+
+    // Initializing default values for options
+    if (!options) {
+      options = {};
+    }
+    const defaults: SkipLibCheckClientOptionalParams = {
+      requestContentType: "application/json; charset=utf-8"
+    };
+
+    const optionsWithDefaults = {
+      ...defaults,
+      ...options,
+      baseUri: options.endpoint || "{$host}"
+    };
+    super(optionsWithDefaults);
+    // Parameter assignments
+    this.$host = $host;
+    this.apiVersion = apiVersion;
+  }
+}

--- a/test/integration/generated/skiplibcheck/tsconfig.json
+++ b/test/integration/generated/skiplibcheck/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "es6",
+    "moduleResolution": "node",
+    "strict": true,
+    "target": "es5",
+    "sourceMap": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "preserveConstEnums": true,
+    "lib": ["es6", "dom"],
+    "declaration": true,
+    "outDir": "./esm",
+    "importHelpers": true,
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/test/integration/skipLibCheck.spec.ts
+++ b/test/integration/skipLibCheck.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from "chai";
+import * as fs from "fs";
+
+describe("Skiplib Check", () => {
+  it("tsconfig must have skiplibcheck property", async () => {
+    const content: string = fs.readFileSync(
+      "./test/integration/generated/skiplibcheck/tsconfig.json",
+      "utf-8"
+    );
+    const containsLicenseHeader = content.includes('"skipLibCheck": true');
+    expect(containsLicenseHeader).to.equal(
+      true,
+      "Expected skipLibCheck in tsconfig file"
+    );
+  });
+});

--- a/test/utils/run.ts
+++ b/test/utils/run.ts
@@ -24,7 +24,8 @@ export async function runAutorest(
     hideClients,
     ignoreNullableOnOptional,
     title,
-    restLevelClient
+    restLevelClient,
+    skipLibCheck
   } = options;
   let autorestCommand = `autorest${
     /^win/.test(process.platform) ? ".cmd" : ""
@@ -79,6 +80,9 @@ export async function runAutorest(
   }
   if (packageDetails.version !== "") {
     commandArguments.push(`--package-version=${packageDetails.version}`);
+  }
+  if (skipLibCheck) {
+    commandArguments.push(`--skip-lib-check=${!!skipLibCheck}`);
   }
 
   commandArguments.push(

--- a/test/utils/test-swagger-gen.ts
+++ b/test/utils/test-swagger-gen.ts
@@ -17,6 +17,7 @@ interface SwaggerConfig {
   useCoreV2?: boolean;
   allowInsecureConnection?: boolean;
   restLevelClient?: boolean;
+  skipLibCheck?: boolean;
 }
 
 const package_version = "1.0.0-preview1";
@@ -665,6 +666,13 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     allowInsecureConnection: true,
     addCredentials: false
   },
+  skiplibcheck: {
+    swaggerOrConfig: "test/integration/swaggers/license-header.json",
+    clientName: "SkipLibCheckClient",
+    packageName: "skip-lib-check",
+    addCredentials: false,
+    skipLibCheck: true
+  },
   // TEST REST LEVEL CLIENTS
   bodyStringRest: {
     swaggerOrConfig: "body-string.json",
@@ -701,6 +709,7 @@ const generateSwaggers = async (
       ignoreNullableOnOptional,
       useCoreV2,
       allowInsecureConnection,
+      skipLibCheck,
       restLevelClient
     } = testSwaggers[name];
 
@@ -734,7 +743,8 @@ const generateSwaggers = async (
         ignoreNullableOnOptional,
         useCoreV2,
         allowInsecureConnection,
-        restLevelClient
+        restLevelClient,
+        skipLibCheck
       },
       isDebugging
     );

--- a/tsconfig.browser-test.json
+++ b/tsconfig.browser-test.json
@@ -34,10 +34,12 @@
     "test/integration/generated/appconfigurationexport/*.ts",
     "test/integration/generated/mapperrequired/*.ts",
     "test/integration/generated/nameChecker/*.ts",
+    "test/integration/generated/skiplibcheck/*.ts",
     "test/integration/licenseHeader.spec.ts",
     "test/integration/bodyFormData.spec.ts",
     "test/integration/appConfigurationExport.spec.ts",
     "test/integration/mapperRequired.spec.ts",
-    "test/integration/nameChecker.spec.ts"
+    "test/integration/nameChecker.spec.ts",
+    "test/integration/skipLibCheck.spec.ts"
   ]
 }


### PR DESCRIPTION
Before  a few days, We encountered a CI failure in our SDK Generator repository that was caused by a break in one of our underlying dependency packages (express). We were able to remove that dependency (since it was not used anyway) and resolve the CI failures. If we could not have removed it, then we might be forced to add skipLibCheck to our tsconfig json files.

Accidentally, a similar request has come from a customer at https://github.com/Azure/autorest.typescript/issues/883. So, I have added a flag `skip-lib-check` to check and add the flag to the generated tsconfig.json file.

@joheredi @deyaaeldeen Please review and approve.

@ramya-rao-a FYI...