### PR TITLE
Remove @autorest/test-server dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,15 +82,6 @@
                 }
             }
         },
-        "@autorest/test-server": {
-            "version": "3.0.27",
-            "resolved": "https://registry.npmjs.org/@autorest/test-server/-/test-server-3.0.27.tgz",
-            "integrity": "sha512-pNXGVrnUgYtW5tGR3ko0JFbuQPDQA5dQGPkXuis9Kvj+aAeIsAFy37H4KkhJpW5nFw9/QT0vKkB5Ds/5FXx4ug==",
-            "dev": true,
-            "requires": {
-                "wiremock": "2.25.0"
-            }
-        },
         "@azure-rest/core-client": {
             "version": "1.0.0-alpha.20220112.1",
             "resolved": "https://registry.npmjs.org/@azure-rest/core-client/-/core-client-1.0.0-alpha.20220112.1.tgz",
@@ -7240,12 +7231,6 @@
                 }
             }
         },
-        "interpret": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
-            "dev": true
-        },
         "invariant": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -11051,15 +11036,6 @@
                 }
             }
         },
-        "rechoir": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-            "dev": true,
-            "requires": {
-                "resolve": "^1.1.6"
-            }
-        },
         "regenerate": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
@@ -13225,28 +13201,6 @@
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.0.tgz",
             "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==",
             "dev": true
-        },
-        "wiremock": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/wiremock/-/wiremock-2.25.0.tgz",
-            "integrity": "sha512-F7i9ikOENfz7QnhvDFJGFFVkmSq3+wySLFiNLB5NAThRCw0xdU0FimkAHLP6MLEnqxvg1/O7JEaTg+PAaX24+w==",
-            "dev": true,
-            "requires": {
-                "shelljs": "^0.7.5"
-            },
-            "dependencies": {
-                "shelljs": {
-                    "version": "0.7.8",
-                    "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-                    "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-                    "dev": true,
-                    "requires": {
-                        "glob": "^7.0.0",
-                        "interpret": "^1.0.0",
-                        "rechoir": "^0.6.2"
-                    }
-                }
-            }
         },
         "word-wrap": {
             "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
         "ts-morph": "^9.0.0"
     },
     "devDependencies": {
-        "@autorest/test-server": "^3.0.27",
         "@azure-tools/test-recorder": "^1.0.0",
         "@azure/abort-controller": "^1.0.1",
         "@azure/core-util": "^1.0.0-beta.1",


### PR DESCRIPTION
The last 2 vulnerabilities of the @autorest/typescript package will be removed with this PR. The package `@autorest/test-server` looks like an old and obsolete package that we do not use anymore. So, it is safe to remove it.

![image](https://user-images.githubusercontent.com/602456/164518249-da358ec7-b1e5-4e5b-a0ef-6767b6016fdc.png)


@joheredi Please review and approve the PR