### PR TITLE
[RLC] add new flag multi-client

### DIFF
--- a/src/autorestSession.ts
+++ b/src/autorestSession.ts
@@ -33,6 +33,7 @@ export interface AutorestOptions {
   isTestPackage?: boolean;
   generateTest?: boolean;
   batch?: [string, any][];
+  multiClient?: boolean;
   generateSample?: boolean;
 }
 

--- a/src/generators/indexGenerator.ts
+++ b/src/generators/indexGenerator.ts
@@ -12,7 +12,7 @@ export function generateIndexFile(
   project: Project,
   clientDetails?: ClientDetails
 ) {
-  const { restLevelClient, srcPath, batch } = getAutorestOptions();
+  const { restLevelClient, srcPath, multiClient } = getAutorestOptions();
   const indexFile = project.createSourceFile(`${srcPath}/index.ts`, undefined, {
     overwrite: true
   });
@@ -24,7 +24,7 @@ export function generateIndexFile(
       );
     }
     generateHLCIndex(clientDetails, indexFile);
-  } else if (!batch || batch?.length === 1) {
+  } else if (!multiClient) {
     // if we are generate single client package for RLC
     generateRLCIndex(indexFile);
   } else {
@@ -153,7 +153,7 @@ function generateRLCIndex(file: SourceFile) {
       }
     ]);
   }
