### PR TITLE
[RLC] Generate missing header interfaces

### DIFF
--- a/src/restLevelClient/generateResponseTypes.ts
+++ b/src/restLevelClient/generateResponseTypes.ts
@@ -64,6 +64,7 @@ export function generateResponseInterfaces(model: CodeModel, project: Project) {
 
       if (headersInterface) {
         hasHeaders = true;
+        responsesFile.addInterface(headersInterface);
       }
 
       const bodyType = getBodyTypeName(schemaResponse, importedModels);


### PR DESCRIPTION
Generator builds the Header interfaces but never actually generates them