### PR TITLE
Skip installing dev deps for Smoke Tests 

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "LICENSE"
     ],
     "dependencies": {
+        "@microsoft/api-extractor": "^7.18.11",
         "@autorest/codemodel": "^4.15.0",
         "@autorest/extension-base": "^3.2.1",
         "@azure-rest/core-client": "^1.0.0-beta.7",

--- a/test/utils/smoke-test.ts
+++ b/test/utils/smoke-test.ts
@@ -68,7 +68,19 @@ const buildGenerated = async (projectPath?: string) => {
     return;
   }
   const npmCommand = `npm${/^win/.test(process.platform) ? ".cmd" : ""}`;
-  const npmInstall = spawn(npmCommand, ["install"], {
+
+  const apiExtractorInstall = spawn(
+    npmCommand,
+    ["install", "-g", `@microsoft/api-extractor@7.18.11`],
+    {
+      stdio: [process.stdin, process.stdout, process.stderr],
+      cwd: projectPath
+    }
+  );
+
+  await onExit(apiExtractorInstall);
+
+  const npmInstall = spawn(npmCommand, ["install", "--only=prod"], {
     stdio: [process.stdin, process.stdout, process.stderr],
     cwd: projectPath
   });

--- a/test/utils/smoke-test.ts
+++ b/test/utils/smoke-test.ts
@@ -69,17 +69,6 @@ const buildGenerated = async (projectPath?: string) => {
   }
   const npmCommand = `npm${/^win/.test(process.platform) ? ".cmd" : ""}`;
 
-  const apiExtractorInstall = spawn(
-    npmCommand,
-    ["install", "-g", `@microsoft/api-extractor@7.18.11`],
-    {
-      stdio: [process.stdin, process.stdout, process.stderr],
-      cwd: projectPath
-    }
-  );
-
-  await onExit(apiExtractorInstall);
-
   const npmInstall = spawn(npmCommand, ["install", "--only=prod"], {
     stdio: [process.stdin, process.stdout, process.stderr],
     cwd: projectPath


### PR DESCRIPTION
This is to avoid the need to consume packages that are not published and tightly coupled to the azure-sdk-for-js mono repo