### PR TITLE
Update @microsoft/api-extractor to latest version

### DIFF
--- a/src/generators/static/packageFileGenerator.ts
+++ b/src/generators/static/packageFileGenerator.ts
@@ -103,7 +103,7 @@ function restLevelPackage(packageDetails: PackageDetails) {
     },
     devDependencies: {
       autorest: "latest",
-      "@microsoft/api-extractor": "^7.13.2",
+      "@microsoft/api-extractor": "^7.18.11",
       "@types/node": "^14.14.22",
       dotenv: "^8.2.0",
       prettier: "^2.2.1",
@@ -173,7 +173,7 @@ function regularAutorestPackage(
     module: `./dist-esm/index.js`,
     types: `./types/${packageDetails.nameWithoutScope}.d.ts`,
     devDependencies: {
-      "@microsoft/api-extractor": "7.7.11",
+      "@microsoft/api-extractor": "^7.18.11",
       "@rollup/plugin-commonjs": "11.0.2",
       "@rollup/plugin-json": "^4.0.0",
       "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/additionalProperties/package.json
+++ b/test/integration/generated/additionalProperties/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/src/index.js",
   "types": "./types/additional-properties.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/appconfiguration/package.json
+++ b/test/integration/generated/appconfiguration/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/appconfiguration.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/appconfigurationexport/package.json
+++ b/test/integration/generated/appconfigurationexport/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/appconfiguration.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/arrayConstraints/package.json
+++ b/test/integration/generated/arrayConstraints/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/array-constraints-client.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/attestation/package.json
+++ b/test/integration/generated/attestation/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/attestation.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/azureParameterGrouping/package.json
+++ b/test/integration/generated/azureParameterGrouping/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/azure-parameter-grouping.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/azureReport/package.json
+++ b/test/integration/generated/azureReport/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/zzzAzureReport.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/azureSpecialProperties/package.json
+++ b/test/integration/generated/azureSpecialProperties/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/azure-special-properties.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyArray/package.json
+++ b/test/integration/generated/bodyArray/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-array.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyBoolean/package.json
+++ b/test/integration/generated/bodyBoolean/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-boolean.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyBooleanQuirks/package.json
+++ b/test/integration/generated/bodyBooleanQuirks/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-boolean-quirks.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyByte/package.json
+++ b/test/integration/generated/bodyByte/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-byte.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyComplex/package.json
+++ b/test/integration/generated/bodyComplex/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-complex.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyComplexRest/package.json
+++ b/test/integration/generated/bodyComplexRest/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "autorest": "latest",
-    "@microsoft/api-extractor": "^7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^14.14.22",
     "dotenv": "^8.2.0",
     "prettier": "^2.2.1",

--- a/test/integration/generated/bodyComplexWithTracing/package.json
+++ b/test/integration/generated/bodyComplexWithTracing/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-complex-tracing.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyDate/package.json
+++ b/test/integration/generated/bodyDate/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-date.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyDateTime/package.json
+++ b/test/integration/generated/bodyDateTime/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-datetime.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyDateTimeRfc1123/package.json
+++ b/test/integration/generated/bodyDateTimeRfc1123/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-datetime-rfc1123.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyDictionary/package.json
+++ b/test/integration/generated/bodyDictionary/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-dictionary.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyDuration/package.json
+++ b/test/integration/generated/bodyDuration/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-duration.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyFile/package.json
+++ b/test/integration/generated/bodyFile/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-file.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyFormData/package.json
+++ b/test/integration/generated/bodyFormData/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-formdata.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyInteger/package.json
+++ b/test/integration/generated/bodyInteger/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-integer.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyNumber/package.json
+++ b/test/integration/generated/bodyNumber/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-number.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyString/package.json
+++ b/test/integration/generated/bodyString/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-string.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/bodyStringRest/package.json
+++ b/test/integration/generated/bodyStringRest/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "autorest": "latest",
-    "@microsoft/api-extractor": "^7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^14.14.22",
     "dotenv": "^8.2.0",
     "prettier": "^2.2.1",

--- a/test/integration/generated/bodyTime/package.json
+++ b/test/integration/generated/bodyTime/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/body-time.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/constantParam/package.json
+++ b/test/integration/generated/constantParam/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/constantParam.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/customUrl/package.json
+++ b/test/integration/generated/customUrl/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/customUrlMoreOptions/package.json
+++ b/test/integration/generated/customUrlMoreOptions/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url-MoreOptions.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/customUrlPaging/package.json
+++ b/test/integration/generated/customUrlPaging/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url-paging.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/datalakestorage/package.json
+++ b/test/integration/generated/datalakestorage/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/datalakestorage.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/extensibleEnums/package.json
+++ b/test/integration/generated/extensibleEnums/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/extensible-enums.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/header/package.json
+++ b/test/integration/generated/header/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/header.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/headerRest/package.json
+++ b/test/integration/generated/headerRest/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "autorest": "latest",
-    "@microsoft/api-extractor": "^7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^14.14.22",
     "dotenv": "^8.2.0",
     "prettier": "^2.2.1",

--- a/test/integration/generated/headerprefix/package.json
+++ b/test/integration/generated/headerprefix/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/headerprefix.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/httpInfrastructure/package.json
+++ b/test/integration/generated/httpInfrastructure/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/httpInfrastructure.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/iotspaces/package.json
+++ b/test/integration/generated/iotspaces/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/iotspaces.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/licenseHeader/package.json
+++ b/test/integration/generated/licenseHeader/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/license-header.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/lro/package.json
+++ b/test/integration/generated/lro/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/lro.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/lroParametrizedEndpoints/package.json
+++ b/test/integration/generated/lroParametrizedEndpoints/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/lro-parameterized-endpoints.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/lroRest/package.json
+++ b/test/integration/generated/lroRest/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "autorest": "latest",
-    "@microsoft/api-extractor": "^7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^14.14.22",
     "dotenv": "^8.2.0",
     "prettier": "^2.2.1",

--- a/test/integration/generated/mapperrequired/package.json
+++ b/test/integration/generated/mapperrequired/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/mapperrequired.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/mediaTypes/package.json
+++ b/test/integration/generated/mediaTypes/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-service.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/mediaTypesV3/package.json
+++ b/test/integration/generated/mediaTypesV3/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-v3-client.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/mediaTypesV3Lro/package.json
+++ b/test/integration/generated/mediaTypesV3Lro/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-v3-lro-client.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/mediaTypesWithTracing/package.json
+++ b/test/integration/generated/mediaTypesWithTracing/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-service-tracing.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/modelFlattening/package.json
+++ b/test/integration/generated/modelFlattening/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/model-flattening.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/multipleInheritance/package.json
+++ b/test/integration/generated/multipleInheritance/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/multiple-inheritance.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/multipleInheritanceRest/package.json
+++ b/test/integration/generated/multipleInheritanceRest/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "autorest": "latest",
-    "@microsoft/api-extractor": "^7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^14.14.22",
     "dotenv": "^8.2.0",
     "prettier": "^2.2.1",

--- a/test/integration/generated/nameChecker/package.json
+++ b/test/integration/generated/nameChecker/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/search-documents.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/noLicenseHeader/package.json
+++ b/test/integration/generated/noLicenseHeader/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/nolicense-header.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/noMappers/package.json
+++ b/test/integration/generated/noMappers/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/no-mappers.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/noOperation/package.json
+++ b/test/integration/generated/noOperation/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/no-operation.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/nonStringEnum/package.json
+++ b/test/integration/generated/nonStringEnum/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/non-string-num.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/objectType/package.json
+++ b/test/integration/generated/objectType/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/object-type.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/odataDiscriminator/package.json
+++ b/test/integration/generated/odataDiscriminator/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/odata-discriminator.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/operationgroupclash/package.json
+++ b/test/integration/generated/operationgroupclash/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/operationgroupclash.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/optionalnull/package.json
+++ b/test/integration/generated/optionalnull/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/optionalnull.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/paging/package.json
+++ b/test/integration/generated/paging/package.json
@@ -21,7 +21,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/paging-service.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/pagingNoIterators/package.json
+++ b/test/integration/generated/pagingNoIterators/package.json
@@ -18,7 +18,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/paging-no-iterators.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/pagingRest/package.json
+++ b/test/integration/generated/pagingRest/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "autorest": "latest",
-    "@microsoft/api-extractor": "^7.13.2",
+    "@microsoft/api-extractor": "^7.18.11",
     "@types/node": "^14.14.22",
     "dotenv": "^8.2.0",
     "prettier": "^2.2.1",

--- a/test/integration/generated/petstore/package.json
+++ b/test/integration/generated/petstore/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/petstore.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/readmeFileChecker/package.json
+++ b/test/integration/generated/readmeFileChecker/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/keyvault-secrets.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/regexConstraint/package.json
+++ b/test/integration/generated/regexConstraint/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/regex-constraint.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/report/package.json
+++ b/test/integration/generated/report/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/zzzReport.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/requiredOptional/package.json
+++ b/test/integration/generated/requiredOptional/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/required-optional.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/resources/package.json
+++ b/test/integration/generated/resources/package.json
@@ -17,7 +17,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/resources.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/sealedchoice/package.json
+++ b/test/integration/generated/sealedchoice/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/sealedchoice.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/storageblob/package.json
+++ b/test/integration/generated/storageblob/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/storageblob.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/storagefileshare/package.json
+++ b/test/integration/generated/storagefileshare/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/storagefileshare.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/subscriptionIdApiVersion/package.json
+++ b/test/integration/generated/subscriptionIdApiVersion/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/subscriptionid-apiversion.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/textanalytics/package.json
+++ b/test/integration/generated/textanalytics/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/textanalytics.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/url/package.json
+++ b/test/integration/generated/url/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/url.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/url2/package.json
+++ b/test/integration/generated/url2/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/url.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/urlMulti/package.json
+++ b/test/integration/generated/urlMulti/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/url-multi.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/useragentcorev1/package.json
+++ b/test/integration/generated/useragentcorev1/package.json
@@ -12,7 +12,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/useragent-corev1.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/useragentcorev2/package.json
+++ b/test/integration/generated/useragentcorev2/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/useragent-corev2.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/uuid/package.json
+++ b/test/integration/generated/uuid/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/uuid.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/validation/package.json
+++ b/test/integration/generated/validation/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/validation.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/xmlservice/package.json
+++ b/test/integration/generated/xmlservice/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/xml-service.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",

--- a/test/integration/generated/xmsErrorResponses/package.json
+++ b/test/integration/generated/xmsErrorResponses/package.json
@@ -16,7 +16,7 @@
   "module": "./dist-esm/index.js",
   "types": "./types/xms-error-responses.d.ts",
   "devDependencies": {
-    "@microsoft/api-extractor": "7.7.11",
+    "@microsoft/api-extractor": "^7.18.11",
     "@rollup/plugin-commonjs": "11.0.2",
     "@rollup/plugin-json": "^4.0.0",
     "@rollup/plugin-multi-entry": "^3.0.0",


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.typescript/issues/1204

Updated @microsoft/api-extractor version from `^7.13.2` to `^7.18.11`
Swaggers and integration tests were regenerated.
