### PR TITLE
Issue with npm install scripts in test libraries

### DIFF
--- a/src/autorestSession.ts
+++ b/src/autorestSession.ts
@@ -25,6 +25,7 @@ export interface AutorestOptions {
   skipEnumValidation?: boolean;
   azureOutputDirectory?: string;
   headAsBoolean?: boolean;
+  isTestPackage?: boolean;
 }
 
 let host: Host;

--- a/src/generators/static/README.md.hbs
+++ b/src/generators/static/README.md.hbs
@@ -30,7 +30,7 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - An [Azure subscription][azure_sub].
 {{/if}}
 
-{{#if isRealPackage}}
+{{#if isReleasablePackage}}
 ### Install the `{{ clientPackageName }}` package
 
 Install the {{ clientDescriptiveName }} library for JavaScript with `npm`:

--- a/src/generators/static/README.md.hbs
+++ b/src/generators/static/README.md.hbs
@@ -30,6 +30,7 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - An [Azure subscription][azure_sub].
 {{/if}}
 
+{{#if isRealPackage}}
 ### Install the `{{ clientPackageName }}` package
 
 Install the {{ clientDescriptiveName }} library for JavaScript with `npm`:
@@ -37,6 +38,7 @@ Install the {{ clientDescriptiveName }} library for JavaScript with `npm`:
 ```bash
 npm install {{ clientPackageName }}
 ```
+{{/if}}
 
 {{#if azure}}
 {{#if addCredentials}}

--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -47,8 +47,8 @@ interface Metadata {
   addCredentials?: boolean;
   /** The link to the identity package in the repository */
   identityPackageURL?: string;
-  /** Indicates if the package is a test/Package package. */
-  isRealPackage?: boolean;
+  /** Indicates if the package is a test/releasable package. */
+  isReleasablePackage?: boolean;
 }
 
 /**
@@ -124,7 +124,7 @@ function createMetadata(
     projectName: azureHuh ? "Microsoft Azure SDK for JavaScript" : undefined,
     addCredentials,
     identityPackageURL,
-    isRealPackage: !isTestPackage
+    isReleasablePackage: !isTestPackage
   };
 }
 

--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -47,6 +47,8 @@ interface Metadata {
   addCredentials?: boolean;
   /** The link to the identity package in the repository */
   identityPackageURL?: string;
+  /** Indicates if the package is a test/Package package. */
+  isRealPackage?: boolean;
 }
 
 /**
@@ -60,7 +62,8 @@ function createMetadata(
   clientDetails: ClientDetails,
   azureOutputDirectory?: string,
   addCredentials?: boolean,
-  azureArm?: boolean
+  azureArm?: boolean,
+  isTestPackage?: boolean
 ): Metadata {
   const azureHuh = packageDetails.scopeName === "azure";
   const repoURL = azureHuh
@@ -120,7 +123,8 @@ function createMetadata(
     contributingGuideURL: repoURL && `${repoURL}/blob/master/CONTRIBUTING.md`,
     projectName: azureHuh ? "Microsoft Azure SDK for JavaScript" : undefined,
     addCredentials,
-    identityPackageURL
+    identityPackageURL,
+    isRealPackage: !isTestPackage
   };
 }
 
@@ -133,7 +137,8 @@ export function generateReadmeFile(
     azureOutputDirectory,
     generateMetadata,
     addCredentials,
-    azureArm
+    azureArm,
+    isTestPackage
   } = getAutorestOptions();
 
   if (!generateMetadata) {
@@ -145,7 +150,8 @@ export function generateReadmeFile(
     clientDetails,
     azureOutputDirectory,
     addCredentials,
-    azureArm
+    azureArm,
+    isTestPackage
   );
   const file = fs.readFileSync(path.join(__dirname, "README.md.hbs"), {
     encoding: "utf-8"

--- a/src/utils/autorestOptions.ts
+++ b/src/utils/autorestOptions.ts
@@ -30,6 +30,7 @@ export async function extractAutorestOptions(): Promise<AutorestOptions> {
   const skipEnumValidation = await getSkipEnumValidation(host);
   const azureOutputDirectory = await getAzureOutputDirectoryPath(host);
   const headAsBoolean = await getHeadAsBoolean(host);
+  const isTestPackage = await getIsTestPackage(host);
 
   return {
     azureArm,
@@ -51,7 +52,8 @@ export async function extractAutorestOptions(): Promise<AutorestOptions> {
     skipEnumValidation,
     title,
     azureOutputDirectory,
-    headAsBoolean
+    headAsBoolean,
+    isTestPackage
   };
 }
 
@@ -59,6 +61,11 @@ async function getHeadAsBoolean(host: Host): Promise<boolean> {
   const headAsBoolean = await host.GetValue("head-as-boolean");
 
   return Boolean(headAsBoolean);
+}
+
+async function getIsTestPackage(host: Host): Promise<boolean> {
+  const isTestPackage: boolean = await host.GetValue("is-test-package");
+  return isTestPackage === null ? false : Boolean(isTestPackage);
 }
 
 async function getSkipEnumValidation(host: Host): Promise<boolean> {

--- a/test/integration/generated/additionalProperties/README.md
+++ b/test/integration/generated/additionalProperties/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `additional-properties` package
-
-Install the AdditionalProperties client library for JavaScript with `npm`:
-
-```bash
-npm install additional-properties
-```
 
 
 ## Key concepts

--- a/test/integration/generated/appconfiguration/README.md
+++ b/test/integration/generated/appconfiguration/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `appconfiguration` package
-
-Install the AppConfiguration client library for JavaScript with `npm`:
-
-```bash
-npm install appconfiguration
-```
 
 
 ## Key concepts

--- a/test/integration/generated/appconfigurationexport/README.md
+++ b/test/integration/generated/appconfigurationexport/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `appconfiguration` package
-
-Install the AppConfiguration client library for JavaScript with `npm`:
-
-```bash
-npm install appconfiguration
-```
 
 
 ## Key concepts

--- a/test/integration/generated/arrayConstraints/README.md
+++ b/test/integration/generated/arrayConstraints/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `array-constraints-client` package
-
-Install the ArrayConstraints client library for JavaScript with `npm`:
-
-```bash
-npm install array-constraints-client
-```
 
 
 ## Key concepts

--- a/test/integration/generated/attestation/README.md
+++ b/test/integration/generated/attestation/README.md
@@ -15,13 +15,6 @@ Describes the interface for the per-tenant enclave service.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `attestation` package
-
-Install the Generated client library for JavaScript with `npm`:
-
-```bash
-npm install attestation
-```
 
 
 ## Key concepts

--- a/test/integration/generated/azureParameterGrouping/README.md
+++ b/test/integration/generated/azureParameterGrouping/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `azure-parameter-grouping` package
-
-Install the AzureParameterGrouping client library for JavaScript with `npm`:
-
-```bash
-npm install azure-parameter-grouping
-```
 
 
 ## Key concepts

--- a/test/integration/generated/azureReport/README.md
+++ b/test/integration/generated/azureReport/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `zzzAzureReport` package
-
-Install the Report client library for JavaScript with `npm`:
-
-```bash
-npm install zzzAzureReport
-```
 
 
 ## Key concepts

--- a/test/integration/generated/azureSpecialProperties/README.md
+++ b/test/integration/generated/azureSpecialProperties/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `azure-special-properties` package
-
-Install the AzureSpecialProperties client library for JavaScript with `npm`:
-
-```bash
-npm install azure-special-properties
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyArray/README.md
+++ b/test/integration/generated/bodyArray/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-array` package
-
-Install the BodyArray client library for JavaScript with `npm`:
-
-```bash
-npm install body-array
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyBoolean/README.md
+++ b/test/integration/generated/bodyBoolean/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-boolean` package
-
-Install the BodyBoolean client library for JavaScript with `npm`:
-
-```bash
-npm install body-boolean
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyBooleanQuirks/README.md
+++ b/test/integration/generated/bodyBooleanQuirks/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-boolean-quirks` package
-
-Install the BodyBooleanQuirks client library for JavaScript with `npm`:
-
-```bash
-npm install body-boolean-quirks
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyByte/README.md
+++ b/test/integration/generated/bodyByte/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-byte` package
-
-Install the BodyByte client library for JavaScript with `npm`:
-
-```bash
-npm install body-byte
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyComplex/README.md
+++ b/test/integration/generated/bodyComplex/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-complex` package
-
-Install the BodyComplex client library for JavaScript with `npm`:
-
-```bash
-npm install body-complex
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyComplexWithTracing/README.md
+++ b/test/integration/generated/bodyComplexWithTracing/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-complex-tracing` package
-
-Install the Service client library for JavaScript with `npm`:
-
-```bash
-npm install body-complex-tracing
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyDate/README.md
+++ b/test/integration/generated/bodyDate/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-date` package
-
-Install the BodyDate client library for JavaScript with `npm`:
-
-```bash
-npm install body-date
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyDateTime/README.md
+++ b/test/integration/generated/bodyDateTime/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-datetime` package
-
-Install the BodyDateTime client library for JavaScript with `npm`:
-
-```bash
-npm install body-datetime
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyDateTimeRfc1123/README.md
+++ b/test/integration/generated/bodyDateTimeRfc1123/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-datetime-rfc1123` package
-
-Install the BodyDateTimeRfc1123 client library for JavaScript with `npm`:
-
-```bash
-npm install body-datetime-rfc1123
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyDictionary/README.md
+++ b/test/integration/generated/bodyDictionary/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-dictionary` package
-
-Install the BodyDictionary client library for JavaScript with `npm`:
-
-```bash
-npm install body-dictionary
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyDuration/README.md
+++ b/test/integration/generated/bodyDuration/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-duration` package
-
-Install the BodyDuration client library for JavaScript with `npm`:
-
-```bash
-npm install body-duration
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyFile/README.md
+++ b/test/integration/generated/bodyFile/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-file` package
-
-Install the BodyFile client library for JavaScript with `npm`:
-
-```bash
-npm install body-file
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyFormData/README.md
+++ b/test/integration/generated/bodyFormData/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-formdata` package
-
-Install the BodyFormData client library for JavaScript with `npm`:
-
-```bash
-npm install body-formdata
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyInteger/README.md
+++ b/test/integration/generated/bodyInteger/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-integer` package
-
-Install the BodyInteger client library for JavaScript with `npm`:
-
-```bash
-npm install body-integer
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyNumber/README.md
+++ b/test/integration/generated/bodyNumber/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-number` package
-
-Install the BodyNumber client library for JavaScript with `npm`:
-
-```bash
-npm install body-number
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyString/README.md
+++ b/test/integration/generated/bodyString/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-string` package
-
-Install the BodyString client library for JavaScript with `npm`:
-
-```bash
-npm install body-string
-```
 
 
 ## Key concepts

--- a/test/integration/generated/bodyTime/README.md
+++ b/test/integration/generated/bodyTime/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `body-time` package
-
-Install the BodyTime client library for JavaScript with `npm`:
-
-```bash
-npm install body-time
-```
 
 
 ## Key concepts

--- a/test/integration/generated/constantParam/README.md
+++ b/test/integration/generated/constantParam/README.md
@@ -15,13 +15,6 @@ The Text Analytics API is a suite of natural language processing (NLP) services 
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `constantParam` package
-
-Install the Generated client library for JavaScript with `npm`:
-
-```bash
-npm install constantParam
-```
 
 
 ## Key concepts

--- a/test/integration/generated/customUrl/README.md
+++ b/test/integration/generated/customUrl/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `custom-url` package
-
-Install the CustomUrl client library for JavaScript with `npm`:
-
-```bash
-npm install custom-url
-```
 
 
 ## Key concepts

--- a/test/integration/generated/customUrlMoreOptions/README.md
+++ b/test/integration/generated/customUrlMoreOptions/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `custom-url-MoreOptions` package
-
-Install the CustomUrlMoreOptions client library for JavaScript with `npm`:
-
-```bash
-npm install custom-url-MoreOptions
-```
 
 
 ## Key concepts

--- a/test/integration/generated/customUrlPaging/README.md
+++ b/test/integration/generated/customUrlPaging/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `custom-url-paging` package
-
-Install the CustomUrlPaging client library for JavaScript with `npm`:
-
-```bash
-npm install custom-url-paging
-```
 
 
 ## Key concepts

--- a/test/integration/generated/extensibleEnums/README.md
+++ b/test/integration/generated/extensibleEnums/README.md
@@ -15,13 +15,6 @@ PetStore
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `extensible-enums` package
-
-Install the ExtensibleEnums client library for JavaScript with `npm`:
-
-```bash
-npm install extensible-enums
-```
 
 
 ## Key concepts

--- a/test/integration/generated/header/README.md
+++ b/test/integration/generated/header/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `header` package
-
-Install the Header client library for JavaScript with `npm`:
-
-```bash
-npm install header
-```
 
 
 ## Key concepts

--- a/test/integration/generated/headerprefix/README.md
+++ b/test/integration/generated/headerprefix/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `headerprefix` package
-
-Install the HeaderPrefix client library for JavaScript with `npm`:
-
-```bash
-npm install headerprefix
-```
 
 
 ## Key concepts

--- a/test/integration/generated/httpInfrastructure/README.md
+++ b/test/integration/generated/httpInfrastructure/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `httpInfrastructure` package
-
-Install the HttpInfrastructure client library for JavaScript with `npm`:
-
-```bash
-npm install httpInfrastructure
-```
 
 
 ## Key concepts

--- a/test/integration/generated/iotspaces/README.md
+++ b/test/integration/generated/iotspaces/README.md
@@ -15,13 +15,6 @@ Use this API to manage the IoTSpaces service instances in your Azure subscriptio
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `iotspaces` package
-
-Install the IoTSpaces client library for JavaScript with `npm`:
-
-```bash
-npm install iotspaces
-```
 
 
 ## Key concepts

--- a/test/integration/generated/licenseHeader/README.md
+++ b/test/integration/generated/licenseHeader/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `license-header` package
-
-Install the LicenseHeader client library for JavaScript with `npm`:
-
-```bash
-npm install license-header
-```
 
 
 ## Key concepts

--- a/test/integration/generated/lro/README.md
+++ b/test/integration/generated/lro/README.md
@@ -15,13 +15,6 @@ Long-running Operation for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `lro` package
-
-Install the LRO client library for JavaScript with `npm`:
-
-```bash
-npm install lro
-```
 
 
 ## Key concepts

--- a/test/integration/generated/lroParametrizedEndpoints/README.md
+++ b/test/integration/generated/lroParametrizedEndpoints/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `lro-parameterized-endpoints` package
-
-Install the LroParametrizedEndpoints client library for JavaScript with `npm`:
-
-```bash
-npm install lro-parameterized-endpoints
-```
 
 
 ## Key concepts

--- a/test/integration/generated/mapperrequired/README.md
+++ b/test/integration/generated/mapperrequired/README.md
@@ -15,13 +15,6 @@ The key vault client performs cryptographic key operations and vault operations 
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `mapperrequired` package
-
-Install the MapperRequired client library for JavaScript with `npm`:
-
-```bash
-npm install mapperrequired
-```
 
 
 ## Key concepts

--- a/test/integration/generated/mediaTypes/README.md
+++ b/test/integration/generated/mediaTypes/README.md
@@ -15,13 +15,6 @@ Play with produces/consumes and media-types in general.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `media-types-service` package
-
-Install the MediaTypes client library for JavaScript with `npm`:
-
-```bash
-npm install media-types-service
-```
 
 
 ## Key concepts

--- a/test/integration/generated/mediaTypesV3/README.md
+++ b/test/integration/generated/mediaTypesV3/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `media-types-v3-client` package
-
-Install the MediaTypesV3 client library for JavaScript with `npm`:
-
-```bash
-npm install media-types-v3-client
-```
 
 
 ## Key concepts

--- a/test/integration/generated/mediaTypesV3Lro/README.md
+++ b/test/integration/generated/mediaTypesV3Lro/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `media-types-v3-lro-client` package
-
-Install the MediaTypesV3LRO client library for JavaScript with `npm`:
-
-```bash
-npm install media-types-v3-lro-client
-```
 
 
 ## Key concepts

--- a/test/integration/generated/mediaTypesWithTracing/README.md
+++ b/test/integration/generated/mediaTypesWithTracing/README.md
@@ -15,13 +15,6 @@ Play with produces/consumes and media-types in general.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `media-types-service-tracing` package
-
-Install the mediaTypesWithTracing client library for JavaScript with `npm`:
-
-```bash
-npm install media-types-service-tracing
-```
 
 
 ## Key concepts

--- a/test/integration/generated/modelFlattening/README.md
+++ b/test/integration/generated/modelFlattening/README.md
@@ -15,13 +15,6 @@ Resource Flattening for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `model-flattening` package
-
-Install the ModelFlattening client library for JavaScript with `npm`:
-
-```bash
-npm install model-flattening
-```
 
 
 ## Key concepts

--- a/test/integration/generated/multipleInheritance/README.md
+++ b/test/integration/generated/multipleInheritance/README.md
@@ -15,13 +15,6 @@ Service client for multiinheritance client testing
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `multiple-inheritance` package
-
-Install the MultipleInheritance client library for JavaScript with `npm`:
-
-```bash
-npm install multiple-inheritance
-```
 
 
 ## Key concepts

--- a/test/integration/generated/nameChecker/README.md
+++ b/test/integration/generated/nameChecker/README.md
@@ -19,13 +19,6 @@ Client that can be used to query an index and upload, merge, or delete documents
 
 - An [Azure subscription][azure_sub].
 
-### Install the `@azure/search-documents` package
-
-Install the Azure Search client library for JavaScript with `npm`:
-
-```bash
-npm install @azure/search-documents
-```
 
 
 ## Key concepts

--- a/test/integration/generated/noLicenseHeader/README.md
+++ b/test/integration/generated/noLicenseHeader/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `nolicense-header` package
-
-Install the NoLicenseHeader client library for JavaScript with `npm`:
-
-```bash
-npm install nolicense-header
-```
 
 
 ## Key concepts

--- a/test/integration/generated/noMappers/README.md
+++ b/test/integration/generated/noMappers/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `no-mappers` package
-
-Install the NoMappers client library for JavaScript with `npm`:
-
-```bash
-npm install no-mappers
-```
 
 
 ## Key concepts

--- a/test/integration/generated/noOperation/README.md
+++ b/test/integration/generated/noOperation/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `no-operation` package
-
-Install the NoOperations client library for JavaScript with `npm`:
-
-```bash
-npm install no-operation
-```
 
 
 ## Key concepts

--- a/test/integration/generated/nonStringEnum/README.md
+++ b/test/integration/generated/nonStringEnum/README.md
@@ -15,13 +15,6 @@ Testing non-string enums.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `non-string-num` package
-
-Install the NonStringEnum client library for JavaScript with `npm`:
-
-```bash
-npm install non-string-num
-```
 
 
 ## Key concepts

--- a/test/integration/generated/objectType/README.md
+++ b/test/integration/generated/objectType/README.md
@@ -15,13 +15,6 @@ Service client for testing basic type: object swaggers
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `object-type` package
-
-Install the ObjectType client library for JavaScript with `npm`:
-
-```bash
-npm install object-type
-```
 
 
 ## Key concepts

--- a/test/integration/generated/odataDiscriminator/README.md
+++ b/test/integration/generated/odataDiscriminator/README.md
@@ -15,13 +15,6 @@ Client that can be used to manage and query indexes and documents, as well as ma
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `odata-discriminator` package
-
-Install the ODataDiscriminator client library for JavaScript with `npm`:
-
-```bash
-npm install odata-discriminator
-```
 
 
 ## Key concepts

--- a/test/integration/generated/operationgroupclash/README.md
+++ b/test/integration/generated/operationgroupclash/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `operationgroupclash` package
-
-Install the OperationGroupClash client library for JavaScript with `npm`:
-
-```bash
-npm install operationgroupclash
-```
 
 
 ## Key concepts

--- a/test/integration/generated/optionalnull/README.md
+++ b/test/integration/generated/optionalnull/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `optionalnull` package
-
-Install the OptionalNull client library for JavaScript with `npm`:
-
-```bash
-npm install optionalnull
-```
 
 
 ## Key concepts

--- a/test/integration/generated/paging/README.md
+++ b/test/integration/generated/paging/README.md
@@ -15,13 +15,6 @@ Long-running Operation for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `paging-service` package
-
-Install the Paging client library for JavaScript with `npm`:
-
-```bash
-npm install paging-service
-```
 
 
 ## Key concepts

--- a/test/integration/generated/pagingNoIterators/README.md
+++ b/test/integration/generated/pagingNoIterators/README.md
@@ -15,13 +15,6 @@ Long-running Operation for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `paging-no-iterators` package
-
-Install the PagingNoIterators client library for JavaScript with `npm`:
-
-```bash
-npm install paging-no-iterators
-```
 
 
 ## Key concepts

--- a/test/integration/generated/petstore/README.md
+++ b/test/integration/generated/petstore/README.md
@@ -15,13 +15,6 @@ This is a sample server Petstore server.  You can find out more about Swagger at
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `petstore` package
-
-Install the Service client library for JavaScript with `npm`:
-
-```bash
-npm install petstore
-```
 
 
 ## Key concepts

--- a/test/integration/generated/readmeFileChecker/README.md
+++ b/test/integration/generated/readmeFileChecker/README.md
@@ -19,13 +19,6 @@ The key vault client performs cryptographic key operations and vault operations 
 
 - An [Azure subscription][azure_sub].
 
-### Install the `@azure/keyvault-secrets` package
-
-Install the Azure KeyVault client library for JavaScript with `npm`:
-
-```bash
-npm install @azure/keyvault-secrets
-```
 
 
 ## Key concepts

--- a/test/integration/generated/regexConstraint/README.md
+++ b/test/integration/generated/regexConstraint/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `regex-constraint` package
-
-Install the Service client library for JavaScript with `npm`:
-
-```bash
-npm install regex-constraint
-```
 
 
 ## Key concepts

--- a/test/integration/generated/report/README.md
+++ b/test/integration/generated/report/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `zzzReport` package
-
-Install the Report client library for JavaScript with `npm`:
-
-```bash
-npm install zzzReport
-```
 
 
 ## Key concepts

--- a/test/integration/generated/requiredOptional/README.md
+++ b/test/integration/generated/requiredOptional/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `required-optional` package
-
-Install the RequiredOptional client library for JavaScript with `npm`:
-
-```bash
-npm install required-optional
-```
 
 
 ## Key concepts

--- a/test/integration/generated/resources/README.md
+++ b/test/integration/generated/resources/README.md
@@ -15,13 +15,6 @@ Provides operations for working with resources and resource groups.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `resources` package
-
-Install the Resources client library for JavaScript with `npm`:
-
-```bash
-npm install resources
-```
 
 
 ## Key concepts

--- a/test/integration/generated/sealedchoice/README.md
+++ b/test/integration/generated/sealedchoice/README.md
@@ -15,13 +15,6 @@ Metadata API definition for the Azure Container Registry runtime
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `sealedchoice` package
-
-Install the SealedChoice client library for JavaScript with `npm`:
-
-```bash
-npm install sealedchoice
-```
 
 
 ## Key concepts

--- a/test/integration/generated/storageblob/README.md
+++ b/test/integration/generated/storageblob/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `storageblob` package
-
-Install the StorageBlob client library for JavaScript with `npm`:
-
-```bash
-npm install storageblob
-```
 
 
 ## Key concepts

--- a/test/integration/generated/storagefileshare/README.md
+++ b/test/integration/generated/storagefileshare/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `storagefileshare` package
-
-Install the StorageFileShare client library for JavaScript with `npm`:
-
-```bash
-npm install storagefileshare
-```
 
 
 ## Key concepts

--- a/test/integration/generated/subscriptionIdApiVersion/README.md
+++ b/test/integration/generated/subscriptionIdApiVersion/README.md
@@ -15,13 +15,6 @@ Some cool documentation.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `subscriptionid-apiversion` package
-
-Install the SubscriptionIdApiVersion client library for JavaScript with `npm`:
-
-```bash
-npm install subscriptionid-apiversion
-```
 
 
 ## Key concepts

--- a/test/integration/generated/textanalytics/README.md
+++ b/test/integration/generated/textanalytics/README.md
@@ -15,13 +15,6 @@ TextAnalytics Client
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `textanalytics` package
-
-Install the Generated client library for JavaScript with `npm`:
-
-```bash
-npm install textanalytics
-```
 
 
 ## Key concepts

--- a/test/integration/generated/url/README.md
+++ b/test/integration/generated/url/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `url` package
-
-Install the Url client library for JavaScript with `npm`:
-
-```bash
-npm install url
-```
 
 
 ## Key concepts

--- a/test/integration/generated/url2/README.md
+++ b/test/integration/generated/url2/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `url` package
-
-Install the Url client library for JavaScript with `npm`:
-
-```bash
-npm install url
-```
 
 
 ## Key concepts

--- a/test/integration/generated/urlMulti/README.md
+++ b/test/integration/generated/urlMulti/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `url-multi` package
-
-Install the UrlMulti client library for JavaScript with `npm`:
-
-```bash
-npm install url-multi
-```
 
 
 ## Key concepts

--- a/test/integration/generated/useragentcorev1/README.md
+++ b/test/integration/generated/useragentcorev1/README.md
@@ -15,13 +15,6 @@ Some cool documentation.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `useragent-corev1` package
-
-Install the UserAgentCoreV1 client library for JavaScript with `npm`:
-
-```bash
-npm install useragent-corev1
-```
 
 
 ## Key concepts

--- a/test/integration/generated/useragentcorev2/README.md
+++ b/test/integration/generated/useragentcorev2/README.md
@@ -15,13 +15,6 @@ Some cool documentation.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `useragent-corev2` package
-
-Install the UserAgentCoreV2 client library for JavaScript with `npm`:
-
-```bash
-npm install useragent-corev2
-```
 
 
 ## Key concepts

--- a/test/integration/generated/uuid/README.md
+++ b/test/integration/generated/uuid/README.md
@@ -15,13 +15,6 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `uuid` package
-
-Install the Uuid client library for JavaScript with `npm`:
-
-```bash
-npm install uuid
-```
 
 
 ## Key concepts

--- a/test/integration/generated/validation/README.md
+++ b/test/integration/generated/validation/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest. No server backend exists for these tests.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `validation` package
-
-Install the Validation client library for JavaScript with `npm`:
-
-```bash
-npm install validation
-```
 
 
 ## Key concepts

--- a/test/integration/generated/xmlservice/README.md
+++ b/test/integration/generated/xmlservice/README.md
@@ -15,13 +15,6 @@ Test Infrastructure for AutoRest Swagger BAT
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `xml-service` package
-
-Install the XmlService client library for JavaScript with `npm`:
-
-```bash
-npm install xml-service
-```
 
 
 ## Key concepts

--- a/test/integration/generated/xmsErrorResponses/README.md
+++ b/test/integration/generated/xmsErrorResponses/README.md
@@ -15,13 +15,6 @@ XMS Error Response Extensions
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `xms-error-responses` package
-
-Install the XmsErrorResponses client library for JavaScript with `npm`:
-
-```bash
-npm install xms-error-responses
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/README.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/README.md
@@ -15,13 +15,6 @@ The APIs listed in this specification can be used to manage Deployment Scripts r
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-deploymentscripts-2019-10-preview` package
-
-Install the DeploymentScripts client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-deploymentscripts-2019-10-preview
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-features-2015-12/README.md
+++ b/test/smoke/generated/arm-package-features-2015-12/README.md
@@ -15,13 +15,6 @@ Azure Feature Exposure Control (AFEC) provides a mechanism for the resource prov
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-features-2015-12` package
-
-Install the Feature client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-features-2015-12
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-links-2016-09/README.md
+++ b/test/smoke/generated/arm-package-links-2016-09/README.md
@@ -15,13 +15,6 @@ Azure resources can be linked together to form logical relationships. You can es
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-links-2016-09` package
-
-Install the ManagementLink client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-links-2016-09
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-locks-2016-09/README.md
+++ b/test/smoke/generated/arm-package-locks-2016-09/README.md
@@ -15,13 +15,6 @@ Azure resources can be locked to prevent other users in your organization from d
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-locks-2016-09` package
-
-Install the ManagementLock client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-locks-2016-09
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/README.md
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/README.md
@@ -15,13 +15,6 @@ ARM applications
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-managedapplications-2018-06` package
-
-Install the Application client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-managedapplications-2018-06
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-policy-2019-09/README.md
+++ b/test/smoke/generated/arm-package-policy-2019-09/README.md
@@ -15,13 +15,6 @@ To manage and control access to your resources, you can define customized polici
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-policy-2019-09` package
-
-Install the Policy client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-policy-2019-09
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-resources-2019-08/README.md
+++ b/test/smoke/generated/arm-package-resources-2019-08/README.md
@@ -15,13 +15,6 @@ Provides operations for working with resources and resource groups.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-resources-2019-08` package
-
-Install the ResourceManagement client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-resources-2019-08
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/README.md
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/README.md
@@ -15,13 +15,6 @@ All resource groups and resources exist within subscriptions. These operation en
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `arm-package-subscriptions-2019-06` package
-
-Install the Subscription client library for JavaScript with `npm`:
-
-```bash
-npm install arm-package-subscriptions-2019-06
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/compute-resource-manager/README.md
+++ b/test/smoke/generated/compute-resource-manager/README.md
@@ -15,13 +15,6 @@ Compute Client
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `compute-resource-manager` package
-
-Install the ComputeManagement client library for JavaScript with `npm`:
-
-```bash
-npm install compute-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/cosmos-db-resource-manager/README.md
+++ b/test/smoke/generated/cosmos-db-resource-manager/README.md
@@ -15,13 +15,6 @@ Azure Cosmos DB Database Service Resource Provider REST API
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `cosmos-db-resource-manager` package
-
-Install the CosmosDBManagement client library for JavaScript with `npm`:
-
-```bash
-npm install cosmos-db-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/graphrbac-data-plane/README.md
+++ b/test/smoke/generated/graphrbac-data-plane/README.md
@@ -14,13 +14,6 @@ The Graph RBAC Management Client
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `graphrbac-data-plane` package
-
-Install the GraphRbacManagement client library for JavaScript with `npm`:
-
-```bash
-npm install graphrbac-data-plane
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/keyvault-resource-manager/README.md
+++ b/test/smoke/generated/keyvault-resource-manager/README.md
@@ -15,13 +15,6 @@ The Azure management API provides a RESTful set of web services that interact wi
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `keyvault-resource-manager` package
-
-Install the KeyVaultManagement client library for JavaScript with `npm`:
-
-```bash
-npm install keyvault-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/monitor-data-plane/README.md
+++ b/test/smoke/generated/monitor-data-plane/README.md
@@ -14,13 +14,6 @@ Monitor Management Client
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `monitor-data-plane` package
-
-Install the Monitor client library for JavaScript with `npm`:
-
-```bash
-npm install monitor-data-plane
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/msi-resource-manager/README.md
+++ b/test/smoke/generated/msi-resource-manager/README.md
@@ -15,13 +15,6 @@ The Managed Service Identity Client.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `msi-resource-manager` package
-
-Install the ManagedServiceIdentity client library for JavaScript with `npm`:
-
-```bash
-npm install msi-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/network-resource-manager/README.md
+++ b/test/smoke/generated/network-resource-manager/README.md
@@ -15,13 +15,6 @@ Network Client
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `network-resource-manager` package
-
-Install the NetworkManagement client library for JavaScript with `npm`:
-
-```bash
-npm install network-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/sql-resource-manager/README.md
+++ b/test/smoke/generated/sql-resource-manager/README.md
@@ -15,13 +15,6 @@ The Azure SQL Database management API provides a RESTful set of web services tha
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `sql-resource-manager` package
-
-Install the SqlManagement client library for JavaScript with `npm`:
-
-```bash
-npm install sql-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/storage-resource-manager/README.md
+++ b/test/smoke/generated/storage-resource-manager/README.md
@@ -15,13 +15,6 @@ The Azure Storage Management API.
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `storage-resource-manager` package
-
-Install the StorageManagement client library for JavaScript with `npm`:
-
-```bash
-npm install storage-resource-manager
-```
 
 
 ## Key concepts

--- a/test/smoke/generated/web-resource-manager/README.md
+++ b/test/smoke/generated/web-resource-manager/README.md
@@ -15,13 +15,6 @@ WebSite Management Client
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
 
-### Install the `web-resource-manager` package
-
-Install the WebSiteManagement client library for JavaScript with `npm`:
-
-```bash
-npm install web-resource-manager
-```
 
 
 ## Key concepts

--- a/test/utils/run.ts
+++ b/test/utils/run.ts
@@ -25,7 +25,8 @@ export async function runAutorest(
     ignoreNullableOnOptional,
     title,
     restLevelClient,
-    headAsBoolean
+    headAsBoolean,
+    isTestPackage
   } = options;
   let autorestCommand = `autorest${
     /^win/.test(process.platform) ? ".cmd" : ""
@@ -74,6 +75,9 @@ export async function runAutorest(
   }
   if (hideClients) {
     commandArguments.push(`--hide-clients=${hideClients}`);
+  }
+  if (isTestPackage) {
+    commandArguments.push(`--is-test-package=${isTestPackage}`);
   }
   if (licenseHeader !== undefined) {
     commandArguments.push(`--license-header=${licenseHeader}`);

--- a/test/utils/smoke-test.ts
+++ b/test/utils/smoke-test.ts
@@ -54,7 +54,8 @@ const generateFromReadme = async ({
         version: "",
         nameWithoutScope: ""
       },
-      allowInsecureConnection: true
+      allowInsecureConnection: true,
+      isTestPackage: true
     },
     false,
     params

--- a/test/utils/test-swagger-gen.ts
+++ b/test/utils/test-swagger-gen.ts
@@ -18,6 +18,7 @@ interface SwaggerConfig {
   allowInsecureConnection?: boolean;
   restLevelClient?: boolean;
   headAsBoolean?: boolean;
+  isTestPackage?: boolean;
 }
 
 const package_version = "1.0.0-preview1";
@@ -31,7 +32,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   arrayConstraints: {
     swaggerOrConfig: "test/integration/swaggers/arrayConstraints.json",
@@ -40,7 +42,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   attestation: {
     swaggerOrConfig: "test/integration/swaggers/attestation.json",
@@ -50,7 +53,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   azureParameterGrouping: {
     swaggerOrConfig: "azure-parameter-grouping.json",
@@ -59,7 +63,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   azureReport: {
     swaggerOrConfig: "azure-report.json",
@@ -68,7 +73,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   azureSpecialProperties: {
     swaggerOrConfig: "azure-special-properties.json",
@@ -79,7 +85,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     credentialScopes:
       "https://microsoft.com/.default,http://microsoft.com/.default",
     useCoreV2: true,
-    allowInsecureConnection: true
+    allowInsecureConnection: true,
+    isTestPackage: true
   },
   bodyArray: {
     swaggerOrConfig: "body-array.json",
@@ -88,7 +95,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyBoolean: {
     swaggerOrConfig: "body-boolean.json",
@@ -97,7 +105,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyBooleanQuirks: {
     swaggerOrConfig: "body-boolean.quirks.json",
@@ -106,7 +115,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyByte: {
     swaggerOrConfig: "body-byte.json",
@@ -115,7 +125,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyComplex: {
     swaggerOrConfig: "test/integration/swaggers/bodyComplex.md",
@@ -124,7 +135,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyComplexRest: {
     swaggerOrConfig: "test/integration/swaggers/bodyComplex.md",
@@ -133,7 +145,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     restLevelClient: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyComplexWithTracing: {
     swaggerOrConfig: "test/integration/swaggers/bodyComplex.md",
@@ -146,7 +159,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     },
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyDate: {
     swaggerOrConfig: "body-date.json",
@@ -155,7 +169,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyDateTime: {
     swaggerOrConfig: "body-datetime.json",
@@ -164,7 +179,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyDateTimeRfc1123: {
     swaggerOrConfig: "body-datetime-rfc1123.json",
@@ -173,7 +189,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyDictionary: {
     swaggerOrConfig: "body-dictionary.json",
@@ -182,7 +199,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyDuration: {
     swaggerOrConfig: "body-duration.json",
@@ -191,7 +209,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyFile: {
     swaggerOrConfig: "body-file.json",
@@ -200,7 +219,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyInteger: {
     swaggerOrConfig: "body-integer.json",
@@ -209,7 +229,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyNumber: {
     swaggerOrConfig: "body-number.json",
@@ -218,7 +239,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyString: {
     swaggerOrConfig: "body-string.json",
@@ -227,7 +249,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyTime: {
     swaggerOrConfig: "body-time.json",
@@ -236,7 +259,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   customUrl: {
     swaggerOrConfig: "custom-baseUrl.json",
@@ -245,7 +269,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   customUrlMoreOptions: {
     swaggerOrConfig: "custom-baseUrl-more-options.json",
@@ -254,7 +279,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   customUrlPaging: {
     swaggerOrConfig: "custom-baseUrl-paging.json",
@@ -263,7 +289,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   header: {
     swaggerOrConfig: "header.json",
@@ -272,7 +299,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   httpInfrastructure: {
     swaggerOrConfig: "httpInfrastructure.json",
@@ -281,7 +309,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   lro: {
     swaggerOrConfig: "lro.json",
@@ -290,7 +319,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   lroParametrizedEndpoints: {
     swaggerOrConfig: "lro-parameterized-endpoints.json",
@@ -299,7 +329,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   mediaTypes: {
     swaggerOrConfig: "media_types.json",
@@ -308,7 +339,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   mediaTypesWithTracing: {
     swaggerOrConfig: "media_types.json",
@@ -321,7 +353,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     },
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   mediaTypesV3: {
     swaggerOrConfig: "test/integration/swaggers/media-types-v3.json",
@@ -330,7 +363,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   mediaTypesV3Lro: {
     swaggerOrConfig: "test/integration/swaggers/media-types-v3-lro.json",
@@ -338,7 +372,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "media-types-v3-lro-client",
     licenseHeader: true,
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   modelFlattening: {
     swaggerOrConfig: "model-flattening.json",
@@ -347,7 +382,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   multipleInheritance: {
     swaggerOrConfig: "multiple-inheritance.json",
@@ -356,7 +392,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   multipleInheritanceRest: {
     swaggerOrConfig: "multiple-inheritance.json",
@@ -366,7 +403,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     useCoreV2: true,
     allowInsecureConnection: true,
     addCredentials: false,
-    restLevelClient: true
+    restLevelClient: true,
+    isTestPackage: true
   },
   noMappers: {
     swaggerOrConfig: "test/integration/swaggers/no-mappers.json",
@@ -375,7 +413,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   noOperation: {
     swaggerOrConfig: "test/integration/swaggers/noOperation.json",
@@ -384,7 +423,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   nonStringEnum: {
     swaggerOrConfig: "non-string-enum.json",
@@ -393,7 +433,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   objectType: {
     swaggerOrConfig: "object-type.json",
@@ -402,7 +443,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   paging: {
     swaggerOrConfig: "paging.json",
@@ -414,7 +456,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
       packagePrefix: "Azure.Media.Types"
     },
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   pagingNoIterators: {
     swaggerOrConfig: "paging.json",
@@ -423,7 +466,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     disableAsyncIterators: true,
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   requiredOptional: {
     swaggerOrConfig: "required-optional.json",
@@ -432,7 +476,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   regexConstraint: {
     swaggerOrConfig: "test/integration/swaggers/regex-constraint.json",
@@ -441,7 +486,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   report: {
     swaggerOrConfig: "report.json",
@@ -450,7 +496,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   uuid: {
     swaggerOrConfig: "test/integration/swaggers/uuid.json",
@@ -459,7 +506,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   url: {
     swaggerOrConfig: "url.json",
@@ -468,7 +516,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   urlMulti: {
     swaggerOrConfig: "url-multi-collectionFormat.json",
@@ -477,7 +526,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   url2: {
     swaggerOrConfig: "test/integration/swaggers/url.json",
@@ -486,7 +536,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   xmlservice: {
     swaggerOrConfig: "xml-service.json",
@@ -495,7 +546,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   noLicenseHeader: {
     swaggerOrConfig: "test/integration/swaggers/license-header.json",
@@ -503,7 +555,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "nolicense-header",
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   licenseHeader: {
     swaggerOrConfig: "test/integration/swaggers/license-header.json",
@@ -512,7 +565,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   subscriptionIdApiVersion: {
     swaggerOrConfig: "subscriptionId-apiVersion.json",
@@ -521,7 +575,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   bodyFormData: {
     swaggerOrConfig: "body-formdata.json",
@@ -530,7 +585,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   validation: {
     swaggerOrConfig: "validation.json",
@@ -539,7 +595,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   extensibleEnums: {
     swaggerOrConfig: "test/integration/swaggers/extensibleEnums.md",
@@ -548,7 +605,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   xmsErrorResponses: {
     swaggerOrConfig: "test/integration/swaggers/xmsErrorResponses.md",
@@ -556,7 +614,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "xms-error-responses",
     licenseHeader: true,
     addCredentials: false,
-    useCoreV2: true
+    useCoreV2: true,
+    isTestPackage: true
   },
   odataDiscriminator: {
     swaggerOrConfig: "test/integration/swaggers/odata-discriminator.json",
@@ -565,7 +624,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   appconfiguration: {
     swaggerOrConfig: "test/integration/swaggers/appconfiguration.json",
@@ -574,7 +634,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   appconfigurationexport: {
     swaggerOrConfig: "test/integration/swaggers/appconfiguration.json",
@@ -584,7 +645,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     hideClients: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   mapperrequired: {
     swaggerOrConfig: "test/integration/swaggers/mapperrequired.json",
@@ -593,7 +655,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   readmeFileChecker: {
     swaggerOrConfig: "test/integration/swaggers/keyvaults-secrets.md",
@@ -601,7 +664,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "@azure/keyvault-secrets",
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   nameChecker: {
     swaggerOrConfig: "test/integration/swaggers/Data.md",
@@ -609,7 +673,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "@azure/search-documents",
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   polymorphicSkipNormalize: {
     swaggerOrConfig:
@@ -618,7 +683,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "@azure/media-services",
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   petstore: {
     swaggerOrConfig: "test/integration/swaggers/petstore.json",
@@ -626,7 +692,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "petstore",
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   textanalytics: {
     swaggerOrConfig: "test/integration/swaggers/textAnalytics.md",
@@ -636,7 +703,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   constantParam: {
     swaggerOrConfig: "test/integration/swaggers/textAnalytics.json",
@@ -646,14 +714,16 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   storagefileshare: {
     swaggerOrConfig: "test/integration/swaggers/storagefileshare.json",
     clientName: "StorageFileShareClient",
     packageName: "storagefileshare",
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   optionalnull: {
     swaggerOrConfig: "test/integration/swaggers/optionalnull.json",
@@ -661,21 +731,24 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "optionalnull",
     ignoreNullableOnOptional: true,
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   storageblob: {
     swaggerOrConfig: "test/integration/swaggers/storageblob.json",
     clientName: "StorageBlobClient",
     packageName: "storageblob",
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   headerprefix: {
     swaggerOrConfig: "test/integration/swaggers/headerprefix.json",
     clientName: "HeaderPrefixClient",
     packageName: "headerprefix",
     useCoreV2: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   operationgroupclash: {
     swaggerOrConfig: "test/integration/swaggers/operationGroupClash.json",
@@ -683,7 +756,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "operationgroupclash",
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   useragentcorev1: {
     swaggerOrConfig: "subscriptionId-apiVersion.json",
@@ -692,7 +766,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: false,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   useragentcorev2: {
     swaggerOrConfig: "subscriptionId-apiVersion.json",
@@ -701,7 +776,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   iotspaces: {
     swaggerOrConfig: "test/integration/swaggers/iotspaces.json",
@@ -710,7 +786,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: true
+    addCredentials: true,
+    isTestPackage: true
   },
   resources: {
     swaggerOrConfig: "test/integration/swaggers/resources.json",
@@ -720,7 +797,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     useCoreV2: true,
     allowInsecureConnection: true,
     addCredentials: true,
-    headAsBoolean: true
+    headAsBoolean: true,
+    isTestPackage: true
   },
   sealedchoice: {
     swaggerOrConfig: "test/integration/swaggers/sealedchoice.json",
@@ -729,7 +807,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     licenseHeader: true,
     useCoreV2: true,
     allowInsecureConnection: true,
-    addCredentials: false
+    addCredentials: false,
+    isTestPackage: true
   },
   // TEST REST LEVEL CLIENTS
   bodyStringRest: {
@@ -738,7 +817,8 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     packageName: "body-string-rest",
     addCredentials: false,
     restLevelClient: true,
-    licenseHeader: true
+    licenseHeader: true,
+    isTestPackage: true
   }
 };
 
@@ -768,7 +848,8 @@ const generateSwaggers = async (
       useCoreV2,
       allowInsecureConnection,
       restLevelClient,
-      headAsBoolean
+      headAsBoolean,
+      isTestPackage
     } = testSwaggers[name];
 
     let swaggerPath = swaggerOrConfig;
@@ -802,7 +883,8 @@ const generateSwaggers = async (
         useCoreV2,
         allowInsecureConnection,
         restLevelClient,
-        headAsBoolean
+        headAsBoolean,
+        isTestPackage
       },
       isDebugging
     );


### PR DESCRIPTION
In our SDK repository, we have several test libraries created for integration & smoke test scenarios. In these test libraries, we have the `README.md` in which we have installation instructions with `npm install .....` command. But, all these libraries are test libraries and will not be released to npm.  

Now, this causes a security vulnerability. An attacker can create an actual npm library with that name and if someone follows the instruction from our repository and installed that library, it could potentially contain malicious code and could be used for hacking. This scenario has already happened and security team wanted to remove that instruction from our test libraries. This PR is created to remove that instruction from test libraries. 

@deyaaeldeen @joheredi Please review and approve.

@ramya-rao-a FYI.....