### PR TITLE
Remove Component Det from Test Stages

### DIFF
--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -54,7 +54,7 @@ stages:
       - job: HLC_Generation
         dependsOn: Build
         variables:
-          skipComponentGovernanceDetection: true
+          - template: globals.yml
         strategy:
           matrix:
             macOS_Node12:
@@ -86,7 +86,7 @@ stages:
       - job: RLC_Generation
         dependsOn: Build
         variables:
-          skipComponentGovernanceDetection: true
+          - template: globals.yml
         strategy:
           matrix:
             macOS_Node12:
@@ -121,7 +121,7 @@ stages:
       - job: Test
         dependsOn: Build
         variables:
-          skipComponentGovernanceDetection: true
+          - template: globals.yml
         strategy:
           matrix:
             macOS_Node12:

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -53,6 +53,8 @@ stages:
               path: $(Build.ArtifactStagingDirectory)
       - job: HLC_Generation
         dependsOn: Build
+        variables:
+          skipComponentGovernanceDetection: true
         strategy:
           matrix:
             macOS_Node12:
@@ -79,10 +81,12 @@ stages:
           - script: npm run generate-swaggers
             displayName: "Generate HLC Test Clients"
           - script: npm run check:tree
-            displayName: "Check git Tree"            
+            displayName: "Check git Tree"
 
       - job: RLC_Generation
         dependsOn: Build
+        variables:
+          skipComponentGovernanceDetection: true
         strategy:
           matrix:
             macOS_Node12:
@@ -111,11 +115,13 @@ stages:
           - script: npm run generate-version-tolerance
             displayName: "Generate RLC version tolerance initial version"
           - script: npm run generate-version-tolerance:tests
-            displayName: "Generate RLC version tolerance update version"  
+            displayName: "Generate RLC version tolerance update version"
           - script: npm run check:tree
-            displayName: "Check git Tree"  
+            displayName: "Check git Tree"
       - job: Test
         dependsOn: Build
+        variables:
+          skipComponentGovernanceDetection: true
         strategy:
           matrix:
             macOS_Node12:
@@ -144,13 +150,13 @@ stages:
               versionSpec: $(NodeTestVersion)
             displayName: "Use Node $(NodeTestVersion)"
           - script: npm run start-test-server:v2 &
-            displayName: "Start Test Server"     
+            displayName: "Start Test Server"
           - script: npm run test:node:alone
             displayName: "Run Node Tests"
           - script: npm run test:browser:alone
             displayName: "Run Browser Tests"
           - script: npm run stop-test-server
-            displayName: "Stop Test Server"   
+            displayName: "Stop Test Server"
           - script: npm run check:tree
             displayName: "Check git Tree"
           - script: |

--- a/.scripts/globals.yml
+++ b/.scripts/globals.yml
@@ -1,0 +1,2 @@
+variables:
+  skipComponentGovernanceDetection: true

--- a/.scripts/smoke-test.yml
+++ b/.scripts/smoke-test.yml
@@ -5,7 +5,7 @@ parameters:
 jobs:
   - job: ${{ parameters.name }}
     variables:
-      skipComponentGovernanceDetection: true
+      - template: globals.yml
     steps:
       - template: build.yml
       - script: npm run clone:specs

--- a/.scripts/smoke-test.yml
+++ b/.scripts/smoke-test.yml
@@ -4,6 +4,8 @@ parameters:
 
 jobs:
   - job: ${{ parameters.name }}
+    variables:
+      skipComponentGovernanceDetection: true
     steps:
       - template: build.yml
       - script: npm run clone:specs


### PR DESCRIPTION
While working on the Component Governance Issues, I have noticed that the Component Detection Job is run at every stage (Build, HLC Test, RLC Test, Smoke Test, Unit Test). This is not only time cosuming and unnecessary. Sometime, when it hangs it will create a component governance violations  that are not there. 

@praveenkuttappan suggested to remove the component governance from all steps other than build. This PR is to do that. You can see a test run here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1524546&view=logs&j=462ec23f-14a8-561c-bd2a-3cc23815db36 - This one has Component Governance only under the Build Stage 

Compare it with the old run - https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1524441&view=logs&j=88cef286-44ca-5c67-b516-cbd63d8b0608 where every stage has Component Governance. 

@joheredi @praveenkuttappan  Please review and approve the PR