### PR TITLE
Convert Target of generated SDKs to v6

### DIFF
--- a/src/generators/static/tsConfigFileGenerator.ts
+++ b/src/generators/static/tsConfigFileGenerator.ts
@@ -9,7 +9,7 @@ const highLevelTsConfig = {
     module: "es6",
     moduleResolution: "node",
     strict: true,
-    target: "es5",
+    target: "es6",
     sourceMap: true,
     declarationMap: true,
     esModuleInterop: true,

--- a/test/integration/generated/additionalProperties/tsconfig.json
+++ b/test/integration/generated/additionalProperties/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/appconfiguration/tsconfig.json
+++ b/test/integration/generated/appconfiguration/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/appconfigurationexport/tsconfig.json
+++ b/test/integration/generated/appconfigurationexport/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/arrayConstraints/tsconfig.json
+++ b/test/integration/generated/arrayConstraints/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/attestation/tsconfig.json
+++ b/test/integration/generated/attestation/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/azureParameterGrouping/tsconfig.json
+++ b/test/integration/generated/azureParameterGrouping/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/azureReport/tsconfig.json
+++ b/test/integration/generated/azureReport/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/azureSpecialProperties/tsconfig.json
+++ b/test/integration/generated/azureSpecialProperties/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyArray/tsconfig.json
+++ b/test/integration/generated/bodyArray/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyBoolean/tsconfig.json
+++ b/test/integration/generated/bodyBoolean/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyBooleanQuirks/tsconfig.json
+++ b/test/integration/generated/bodyBooleanQuirks/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyByte/tsconfig.json
+++ b/test/integration/generated/bodyByte/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyComplex/tsconfig.json
+++ b/test/integration/generated/bodyComplex/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyComplexWithTracing/tsconfig.json
+++ b/test/integration/generated/bodyComplexWithTracing/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyDate/tsconfig.json
+++ b/test/integration/generated/bodyDate/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyDateTime/tsconfig.json
+++ b/test/integration/generated/bodyDateTime/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyDateTimeRfc1123/tsconfig.json
+++ b/test/integration/generated/bodyDateTimeRfc1123/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyDictionary/tsconfig.json
+++ b/test/integration/generated/bodyDictionary/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyDuration/tsconfig.json
+++ b/test/integration/generated/bodyDuration/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyFile/tsconfig.json
+++ b/test/integration/generated/bodyFile/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyFormData/tsconfig.json
+++ b/test/integration/generated/bodyFormData/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyInteger/tsconfig.json
+++ b/test/integration/generated/bodyInteger/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyNumber/tsconfig.json
+++ b/test/integration/generated/bodyNumber/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyString/tsconfig.json
+++ b/test/integration/generated/bodyString/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/bodyTime/tsconfig.json
+++ b/test/integration/generated/bodyTime/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/constantParam/tsconfig.json
+++ b/test/integration/generated/constantParam/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/customUrl/tsconfig.json
+++ b/test/integration/generated/customUrl/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/customUrlMoreOptions/tsconfig.json
+++ b/test/integration/generated/customUrlMoreOptions/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/customUrlPaging/tsconfig.json
+++ b/test/integration/generated/customUrlPaging/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/extensibleEnums/tsconfig.json
+++ b/test/integration/generated/extensibleEnums/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/header/tsconfig.json
+++ b/test/integration/generated/header/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/headerprefix/tsconfig.json
+++ b/test/integration/generated/headerprefix/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/httpInfrastructure/tsconfig.json
+++ b/test/integration/generated/httpInfrastructure/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/licenseHeader/tsconfig.json
+++ b/test/integration/generated/licenseHeader/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/lro/tsconfig.json
+++ b/test/integration/generated/lro/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/lroParametrizedEndpoints/tsconfig.json
+++ b/test/integration/generated/lroParametrizedEndpoints/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/mapperrequired/tsconfig.json
+++ b/test/integration/generated/mapperrequired/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/mediaTypes/tsconfig.json
+++ b/test/integration/generated/mediaTypes/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/mediaTypesV3/tsconfig.json
+++ b/test/integration/generated/mediaTypesV3/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/mediaTypesV3Lro/tsconfig.json
+++ b/test/integration/generated/mediaTypesV3Lro/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/mediaTypesWithTracing/tsconfig.json
+++ b/test/integration/generated/mediaTypesWithTracing/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/modelFlattening/tsconfig.json
+++ b/test/integration/generated/modelFlattening/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/multipleInheritance/tsconfig.json
+++ b/test/integration/generated/multipleInheritance/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/nameChecker/tsconfig.json
+++ b/test/integration/generated/nameChecker/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/noLicenseHeader/tsconfig.json
+++ b/test/integration/generated/noLicenseHeader/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/noMappers/tsconfig.json
+++ b/test/integration/generated/noMappers/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/noOperation/tsconfig.json
+++ b/test/integration/generated/noOperation/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/nonStringEnum/tsconfig.json
+++ b/test/integration/generated/nonStringEnum/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/objectType/tsconfig.json
+++ b/test/integration/generated/objectType/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/odataDiscriminator/tsconfig.json
+++ b/test/integration/generated/odataDiscriminator/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/operationgroupclash/tsconfig.json
+++ b/test/integration/generated/operationgroupclash/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/optionalnull/tsconfig.json
+++ b/test/integration/generated/optionalnull/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/paging/tsconfig.json
+++ b/test/integration/generated/paging/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/pagingNoIterators/tsconfig.json
+++ b/test/integration/generated/pagingNoIterators/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/petstore/tsconfig.json
+++ b/test/integration/generated/petstore/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/readmeFileChecker/tsconfig.json
+++ b/test/integration/generated/readmeFileChecker/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/regexConstraint/tsconfig.json
+++ b/test/integration/generated/regexConstraint/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/report/tsconfig.json
+++ b/test/integration/generated/report/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/requiredOptional/tsconfig.json
+++ b/test/integration/generated/requiredOptional/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/storageblob/tsconfig.json
+++ b/test/integration/generated/storageblob/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/storagefileshare/tsconfig.json
+++ b/test/integration/generated/storagefileshare/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/subscriptionIdApiVersion/tsconfig.json
+++ b/test/integration/generated/subscriptionIdApiVersion/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/textanalytics/src/models/index.ts
+++ b/test/integration/generated/textanalytics/src/models/index.ts
@@ -14,7 +14,7 @@ export interface MultiLanguageBatchInput {
   documents: TextDocumentInput[];
 }
 
-/** Contains an input document to be analyzed by the service. */
+/** An object representing an individual text document to be analyzed by the Text Analytics service. The document contains a unique document ID, the full text of the document, and the language of the document's text. */
 export interface TextDocumentInput {
   /** A unique, non-empty document identifier. */
   id: string;
@@ -391,6 +391,7 @@ export interface LanguageBatchInput {
   documents: DetectLanguageInput[];
 }
 
+/** An input to the language detection operation. This object specifies a unique document id, as well as the full text of a document and a hint indicating the document's country of origin to assist the text analytics predictive model in detecting the document's language. */
 export interface DetectLanguageInput {
   /** Unique, non-empty document identifier. */
   id: string;

--- a/test/integration/generated/textanalytics/src/models/index.ts
+++ b/test/integration/generated/textanalytics/src/models/index.ts
@@ -14,7 +14,7 @@ export interface MultiLanguageBatchInput {
   documents: TextDocumentInput[];
 }
 
-/** An object representing an individual text document to be analyzed by the Text Analytics service. The document contains a unique document ID, the full text of the document, and the language of the document's text. */
+/** Contains an input document to be analyzed by the service. */
 export interface TextDocumentInput {
   /** A unique, non-empty document identifier. */
   id: string;
@@ -391,7 +391,6 @@ export interface LanguageBatchInput {
   documents: DetectLanguageInput[];
 }
 
-/** An input to the language detection operation. This object specifies a unique document id, as well as the full text of a document and a hint indicating the document's country of origin to assist the text analytics predictive model in detecting the document's language. */
 export interface DetectLanguageInput {
   /** Unique, non-empty document identifier. */
   id: string;

--- a/test/integration/generated/textanalytics/tsconfig.json
+++ b/test/integration/generated/textanalytics/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/url/tsconfig.json
+++ b/test/integration/generated/url/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/url2/tsconfig.json
+++ b/test/integration/generated/url2/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/urlMulti/tsconfig.json
+++ b/test/integration/generated/urlMulti/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/uuid/tsconfig.json
+++ b/test/integration/generated/uuid/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/validation/tsconfig.json
+++ b/test/integration/generated/validation/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/xmlservice/tsconfig.json
+++ b/test/integration/generated/xmlservice/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/integration/generated/xmsErrorResponses/tsconfig.json
+++ b/test/integration/generated/xmsErrorResponses/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/tsconfig.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-features-2015-12/tsconfig.json
+++ b/test/smoke/generated/arm-package-features-2015-12/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-links-2016-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-links-2016-09/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-locks-2016-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/tsconfig.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-policy-2019-09/tsconfig.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-resources-2019-08/tsconfig.json
+++ b/test/smoke/generated/arm-package-resources-2019-08/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/tsconfig.json
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/compute-resource-manager/tsconfig.json
+++ b/test/smoke/generated/compute-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/cosmos-db-resource-manager/tsconfig.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/graphrbac-data-plane/tsconfig.json
+++ b/test/smoke/generated/graphrbac-data-plane/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/keyvault-resource-manager/tsconfig.json
+++ b/test/smoke/generated/keyvault-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/monitor-data-plane/tsconfig.json
+++ b/test/smoke/generated/monitor-data-plane/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/msi-resource-manager/tsconfig.json
+++ b/test/smoke/generated/msi-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/network-resource-manager/tsconfig.json
+++ b/test/smoke/generated/network-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/sql-resource-manager/tsconfig.json
+++ b/test/smoke/generated/sql-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/storage-resource-manager/tsconfig.json
+++ b/test/smoke/generated/storage-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,

--- a/test/smoke/generated/web-resource-manager/tsconfig.json
+++ b/test/smoke/generated/web-resource-manager/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "es6",
     "moduleResolution": "node",
     "strict": true,
-    "target": "es5",
+    "target": "es6",
     "sourceMap": true,
     "declarationMap": true,
     "esModuleInterop": true,


### PR DESCRIPTION
As discussed in today's meeting, I am converting the target of the generated SDKs to v6. Related to https://github.com/Azure/autorest.typescript/issues/1026. 

@joheredi @deyaaeldeen Please review and approve.

@ramya-rao-a FYI....