### PR TITLE
fix-dictionary-type-sample-generation-bug

### DIFF
--- a/src/transforms/samplesTransforms.ts
+++ b/src/transforms/samplesTransforms.ts
@@ -188,7 +188,7 @@ import {
                   methodParameter.exampleValue.schema.type === SchemaType.Any
                 ) {
                   bodySchemaName = "Record<string, unknown>";
-                } else {
+                } else if (methodParameter.exampleValue.schema.type !== SchemaType.Dictionary) {
                   importedTypeSet.add(parameterTypeName);
                 }
                 paramAssignment =


### PR DESCRIPTION
This PR is trying to fix the sample generation error of Dictionary body object. 

Previously, the generated samples will try to import the Dictionary type from generated package like this 

```
import {
   { [propertyName: string]: any }
} from "@azure/arm-datafactory"
```

which is incorrect