### PR TITLE
Fix Non String Sealed Choices Generated Code

### DIFF
--- a/src/generators/modelsGenerator.ts
+++ b/src/generators/modelsGenerator.ts
@@ -537,7 +537,9 @@ const writeSealedChoice = (
   modelsIndexFile: SourceFile
 ) => {
   const values = choice.properties
-    .map(p => (choice.itemType === SchemaType.String ? `"${p.value}"` : p.name))
+    .map(p =>
+      choice.itemType === SchemaType.String ? `"${p.value}"` : p.value
+    )
     .join(" | ");
 
   modelsIndexFile.addTypeAlias({

--- a/test/integration/generated/sealedchoice/src/models/index.ts
+++ b/test/integration/generated/sealedchoice/src/models/index.ts
@@ -8,6 +8,21 @@
 
 import * as coreClient from "@azure/core-client";
 
+/** Profile for the container service master. */
+export interface ContainerServiceMasterProfile {
+  /** Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1. */
+  count?: Count;
+  /** DNS prefix to be used to create the FQDN for the master pool. */
+  dnsPrefix: string;
+  /** FirstConsecutiveStaticIP used to specify the first static ip of masters. */
+  firstConsecutiveStaticIP?: string;
+  /**
+   * FQDN for the master pool.
+   * NOTE: This property will not be serialized. It can only be populated by the server.
+   */
+  readonly fqdn?: string;
+}
+
 export interface PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema {
   /** Grant type is expected to be refresh_token */
   grantType: TokenGrantType;
@@ -15,6 +30,8 @@ export interface PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwForm
 
 /** Defines values for TokenGrantType. */
 export type TokenGrantType = "refresh_token" | "password";
+/** Defines values for Count. */
+export type Count = 1 | 3 | 5;
 
 /** Optional parameters. */
 export interface AuthenticationExchangeAcrRefreshTokenForAcrAccessTokenOptionalParams

--- a/test/integration/generated/sealedchoice/src/models/mappers.ts
+++ b/test/integration/generated/sealedchoice/src/models/mappers.ts
@@ -8,6 +8,44 @@
 
 import * as coreClient from "@azure/core-client";
 
+export const ContainerServiceMasterProfile: coreClient.CompositeMapper = {
+  type: {
+    name: "Composite",
+    className: "ContainerServiceMasterProfile",
+    modelProperties: {
+      count: {
+        defaultValue: "1",
+        serializedName: "count",
+        type: {
+          name: "Enum",
+          allowedValues: [1, 3, 5]
+        }
+      },
+      dnsPrefix: {
+        serializedName: "dnsPrefix",
+        required: true,
+        type: {
+          name: "String"
+        }
+      },
+      firstConsecutiveStaticIP: {
+        defaultValue: "10.240.255.5",
+        serializedName: "firstConsecutiveStaticIP",
+        type: {
+          name: "String"
+        }
+      },
+      fqdn: {
+        serializedName: "fqdn",
+        readOnly: true,
+        type: {
+          name: "String"
+        }
+      }
+    }
+  }
+};
+
 export const PathsV3R3RxOauth2TokenPostRequestbodyContentApplicationXWwwFormUrlencodedSchema: coreClient.CompositeMapper = {
   type: {
     name: "Composite",

--- a/test/integration/swaggers/sealedchoice.json
+++ b/test/integration/swaggers/sealedchoice.json
@@ -55,5 +55,38 @@
       }
     }
   },
+  "definitions": {
+    "ContainerServiceMasterProfile": {
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "enum": [1, 3, 5],
+          "x-ms-enum": {
+            "name": "Count",
+            "modelAsString": false
+          },
+          "description": "Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, and 5. The default value is 1.",
+          "default": 1
+        },
+        "dnsPrefix": {
+          "type": "string",
+          "description": "DNS prefix to be used to create the FQDN for the master pool."
+        },
+        "firstConsecutiveStaticIP": {
+          "type": "string",
+          "description": "FirstConsecutiveStaticIP used to specify the first static ip of masters.",
+          "default": "10.240.255.5"
+        },
+        "fqdn": {
+          "readOnly": true,
+          "type": "string",
+          "description": "FQDN for the master pool."
+        }
+      },
+      "required": ["dnsPrefix", "vmSize"],
+      "description": "Profile for the container service master."
+    }
+  },
   "parameters": {}
 }


### PR DESCRIPTION
This PR is to fix the issue reported in https://github.com/Azure/autorest.typescript/issues/1159. The Swagger has a sealed choice object such as:

```
"count": {
    "type": "integer",
    "format": "int32",
    "enum": [ 1, 3, 5 ],
    "x-ms-enum": {
        "name": "Count",
        "modelAsString": false
    },
    "description": "Number of masters (VMs) in the container service cluster. Allowed values are 1, 3, & 5.The default value is 1.",
    "default": 1
}
```

The above swagger generates the following SDK code:

`export type Count = One | Three | Five;`

But it should be 

`export type Count = 1 | 3 | 5;`

This is happening because for Non-String Enum Values, the generator uses the `name` instead of `value`. This PR fixes it.

@joheredi Please approve it. 