### PR TITLE
Update readmeFileGenerator.ts

### DIFF
--- a/src/generators/static/readmeFileGenerator.ts
+++ b/src/generators/static/readmeFileGenerator.ts
@@ -101,12 +101,9 @@ function createMetadata(
   const identityPackageURL =
     repoURL && `${repoURL}/tree/main/sdk/identity/identity`;
 
-  var apiRefUrlPreviewSufix: string = "";
-  if (
-    packageDetails.version.includes("preview") ||
-    packageDetails.version.includes("beta")
-  ) {
-    apiRefUrlPreviewSufix = "?view=azure-node-preview";
+  var apiRefUrlQueryParameter: string = "";
+  if (packageDetails.version.includes("beta")) {
+    apiRefUrlQueryParameter = "?view=azure-node-preview";
   }
 
   return {
@@ -128,7 +125,7 @@ function createMetadata(
     clientDescriptiveName: `${serviceName} client`,
     description: clientDetails.info?.description,
     apiRefURL: azureHuh
-      ? `https://docs.microsoft.com/javascript/api/${clientPackageName}${apiRefUrlPreviewSufix}`
+      ? `https://docs.microsoft.com/javascript/api/${clientPackageName}${apiRefUrlQueryParameter}`
       : undefined,
     packageNPMURL: `https://www.npmjs.com/package/${clientPackageName}`,
     contributingGuideURL: repoURL && `${repoURL}/blob/main/CONTRIBUTING.md`,

--- a/test/smoke/generated/agrifood-data-plane/temp/agrifood-data-plane.api.json
+++ b/test/smoke/generated/agrifood-data-plane/temp/agrifood-data-plane.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/agrifood-data-plane/types/tsdoc-metadata.json
+++ b/test/smoke/generated/agrifood-data-plane/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/temp/arm-package-deploymentscripts-2019-10-preview.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-features-2015-12/temp/arm-package-features-2015-12.api.json
+++ b/test/smoke/generated/arm-package-features-2015-12/temp/arm-package-features-2015-12.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-features-2015-12/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-features-2015-12/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-links-2016-09/temp/arm-package-links-2016-09.api.json
+++ b/test/smoke/generated/arm-package-links-2016-09/temp/arm-package-links-2016-09.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-links-2016-09/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-links-2016-09/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/temp/arm-package-locks-2016-09.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-locks-2016-09/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-locks-2016-09/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/temp/arm-package-managedapplications-2018-06.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/temp/arm-package-policy-2019-09.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-policy-2019-09/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-policy-2019-09/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-resources-2019-08/temp/arm-package-resources-2019-08.api.json
+++ b/test/smoke/generated/arm-package-resources-2019-08/temp/arm-package-resources-2019-08.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-resources-2019-08/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-resources-2019-08/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/temp/arm-package-subscriptions-2019-06.api.json
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/temp/arm-package-subscriptions-2019-06.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/types/tsdoc-metadata.json
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.json
+++ b/test/smoke/generated/compute-resource-manager/temp/compute-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/compute-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/compute-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/temp/cosmos-db-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/cosmos-db-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/cosmos-db-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
+++ b/test/smoke/generated/graphrbac-data-plane/temp/graphrbac-data-plane.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/graphrbac-data-plane/types/tsdoc-metadata.json
+++ b/test/smoke/generated/graphrbac-data-plane/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.json
+++ b/test/smoke/generated/keyvault-resource-manager/temp/keyvault-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/keyvault-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/keyvault-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/monitor-data-plane/temp/monitor-data-plane.api.json
+++ b/test/smoke/generated/monitor-data-plane/temp/monitor-data-plane.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/monitor-data-plane/types/tsdoc-metadata.json
+++ b/test/smoke/generated/monitor-data-plane/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/msi-resource-manager/temp/msi-resource-manager.api.json
+++ b/test/smoke/generated/msi-resource-manager/temp/msi-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/msi-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/msi-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/network-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/network-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/sql-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/sql-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.json
+++ b/test/smoke/generated/storage-resource-manager/temp/storage-resource-manager.api.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "toolPackage": "@microsoft/api-extractor",
-    "toolVersion": "7.18.17",
+    "toolVersion": "7.18.18",
     "schemaVersion": 1004,
     "oldestForwardsCompatibleVersion": 1001,
     "tsdocConfig": {

--- a/test/smoke/generated/storage-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/storage-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }

--- a/test/smoke/generated/web-resource-manager/types/tsdoc-metadata.json
+++ b/test/smoke/generated/web-resource-manager/types/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.18.17"
+      "packageVersion": "7.18.18"
     }
   ]
 }


### PR DESCRIPTION
Follow up for comments in PR https://github.com/Azure/autorest.typescript/pull/1235

- Readme generator only checks for `beta` kweyword to know if a package version is a preview. Keyword `preview` was remove from the if statement.
- Var `apiRefUrlPreviewSufix` name was changed to `apiRefUrlQueryParameter` by @ramya-rao-a suggestion.