### PR TITLE
Normalize only the required properties

### DIFF
--- a/src/transforms/objectTransforms.ts
+++ b/src/transforms/objectTransforms.ts
@@ -97,7 +97,9 @@ export function transformProperty({
     ),
     description,
     serializedName: serializedName,
-    type: typeName,
+    type: typeName.startsWith("$DO_NOT_NORMALIZE$")
+      ? typeName.replace("$DO_NOT_NORMALIZE$", "")
+      : typeName,
     required: !!required,
     readOnly: !!readOnly,
     nullable: !!nullable,

--- a/src/transforms/transforms.ts
+++ b/src/transforms/transforms.ts
@@ -70,7 +70,10 @@ export function transformChoice(
     name,
     schemaType,
     itemType,
-    description: `Defines values for ${metadata.name}.`,
+    description: `Defines values for ${normalizeName(
+      metadata.name,
+      NameType.Interface
+    )}.`,
     serializedName: metadata.name,
     properties: extractProperties(choice)
   };

--- a/test/integration/generated/arrayConstraints/src/models/index.ts
+++ b/test/integration/generated/arrayConstraints/src/models/index.ts
@@ -11,6 +11,8 @@ import * as coreClient from "@azure/core-client";
 export interface Product {
   integer?: number;
   string?: string;
+  /** The OS of agent machine */
+  custom?: OS;
 }
 
 /** Known values of {@link Enum0} that the service accepts. */
@@ -28,6 +30,22 @@ export enum KnownEnum0 {
  * **two**
  */
 export type Enum0 = string;
+
+/** Known values of {@link OS} that the service accepts. */
+export enum KnownOS {
+  Windows = "Windows",
+  Linux = "Linux"
+}
+
+/**
+ * Defines values for OS. \
+ * {@link KnownOS} can be used interchangeably with OS,
+ *  this enum contains the known values that the service supports.
+ * ### Known values supported by the service
+ * **Windows** \
+ * **Linux**
+ */
+export type OS = string;
 
 /** Optional parameters. */
 export interface ArrayConstraintsClientPostValueOptionalParams

--- a/test/integration/generated/arrayConstraints/src/models/mappers.ts
+++ b/test/integration/generated/arrayConstraints/src/models/mappers.ts
@@ -24,6 +24,12 @@ export const Product: coreClient.CompositeMapper = {
         type: {
           name: "String"
         }
+      },
+      custom: {
+        serializedName: "custom",
+        type: {
+          name: "String"
+        }
       }
     }
   }

