### PR TITLE
Clear Source Folder before generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2445,6 +2445,15 @@
             "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
             "dev": true
         },
+        "@types/fs-extra": {
+            "version": "9.0.12",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.12.tgz",
+            "integrity": "sha512-I+bsBr67CurCGnSenZZ7v94gd3tc3+Aj2taxMT4yu4ABLuOgOjeFxX3dokG24ztSRg5tnT00sL8BszO7gSMoIw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -6310,20 +6319,26 @@
             "dev": true
         },
         "fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
+            "integrity": "sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             },
             "dependencies": {
                 "graceful-fs": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-                    "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+                    "version": "4.2.8",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+                    "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+                    "dev": true
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
                     "dev": true
                 }
             }
@@ -8640,12 +8655,21 @@
             }
         },
         "jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+            },
+            "dependencies": {
+                "universalify": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+                    "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+                    "dev": true
+                }
             }
         },
         "jsonparse": {
@@ -12857,6 +12881,32 @@
                     "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
+                    }
+                },
+                "fs-extra": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.8",
+                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+                    "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+                    "dev": true
+                },
+                "jsonfile": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "ms": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "@azure/core-xml": "^1.0.0-beta.1",
         "@microsoft.azure/autorest.testserver": "^3.0.21",
         "@types/chai": "^4.2.8",
+        "@types/fs-extra": "^9.0.12",
         "@types/js-yaml": "3.12.1",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.7.12",
@@ -71,8 +72,10 @@
         "autorest": "^3.1.1",
         "chai": "^4.2.0",
         "chalk": "^4.0.0",
+        "copyfiles": "^2.4.1",
         "directory-tree": "^2.2.7",
         "eslint": "~6.2.2",
+        "fs-extra": "^10.0.0",
         "karma": "^5.0.9",
         "karma-chrome-launcher": "^3.1.0",
         "karma-mocha": "^2.0.1",
@@ -95,7 +98,6 @@
         "wait-port": "^0.2.6",
         "webpack": "^4.43.0",
         "webpack-cli": "^3.3.12",
-        "yargs": "^15.3.1",
-        "copyfiles": "^2.4.1"
+        "yargs": "^15.3.1"
     }
 }

--- a/src/typescriptGenerator.ts
+++ b/src/typescriptGenerator.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 import * as prettier from "prettier";
+import * as fsextra from "fs-extra";
+import * as path from "path";
 import { CodeModel } from "@autorest/codemodel";
 import { Project, IndentationText } from "ts-morph";
 import { Host } from "@autorest/extension-base";
@@ -61,7 +63,9 @@ export async function generateTypeScriptLibrary(
 
   const {
     packageDetails,
-    licenseHeader: shouldGenerateLicense
+    licenseHeader: shouldGenerateLicense,
+    outputPath,
+    srcPath
   } = getAutorestOptions();
 
   const clientDetails = await transformCodeModel(codeModel, host);
@@ -117,6 +121,8 @@ export async function generateTypeScriptLibrary(
   // Save the source files to the virtual filesystem
   project.saveSync();
   const fs = project.getFileSystem();
+  const pathToClear = outputPath ? path.join(outputPath, srcPath) : srcPath;
+  fsextra.emptyDirSync(`${pathToClear}`);
 
   // Loop over the files
   for (const file of project.getSourceFiles()) {


### PR DESCRIPTION
This is to address the issue reported at https://github.com/Azure/autorest.typescript/issues/1166. 

Basically, the src folder could have many files (especially while migrating from Track 1). It is a pain to check and remove the files. Normally, we do not want the metadata to be regenerated but we would like to clear all the previous files within the src folder. This PR accomplishes the task.

@joheredi @qiaozha  Please review and approve it.