### PR TITLE
Pin @autorest/extension package to patch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.0-beta.15 (2021-11-22)
+
+- [Fix] Pinned version of `@autorest/extension-base` to previous version without breaking change.
+
 ## 6.0.0-beta.15 (2021-11-10)
 
 - [Feature] Bumped the modeler m4 version to 4.21.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/typescript",
-    "version": "6.0.0-beta.15",
+    "version": "6.0.0-beta.16",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -30,15 +30,25 @@
             }
         },
         "@autorest/extension-base": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@autorest/extension-base/-/extension-base-3.2.1.tgz",
-            "integrity": "sha512-Z2iRueMevW0YJDBN6x6UAedQNoiMQm9R7tuWo0f3kj4d4VqHOT8jpL1dJ4J4+ojI9yTTisD86SUffkxCOLu2IQ==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/@autorest/extension-base/-/extension-base-3.3.2.tgz",
+            "integrity": "sha512-kBTusd0GvjmBhN3NypCm/WxpmIxZL2/qCfI5sIYz7ICl7BW6LCGpM3yO1MBQY/pC3VGUT/ypzeW8+X691uh7fA==",
             "requires": {
-                "@azure-tools/codegen": "~2.5.294",
+                "@azure-tools/codegen": "~2.8.0",
                 "js-yaml": "~4.0.0",
                 "vscode-jsonrpc": "^3.5.0"
             },
             "dependencies": {
+                "@azure-tools/codegen": {
+                    "version": "2.8.0",
+                    "resolved": "https://registry.npmjs.org/@azure-tools/codegen/-/codegen-2.8.0.tgz",
+                    "integrity": "sha512-HzIWjWzzjCAiUr8uXH1EfeCiC9Gln5YPTbJyfPQCBQeXAQIMRFo1IabFnBXhJpuRl7R11vpt4THELydYZLbalw==",
+                    "requires": {
+                        "@azure-tools/async-io": "~3.0.0",
+                        "js-yaml": "~4.0.0",
+                        "semver": "^5.5.1"
+                    }
+                },
                 "argparse": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/typescript",
-    "version": "6.0.0-beta.15",
+    "version": "6.0.0-beta.16",
     "scripts": {
         "build": "tsc -p . && npm run copyFiles",
         "build:test:browser": "tsc -p tsconfig.browser-test.json && webpack --config webpack.config.test.js",
@@ -33,7 +33,7 @@
     ],
     "dependencies": {
         "@autorest/codemodel": "^4.15.0",
-        "@autorest/extension-base": "^3.2.1",
+        "@autorest/extension-base": "~3.3.2",
         "@azure-rest/core-client": "1.0.0-beta.8",
         "@azure-tools/codegen": "^2.5.294",
         "@azure/core-client": "^1.3.0",


### PR DESCRIPTION
That package doesn't follow semver as it need to have major version match autorest major version. this means current state pulls in the latest always with potential breaking changes