### PR TITLE
add api-extractor.json, CHANGELOG.md and _meta.json to published package

### DIFF
--- a/src/generators/static/packageFileGenerator.ts
+++ b/src/generators/static/packageFileGenerator.ts
@@ -166,7 +166,10 @@ function regularAutorestPackage(
       "README.md",
       "rollup.config.js",
       "tsconfig.json",
-      "review/*"
+      "review/*",
+      "api-extractor.json",
+      "CHANGELOG.md",
+      "_meta.json"
     ],
     scripts: {
       build:

--- a/src/generators/static/packageFileGenerator.ts
+++ b/src/generators/static/packageFileGenerator.ts
@@ -167,9 +167,7 @@ function regularAutorestPackage(
       "rollup.config.js",
       "tsconfig.json",
       "review/*",
-      "api-extractor.json",
-      "CHANGELOG.md",
-      "_meta.json"
+      "CHANGELOG.md"
     ],
     scripts: {
       build:


### PR DESCRIPTION
This pr is to resolve https://github.com/Azure/autorest.typescript/issues/1028
I try to run `npm run test` in local, but it hungs in:
```
info: Registering route put /string/enum/Referenced (putEnumReferenced)
info: Registering route get /string/enum/ReferencedConstant (getEnumReferencedConstant)
info: Registering route put /string/enum/ReferencedConstant (putEnumReferencedConstant)
info: Registering route get /xml/bytes (XmlGetBytes)
info: Registering route put /xml/bytes (XmlPutBytes)
info: Registering route get /xml/url (XmlGetUrl)
info: Registering route put /xml/url (XmlPutUrl)
info: Started server on port 3000
```
Is there any other steps I missed?