### PR TITLE
Polling Reqs should not have bodies

### DIFF
--- a/src/lroImpl.ts
+++ b/src/lroImpl.ts
@@ -114,10 +114,7 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: (
-      args: Record<string, unknown>,
-      spec: Record<string, unknown>
-    ) => Promise<LroResponse<T>>,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
     private args: Record<string, unknown>,
     private spec: {
       requestBody?: unknown;

--- a/src/lroImpl.ts
+++ b/src/lroImpl.ts
@@ -4,8 +4,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -116,9 +114,16 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (
+      args: Record<string, unknown>,
+      spec: Record<string, unknown>
+    ) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      requestBody?: unknown;
+      path?: string;
+      httpMethod: string;
+    } & Record<string, unknown>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -126,12 +131,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/src/lroImpl.ts
+++ b/src/lroImpl.ts
@@ -117,10 +117,10 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
     private args: Record<string, unknown>,
     private spec: {
-      requestBody?: unknown;
-      path?: string;
-      httpMethod: string;
-    } & Record<string, unknown>,
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}

--- a/test/integration/generated/lro/src/lroImpl.ts
+++ b/test/integration/generated/lro/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/integration/generated/lroParametrizedEndpoints/src/lroImpl.ts
+++ b/test/integration/generated/lroParametrizedEndpoints/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/integration/generated/mediaTypesV3Lro/src/lroImpl.ts
+++ b/test/integration/generated/mediaTypesV3Lro/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/integration/generated/paging/src/lroImpl.ts
+++ b/test/integration/generated/paging/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/integration/generated/pagingNoIterators/src/lroImpl.ts
+++ b/test/integration/generated/pagingNoIterators/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lroImpl.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/lroImpl.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/arm-package-resources-2019-08/src/lroImpl.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/compute-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/compute-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/cosmos-db-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/keyvault-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/network-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/network-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/sql-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/sql-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/storage-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/storage-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });

--- a/test/smoke/generated/web-resource-manager/src/lroImpl.ts
+++ b/test/smoke/generated/web-resource-manager/src/lroImpl.ts
@@ -12,8 +12,6 @@ const successStates = ["succeeded"];
 const failureStates = ["failed", "canceled", "cancelled"];
 const terminalStates = successStates.concat(failureStates);
 
-type SendOperationFn<T> = (args: any, spec: any) => Promise<LroResponse<T>>;
-
 /**
  * We need to selectively deserialize our responses, only deserializing if we
  * are in a final Lro response, not deserializing any polling non-terminal responses
@@ -124,9 +122,13 @@ function getLroData(result: any): LroResponseInfo {
 
 export class LroImpl<T> implements LongRunningOperation<T> {
   constructor(
-    private sendOperationFn: SendOperationFn<T>,
-    private args: any,
-    private spec: any,
+    private sendOperationFn: (args: any, spec: any) => Promise<LroResponse<T>>,
+    private args: Record<string, unknown>,
+    private spec: {
+      readonly requestBody?: unknown;
+      readonly path?: string;
+      readonly httpMethod: string;
+    } & Record<string, any>,
     public requestPath: string = spec.path!,
     public requestMethod: string = spec.httpMethod
   ) {}
@@ -134,12 +136,13 @@ export class LroImpl<T> implements LongRunningOperation<T> {
     return this.sendOperationFn(this.args, this.spec);
   }
   public async sendPollRequest(path: string): Promise<LroResponse<T>> {
+    const { requestBody, ...restSpec } = this.spec;
     const updatedArgs = { ...this.args };
     if (updatedArgs.options) {
       (updatedArgs.options as any).shouldDeserialize = true;
     }
     return this.sendOperationFn(updatedArgs, {
-      ...this.spec,
+      ...restSpec,
       path,
       httpMethod: "GET"
     });


### PR DESCRIPTION
Polling requests should not have bodies so this PR leaves out the requestBody part from the operation spec used to send the GET request. This PR also gives stronger types for the operation spec field in `lroImpl` class.

Fixes https://github.com/Azure/autorest.typescript/issues/1117

~TODO: regenerate all tests.~

@sarangan12 could you please bring this issue up in the code gen crew and see if folks agree on adding a route to the autorest test server to test this behavior?