### PR TITLE
Reference docs links for preview packages

### DIFF
--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -50,7 +50,7 @@ interface Metadata {
   /** Indicates if the package is a test/releasable package. */
   isReleasablePackage?: boolean;
   /** indicate if the package is management plane SDK */
-  azureArm?: boolean
+  azureArm?: boolean;
 }
 
 /**
@@ -100,6 +100,12 @@ function createMetadata(
     : simpleServiceName;
   const identityPackageURL =
     repoURL && `${repoURL}/tree/main/sdk/identity/identity`;
+
+  var PackageNPMURLSufix: string = "";
+  if (clientPackageName.includes("-beta")) {
+    PackageNPMURLSufix = "?view=azure-node-preview";
+  }
+
   return {
     serviceName: serviceName,
     clientPackageName: clientPackageName,
@@ -121,7 +127,7 @@ function createMetadata(
     apiRefURL: azureHuh
       ? `https://docs.microsoft.com/javascript/api/${clientPackageName}`
       : undefined,
-    packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}`,
+    packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}${PackageNPMURLSufix}`,
     contributingGuideURL: repoURL && `${repoURL}/blob/main/CONTRIBUTING.md`,
     projectName: azureHuh ? "Microsoft Azure SDK for JavaScript" : undefined,
     addCredentials,

--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -101,9 +101,12 @@ function createMetadata(
   const identityPackageURL =
     repoURL && `${repoURL}/tree/main/sdk/identity/identity`;
 
-  var PackageNPMURLSufix: string = "";
-  if (clientPackageName.includes("-beta")) {
-    PackageNPMURLSufix = "?view=azure-node-preview";
+  var apiRefUrlPreviewSufix: string = "";
+  if (
+    packageDetails.version.includes("preview") ||
+    packageDetails.version.includes("beta")
+  ) {
+    apiRefUrlPreviewSufix = "?view=azure-node-preview";
   }
 
   return {
@@ -125,9 +128,9 @@ function createMetadata(
     clientDescriptiveName: `${serviceName} client`,
     description: clientDetails.info?.description,
     apiRefURL: azureHuh
-      ? `https://docs.microsoft.com/javascript/api/${clientPackageName}`
+      ? `https://docs.microsoft.com/javascript/api/${clientPackageName}${apiRefUrlPreviewSufix}`
       : undefined,
-    packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}${PackageNPMURLSufix}`,
+    packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}`,
     contributingGuideURL: repoURL && `${repoURL}/blob/main/CONTRIBUTING.md`,
     projectName: azureHuh ? "Microsoft Azure SDK for JavaScript" : undefined,
     addCredentials,


### PR DESCRIPTION
Solves https://github.com/Azure/autorest.typescript/issues/1213

If the generated package is a preview version, the API reference docs URL contains `?view=azure-node-preview` at the end. To determine if a package is a preview SDK it looks for the keyword `preview` or `beta` on the package version.

Tested this change by manually modifying the `const package_version` and `packageName` to add `@azure` in _test-swagger-gen.ts_. These changes were not committed.