### PR TITLE
remove unused import in clientDefinitions

### DIFF
--- a/src/restLevelClient/generateClientDefinition.ts
+++ b/src/restLevelClient/generateClientDefinition.ts
@@ -116,14 +116,6 @@ export function generatePathFirstClient(model: CodeModel, project: Project) {
   });
 
   const clientName = getLanguageMetadata(model.language).name;
-  const uriParameter = getClientUriParameter();
-
-  const { addCredentials, credentialKeyHeaderName } = getAutorestOptions();
-  const credentialTypes = addCredentials ? ["TokenCredential"] : [];
-
-  if (credentialKeyHeaderName) {
-    credentialTypes.push("KeyCredential");
-  }
 
   const clientIterfaceName = `${clientName}RestClient`;
 
@@ -192,13 +184,6 @@ export function generatePathFirstClient(model: CodeModel, project: Project) {
     {
       namedImports: ["Client"],
       moduleSpecifier: "@azure-rest/core-client"
-    }
-  ]);
-
-  clientFile.addImportDeclarations([
-    {
-      namedImports: credentialTypes,
-      moduleSpecifier: "@azure/core-auth"
     }
   ]);
 }

--- a/test/integration/generated/bodyComplexRest/src/clientDefinitions.ts
+++ b/test/integration/generated/bodyComplexRest/src/clientDefinitions.ts
@@ -170,7 +170,6 @@ import {
   FlattencomplexGetValid200Response
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface BasicGetValid {
   /** Get complex type {id: 2, name: 'abc', color: 'YELLOW'} */

--- a/test/integration/generated/bodyFileRest/src/clientDefinitions.ts
+++ b/test/integration/generated/bodyFileRest/src/clientDefinitions.ts
@@ -15,7 +15,6 @@ import {
   GetEmptyFiledefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface GetFile {
   /** Get file */

--- a/test/integration/generated/bodyFormDataRest/src/clientDefinitions.ts
+++ b/test/integration/generated/bodyFormDataRest/src/clientDefinitions.ts
@@ -15,7 +15,6 @@ import {
   UploadFilesdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface UploadFile {
   /** Upload file */

--- a/test/integration/generated/bodyStringRest/src/clientDefinitions.ts
+++ b/test/integration/generated/bodyStringRest/src/clientDefinitions.ts
@@ -63,7 +63,6 @@ import {
   EnumPutReferencedConstantdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface StringGetNull {
   /** Get null string value value */

--- a/test/integration/generated/customUrlRest/src/clientDefinitions.ts
+++ b/test/integration/generated/customUrlRest/src/clientDefinitions.ts
@@ -4,7 +4,6 @@
 import { GetEmptyParameters } from "./parameters";
 import { GetEmpty200Response, GetEmptydefaultResponse } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 /** Contains operations for Paths operations */
 export interface PathsOperations {

--- a/test/integration/generated/headerRest/src/clientDefinitions.ts
+++ b/test/integration/generated/headerRest/src/clientDefinitions.ts
@@ -93,7 +93,6 @@ import {
   CustomRequestIddefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface ParamExistingKey {
   /** Send a post request with header value "User-Agent": "overwrite" */

--- a/test/integration/generated/lroRest/src/clientDefinitions.ts
+++ b/test/integration/generated/lroRest/src/clientDefinitions.ts
@@ -265,7 +265,6 @@ import {
   LROsCustomHeaderPostAsyncRetrySucceededdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface LROsPut200Succeeded {
   /** Long running put request, service returns a 200 to the initial request, with an entity that contains ProvisioningState=’Succeeded’. */

--- a/test/integration/generated/mediaTypesRest/src/clientDefinitions.ts
+++ b/test/integration/generated/mediaTypesRest/src/clientDefinitions.ts
@@ -19,7 +19,6 @@ import {
   PutTextAndJsonBody200Response
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface AnalyzeBody {
   /** Analyze body, that could be different media types. */

--- a/test/integration/generated/multipleInheritanceRest/src/clientDefinitions.ts
+++ b/test/integration/generated/multipleInheritanceRest/src/clientDefinitions.ts
@@ -31,7 +31,6 @@ import {
   PutKitten200Response
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 /** Contains operations for Client operations */
 export interface ClientOperations {

--- a/test/integration/generated/pagingRest/src/clientDefinitions.ts
+++ b/test/integration/generated/pagingRest/src/clientDefinitions.ts
@@ -66,7 +66,6 @@ import {
   GetPagingModelWithItemNameWithXMSClientNamedefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 export interface GetNoItemNamePages {
   /** A paging operation that must return result of the default 'value' node. */

--- a/test/integration/generated/urlRest/src/clientDefinitions.ts
+++ b/test/integration/generated/urlRest/src/clientDefinitions.ts
@@ -204,7 +204,6 @@ import {
   PathItemsGetLocalPathItemQueryNulldefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 /** Contains operations for Paths operations */
 export interface PathsOperations {

--- a/test/smoke/generated/agrifood-data-plane/src/clientDefinitions.ts
+++ b/test/smoke/generated/agrifood-data-plane/src/clientDefinitions.ts
@@ -307,7 +307,6 @@ import {
   WeatherCreateDataDeleteJobdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import { TokenCredential } from "@azure/core-auth";
 
 export interface ApplicationDataListByFarmerId {
   /** Returns a paginated list of application data resources under a particular farm. */

--- a/test/smoke/generated/purview-administration-rest/src/account/clientDefinitions.ts
+++ b/test/smoke/generated/purview-administration-rest/src/account/clientDefinitions.ts
@@ -49,7 +49,6 @@ import {
   ResourceSetRulesListResourceSetRulesdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import { TokenCredential } from "@azure/core-auth";
 
 export interface AccountsGetAccountProperties {
   /** Get an account */

--- a/test/smoke/generated/purview-administration-rest/src/metadataPolicies/clientDefinitions.ts
+++ b/test/smoke/generated/purview-administration-rest/src/metadataPolicies/clientDefinitions.ts
@@ -18,7 +18,6 @@ import {
   MetadataPolicyGetdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import { TokenCredential } from "@azure/core-auth";
 
 export interface MetadataRolesList {
   /** Lists roles for Purview Account */

--- a/test/smoke/generated/synapse-artifacts-rest/src/clientDefinitions.ts
+++ b/test/smoke/generated/synapse-artifacts-rest/src/clientDefinitions.ts
@@ -337,7 +337,6 @@ import {
   WorkspaceGetdefaultResponse
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import { TokenCredential } from "@azure/core-auth";
 
 /** Contains operations for KqlScripts operations */
 export interface KqlScriptsOperations {

--- a/test/version-tolerance/generated/llc-initial/src/clientDefinitions.ts
+++ b/test/version-tolerance/generated/llc-initial/src/clientDefinitions.ts
@@ -4,7 +4,6 @@
 import { GetRequiredParameters, PostParametersParameters } from "./parameters";
 import { GetRequired200Response, PostParameters200Response } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 /** Contains operations for Params operations */
 export interface ParamsOperations {

--- a/test/version-tolerance/generated/llc-updated/src/clientDefinitions.ts
+++ b/test/version-tolerance/generated/llc-updated/src/clientDefinitions.ts
@@ -14,7 +14,6 @@ import {
   GetNewOperation200Response
 } from "./responses";
 import { Client } from "@azure-rest/core-client";
-import "@azure/core-auth";
 
 /** Contains operations for Params operations */
 export interface ParamsOperations {


### PR DESCRIPTION
fix https://github.com/Azure/autorest.typescript/issues/1293

Issue description: The generated `clientDefinitions` contains credential related import, which is not used in the generated file `clientDefinions.ts`. The unused import leads to build failure when we build it by using azure-sdk-for-js 's tsconfig.