### PR TITLE
Reserve pipeline client member

### DIFF
--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -25,6 +25,11 @@ import { generateLroFiles } from "./generators/LROGenerator";
 import { generateTracingFile } from "./generators/tracingFileGenerator";
 import { getAutorestOptions } from "./autorestSession";
 
+/**
+ * ServiceClient members should be reserved
+ */
+const RESERVED_MEMBER_NAMES = ["pipeline"];
+
 const prettierTypeScriptOptions: prettier.Options = {
   parser: "typescript",
   arrowParens: "always",
@@ -145,11 +150,15 @@ function checkForConflictWithDefinitions(
   operationGroupName: string,
   clientDetails: ClientDetails
 ): boolean {
-  let conflict: boolean = false;
-  clientDetails.objects.forEach(model => {
+  if (RESERVED_MEMBER_NAMES.includes(operationGroupName.toLowerCase())) {
+    return true;
+  }
+
+  for (const model of clientDetails.objects) {
     if (model.name === operationGroupName) {
-      conflict = true;
+      return true;
     }
-  });
-  return conflict;
+  }
+
+  return false;
 }

--- a/test/integration/generated/operationgroupclash/src/models/index.ts
+++ b/test/integration/generated/operationgroupclash/src/models/index.ts
@@ -40,6 +40,16 @@ export type ProductOperationsApiV1ValueGetResponse = {
 };
 
 /** Optional parameters. */
+export interface PipelineOperationsApiV1ValueGetOptionalParams
+  extends coreClient.OperationOptions {}
+
+/** Contains response data for the apiV1ValueGet operation. */
+export type PipelineOperationsApiV1ValueGetResponse = {
+  /** The parsed response body. */
+  body: string[];
+};
+
+/** Optional parameters. */
 export interface OperationGroupClashClientOptionalParams
   extends coreClient.ServiceClientOptions {
   /** Overrides client endpoint. */

--- a/test/integration/generated/operationgroupclash/src/operationGroupClashClient.ts
+++ b/test/integration/generated/operationgroupclash/src/operationGroupClashClient.ts
@@ -1,5 +1,5 @@
-import { ProductOperationsImpl } from "./operations";
-import { ProductOperations } from "./operationsInterfaces";
+import { ProductOperationsImpl, PipelineOperationsImpl } from "./operations";
+import { ProductOperations, PipelineOperations } from "./operationsInterfaces";
 import { OperationGroupClashClientContext } from "./operationGroupClashClientContext";
 import { OperationGroupClashClientOptionalParams, Enum0 } from "./models";
 
@@ -17,7 +17,9 @@ export class OperationGroupClashClient extends OperationGroupClashClientContext 
   ) {
     super($host, apiVersion, options);
     this.productOperations = new ProductOperationsImpl(this);
+    this.pipelineOperations = new PipelineOperationsImpl(this);
   }
 
   productOperations: ProductOperations;
+  pipelineOperations: PipelineOperations;
 }

--- a/test/integration/generated/operationgroupclash/src/operations/index.ts
+++ b/test/integration/generated/operationgroupclash/src/operations/index.ts
@@ -1,1 +1,2 @@
 export * from "./productOperations";
+export * from "./pipelineOperations";

--- a/test/integration/generated/operationgroupclash/src/operations/pipelineOperations.ts
+++ b/test/integration/generated/operationgroupclash/src/operations/pipelineOperations.ts
@@ -1,0 +1,49 @@
+import { PipelineOperations } from "../operationsInterfaces";
+import * as coreClient from "@azure/core-client";
+import * as Mappers from "../models/mappers";
+import * as Parameters from "../models/parameters";
+import { OperationGroupClashClientContext } from "../operationGroupClashClientContext";
+import {
+  PipelineOperationsApiV1ValueGetOptionalParams,
+  PipelineOperationsApiV1ValueGetResponse
+} from "../models";
+
+/** Class representing a PipelineOperations. */
+export class PipelineOperationsImpl implements PipelineOperations {
+  private readonly client: OperationGroupClashClientContext;
+
+  /**
+   * Initialize a new instance of the class PipelineOperations class.
+   * @param client Reference to the service client
+   */
+  constructor(client: OperationGroupClashClientContext) {
+    this.client = client;
+  }
+
+  /** @param options The options parameters. */
+  apiV1ValueGet(
+    options?: PipelineOperationsApiV1ValueGetOptionalParams
+  ): Promise<PipelineOperationsApiV1ValueGetResponse> {
+    return this.client.sendOperationRequest(
+      { options },
+      apiV1ValueGetOperationSpec
+    );
+  }
+}
+// Operation Specifications
+const serializer = coreClient.createSerializer(Mappers, /* isXml */ false);
+
+const apiV1ValueGetOperationSpec: coreClient.OperationSpec = {
+  path: "/api/v1/pipeline",
+  httpMethod: "GET",
+  responses: {
+    200: {
+      bodyMapper: {
+        type: { name: "Sequence", element: { type: { name: "String" } } }
+      }
+    }
+  },
+  urlParameters: [Parameters.$host],
+  headerParameters: [Parameters.accept, Parameters.apiVersion],
+  serializer
+};

--- a/test/integration/generated/operationgroupclash/src/operationsInterfaces/index.ts
+++ b/test/integration/generated/operationgroupclash/src/operationsInterfaces/index.ts
@@ -1,1 +1,2 @@
 export * from "./productOperations";
+export * from "./pipelineOperations";

--- a/test/integration/generated/operationgroupclash/src/operationsInterfaces/pipelineOperations.ts
+++ b/test/integration/generated/operationgroupclash/src/operationsInterfaces/pipelineOperations.ts
@@ -1,0 +1,12 @@
+import {
+  PipelineOperationsApiV1ValueGetOptionalParams,
+  PipelineOperationsApiV1ValueGetResponse
+} from "../models";
+
+/** Interface representing a PipelineOperations. */
+export interface PipelineOperations {
+  /** @param options The options parameters. */
+  apiV1ValueGet(
+    options?: PipelineOperationsApiV1ValueGetOptionalParams
+  ): Promise<PipelineOperationsApiV1ValueGetResponse>;
+}

--- a/test/integration/swaggers/operationGroupClash.json
+++ b/test/integration/swaggers/operationGroupClash.json
@@ -42,6 +42,31 @@
           }
         }
       }
+    },
+    "/api/v1/pipeline": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/globalApiVersion"
+        }
+      ],
+      "get": {
+        "tags": ["ValueApi"],
+        "operationId": "Pipeline_ApiV1ValueGet",
+        "consumes": [],
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {


### PR DESCRIPTION
pipeline is a member of core-client's ServiceClient. If a swagger defines an operation group named Pipeline we'd get a collision and a build error.

This PR reserves the Pipeline name and suffixes any operation group named pipeline with `Operations` as all other collisions are handled.