-  
+
   file.addExportAssignment({
     expression: clientName,
     isExportEquals: false

--- a/src/generators/indexGenerator.ts
+++ b/src/generators/indexGenerator.ts
@@ -12,7 +12,7 @@ export function generateIndexFile(
   project: Project,
   clientDetails?: ClientDetails
 ) {
-  const { restLevelClient, srcPath, multiClient } = getAutorestOptions();
+  const { restLevelClient, srcPath, multiClient, batch } = getAutorestOptions();
   const indexFile = project.createSourceFile(`${srcPath}/index.ts`, undefined, {
     overwrite: true
   });
@@ -24,7 +24,7 @@ export function generateIndexFile(
       );
     }
     generateHLCIndex(clientDetails, indexFile);
-  } else if (!multiClient) {
+  } else if (!multiClient || !batch || batch?.length === 1) {
     // if we are generate single client package for RLC
     generateRLCIndex(indexFile);
   } else {

--- a/src/restLevelClient/generateClient.ts
+++ b/src/restLevelClient/generateClient.ts
@@ -38,7 +38,7 @@ export function generateClient(model: CodeModel, project: Project) {
   const clientName = getLanguageMetadata(model.language).name;
   const uriParameter = getClientUriParameter();
 
-  const { addCredentials, credentialKeyHeaderName, multiClient } = getAutorestOptions();
+  const { addCredentials, credentialKeyHeaderName, multiClient, batch } = getAutorestOptions();
   const credentialTypes = addCredentials ? ["TokenCredential"] : [];
 
   if (credentialKeyHeaderName) {
@@ -65,7 +65,7 @@ export function generateClient(model: CodeModel, project: Project) {
     statements: getClientFactoryBody(clientInterfaceName, pathDictionary)
   }
 
-  if (!multiClient) {
+  if (!multiClient || !batch || batch.length === 1) {
     functionStatement.isDefaultExport = true;
   }
   clientFile.addFunction(functionStatement);

--- a/src/restLevelClient/generateClient.ts
+++ b/src/restLevelClient/generateClient.ts
@@ -38,7 +38,7 @@ export function generateClient(model: CodeModel, project: Project) {
   const clientName = getLanguageMetadata(model.language).name;
   const uriParameter = getClientUriParameter();
 
-  const { addCredentials, credentialKeyHeaderName, batch } = getAutorestOptions();
+  const { addCredentials, credentialKeyHeaderName, multiClient } = getAutorestOptions();
   const credentialTypes = addCredentials ? ["TokenCredential"] : [];
 
   if (credentialKeyHeaderName) {
@@ -65,7 +65,7 @@ export function generateClient(model: CodeModel, project: Project) {
     statements: getClientFactoryBody(clientInterfaceName, pathDictionary)
   }
 
-  if (!batch || batch.length === 1) {
+  if (!multiClient) {
     functionStatement.isDefaultExport = true;
   }
   clientFile.addFunction(functionStatement);

--- a/src/restLevelClient/generateTopLevelIndexFile.ts
+++ b/src/restLevelClient/generateTopLevelIndexFile.ts
@@ -7,22 +7,22 @@ import { NameType, normalizeName } from '../utils/nameUtils';
 const batchOutputFolder: [string, string, string][] = [];
 
 export function generateTopLevelIndexFile(model: CodeModel, project: Project) {
-    const { batch, srcPath } = getAutorestOptions();
+    const { multiClient, batch, srcPath } = getAutorestOptions();
     if (srcPath) {
         const clientName = model.language.default.name;
         const moduleName = normalizeName(clientName, NameType.File);
         const relativePath = srcPath.replace('/src', '');
         batchOutputFolder.push([relativePath, clientName, moduleName]);
     }
-    
-    if (batch && batch.length > 1 && batchOutputFolder.length === batch.length) {
+
+    if (multiClient && batch && batch.length > 1 && batchOutputFolder.length === batch.length) {
         const { srcPath } = getAutorestOptions();
         const fileDirectory= path.join(srcPath as string, '../../');
         const file = project.createSourceFile('/src/index.ts', undefined, {
             overwrite: true
         });
         file.moveToDirectory(fileDirectory);
-        const allModules: string[] = [];  
+        const allModules: string[] = [];
         batchOutputFolder.forEach(item => {
             file.addImportDeclaration({
                 namespaceImport: item[1],

--- a/src/utils/autorestOptions.ts
+++ b/src/utils/autorestOptions.ts
@@ -34,6 +34,7 @@ export async function extractAutorestOptions(): Promise<AutorestOptions> {
   const isTestPackage = await getIsTestPackage(host);
   const generateTest = await getGenerateTest(host);
   const batch = await getBatch(host);
+  const multiClient = await getMultiClient(host);
   const generateSample = await getGenerateSample(host);
 
   return {
@@ -61,6 +62,7 @@ export async function extractAutorestOptions(): Promise<AutorestOptions> {
     isTestPackage,
     generateTest,
     batch,
+    multiClient,
     generateSample
   };
 }
@@ -287,9 +289,12 @@ async function getAzureOutputDirectoryPath(
     : undefined;
 }
 
-
 async function getBatch(host: AutorestExtensionHost): Promise<[string, any][] | undefined> {
   const batch = await host.getValue<[string, any][]>('batch');
   return batch;
-  
+}
+
+async function getMultiClient(host: AutorestExtensionHost): Promise<boolean> {
+  const multiClient = await host.getValue("multi-client") || undefined;
+  return !!multiClient;
 }

--- a/test/smoke/swagger/purview-administration-rest.md
+++ b/test/smoke/swagger/purview-administration-rest.md
@@ -21,7 +21,7 @@ input-file:  https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/s
 ```
 
 
-```yaml
+```yaml $(multi-client)
 modelerfour.lenient-model-deduplication: true
 package-name: "@azure-rest/purview-administration"
 generate-metadata: true

--- a/test/utils/smoke-test-list.ts
+++ b/test/utils/smoke-test-list.ts
@@ -14,7 +14,8 @@ export enum AutorestParams {
   ModelDedup = "--modelerfour.lenient-model-deduplication",
   RestClient = "--rest-level-client=true",
   GenerateTest = "--generate-test=true",
-  GenerateSamples = "--generate-sample=true"
+  GenerateSamples = "--generate-sample=true",
+  MultiClient = "--multi-client"
 }
 
 const getArmReadmes = (): SpecDefinition[] => {
@@ -178,7 +179,7 @@ export const readmes: SpecDefinition[] = [
       "..",
       "./smoke/swagger/purview-administration-rest.md"
     ),
-    params: [AutorestParams.RestClient],
+    params: [AutorestParams.RestClient, AutorestParams.MultiClient],
     buildTag: "ci_rlc"
   },
   {


### PR DESCRIPTION
This PR adds a new flag `multi-client` to represents it's generating multi clients.

Previously, codegen generates multi clients when `batch` task is set. However, if we only want to use `batch` task to generate multi packages, it's no way. So we need a new flag `multi-client` to indicate codegen is generating multi client.