### PR TITLE
Replace Copy command with a script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "test-version-tolerance": "mocha -r ts-node/register --timeout 2000 './test/version-tolerance/**/!(sampleTest).spec.ts'",
         "clone:specs": "git clone https://github.com/Azure/azure-rest-api-specs.git ./.tmp/specs",
         "smoke-test": "ts-node ./test/commands/smoke-test.ts",
-        "copyFiles": "cp src/**/*.hbs dist/ && cp src/**/**/*.hbs dist/ && cp src/generators/samples/*.hbs dist/src/generators/samples/ && cp src/generators/static/*.hbs dist/src/generators/static/ && cp src/generators/test/*.hbs dist/src/generators/test/ && cp src/restLevelClient/*.hbs dist/src/restLevelClient/"
+        "copyFiles": "ts-node ./src/utils/copyFiles.ts"
     },
     "browser": {
         "./test-browser/utils/stream-helpers.js": "./test-browser/utils/stream-helpers.browser.js",

--- a/src/utils/copyFiles.ts
+++ b/src/utils/copyFiles.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import * as fsextra from "fs-extra";
+
+export function copyFiles(srcDir: string, destDir: string[]) {
+  const dirContents: string[] = fsextra.readdirSync(srcDir);
+  dirContents.forEach((dirEntry: string) => {
+    if (dirEntry.endsWith(".hbs")) {
+      destDir.forEach((destDirEntry: string) => {
+        console.log(
+          `Copying ${srcDir}/${dirEntry} to ${destDirEntry}/${dirEntry}`
+        );
+        fsextra.copyFileSync(
+          `${srcDir}/${dirEntry}`,
+          `${destDirEntry}/${dirEntry}`
+        );
+      });
+    }
+  });
+}
+
+copyFiles("./src/restLevelClient", ["./dist/src/restLevelClient", "./dist"]);
+copyFiles("./src/generators/test", ["./dist/src/generators/test", "./dist"]);
+copyFiles("./src/generators/static", [
+  "./dist/src/generators/static",
+  "./dist"
+]);
+copyFiles("./src/generators/samples", [
+  "./dist/src/generators/samples",
+  "./dist"
+]);
+copyFiles("./src/restLevelClient/samples", [
+  "./dist/src/restLevelClient/samples",
+  "./dist"
+]);


### PR DESCRIPTION
A few weeks back, I was working on resolving the Audit Issues reported for the `autorest.typescript` repository. At that time, the package had a dependency on the `copyfiles` package which had a security vulnerability and thus have to be removed. So, I removed that and just used the regular `cp` command. It was working fine on my (windows) machine. 

But, now I have found that the `cp` was working fine on my machine, because I had the git bash installed. It was causing errors on other machines, where git bash was not installed. So, with this PR, I have replaced the `cp` command with a separate script. 

@joheredi Please review and approve the PR