### PR TITLE
fix-any-object-body-parameter-for-sample-generation

### DIFF
--- a/src/transforms/samplesTransforms.ts
+++ b/src/transforms/samplesTransforms.ts
@@ -146,9 +146,10 @@ export async function getAllExamples(codeModel: TestCodeModel, clientDetails: Cl
             let paramAssignment = "";
             if (methodParameter.parameter.protocol?.http?.["in"] === "body") {
               let bodySchemaName = parameterTypeName;
-              importedTypeSet.add(parameterTypeName);
               if (methodParameter.exampleValue.schema.type === SchemaType.AnyObject || methodParameter.exampleValue.schema.type === SchemaType.Any) {
                 bodySchemaName = "Record<string, unknown>";
+              } else {
+                importedTypeSet.add(parameterTypeName);
               }
               paramAssignment =
                 `const ${parameterName}: ${bodySchemaName} = ` +


### PR DESCRIPTION
to remove the import of Record<string, unknown> if the body schema type is any object in sample generation