### PR TITLE
[RLC] Add test coverage for body string

### DIFF
--- a/src/generators/indexGenerator.ts
+++ b/src/generators/indexGenerator.ts
@@ -1,21 +1,67 @@
-import { Project } from "ts-morph";
+import { Project, SourceFile } from "ts-morph";
 import { ClientDetails } from "../models/clientDetails";
-import { getAutorestOptions } from "../autorestSession";
+import { getAutorestOptions, getSession } from "../autorestSession";
+import { NameType, normalizeName } from "../utils/nameUtils";
 
 export function generateIndexFile(
-  clientDetails: ClientDetails,
-  project: Project
+  project: Project,
+  clientDetails?: ClientDetails
 ) {
-  const { srcPath, disablePagingAsyncIterators } = getAutorestOptions();
+  const { restLevelClient, srcPath } = getAutorestOptions();
   const indexFile = project.createSourceFile(`${srcPath}/index.ts`, undefined, {
     overwrite: true
   });
 
+  if (!restLevelClient) {
+    if (!clientDetails) {
+      throw new Error(
+        "ClientDetails are required when generating High Level Clients"
+      );
+    }
+    generateHLCIndex(clientDetails, indexFile);
+  } else {
+    generateRLCIndex(indexFile);
+  }
+}
+
+function generateRLCIndex(file: SourceFile) {
+  const { model } = getSession();
+  const clientName = model.language.default.name;
+  const moduleName = normalizeName(clientName, NameType.File);
+
+  file.addImportDeclaration({
+    moduleSpecifier: `./${moduleName}`,
+    defaultImport: clientName
+  });
+
+  file.addExportDeclarations([
+    {
+      moduleSpecifier: `./${moduleName}`
+    },
+    {
+      moduleSpecifier: "./models"
+    },
+    {
+      moduleSpecifier: "./parameters"
+    },
+    {
+      moduleSpecifier: "./responses"
+    }
+  ]);
+
+  file.addExportAssignment({
+    expression: clientName,
+    isExportEquals: false
+  });
+}
+
+function generateHLCIndex(clientDetails: ClientDetails, file: SourceFile) {
+  const { disablePagingAsyncIterators } = getAutorestOptions();
   if (clientDetails.options.hasPaging && !disablePagingAsyncIterators) {
-    indexFile.addStatements([`/// <reference lib="esnext.asynciterable" />`]);
+    file.addStatements([`/// <reference lib="esnext.asynciterable" />`]);
   }
 
-  indexFile.addExportDeclarations([
+  file.addExportDeclarations([
     {
       moduleSpecifier: "./models"
     },
@@ -34,12 +80,12 @@ export function generateIndexFile(
   );
 
   if (operationGroups.length) {
-    indexFile.addExportDeclarations([
+    file.addExportDeclarations([
       {
         moduleSpecifier: "./operationsInterfaces"
       }
     ]);
   }
 
-  indexFile.fixUnusedIdentifiers();
+  file.fixUnusedIdentifiers();
 }

--- a/src/restLevelClient/generateParameterTypes.ts
+++ b/src/restLevelClient/generateParameterTypes.ts
@@ -107,6 +107,7 @@ function buildBodyParametersDefinition(
     name: bodyParameterInterfaceName,
     properties: [
       {
+        docs: bodySignature.docs,
         name: "body",
         type: bodySignature.type,
         hasQuestionToken: bodySignature.hasQuestionToken

--- a/src/restLevelClient/generateRestLevel.ts
+++ b/src/restLevelClient/generateRestLevel.ts
@@ -11,6 +11,7 @@ import { format } from "prettier";
 import { prettierJSONOptions, prettierTypeScriptOptions } from "./config";
 import { generateParameterInterfaces } from "./generateParameterTypes";
 import { generatePathFirstClient } from "./generateClient";
+import { generateIndexFile } from "../generators/indexGenerator";
 /**
  * Generates a Rest Level Client library
  */
@@ -34,6 +35,7 @@ export async function generateRestLevelClient() {
   generateSchemaTypes(model, project);
   generateParameterInterfaces(model, project);
   generatePathFirstClient(model, project);
+  generateIndexFile(project);
 
   // Save the source files to the virtual filesystem
   project.saveSync();

--- a/src/restLevelClient/getPropertySignature.ts
+++ b/src/restLevelClient/getPropertySignature.ts
@@ -1,7 +1,7 @@
 import { Parameter, Property } from "@autorest/codemodel";
 import { PropertySignatureStructure, StructureKind } from "ts-morph";
 import { getLanguageMetadata } from "../utils/languageHelpers";
-import { getElementType } from "./schemaHelpers";
+import { getElementType, getFormatDocs } from "./schemaHelpers";
 
 /**
  * Builds a Typescript property or parameter signature
@@ -16,7 +16,7 @@ export function getPropertySignature(
   const propertyLangMetadata = getLanguageMetadata(property.language);
   const propertyName = `"${propertyLangMetadata.serializedName ||
     propertyLangMetadata.name}"`;
-  const description = propertyLangMetadata.description;
+  const description = getDocs(property);
   const type = getElementType(property.schema, importedModels);
   return {
     name: propertyName,
@@ -25,4 +25,21 @@ export function getPropertySignature(
     type,
     kind: StructureKind.PropertySignature
   };
+}
+
+export function getDocs(property: Property | Parameter) {
+  const { description } = getLanguageMetadata(property.language);
+  const docs: string[] = [];
+
+  if (description) {
+    docs.push(description);
+  }
+
+  const formatDocs = getFormatDocs(property.schema);
+
+  if (formatDocs) {
+    docs.push(formatDocs);
+  }
+
+  return docs.join("\n\n");
 }

--- a/src/restLevelClient/schemaHelpers.ts
+++ b/src/restLevelClient/schemaHelpers.ts
@@ -1,6 +1,7 @@
 import {
   AnyObjectSchema,
   ArraySchema,
+  ByteArraySchema,
   ChoiceSchema,
   ConstantSchema,
   DictionarySchema,
@@ -97,6 +98,7 @@ function primitiveSchemaToType(schema: PrimitiveSchema): string {
       return "Date";
     case SchemaType.Char:
       return "string";
+    case SchemaType.ByteArray:
     case SchemaType.Binary:
     case SchemaType.Duration:
     case SchemaType.Credential:
@@ -107,8 +109,6 @@ function primitiveSchemaToType(schema: PrimitiveSchema): string {
       return "string";
     case SchemaType.Boolean:
       return "boolean";
-    case SchemaType.ByteArray:
-      return "Uint8Array";
     case SchemaType.Choice:
     case SchemaType.SealedChoice:
       return (schema as ChoiceSchema).choices
@@ -151,4 +151,24 @@ export function isDictionarySchema(schema: Schema): schema is DictionarySchema {
 
 export function isConstantSchema(schema: Schema): schema is ConstantSchema {
   return schema.type === SchemaType.Constant;
+}
+
+/**
+ * Gets additional documentation for a given schema
+ */
+export function getFormatDocs(schema: Schema) {
+  switch (schema.type) {
+    case SchemaType.ByteArray:
+      return "Value may contain base64 encoded characters";
+    case SchemaType.Binary:
+      return "Value may contain any sequence of octets";
+    case SchemaType.Credential:
+      return "Value may contain a password";
+    case SchemaType.Uuid:
+      return "Value may contain a UUID";
+    case SchemaType.Uri:
+      return "Value may contain a URL";
+    default:
+      return undefined;
+  }
 }

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -95,7 +95,7 @@ export async function generateTypeScriptLibrary(
   generateOperations(clientDetails, project);
   generateOperationsInterfaces(clientDetails, project);
   generateParameters(clientDetails, project);
-  generateIndexFile(clientDetails, project);
+  generateIndexFile(project, clientDetails);
   await generateLroFiles(clientDetails, project);
   generateTracingFile(project);
 

--- a/test/integration/bodyStringRest.spec.ts
+++ b/test/integration/bodyStringRest.spec.ts
@@ -1,0 +1,192 @@
+import { assert } from "chai";
+import BodyStringClient, {
+  BodyStringRestRestClient
+} from "./generated/bodyStringRest/src";
+
+describe(" BodyStringRest", () => {
+  let client: BodyStringRestRestClient;
+
+  beforeEach(() => {
+    client = BodyStringClient();
+  });
+
+  describe("Acceptance tests", () => {
+    it("should support valid null value", async function() {
+      const resource = client.path("/string/null");
+      const result = await resource.get({ allowInsecureConnection: true });
+
+      assert.equal(result.body, undefined);
+
+      const putResult = await resource.put({ allowInsecureConnection: true });
+      assert.equal(putResult.status, "200");
+    });
+
+    it("should support valid empty string value", async function() {
+      const resource = client.path("/string/empty");
+
+      const putResponse = await resource.put({
+        allowInsecureConnection: true,
+        body: ""
+      });
+      assert.equal(putResponse.status, "200");
+
+      const result = await resource.get({ allowInsecureConnection: true });
+      assert.equal(result.body, "");
+    });
+
+    it("should support whitespace string value", async function() {
+      const resource = client.path("/string/whitespace");
+      const putResult = await resource.put({
+        allowInsecureConnection: true,
+        body:
+          "    Now is the time for all good men to come to the aid of their country    "
+      });
+
+      const result = await resource.get({ allowInsecureConnection: true });
+
+      assert.equal(putResult.status, "200");
+      assert.equal(
+        result.body,
+        "    Now is the time for all good men to come to the aid of their country    "
+      );
+    });
+
+    it("should support not provided value", async function() {
+      const result = await client
+        .path("/string/notProvided")
+        .get({ allowInsecureConnection: true });
+      assert.isUndefined(result.body);
+    });
+
+    it("should support valid enum valid value", async function() {
+      const resource = client.path("/string/enum/Referenced");
+      const result = await resource.get({ allowInsecureConnection: true });
+
+      const putResult = await resource.put({
+        allowInsecureConnection: true,
+        body: "red color"
+      });
+
+      assert.equal(putResult.status, "200");
+      assert.equal(result.body, "red color");
+    });
+
+    it("should correctly handle invalid values for enum", async function() {
+      try {
+        await client
+          .path("/string/enum/notExpandable")
+          .put({ allowInsecureConnection: true, body: "orange color" } as any);
+        assert.fail("should have thrown error 'is not a valid value'");
+      } catch (error) {
+        assert.ok(error.message.match(/.*is not a valid value.*/gi));
+      }
+    });
+
+    it("should get a base64 encoded string", async function() {
+      const result = await client
+        .path("/string/base64Encoding")
+        .get({ allowInsecureConnection: true });
+
+      if (result.status !== "200") {
+        const error = `Unexpected status code ${result.status}`;
+        assert.fail(error);
+        throw error;
+      }
+
+      // a string that gets encoded with base64
+      const expected = "YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjQ=";
+
+      assert.equal(result.body, expected);
+    });
+
+    it("should correctly handle null base64url encoded string", async () => {
+      const result = await client
+        .path("/string/nullBase64UrlEncoding")
+        .get({ allowInsecureConnection: true });
+      assert.equal(result.status, "200");
+      assert.isUndefined(result.body);
+    });
+
+    it("should correctly send and receive a base64Url encoded string", async () => {
+      const result = await client
+        .path("/string/base64UrlEncoding")
+        .get({ allowInsecureConnection: true });
+      assert.equal(result.status, "200");
+
+      if (result.status !== "200") {
+        const error = `Unexpected status code ${result.status}`;
+        assert.fail(error);
+        throw error;
+      }
+
+      // a string that gets encoded with base64url
+      const expected =
+        "YSBzdHJpbmcgdGhhdCBnZXRzIGVuY29kZWQgd2l0aCBiYXNlNjR1cmw";
+
+      assert.equal(result.body, expected);
+
+      const result2 = await client
+        .path("/string/base64UrlEncoding")
+        .put({ allowInsecureConnection: true, body: expected });
+
+      assert.equal(result2.status, "200");
+    });
+
+    it("should getEnumReferenced", async function() {
+      const { body } = await client
+        .path("/string/enum/Referenced")
+        .get({ allowInsecureConnection: true });
+      assert.equal(body, "red color");
+    });
+
+    it("should putEnumReferenced", async function() {
+      const result = await client
+        .path("/string/enum/Referenced")
+        .put({ allowInsecureConnection: true, body: "red color" });
+
+      assert.equal(result.status, "200");
+    });
+
+    it("should getEnumReferencedConstant", async function() {
+      const result = await client
+        .path("/string/enum/ReferencedConstant")
+        .get({ allowInsecureConnection: true });
+
+      if (result.status !== "200") {
+        const error = `Unexpected status code ${result.status}`;
+        assert.fail(error);
+        throw error;
+      }
+
+      assert.equal(result.body.field1, "Sample String");
+    });
+
+    it("should putEnumReferencedConstant", async function() {
+      const result = await client.path("/string/enum/ReferencedConstant").put({
+        allowInsecureConnection: true,
+        body: { colorConstant: "green-color" }
+      });
+    });
+  });
+
+  describe("Mbcs", () => {
+    it("should receive an UTF8 string in the response body", async () => {
+      const result = await client
+        .path("/string/mbcs")
+        .get({ allowInsecureConnection: true });
+      assert.equal(
+        result.body,
+        "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"
+      );
+    });
+
+    it("should send an UTF8 string in the request body", async () => {
+      const result = await client.path("/string/mbcs").put({
+        allowInsecureConnection: true,
+        body:
+          "啊齄丂狛狜隣郎隣兀﨩ˊ〞〡￤℡㈱‐ー﹡﹢﹫、〓ⅰⅹ⒈€㈠㈩ⅠⅫ！￣ぁんァヶΑ︴АЯаяāɡㄅㄩ─╋︵﹄︻︱︳︴ⅰⅹɑɡ〇〾⿻⺁䜣€"
+      });
+      assert.equal(result.status, "200");
+    });
+  });
+});

--- a/test/integration/generated/bodyComplexRest/src/index.ts
+++ b/test/integration/generated/bodyComplexRest/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import BodyComplexRestClient from "./bodyComplexRestClient";
+
+export * from "./bodyComplexRestClient";
+export * from "./models";
+export * from "./parameters";
+export * from "./responses";
+
+export default BodyComplexRestClient;

--- a/test/integration/generated/bodyComplexRest/src/models.ts
+++ b/test/integration/generated/bodyComplexRest/src/models.ts
@@ -65,7 +65,8 @@ export interface DurationWrapper {
 }
 
 export interface ByteWrapper {
-  field?: Uint8Array;
+  /** Value may contain base64 encoded characters */
+  field?: string;
 }
 
 export interface ArrayWrapper {
@@ -160,7 +161,8 @@ export interface SharkBase extends FishBase {
 }
 
 export interface Sawshark extends SharkBase {
-  picture?: Uint8Array;
+  /** Value may contain base64 encoded characters */
+  picture?: string;
   fishtype: "sawshark";
 }
 

--- a/test/integration/generated/bodyComplexRest/src/parameters.ts
+++ b/test/integration/generated/bodyComplexRest/src/parameters.ts
@@ -26,6 +26,7 @@ import {
 export type BasicGetValidParameters = RequestParameters;
 
 export interface BasicPutValidBodyParam {
+  /** Please put {id: 2, name: 'abc', color: 'Magenta'} */
   body: BasicDef;
 }
 
@@ -38,6 +39,7 @@ export type BasicGetNotProvidedParameters = RequestParameters;
 export type PrimitiveGetIntParameters = RequestParameters;
 
 export interface PrimitivePutIntBodyParam {
+  /** Please put -1 and 2 */
   body: IntWrapper;
 }
 
@@ -46,6 +48,7 @@ export type PrimitivePutIntParameters = PrimitivePutIntBodyParam &
 export type PrimitiveGetLongParameters = RequestParameters;
 
 export interface PrimitivePutLongBodyParam {
+  /** Please put 1099511627775 and -999511627788 */
   body: LongWrapper;
 }
 
@@ -54,6 +57,7 @@ export type PrimitivePutLongParameters = PrimitivePutLongBodyParam &
 export type PrimitiveGetFloatParameters = RequestParameters;
 
 export interface PrimitivePutFloatBodyParam {
+  /** Please put 1.05 and -0.003 */
   body: FloatWrapper;
 }
 
@@ -62,6 +66,7 @@ export type PrimitivePutFloatParameters = PrimitivePutFloatBodyParam &
 export type PrimitiveGetDoubleParameters = RequestParameters;
 
 export interface PrimitivePutDoubleBodyParam {
+  /** Please put 3e-100 and -0.000000000000000000000000000000000000000000000000000000005 */
   body: DoubleWrapper;
 }
 
@@ -70,6 +75,7 @@ export type PrimitivePutDoubleParameters = PrimitivePutDoubleBodyParam &
 export type PrimitiveGetBoolParameters = RequestParameters;
 
 export interface PrimitivePutBoolBodyParam {
+  /** Please put true and false */
   body: BooleanWrapper;
 }
 
@@ -78,6 +84,7 @@ export type PrimitivePutBoolParameters = PrimitivePutBoolBodyParam &
 export type PrimitiveGetStringParameters = RequestParameters;
 
 export interface PrimitivePutStringBodyParam {
+  /** Please put 'goodrequest', '', and null */
   body: StringWrapper;
 }
 
@@ -86,6 +93,7 @@ export type PrimitivePutStringParameters = PrimitivePutStringBodyParam &
 export type PrimitiveGetDateParameters = RequestParameters;
 
 export interface PrimitivePutDateBodyParam {
+  /** Please put '0001-01-01' and '2016-02-29' */
   body: DateWrapper;
 }
 
@@ -94,6 +102,7 @@ export type PrimitivePutDateParameters = PrimitivePutDateBodyParam &
 export type PrimitiveGetDateTimeParameters = RequestParameters;
 
 export interface PrimitivePutDateTimeBodyParam {
+  /** Please put '0001-01-01T12:00:00-04:00' and '2015-05-18T11:38:00-08:00' */
   body: DatetimeWrapper;
 }
 
@@ -102,6 +111,7 @@ export type PrimitivePutDateTimeParameters = PrimitivePutDateTimeBodyParam &
 export type PrimitiveGetDateTimeRfc1123Parameters = RequestParameters;
 
 export interface PrimitivePutDateTimeRfc1123BodyParam {
+  /** Please put 'Mon, 01 Jan 0001 12:00:00 GMT' and 'Mon, 18 May 2015 11:38:00 GMT' */
   body: Datetimerfc1123Wrapper;
 }
 
@@ -110,6 +120,7 @@ export type PrimitivePutDateTimeRfc1123Parameters = PrimitivePutDateTimeRfc1123B
 export type PrimitiveGetDurationParameters = RequestParameters;
 
 export interface PrimitivePutDurationBodyParam {
+  /** Please put 'P123DT22H14M12.011S' */
   body: DurationWrapper;
 }
 
@@ -118,6 +129,7 @@ export type PrimitivePutDurationParameters = PrimitivePutDurationBodyParam &
 export type PrimitiveGetByteParameters = RequestParameters;
 
 export interface PrimitivePutByteBodyParam {
+  /** Please put non-ascii byte string hex(FF FE FD FC 00 FA F9 F8 F7 F6) */
   body: ByteWrapper;
 }
 
@@ -126,6 +138,7 @@ export type PrimitivePutByteParameters = PrimitivePutByteBodyParam &
 export type ArrayGetValidParameters = RequestParameters;
 
 export interface ArrayPutValidBodyParam {
+  /** Please put an array with 4 items: "1, 2, 3, 4", "", null, "&S#$(*Y", "The quick brown fox jumps over the lazy dog" */
   body: ArrayWrapper;
 }
 
@@ -134,6 +147,7 @@ export type ArrayPutValidParameters = ArrayPutValidBodyParam &
 export type ArrayGetEmptyParameters = RequestParameters;
 
 export interface ArrayPutEmptyBodyParam {
+  /** Please put an empty array */
   body: ArrayWrapper;
 }
 
@@ -143,6 +157,7 @@ export type ArrayGetNotProvidedParameters = RequestParameters;
 export type DictionaryGetValidParameters = RequestParameters;
 
 export interface DictionaryPutValidBodyParam {
+  /** Please put a dictionary with 5 key-value pairs: "txt":"notepad", "bmp":"mspaint", "xls":"excel", "exe":"", "":null */
   body: DictionaryWrapper;
 }
 
@@ -151,6 +166,7 @@ export type DictionaryPutValidParameters = DictionaryPutValidBodyParam &
 export type DictionaryGetEmptyParameters = RequestParameters;
 
 export interface DictionaryPutEmptyBodyParam {
+  /** Please put an empty dictionary */
   body: DictionaryWrapper;
 }
 
@@ -161,6 +177,7 @@ export type DictionaryGetNotProvidedParameters = RequestParameters;
 export type InheritanceGetValidParameters = RequestParameters;
 
 export interface InheritancePutValidBodyParam {
+  /** Please put a siamese with id=2, name="Siameee", color=green, breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1 and food="french fries". */
   body: Siamese;
 }
 
@@ -169,6 +186,41 @@ export type InheritancePutValidParameters = InheritancePutValidBodyParam &
 export type PolymorphismGetValidParameters = RequestParameters;
 
 export interface PolymorphismPutValidBodyParam {
+  /**
+   * Please put a salmon that looks like this:
+   * {
+   *         'fishtype':'Salmon',
+   *         'location':'alaska',
+   *         'iswild':true,
+   *         'species':'king',
+   *         'length':1.0,
+   *         'siblings':[
+   *           {
+   *             'fishtype':'Shark',
+   *             'age':6,
+   *             'birthday': '2012-01-05T01:00:00Z',
+   *             'length':20.0,
+   *             'species':'predator',
+   *           },
+   *           {
+   *             'fishtype':'Sawshark',
+   *             'age':105,
+   *             'birthday': '1900-01-05T01:00:00Z',
+   *             'length':10.0,
+   *             'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
+   *             'species':'dangerous',
+   *           },
+   *           {
+   *             'fishtype': 'goblin',
+   *             'age': 1,
+   *             'birthday': '2015-08-08T00:00:00Z',
+   *             'length': 30.0,
+   *             'species': 'scary',
+   *             'jawsize': 5
+   *           }
+   *         ]
+   *       };
+   */
   body: Fish;
 }
 
@@ -194,6 +246,34 @@ export type PolymorphismPutMissingDiscriminatorParameters = PolymorphismPutMissi
   RequestParameters;
 
 export interface PolymorphismPutValidMissingRequiredBodyParam {
+  /**
+   * Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:
+   * {
+   *     "fishtype": "sawshark",
+   *     "species": "snaggle toothed",
+   *     "length": 18.5,
+   *     "age": 2,
+   *     "birthday": "2013-06-01T01:00:00Z",
+   *     "location": "alaska",
+   *     "picture": base64(FF FF FF FF FE),
+   *     "siblings": [
+   *         {
+   *             "fishtype": "shark",
+   *             "species": "predator",
+   *             "birthday": "2012-01-05T01:00:00Z",
+   *             "length": 20,
+   *             "age": 6
+   *         },
+   *         {
+   *             "fishtype": "sawshark",
+   *             "species": "dangerous",
+   *             "picture": base64(FF FF FF FF FE),
+   *             "length": 10,
+   *             "age": 105
+   *         }
+   *     ]
+   * }
+   */
   body: Fish;
 }
 
@@ -202,6 +282,61 @@ export type PolymorphismPutValidMissingRequiredParameters = PolymorphismPutValid
 export type PolymorphicrecursiveGetValidParameters = RequestParameters;
 
 export interface PolymorphicrecursivePutValidBodyParam {
+  /**
+   * Please put a salmon that looks like this:
+   * {
+   *     "fishtype": "salmon",
+   *     "species": "king",
+   *     "length": 1,
+   *     "age": 1,
+   *     "location": "alaska",
+   *     "iswild": true,
+   *     "siblings": [
+   *         {
+   *             "fishtype": "shark",
+   *             "species": "predator",
+   *             "length": 20,
+   *             "age": 6,
+   *             "siblings": [
+   *                 {
+   *                     "fishtype": "salmon",
+   *                     "species": "coho",
+   *                     "length": 2,
+   *                     "age": 2,
+   *                     "location": "atlantic",
+   *                     "iswild": true,
+   *                     "siblings": [
+   *                         {
+   *                             "fishtype": "shark",
+   *                             "species": "predator",
+   *                             "length": 20,
+   *                             "age": 6
+   *                         },
+   *                         {
+   *                             "fishtype": "sawshark",
+   *                             "species": "dangerous",
+   *                             "length": 10,
+   *                             "age": 105
+   *                         }
+   *                     ]
+   *                 },
+   *                 {
+   *                     "fishtype": "sawshark",
+   *                     "species": "dangerous",
+   *                     "length": 10,
+   *                     "age": 105
+   *                 }
+   *             ]
+   *         },
+   *         {
+   *             "fishtype": "sawshark",
+   *             "species": "dangerous",
+   *             "length": 10,
+   *             "age": 105
+   *         }
+   *     ]
+   * }
+   */
   body: Fish;
 }
 

--- a/test/integration/generated/bodyStringRest/src/index.ts
+++ b/test/integration/generated/bodyStringRest/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import BodyStringRest from "./bodyStringRest";
+
+export * from "./bodyStringRest";
+export * from "./models";
+export * from "./parameters";
+export * from "./responses";
+
+export default BodyStringRest;

--- a/test/integration/generated/bodyStringRest/src/parameters.ts
+++ b/test/integration/generated/bodyStringRest/src/parameters.ts
@@ -7,6 +7,7 @@ import { RefColorConstant } from "./models";
 export type StringGetNullParameters = RequestParameters;
 
 export interface StringPutNullBodyParam {
+  /** string body */
   body?: string;
 }
 
@@ -23,7 +24,12 @@ export type StringGetBase64EncodedParameters = RequestParameters;
 export type StringGetBase64UrlEncodedParameters = RequestParameters;
 
 export interface StringPutBase64UrlEncodedBodyParam {
-  body: Uint8Array;
+  /**
+   * string body
+   *
+   * Value may contain base64 encoded characters
+   */
+  body: string;
 }
 
 export type StringPutBase64UrlEncodedParameters = StringPutBase64UrlEncodedBodyParam &
@@ -32,6 +38,7 @@ export type StringGetNullBase64UrlEncodedParameters = RequestParameters;
 export type EnumGetNotExpandableParameters = RequestParameters;
 
 export interface EnumPutNotExpandableBodyParam {
+  /** string body */
   body: "red color" | "green-color" | "blue_color";
 }
 
@@ -40,6 +47,7 @@ export type EnumPutNotExpandableParameters = EnumPutNotExpandableBodyParam &
 export type EnumGetReferencedParameters = RequestParameters;
 
 export interface EnumPutReferencedBodyParam {
+  /** enum string body */
   body: "red color" | "green-color" | "blue_color";
 }
 
@@ -48,6 +56,7 @@ export type EnumPutReferencedParameters = EnumPutReferencedBodyParam &
 export type EnumGetReferencedConstantParameters = RequestParameters;
 
 export interface EnumPutReferencedConstantBodyParam {
+  /** enum string body */
   body: RefColorConstant;
 }
 

--- a/test/integration/generated/bodyStringRest/src/responses.ts
+++ b/test/integration/generated/bodyStringRest/src/responses.ts
@@ -115,7 +115,8 @@ export interface StringGetNotProvideddefaultResponse extends HttpResponse {
 /** Get value that is base64 encoded */
 export interface StringGetBase64Encoded200Response extends HttpResponse {
   status: "200";
-  body: Uint8Array;
+  /** Value may contain base64 encoded characters */
+  body: string;
 }
 
 /** Get value that is base64 encoded */
@@ -127,7 +128,8 @@ export interface StringGetBase64EncodeddefaultResponse extends HttpResponse {
 /** Get value that is base64url encoded */
 export interface StringGetBase64UrlEncoded200Response extends HttpResponse {
   status: "200";
-  body: Uint8Array;
+  /** Value may contain base64 encoded characters */
+  body: string;
 }
 
 /** Get value that is base64url encoded */
@@ -151,7 +153,8 @@ export interface StringPutBase64UrlEncodeddefaultResponse extends HttpResponse {
 /** Get null value that is expected to be base64url encoded */
 export interface StringGetNullBase64UrlEncoded200Response extends HttpResponse {
   status: "200";
-  body: Uint8Array;
+  /** Value may contain base64 encoded characters */
+  body: string;
 }
 
 /** Get null value that is expected to be base64url encoded */

--- a/test/integration/generated/multipleInheritanceRest/src/index.ts
+++ b/test/integration/generated/multipleInheritanceRest/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import MultipleInheritanceRestClient from "./multipleInheritanceRestClient";
+
+export * from "./multipleInheritanceRestClient";
+export * from "./models";
+export * from "./parameters";
+export * from "./responses";
+
+export default MultipleInheritanceRestClient;

--- a/test/integration/generated/multipleInheritanceRest/src/parameters.ts
+++ b/test/integration/generated/multipleInheritanceRest/src/parameters.ts
@@ -7,6 +7,7 @@ import { Horse, Pet, Feline, Cat, Kitten } from "./models";
 export type GetHorseParameters = RequestParameters;
 
 export interface PutHorseBodyParam {
+  /** Put a horse with name 'General' and isAShowHorse false */
   body: Horse;
 }
 
@@ -14,6 +15,7 @@ export type PutHorseParameters = PutHorseBodyParam & RequestParameters;
 export type GetPetParameters = RequestParameters;
 
 export interface PutPetBodyParam {
+  /** Put a pet with name 'Butter' */
   body: Pet;
 }
 
@@ -21,6 +23,7 @@ export type PutPetParameters = PutPetBodyParam & RequestParameters;
 export type GetFelineParameters = RequestParameters;
 
 export interface PutFelineBodyParam {
+  /** Put a feline who hisses and doesn't meow */
   body: Feline;
 }
 
@@ -28,6 +31,7 @@ export type PutFelineParameters = PutFelineBodyParam & RequestParameters;
 export type GetCatParameters = RequestParameters;
 
 export interface PutCatBodyParam {
+  /** Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true */
   body: Cat;
 }
 
@@ -35,6 +39,7 @@ export type PutCatParameters = PutCatBodyParam & RequestParameters;
 export type GetKittenParameters = RequestParameters;
 
 export interface PutKittenBodyParam {
+  /** Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true */
   body: Kitten;
 }
 


### PR DESCRIPTION
Adding test coverage for body string and making the following changes to the generator:

1. Generate index.ts
2. generate byteArray schemas as strings and add documentation to tell customers that the value may contain a base64 encoded string. We are not making it a Uint8Array because there is no good way to deserialize these strings without using some kind of mappers. We have decided to keep runtime thin and hand off that responsibility to the user, the SDK will return the value that the service returns, plus extra documentation to hint the user about the possible contents.
