### PR TITLE
Update readme generator to include information about InteractiveBrowserCredential and our support policy

### DIFF
--- a/src/generators/static/README.md.hbs
+++ b/src/generators/static/README.md.hbs
@@ -67,15 +67,30 @@ For more information about how to create an Azure AD Application check out [this
 const { {{ clientClassName }} } = require("{{ clientPackageName }}");
 const { DefaultAzureCredential } = require("@azure/identity");
 // For client-side applications running in the browser, use InteractiveBrowserCredential instead of DefaultAzureCredential. See https://aka.ms/azsdk/js/identity/examples for more details.
+
 const subscriptionId = "00000000-0000-0000-0000-000000000000";
 const client = new {{ clientClassName }}(new DefaultAzureCredential(), subscriptionId);
+
+// For client-side applications running in the browser, use this code instead:
+// const credential = new InteractiveBrowserCredential({
+//   tenantId: "<YOUR_TENANT_ID>",
+//   clientId: "<YOUR_CLIENT_ID>"
+// });
+// const client = new {{ clientClassName }}(credential, subscriptionId);
 ```
 {{else}}
 ```javascript
 const { {{ clientClassName }} } = require("{{ clientPackageName }}");
 const { DefaultAzureCredential } = require("@azure/identity");
 // For client-side applications running in the browser, use InteractiveBrowserCredential instead of DefaultAzureCredential. See https://aka.ms/azsdk/js/identity/examples for more details.
+
 const client = new {{ clientClassName }}("<endpoint>", new DefaultAzureCredential());
+// For client-side applications running in the browser, use this code instead:
+// const credential = new InteractiveBrowserCredential({
+//   tenantId: "<YOUR_TENANT_ID>",
+//   clientId: "<YOUR_CLIENT_ID>"
+// });
+// const client = new {{ clientClassName }}("<endpoint>", credential);
 ```
 {{/if}}
 {{/if}}{{/if}}

--- a/src/generators/static/README.md.hbs
+++ b/src/generators/static/README.md.hbs
@@ -24,6 +24,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 {{#if azure}}
 ### Prerequisites
 
@@ -64,6 +66,7 @@ For more information about how to create an Azure AD Application check out [this
 ```javascript
 const { {{ clientClassName }} } = require("{{ clientPackageName }}");
 const { DefaultAzureCredential } = require("@azure/identity");
+// For client-side applications running in the browser, use InteractiveBrowserCredential instead of DefaultAzureCredential. See https://aka.ms/azsdk/js/identity/examples for more details.
 const subscriptionId = "00000000-0000-0000-0000-000000000000";
 const client = new {{ clientClassName }}(new DefaultAzureCredential(), subscriptionId);
 ```
@@ -71,6 +74,7 @@ const client = new {{ clientClassName }}(new DefaultAzureCredential(), subscript
 ```javascript
 const { {{ clientClassName }} } = require("{{ clientPackageName }}");
 const { DefaultAzureCredential } = require("@azure/identity");
+// For client-side applications running in the browser, use InteractiveBrowserCredential instead of DefaultAzureCredential. See https://aka.ms/azsdk/js/identity/examples for more details.
 const client = new {{ clientClassName }}("<endpoint>", new DefaultAzureCredential());
 ```
 {{/if}}

--- a/test/integration/generated/additionalProperties/README.md
+++ b/test/integration/generated/additionalProperties/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/appconfiguration/README.md
+++ b/test/integration/generated/appconfiguration/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/appconfigurationexport/README.md
+++ b/test/integration/generated/appconfigurationexport/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/arrayConstraints/README.md
+++ b/test/integration/generated/arrayConstraints/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/attestation/README.md
+++ b/test/integration/generated/attestation/README.md
@@ -14,6 +14,8 @@ Describes the interface for the per-tenant enclave service.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/azureParameterGrouping/README.md
+++ b/test/integration/generated/azureParameterGrouping/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/azureReport/README.md
+++ b/test/integration/generated/azureReport/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/azureSpecialProperties/README.md
+++ b/test/integration/generated/azureSpecialProperties/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyArray/README.md
+++ b/test/integration/generated/bodyArray/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyBoolean/README.md
+++ b/test/integration/generated/bodyBoolean/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyBooleanQuirks/README.md
+++ b/test/integration/generated/bodyBooleanQuirks/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyByte/README.md
+++ b/test/integration/generated/bodyByte/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyComplex/README.md
+++ b/test/integration/generated/bodyComplex/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyComplexWithTracing/README.md
+++ b/test/integration/generated/bodyComplexWithTracing/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyDate/README.md
+++ b/test/integration/generated/bodyDate/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyDateTime/README.md
+++ b/test/integration/generated/bodyDateTime/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyDateTimeRfc1123/README.md
+++ b/test/integration/generated/bodyDateTimeRfc1123/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyDictionary/README.md
+++ b/test/integration/generated/bodyDictionary/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyDuration/README.md
+++ b/test/integration/generated/bodyDuration/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyFile/README.md
+++ b/test/integration/generated/bodyFile/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyFormData/README.md
+++ b/test/integration/generated/bodyFormData/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyInteger/README.md
+++ b/test/integration/generated/bodyInteger/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyNumber/README.md
+++ b/test/integration/generated/bodyNumber/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyString/README.md
+++ b/test/integration/generated/bodyString/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/bodyTime/README.md
+++ b/test/integration/generated/bodyTime/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/constantParam/README.md
+++ b/test/integration/generated/constantParam/README.md
@@ -14,6 +14,8 @@ The Text Analytics API is a suite of natural language processing (NLP) services 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/customUrl/README.md
+++ b/test/integration/generated/customUrl/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/customUrlMoreOptions/README.md
+++ b/test/integration/generated/customUrlMoreOptions/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/customUrlPaging/README.md
+++ b/test/integration/generated/customUrlPaging/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/datafactory/README.md
+++ b/test/integration/generated/datafactory/README.md
@@ -14,6 +14,8 @@ The Azure Data Factory V2 management API provides a RESTful set of web services 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/datalakestorage/README.md
+++ b/test/integration/generated/datalakestorage/README.md
@@ -14,6 +14,8 @@ Azure Data Lake Storage provides storage for Hadoop and other big data workloads
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/deviceprovisioningservice/README.md
+++ b/test/integration/generated/deviceprovisioningservice/README.md
@@ -14,6 +14,8 @@ API for using the Azure IoT Hub Device Provisioning Service features.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/domainservices/README.md
+++ b/test/integration/generated/domainservices/README.md
@@ -14,6 +14,8 @@ The AAD Domain Services API.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/extensibleEnums/README.md
+++ b/test/integration/generated/extensibleEnums/README.md
@@ -14,6 +14,8 @@ PetStore
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/header/README.md
+++ b/test/integration/generated/header/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/headerprefix/README.md
+++ b/test/integration/generated/headerprefix/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/healthcareapis/README.md
+++ b/test/integration/generated/healthcareapis/README.md
@@ -14,6 +14,8 @@ Azure Healthcare APIs Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/httpInfrastructure/README.md
+++ b/test/integration/generated/httpInfrastructure/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/iotspaces/README.md
+++ b/test/integration/generated/iotspaces/README.md
@@ -14,6 +14,8 @@ Use this API to manage the IoTSpaces service instances in your Azure subscriptio
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/licenseHeader/README.md
+++ b/test/integration/generated/licenseHeader/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/lro/README.md
+++ b/test/integration/generated/lro/README.md
@@ -14,6 +14,8 @@ Long-running Operation for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/lroParametrizedEndpoints/README.md
+++ b/test/integration/generated/lroParametrizedEndpoints/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/mapperrequired/README.md
+++ b/test/integration/generated/mapperrequired/README.md
@@ -14,6 +14,8 @@ The key vault client performs cryptographic key operations and vault operations 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/mediaTypes/README.md
+++ b/test/integration/generated/mediaTypes/README.md
@@ -14,6 +14,8 @@ Play with produces/consumes and media-types in general.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/mediaTypesV3/README.md
+++ b/test/integration/generated/mediaTypesV3/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/mediaTypesV3Lro/README.md
+++ b/test/integration/generated/mediaTypesV3Lro/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/mediaTypesWithTracing/README.md
+++ b/test/integration/generated/mediaTypesWithTracing/README.md
@@ -14,6 +14,8 @@ Play with produces/consumes and media-types in general.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/modelFlattening/README.md
+++ b/test/integration/generated/modelFlattening/README.md
@@ -14,6 +14,8 @@ Resource Flattening for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/multipleInheritance/README.md
+++ b/test/integration/generated/multipleInheritance/README.md
@@ -14,6 +14,8 @@ Service client for multiinheritance client testing
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/nameChecker/README.md
+++ b/test/integration/generated/nameChecker/README.md
@@ -14,6 +14,8 @@ Client that can be used to query an index and upload, merge, or delete documents
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/noLicenseHeader/README.md
+++ b/test/integration/generated/noLicenseHeader/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/noMappers/README.md
+++ b/test/integration/generated/noMappers/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/noOperation/README.md
+++ b/test/integration/generated/noOperation/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/nonStringEnum/README.md
+++ b/test/integration/generated/nonStringEnum/README.md
@@ -14,6 +14,8 @@ Testing non-string enums.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/objectType/README.md
+++ b/test/integration/generated/objectType/README.md
@@ -14,6 +14,8 @@ Service client for testing basic type: object swaggers
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/odataDiscriminator/README.md
+++ b/test/integration/generated/odataDiscriminator/README.md
@@ -14,6 +14,8 @@ Client that can be used to manage and query indexes and documents, as well as ma
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/operationgroupclash/README.md
+++ b/test/integration/generated/operationgroupclash/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/optionalnull/README.md
+++ b/test/integration/generated/optionalnull/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/paging/README.md
+++ b/test/integration/generated/paging/README.md
@@ -14,6 +14,8 @@ Long-running Operation for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/pagingNoIterators/README.md
+++ b/test/integration/generated/pagingNoIterators/README.md
@@ -14,6 +14,8 @@ Long-running Operation for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/petstore/README.md
+++ b/test/integration/generated/petstore/README.md
@@ -14,6 +14,8 @@ This is a sample server Petstore server.  You can find out more about Swagger at
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/readmeFileChecker/README.md
+++ b/test/integration/generated/readmeFileChecker/README.md
@@ -14,6 +14,8 @@ The key vault client performs cryptographic key operations and vault operations 
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/regexConstraint/README.md
+++ b/test/integration/generated/regexConstraint/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/report/README.md
+++ b/test/integration/generated/report/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/requiredOptional/README.md
+++ b/test/integration/generated/requiredOptional/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/resources/README.md
+++ b/test/integration/generated/resources/README.md
@@ -14,6 +14,8 @@ Provides operations for working with resources and resource groups.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/sealedchoice/README.md
+++ b/test/integration/generated/sealedchoice/README.md
@@ -14,6 +14,8 @@ Metadata API definition for the Azure Container Registry runtime
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/storageblob/README.md
+++ b/test/integration/generated/storageblob/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/storagefileshare/README.md
+++ b/test/integration/generated/storagefileshare/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/subscriptionIdApiVersion/README.md
+++ b/test/integration/generated/subscriptionIdApiVersion/README.md
@@ -14,6 +14,8 @@ Some cool documentation.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/textanalytics/README.md
+++ b/test/integration/generated/textanalytics/README.md
@@ -14,6 +14,8 @@ TextAnalytics Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/url/README.md
+++ b/test/integration/generated/url/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/url2/README.md
+++ b/test/integration/generated/url2/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/urlMulti/README.md
+++ b/test/integration/generated/urlMulti/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/useragentcorev1/README.md
+++ b/test/integration/generated/useragentcorev1/README.md
@@ -14,6 +14,8 @@ Some cool documentation.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/useragentcorev2/README.md
+++ b/test/integration/generated/useragentcorev2/README.md
@@ -14,6 +14,8 @@ Some cool documentation.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/uuid/README.md
+++ b/test/integration/generated/uuid/README.md
@@ -14,6 +14,8 @@ This package contains an isomorphic SDK (runs both in Node.js and in browsers) f
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/validation/README.md
+++ b/test/integration/generated/validation/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest. No server backend exists for these tests.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/xmlservice/README.md
+++ b/test/integration/generated/xmlservice/README.md
@@ -14,6 +14,8 @@ Test Infrastructure for AutoRest Swagger BAT
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/integration/generated/xmsErrorResponses/README.md
+++ b/test/integration/generated/xmsErrorResponses/README.md
@@ -14,6 +14,8 @@ XMS Error Response Extensions
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/README.md
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/README.md
@@ -14,6 +14,8 @@ The APIs listed in this specification can be used to manage Deployment Scripts r
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-features-2015-12/README.md
+++ b/test/smoke/generated/arm-package-features-2015-12/README.md
@@ -14,6 +14,8 @@ Azure Feature Exposure Control (AFEC) provides a mechanism for the resource prov
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-links-2016-09/README.md
+++ b/test/smoke/generated/arm-package-links-2016-09/README.md
@@ -14,6 +14,8 @@ Azure resources can be linked together to form logical relationships. You can es
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-locks-2016-09/README.md
+++ b/test/smoke/generated/arm-package-locks-2016-09/README.md
@@ -14,6 +14,8 @@ Azure resources can be locked to prevent other users in your organization from d
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/README.md
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/README.md
@@ -14,6 +14,8 @@ ARM applications
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-policy-2019-09/README.md
+++ b/test/smoke/generated/arm-package-policy-2019-09/README.md
@@ -14,6 +14,8 @@ To manage and control access to your resources, you can define customized polici
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-resources-2019-08/README.md
+++ b/test/smoke/generated/arm-package-resources-2019-08/README.md
@@ -14,6 +14,8 @@ Provides operations for working with resources and resource groups.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/README.md
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/README.md
@@ -14,6 +14,8 @@ All resource groups and resources exist within subscriptions. These operation en
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/compute-resource-manager/README.md
+++ b/test/smoke/generated/compute-resource-manager/README.md
@@ -14,6 +14,8 @@ Compute Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/cosmos-db-resource-manager/README.md
+++ b/test/smoke/generated/cosmos-db-resource-manager/README.md
@@ -14,6 +14,8 @@ Azure Cosmos DB Database Service Resource Provider REST API
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/graphrbac-data-plane/README.md
+++ b/test/smoke/generated/graphrbac-data-plane/README.md
@@ -13,6 +13,8 @@ The Graph RBAC Management Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/keyvault-resource-manager/README.md
+++ b/test/smoke/generated/keyvault-resource-manager/README.md
@@ -14,6 +14,8 @@ The Azure management API provides a RESTful set of web services that interact wi
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/monitor-data-plane/README.md
+++ b/test/smoke/generated/monitor-data-plane/README.md
@@ -13,6 +13,8 @@ Monitor Management Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/msi-resource-manager/README.md
+++ b/test/smoke/generated/msi-resource-manager/README.md
@@ -14,6 +14,8 @@ The Managed Service Identity Client.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/network-resource-manager/README.md
+++ b/test/smoke/generated/network-resource-manager/README.md
@@ -14,6 +14,8 @@ Network Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/sql-resource-manager/README.md
+++ b/test/smoke/generated/sql-resource-manager/README.md
@@ -14,6 +14,8 @@ The Azure SQL Database management API provides a RESTful set of web services tha
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/storage-resource-manager/README.md
+++ b/test/smoke/generated/storage-resource-manager/README.md
@@ -14,6 +14,8 @@ The Azure Storage Management API.
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 

--- a/test/smoke/generated/web-resource-manager/README.md
+++ b/test/smoke/generated/web-resource-manager/README.md
@@ -14,6 +14,8 @@ WebSite Management Client
 - [LTS versions of Node.js](https://nodejs.org/about/releases/)
 - Latest versions of Safari, Chrome, Edge and Firefox.
 
+See our [support policy](https://github.com/Azure/azure-sdk-for-js/blob/main/SUPPORT.md) for more details.
+
 
 
 


### PR DESCRIPTION
Solves:

- https://github.com/Azure/autorest.typescript/issues/1274
- https://github.com/Azure/autorest.typescript/issues/1306

This PR modify the readme template to include a line pointing to our support policy, and a comment inside an `@azure/identity` code snippet clarifying that for client-side applications running in the browser, `InteractiveBrowserCredential` should be user instead of `DefaultAzureCredential`.

Integration and smoke tests were regenerated as well.