### PR TITLE
Removing lookbehind RegEx in AutoRest

### DIFF
--- a/src/generators/clientFileGenerator.ts
+++ b/src/generators/clientFileGenerator.ts
@@ -437,7 +437,7 @@ function writeCustomApiVersion(classDeclaration: ClassDeclaration) {
       if (param.length > 1) {
         const newParams = param[1].split('&').map((item) => {
           if(item.indexOf('api-version') > -1) {
-            return item.replace(/(?<==).*$/, apiVersion);
+            return "api-version=" + apiVersion;
           } else {
             return item;
           }

--- a/test/integration/generated/appconfiguration/src/appConfigurationClient.ts
+++ b/test/integration/generated/appconfiguration/src/appConfigurationClient.ts
@@ -123,7 +123,7 @@ export class AppConfigurationClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/appconfigurationexport/src/appConfigurationClient.ts
+++ b/test/integration/generated/appconfigurationexport/src/appConfigurationClient.ts
@@ -124,7 +124,7 @@ export class AppConfigurationClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/arrayConstraints/src/arrayConstraintsClient.ts
+++ b/test/integration/generated/arrayConstraints/src/arrayConstraintsClient.ts
@@ -90,7 +90,7 @@ export class ArrayConstraintsClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/attestation/src/generatedClient.ts
+++ b/test/integration/generated/attestation/src/generatedClient.ts
@@ -78,7 +78,7 @@ export class GeneratedClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClient.ts
+++ b/test/integration/generated/azureSpecialProperties/src/azureSpecialPropertiesClient.ts
@@ -121,7 +121,7 @@ export class AzureSpecialPropertiesClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
+++ b/test/integration/generated/bodyComplex/src/bodyComplexClient.ts
@@ -99,7 +99,7 @@ export class BodyComplexClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/bodyComplexWithTracing/src/bodyComplexWithTracing.ts
+++ b/test/integration/generated/bodyComplexWithTracing/src/bodyComplexWithTracing.ts
@@ -99,7 +99,7 @@ export class BodyComplexWithTracing extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/datafactory/src/dataFactoryClient.ts
+++ b/test/integration/generated/datafactory/src/dataFactoryClient.ts
@@ -138,7 +138,7 @@ export class DataFactoryClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/datasearch/src/dataSearchClient.ts
+++ b/test/integration/generated/datasearch/src/dataSearchClient.ts
@@ -90,7 +90,7 @@ export class DataSearchClient extends coreHttpCompat.ExtendedServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/deviceprovisioningservice/src/deviceProvisioningClient.ts
+++ b/test/integration/generated/deviceprovisioningservice/src/deviceProvisioningClient.ts
@@ -85,7 +85,7 @@ export class DeviceProvisioningClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/domainservices/src/domainServicesClient.ts
+++ b/test/integration/generated/domainservices/src/domainServicesClient.ts
@@ -89,7 +89,7 @@ export class DomainServicesClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/healthcareapis/src/healthCareApisClient.ts
+++ b/test/integration/generated/healthcareapis/src/healthCareApisClient.ts
@@ -111,7 +111,7 @@ export class HealthCareApisClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/licenseHeader/src/licenseHeaderClient.ts
+++ b/test/integration/generated/licenseHeader/src/licenseHeaderClient.ts
@@ -86,7 +86,7 @@ export class LicenseHeaderClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/nameChecker/src/searchClient.ts
+++ b/test/integration/generated/nameChecker/src/searchClient.ts
@@ -82,7 +82,7 @@ export class SearchClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/noLicenseHeader/src/noLicenseHeaderClient.ts
+++ b/test/integration/generated/noLicenseHeader/src/noLicenseHeaderClient.ts
@@ -78,7 +78,7 @@ export class NoLicenseHeaderClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/noMappers/src/noMappersClient.ts
+++ b/test/integration/generated/noMappers/src/noMappersClient.ts
@@ -86,7 +86,7 @@ export class NoMappersClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/odataDiscriminator/src/oDataDiscriminatorClient.ts
+++ b/test/integration/generated/odataDiscriminator/src/oDataDiscriminatorClient.ts
@@ -87,7 +87,7 @@ export class ODataDiscriminatorClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/operationgroupclash/src/operationGroupClashClient.ts
+++ b/test/integration/generated/operationgroupclash/src/operationGroupClashClient.ts
@@ -76,7 +76,7 @@ export class OperationGroupClashClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/readmeFileChecker/src/keyVaultClient.ts
+++ b/test/integration/generated/readmeFileChecker/src/keyVaultClient.ts
@@ -100,7 +100,7 @@ export class KeyVaultClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/resources/src/resourcesClient.ts
+++ b/test/integration/generated/resources/src/resourcesClient.ts
@@ -93,7 +93,7 @@ export class ResourcesClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/subscriptionIdApiVersion/src/subscriptionIdApiVersionClient.ts
+++ b/test/integration/generated/subscriptionIdApiVersion/src/subscriptionIdApiVersionClient.ts
@@ -82,7 +82,7 @@ export class SubscriptionIdApiVersionClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/integration/generated/useragentcorev2/src/userAgentCoreV2Client.ts
+++ b/test/integration/generated/useragentcorev2/src/userAgentCoreV2Client.ts
@@ -82,7 +82,7 @@ export class UserAgentCoreV2Client extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClient.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClient.ts
@@ -88,9 +88,9 @@ export class DeploymentScriptsClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClient.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClient.ts
@@ -88,7 +88,7 @@ export class DeploymentScriptsClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClient.ts
+++ b/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/src/deploymentScriptsClient.ts
@@ -90,7 +90,7 @@ export class DeploymentScriptsClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-features-2015-12/src/featureClient.ts
+++ b/test/smoke/generated/arm-package-features-2015-12/src/featureClient.ts
@@ -99,7 +99,7 @@ export class FeatureClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-features-2015-12/src/featureClient.ts
+++ b/test/smoke/generated/arm-package-features-2015-12/src/featureClient.ts
@@ -101,7 +101,7 @@ export class FeatureClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-features-2015-12/src/featureClient.ts
+++ b/test/smoke/generated/arm-package-features-2015-12/src/featureClient.ts
@@ -99,9 +99,9 @@ export class FeatureClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClient.ts
+++ b/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClient.ts
@@ -91,7 +91,7 @@ export class ManagementLinkClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClient.ts
+++ b/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClient.ts
@@ -89,9 +89,9 @@ export class ManagementLinkClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClient.ts
+++ b/test/smoke/generated/arm-package-links-2016-09/src/managementLinkClient.ts
@@ -89,7 +89,7 @@ export class ManagementLinkClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClient.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClient.ts
@@ -92,7 +92,7 @@ export class ManagementLockClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClient.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClient.ts
@@ -92,9 +92,9 @@ export class ManagementLockClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClient.ts
+++ b/test/smoke/generated/arm-package-locks-2016-09/src/managementLockClient.ts
@@ -94,7 +94,7 @@ export class ManagementLockClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClient.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClient.ts
@@ -91,7 +91,7 @@ export class ApplicationClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClient.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClient.ts
@@ -89,9 +89,9 @@ export class ApplicationClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClient.ts
+++ b/test/smoke/generated/arm-package-managedapplications-2018-06/src/applicationClient.ts
@@ -89,7 +89,7 @@ export class ApplicationClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-policy-2019-09/src/policyClient.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/policyClient.ts
@@ -98,9 +98,9 @@ export class PolicyClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-policy-2019-09/src/policyClient.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/policyClient.ts
@@ -98,7 +98,7 @@ export class PolicyClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-policy-2019-09/src/policyClient.ts
+++ b/test/smoke/generated/arm-package-policy-2019-09/src/policyClient.ts
@@ -100,7 +100,7 @@ export class PolicyClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClient.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClient.ts
@@ -112,7 +112,7 @@ export class ResourceManagementClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClient.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClient.ts
@@ -110,9 +110,9 @@ export class ResourceManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClient.ts
+++ b/test/smoke/generated/arm-package-resources-2019-08/src/resourceManagementClient.ts
@@ -110,7 +110,7 @@ export class ResourceManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClient.ts
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClient.ts
@@ -82,7 +82,7 @@ export class SubscriptionClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClient.ts
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClient.ts
@@ -82,9 +82,9 @@ export class SubscriptionClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClient.ts
+++ b/test/smoke/generated/arm-package-subscriptions-2019-06/src/subscriptionClient.ts
@@ -84,7 +84,7 @@ export class SubscriptionClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
@@ -186,7 +186,7 @@ export class CosmosDBManagementClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
@@ -184,7 +184,7 @@ export class CosmosDBManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
+++ b/test/smoke/generated/cosmos-db-resource-manager/src/cosmosDBManagementClient.ts
@@ -184,9 +184,9 @@ export class CosmosDBManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
@@ -120,7 +120,7 @@ export class GraphRbacManagementClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
@@ -118,7 +118,7 @@ export class GraphRbacManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
+++ b/test/smoke/generated/graphrbac-data-plane/src/graphRbacManagementClient.ts
@@ -118,9 +118,9 @@ export class GraphRbacManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
@@ -122,7 +122,7 @@ export class KeyVaultManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
@@ -122,9 +122,9 @@ export class KeyVaultManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
+++ b/test/smoke/generated/keyvault-resource-manager/src/keyVaultManagementClient.ts
@@ -124,7 +124,7 @@ export class KeyVaultManagementClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
+++ b/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
@@ -100,7 +100,7 @@ export class ManagedServiceIdentityClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
+++ b/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
@@ -98,9 +98,9 @@ export class ManagedServiceIdentityClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
+++ b/test/smoke/generated/msi-resource-manager/src/managedServiceIdentityClient.ts
@@ -98,7 +98,7 @@ export class ManagedServiceIdentityClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
@@ -150,7 +150,7 @@ export class StorageManagementClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
@@ -148,9 +148,9 @@ export class StorageManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
+++ b/test/smoke/generated/storage-resource-manager/src/storageManagementClient.ts
@@ -148,7 +148,7 @@ export class StorageManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
@@ -209,9 +209,9 @@ export class WebSiteManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map((item) => {
+          const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return item.replace(/(?<==).*$/, apiVersion);
+              return `api-version=${apiVersion}`;
             } else {
               return item;
             }

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
@@ -211,7 +211,7 @@ export class WebSiteManagementClient extends coreClient.ServiceClient {
         if (param.length > 1) {
           const newParams = param[1].split("&").map(item => {
             if (item.indexOf("api-version") > -1) {
-              return `api-version=${apiVersion}`;
+              return "api-version=" + apiVersion;
             } else {
               return item;
             }

--- a/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
+++ b/test/smoke/generated/web-resource-manager/src/webSiteManagementClient.ts
@@ -209,7 +209,7 @@ export class WebSiteManagementClient extends coreClient.ServiceClient {
       ): Promise<PipelineResponse> {
         const param = request.url.split("?");
         if (param.length > 1) {
-          const newParams = param[1].split("&").map(item => {
+          const newParams = param[1].split("&").map((item) => {
             if (item.indexOf("api-version") > -1) {
               return "api-version=" + apiVersion;
             } else {


### PR DESCRIPTION
Fixes #1422

Lookbehind and negative Lookbehind regular expressions are [not supported in Safari](https://caniuse.com/js-regexp-lookbehind).  Removing in favor of simple string replacement.

cc @qiaozha