### PR TITLE
Fix the wrong links in rlc README.md

### DIFF
--- a/src/generators/static/rlcREADME.md.hbs
+++ b/src/generators/static/rlcREADME.md.hbs
@@ -51,7 +51,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/src/generators/static/rlcREADME.md.hbs
+++ b/src/generators/static/rlcREADME.md.hbs
@@ -30,7 +30,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/){{#if dependencyLink}} and follow [these]({{ dependencyLink }}) instructions{{/if}} to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/){{#if dependencyLink}} and follow [these]({{ dependencyLink }}) instructions{{/if}} to use this package.
 
 ### Install the `{{ clientPackageName }}` package
 
@@ -46,7 +46,7 @@ To use an [Azure Active Directory (AAD) token credential](https://github.com/Azu
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) {{#if dependencyLink}} and
+To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) {{#if dependencyLink}}and
 [{{dependencyDescription }}]({{ dependencyLink }}){{/if}}
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.

--- a/src/generators/static/rlcREADME.md.hbs
+++ b/src/generators/static/rlcREADME.md.hbs
@@ -30,7 +30,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token){{#if dependencyLink}} and follow [these]({{ dependencyLink }}) instructions{{/if}} to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/){{#if dependencyLink}} and follow [these]({{ dependencyLink }}) instructions{{/if}} to use this package.
 
 ### Install the `{{ clientPackageName }}` package
 
@@ -42,7 +42,7 @@ npm install {{ clientPackageName }}
 
 ### Create and authenticate a `{{ clientClassName }}`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/bodyComplexRest/README.md
+++ b/test/rlcIntegration/generated/bodyComplexRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/body-complex-rest` package
 

--- a/test/rlcIntegration/generated/bodyComplexRest/README.md
+++ b/test/rlcIntegration/generated/bodyComplexRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/bodyComplexRest/README.md
+++ b/test/rlcIntegration/generated/bodyComplexRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/body-complex-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/body-complex-rest
 
 ### Create and authenticate a `BodyComplexRestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/bodyFileRest/README.md
+++ b/test/rlcIntegration/generated/bodyFileRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/body-file` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/body-file
 
 ### Create and authenticate a `BodyFile`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/bodyFileRest/README.md
+++ b/test/rlcIntegration/generated/bodyFileRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/body-file` package
 

--- a/test/rlcIntegration/generated/bodyFileRest/README.md
+++ b/test/rlcIntegration/generated/bodyFileRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/bodyFormDataRest/README.md
+++ b/test/rlcIntegration/generated/bodyFormDataRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/bodyFormDataRest/README.md
+++ b/test/rlcIntegration/generated/bodyFormDataRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/body-formdata-rest` package
 

--- a/test/rlcIntegration/generated/bodyFormDataRest/README.md
+++ b/test/rlcIntegration/generated/bodyFormDataRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/body-formdata-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/body-formdata-rest
 
 ### Create and authenticate a `BodyFormData`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/bodyStringRest/README.md
+++ b/test/rlcIntegration/generated/bodyStringRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/body-string-rest` package
 

--- a/test/rlcIntegration/generated/bodyStringRest/README.md
+++ b/test/rlcIntegration/generated/bodyStringRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/bodyStringRest/README.md
+++ b/test/rlcIntegration/generated/bodyStringRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/body-string-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/body-string-rest
 
 ### Create and authenticate a `BodyStringRest`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/customUrlRest/README.md
+++ b/test/rlcIntegration/generated/customUrlRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/custom-url-rest` package
 

--- a/test/rlcIntegration/generated/customUrlRest/README.md
+++ b/test/rlcIntegration/generated/customUrlRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/custom-url-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/custom-url-rest
 
 ### Create and authenticate a `CustomUrlRestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/customUrlRest/README.md
+++ b/test/rlcIntegration/generated/customUrlRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/dpgCustomization/README.md
+++ b/test/rlcIntegration/generated/dpgCustomization/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/dpg-customization-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/dpg-customization-rest
 
 ### Create and authenticate a `DPGCustomizationClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/dpgCustomization/README.md
+++ b/test/rlcIntegration/generated/dpgCustomization/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/dpgCustomization/README.md
+++ b/test/rlcIntegration/generated/dpgCustomization/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/dpg-customization-rest` package
 

--- a/test/rlcIntegration/generated/headerRest/README.md
+++ b/test/rlcIntegration/generated/headerRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/header-rest` package
 

--- a/test/rlcIntegration/generated/headerRest/README.md
+++ b/test/rlcIntegration/generated/headerRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/header-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/header-rest
 
 ### Create and authenticate a `HeaderRestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/headerRest/README.md
+++ b/test/rlcIntegration/generated/headerRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/httpInfrastructureRest/README.md
+++ b/test/rlcIntegration/generated/httpInfrastructureRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/http-infrastructure-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/http-infrastructure-rest
 
 ### Create and authenticate a `HttpInfrastructureRestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/httpInfrastructureRest/README.md
+++ b/test/rlcIntegration/generated/httpInfrastructureRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/httpInfrastructureRest/README.md
+++ b/test/rlcIntegration/generated/httpInfrastructureRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/http-infrastructure-rest` package
 

--- a/test/rlcIntegration/generated/lroRest/README.md
+++ b/test/rlcIntegration/generated/lroRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/lro-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/lro-rest
 
 ### Create and authenticate a `LRORestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/lroRest/README.md
+++ b/test/rlcIntegration/generated/lroRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/lroRest/README.md
+++ b/test/rlcIntegration/generated/lroRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/lro-rest` package
 

--- a/test/rlcIntegration/generated/mediaTypesRest/README.md
+++ b/test/rlcIntegration/generated/mediaTypesRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/mediaTypesRest/README.md
+++ b/test/rlcIntegration/generated/mediaTypesRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/media-types-service-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/media-types-service-rest
 
 ### Create and authenticate a `MediaTypes`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/mediaTypesRest/README.md
+++ b/test/rlcIntegration/generated/mediaTypesRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/media-types-service-rest` package
 

--- a/test/rlcIntegration/generated/multipleInheritanceRest/README.md
+++ b/test/rlcIntegration/generated/multipleInheritanceRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/multipleInheritanceRest/README.md
+++ b/test/rlcIntegration/generated/multipleInheritanceRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/multiple-inheritance-rest` package
 

--- a/test/rlcIntegration/generated/multipleInheritanceRest/README.md
+++ b/test/rlcIntegration/generated/multipleInheritanceRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/multiple-inheritance-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/multiple-inheritance-rest
 
 ### Create and authenticate a `MultipleInheritanceRestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/pagingRest/README.md
+++ b/test/rlcIntegration/generated/pagingRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/pagingRest/README.md
+++ b/test/rlcIntegration/generated/pagingRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/paging-service` package
 

--- a/test/rlcIntegration/generated/pagingRest/README.md
+++ b/test/rlcIntegration/generated/pagingRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/paging-service` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/paging-service
 
 ### Create and authenticate a `Paging`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/rlcIntegration/generated/urlRest/README.md
+++ b/test/rlcIntegration/generated/urlRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/url-rest` package
 

--- a/test/rlcIntegration/generated/urlRest/README.md
+++ b/test/rlcIntegration/generated/urlRest/README.md
@@ -37,7 +37,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/rlcIntegration/generated/urlRest/README.md
+++ b/test/rlcIntegration/generated/urlRest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/url-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/url-rest
 
 ### Create and authenticate a `UrlRestClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/smoke/generated/agrifood-data-plane/README.md
+++ b/test/smoke/generated/agrifood-data-plane/README.md
@@ -16,7 +16,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) to use this package.
 
 ### Install the `@msinternal/agrifood-data-plane` package
 

--- a/test/smoke/generated/agrifood-data-plane/README.md
+++ b/test/smoke/generated/agrifood-data-plane/README.md
@@ -16,7 +16,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) to use this package.
 
 ### Install the `@msinternal/agrifood-data-plane` package
 
@@ -28,7 +28,7 @@ npm install @msinternal/agrifood-data-plane
 
 ### Create and authenticate a `AzureAgriFoodPlatformDataPlaneService`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/smoke/generated/agrifood-data-plane/README.md
+++ b/test/smoke/generated/agrifood-data-plane/README.md
@@ -36,7 +36,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/smoke/generated/purview-administration-rest/README.md
+++ b/test/smoke/generated/purview-administration-rest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) and follow [these](https://docs.microsoft.com/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role) instructions to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) and follow [these](https://docs.microsoft.com/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role) instructions to use this package.
 
 ### Install the `@msinternal/purview-administration-rest` package
 
@@ -29,7 +29,7 @@ npm install @msinternal/purview-administration-rest
 
 ### Create and authenticate a `PurviewAccount`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 

--- a/test/smoke/generated/purview-administration-rest/README.md
+++ b/test/smoke/generated/purview-administration-rest/README.md
@@ -38,7 +38,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/smoke/generated/purview-administration-rest/README.md
+++ b/test/smoke/generated/purview-administration-rest/README.md
@@ -17,7 +17,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://azure.microsoft.com/en-us/free/) and follow [these](https://docs.microsoft.com/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role) instructions to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) and follow [these](https://docs.microsoft.com/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role) instructions to use this package.
 
 ### Install the `@msinternal/purview-administration-rest` package
 
@@ -33,7 +33,7 @@ To use an [Azure Active Directory (AAD) token credential](https://github.com/Azu
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)  and
+To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) and
 [enable AAD authentication on your Purview resource](https://docs.microsoft.com/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role)
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.

--- a/test/unit/generators/static/files/case-rlcReadme.md
+++ b/test/unit/generators/static/files/case-rlcReadme.md
@@ -20,7 +20,7 @@ Key links:
 
 ### Prerequisites
 
-- You must have an [Azure subscription](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token) and follow [these](https://docs.microsoft.com/en-us/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role) instructions to use this package.
+- You must have an [Azure subscription](https://azure.microsoft.com/free/) and follow [these](https://docs.microsoft.com/en-us/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role) instructions to use this package.
 
 ### Install the `@azure-rest/agrifood-farming` package
 
@@ -32,11 +32,11 @@ npm install @azure-rest/agrifood-farming
 
 ### Create and authenticate a `AgfoodClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://docs.microsoft.com/en-us/azure/cognitive-services/authentication?tabs=powershell#authenticate-with-an-authentication-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)  and
+To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) and
 [enable AAD authentication on your Purview resource](https://docs.microsoft.com/en-us/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role)
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.

--- a/test/unit/generators/static/files/case-rlcReadme.md
+++ b/test/unit/generators/static/files/case-rlcReadme.md
@@ -36,7 +36,7 @@ To use an [Azure Active Directory (AAD) token credential](https://github.com/Azu
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) and
+To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)  and
 [enable AAD authentication on your Purview resource](https://docs.microsoft.com/en-us/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role)
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.

--- a/test/unit/generators/static/files/case-rlcReadme.md
+++ b/test/unit/generators/static/files/case-rlcReadme.md
@@ -41,7 +41,7 @@ To authenticate with AAD, you must first `npm` install [`@azure/identity`](https
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.
 As an example, [DefaultAzureCredential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#defaultazurecredential)
-can be used to authenticate the client:
+can be used to authenticate the client.
 
 Set the values of the client ID, tenant ID, and client secret of the AAD application as environment variables:
 AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET

--- a/test/unit/generators/static/files/case-rlcReadme.md
+++ b/test/unit/generators/static/files/case-rlcReadme.md
@@ -32,11 +32,11 @@ npm install @azure-rest/agrifood-farming
 
 ### Create and authenticate a `AgfoodClient`
 
-To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
+To use an [Azure Active Directory (AAD) token credential](https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/identity/identity/samples/AzureIdentityExamples.md#authenticating-with-a-pre-fetched-access-token),
 provide an instance of the desired credential type obtained from the
 [@azure/identity](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) library.
 
-To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity)  and
+To authenticate with AAD, you must first `npm` install [`@azure/identity`](https://www.npmjs.com/package/@azure/identity) and
 [enable AAD authentication on your Purview resource](https://docs.microsoft.com/en-us/azure/purview/create-catalog-portal#add-a-security-principal-to-a-data-plane-role)
 
 After setup, you can choose which type of [credential](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity#credentials) from `@azure/identity` to use.


### PR DESCRIPTION
Fix the wrong links in rlc README.md. These links are related to authentication.