--- a/test/integration/swaggers/arrayConstraints.json
+++ b/test/integration/swaggers/arrayConstraints.json
@@ -1,107 +1,107 @@
 {
-    "swagger": "2.0",
-    "info": {
-        "version": "v1",
-        "title": "My API"
-    },
-    "parameters": {
-        "globalApiVersion": {
-            "name": "api-version",
-            "in": "header",
-            "type": "string",
-            "enum": [
-                "one",
-                "two"
-            ],
-            "required": true
-        }
-    },
-    "paths": {
-        "/api/v1/value": {
-            "parameters": [
-                {
-                    "$ref": "#/parameters/globalApiVersion"
-                },
-                {
-                    "name": "pageRange",
-                    "in": "query",
-                    "description": "Specify page number or range of page numbers to process, e.g: 1, 5, 7, 9-10",
-                    "type": "array",
-                    "collectionFormat": "csv",
-                    "items": {
-                        "type": "string",
-                        "pattern": "^\\d+(-\\d+)?$",
-                        "minLength": 1,
-                        "maxLength": 24
-                    }
-                }
-            ],
-            "post": {
-                "operationId": "PostValue",
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [
-                    {
-                        "name": "arrayBody",
-                        "in": "body",
-                        "schema": {
-                            "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/Product"
-                            }
-                        },
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            },
-            "get": {
-                "tags": [
-                    "ValueApi"
-                ],
-                "operationId": "ApiV1ValueGet",
-                "consumes": [],
-                "produces": [
-                    "application/json"
-                ],
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "Success",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "definitions": {
-        "Product": {
-            "type": "object",
-            "properties": {
-                "integer": {
-                    "type": "integer"
-                },
-                "string": {
-                    "type": "string"
-                }
-            }
-        }
+  "swagger": "2.0",
+  "info": {
+    "version": "v1",
+    "title": "My API"
+  },
+  "parameters": {
+    "globalApiVersion": {
+      "name": "api-version",
+      "in": "header",
+      "type": "string",
+      "enum": ["one", "two"],
+      "required": true
     }
+  },
+  "paths": {
+    "/api/v1/value": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/globalApiVersion"
+        },
+        {
+          "name": "pageRange",
+          "in": "query",
+          "description": "Specify page number or range of page numbers to process, e.g: 1, 5, 7, 9-10",
+          "type": "array",
+          "collectionFormat": "csv",
+          "items": {
+            "type": "string",
+            "pattern": "^\\d+(-\\d+)?$",
+            "minLength": 1,
+            "maxLength": 24
+          }
+        }
+      ],
+      "post": {
+        "operationId": "PostValue",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "name": "arrayBody",
+            "in": "body",
+            "schema": {
+              "description": "array of complex type with [{'integer': 1 'string': '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Product"
+              }
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["ValueApi"],
+        "operationId": "ApiV1ValueGet",
+        "consumes": [],
+        "produces": ["application/json"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Product": {
+      "type": "object",
+      "properties": {
+        "integer": {
+          "type": "integer"
+        },
+        "string": {
+          "type": "string"
+        },
+        "custom": {
+          "description": "The OS of agent machine",
+          "enum": ["Windows", "Linux"],
+          "type": "string",
+          "x-ms-enum": {
+            "name": "OS",
+            "modelAsString": true
+          }
+        }
+      }
+    }
+  }
 }

--- a/test/integration/swaggers/arrayConstraints.md
+++ b/test/integration/swaggers/arrayConstraints.md
@@ -1,0 +1,18 @@
+# Array Constraints Swagger Configuration
+
+> see https://aka.ms/autorest
+
+```yaml
+input-file: ./arrayConstraints.json
+```
+
+## Customizations for Track 2
+
+### Rename OS
+
+```yaml
+modelerfour:
+  naming:
+    override:
+      OS: $DO_NOT_NORMALIZE$OS
+```

--- a/test/utils/test-swagger-gen.ts
+++ b/test/utils/test-swagger-gen.ts
@@ -38,7 +38,7 @@ const testSwaggers: { [name: string]: SwaggerConfig } = {
     generateTest: true
   },
   arrayConstraints: {
-    swaggerOrConfig: "test/integration/swaggers/arrayConstraints.json",
+    swaggerOrConfig: "test/integration/swaggers/arrayConstraints.md",
     clientName: "ArrayConstraintsClient",
     packageName: "array-constraints-client",
     licenseHeader: true,


### PR DESCRIPTION
This PR is created to fix the issue reported in https://github.com/Azure/autorest.typescript/issues/1185.  

**What is the problem?**
Let us assume the following swagger definition:

```json
"custom": {
    "description": "The OS of agent machine",
    "enum": ["Windows", "Linux"],
    "type": "string",
    "x-ms-enum": {
        "name": "OS",
        "modelAsString": true
    }
}
```

Here, if you look at the `name` of the `x-ms-enum`, it is `OS`. But, it gets normalized during the SDK generation and gets converted to `Os` at the time interface creation. But, the same name is used at the place it is referenced. i.e:

```
export interface Product {
  integer?: number;
  string?: string;
  /** The OS of agent machine */
  custom?: OS;
}

export type Os = string;
```

As a result, we get build errors. This error muse be fixed. 

**How should this be fixed?**
Basically, we need a way to identify this particular value and not normalize this. We already have a way to do this by providing a modeler override and mark it with value `$DO_NOT_NORMALIZE$OS`. But, for this override to work, we need some code changes to handle. This PR is to perform that. 

@joheredi Please review and approve. 