### PR TITLE
Fix the value of clientName Property in the Discriminators

### DIFF
--- a/src/transforms/mapperTransforms.ts
+++ b/src/transforms/mapperTransforms.ts
@@ -362,7 +362,10 @@ function transformObjectMapper(pipelineValue: PipelineValue) {
         uberParent,
         polymorphicDiscriminator: {
           serializedName: discriminator!.property.serializedName,
-          clientName: discriminator!.property.serializedName
+          clientName: normalizeName(
+            discriminator!.property.language.default.name,
+            NameType.Property
+          )
         }
       }),
       ...(additionalProperties && { additionalProperties })
@@ -385,7 +388,9 @@ function transformDictionaryMapper(pipelineValue: PipelineValue) {
   }
   let dictionarySchema = schema as DictionarySchema | AnyObjectSchema;
 
-  const elementSchema = isDictionarySchema(dictionarySchema) ? dictionarySchema.elementType : new AnySchema("Schema for AnyObject type");
+  const elementSchema = isDictionarySchema(dictionarySchema)
+    ? dictionarySchema.elementType
+    : new AnySchema("Schema for AnyObject type");
   const mapper = buildMapper(
     schema,
     { name: MapperType.Dictionary, value: getMapperOrRef(elementSchema) },
@@ -400,11 +405,11 @@ function transformDictionaryMapper(pipelineValue: PipelineValue) {
 }
 
 function isDictionarySchema(schema: Schema): schema is DictionarySchema {
-  return schema.type === SchemaType.Dictionary
+  return schema.type === SchemaType.Dictionary;
 }
 
 function isAnyObjectSchema(schema: Schema): schema is AnyObjectSchema {
-  return schema.type === SchemaType.AnyObject
+  return schema.type === SchemaType.AnyObject;
 }
 
 function transformArrayMapper(pipelineValue: PipelineValue) {

--- a/test/integration/generated/bodyComplex/src/models/mappers.ts
+++ b/test/integration/generated/bodyComplex/src/models/mappers.ts
@@ -394,7 +394,7 @@ export const DotFish: coreClient.CompositeMapper = {
     uberParent: "DotFish",
     polymorphicDiscriminator: {
       serializedName: "fish\\.type",
-      clientName: "fish\\.type"
+      clientName: "fishType"
     },
     modelProperties: {
       fishType: {

--- a/test/integration/generated/bodyComplexWithTracing/src/models/mappers.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/models/mappers.ts
@@ -394,7 +394,7 @@ export const DotFish: coreClient.CompositeMapper = {
     uberParent: "DotFish",
     polymorphicDiscriminator: {
       serializedName: "fish\\.type",
-      clientName: "fish\\.type"
+      clientName: "fishType"
     },
     modelProperties: {
       fishType: {

--- a/test/integration/generated/odataDiscriminator/src/models/mappers.ts
+++ b/test/integration/generated/odataDiscriminator/src/models/mappers.ts
@@ -15,7 +15,7 @@ export const LexicalAnalyzer: coreClient.CompositeMapper = {
     uberParent: "LexicalAnalyzer",
     polymorphicDiscriminator: {
       serializedName: "@odata\\.type",
-      clientName: "@odata\\.type"
+      clientName: "odataType"
     },
     modelProperties: {
       odataType: {


### PR DESCRIPTION
Recently, a customer reported an issue with the `search-documents` SDK. The problem is that while they are using the types with Discriminators, only the parent type is getting accessed. So, the properties that are specific to the child type are ignored and not sent to the service side. 

On analysis, I have found that the issue is because of the problem with the property `clientName`. We have 2 properties:

1. clientName
2. serializedName

As of now, both the properties are set to same value. That was not the intention of the 2 properties and is incorrect. If you look at the code within `core-http` (where these values are getting used), it is clear that the property `clientName` should indicate the `name` that is used on the client/SDK side. 

This PR has been created to fix the issue and set the value of the `clientName` correctly. I have not added a seperate test case for this change, as we already have scenarios covering it. 

@joheredi Please review and approve the PR.
