### PR TITLE
[RLC] Update latest core-client-rest

### DIFF
--- a/src/generators/static/packageFileGenerator.ts
+++ b/src/generators/static/packageFileGenerator.ts
@@ -132,7 +132,7 @@ function restLevelPackage(packageDetails: PackageDetails) {
     autoPublish: false,
     dependencies: {
       "@azure/core-auth": "^1.3.0",
-      "@azure-rest/core-client": "dev",
+      "@azure-rest/core-client": "1.0.0-beta.10",
       "@azure/core-rest-pipeline": "^1.8.0",
       "@azure/logger": "^1.0.0",
       tslib: "^2.2.0",

--- a/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/body-complex-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/body-complex-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/body-file.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/body-file.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/body-formdata-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/body-formdata-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/body-string-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/src/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/body-string-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/src/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",

--- a/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/test/rlcIntegration/generated/customUrlRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/test/rlcIntegration/generated/customUrlRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/custom-url-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/dpg-customization-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",

--- a/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/dpg-customization-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -58,7 +72,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/test/rlcIntegration/generated/headerRest/package.json
+++ b/test/rlcIntegration/generated/headerRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/header-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/headerRest/package.json
+++ b/test/rlcIntegration/generated/headerRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/header-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/http-infrastructure-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -58,7 +72,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/http-infrastructure-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",

--- a/test/rlcIntegration/generated/lroRest/package.json
+++ b/test/rlcIntegration/generated/lroRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/lro-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/test/rlcIntegration/generated/lroRest/package.json
+++ b/test/rlcIntegration/generated/lroRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/lro-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-service-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/media-types-service-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/multiple-inheritance-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/multiple-inheritance-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/pagingRest/package.json
+++ b/test/rlcIntegration/generated/pagingRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/paging-service.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/test/rlcIntegration/generated/pagingRest/package.json
+++ b/test/rlcIntegration/generated/pagingRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/paging-service.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/urlRest/package.json
+++ b/test/rlcIntegration/generated/urlRest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/url-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/rlcIntegration/generated/urlRest/package.json
+++ b/test/rlcIntegration/generated/urlRest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-preview1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/url-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0"

--- a/test/smoke/generated/agrifood-data-plane/package.json
+++ b/test/smoke/generated/agrifood-data-plane/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.1",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/agrifood-data-plane.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/src/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",

--- a/test/smoke/generated/agrifood-data-plane/package.json
+++ b/test/smoke/generated/agrifood-data-plane/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.1",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/src/index.js",
   "types": "./types/agrifood-data-plane.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/src/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",

--- a/test/smoke/generated/purview-administration-rest/package.json
+++ b/test/smoke/generated/purview-administration-rest/package.json
@@ -4,23 +4,14 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",
-  "keywords": [
-    "node",
-    "azure",
-    "cloud",
-    "typescript",
-    "browser",
-    "isomorphic"
-  ],
+  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/purview-administration-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": {
-    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-  },
+  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
   "files": [
     "dist/",
     "dist-esm/",
@@ -31,15 +22,10 @@
   ],
   "//metadata": {
     "constantPaths": [
-      {
-        "path": "swagger/README.md",
-        "prefix": "package-version"
-      }
+      { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": {
-    "node": ">=12.0.0"
-  },
+  "engines": { "node": ">=12.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",

--- a/test/smoke/generated/purview-administration-rest/package.json
+++ b/test/smoke/generated/purview-administration-rest/package.json
@@ -4,14 +4,23 @@
   "author": "Microsoft Corporation",
   "version": "1.0.0-beta.2",
   "description": "",
-  "keywords": ["node", "azure", "cloud", "typescript", "browser", "isomorphic"],
+  "keywords": [
+    "node",
+    "azure",
+    "cloud",
+    "typescript",
+    "browser",
+    "isomorphic"
+  ],
   "license": "MIT",
   "main": "dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./types/purview-administration-rest.d.ts",
   "homepage": "https://github.com/Azure/azure-sdk-for-js/tree/main/undefined/README.md",
   "repository": "github:Azure/azure-sdk-for-js",
-  "bugs": { "url": "https://github.com/Azure/azure-sdk-for-js/issues" },
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  },
   "files": [
     "dist/",
     "dist-esm/",
@@ -22,10 +31,15 @@
   ],
   "//metadata": {
     "constantPaths": [
-      { "path": "swagger/README.md", "prefix": "package-version" }
+      {
+        "path": "swagger/README.md",
+        "prefix": "package-version"
+      }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -59,7 +73,7 @@
   "autoPublish": false,
   "dependencies": {
     "@azure/core-auth": "^1.3.0",
-    "@azure-rest/core-client": "dev",
+    "@azure-rest/core-client": "1.0.0-beta.10",
     "@azure/core-rest-pipeline": "^1.8.0",
     "@azure/logger": "^1.0.0",
     "tslib": "^2.2.0",


### PR DESCRIPTION
Moving from "dev" to the latest released core-client-rest