### PR TITLE
Bump node version to v14

### DIFF
--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -83,7 +83,7 @@ function regularAutorestPackage(
       `A generated SDK for ${clientDetails.name}.`,
     version: packageDetails.version,
     engines: {
-      node: ">=12.0.0"
+      node: ">=14.0.0"
     },
     dependencies: {
       ...(hasLro && { "@azure/core-lro": "^2.2.0" }),

--- a/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AdditionalPropertiesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AppConfigurationClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AppConfigurationClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ArrayConstraintsClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/attestation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/attestation/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for GeneratedClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AzureParameterGroupingClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureReport/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ReportClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for AzureSpecialPropertiesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-auth": "^1.3.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyArrayClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyBooleanClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyBooleanQuirksClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyByteClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyComplexClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyComplexWithTracing.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyDateClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyDateTimeClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyDateTimeRfc1123Client.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyDictionaryClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyDurationClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyFileClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyFormDataClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyIntegerClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyNumberClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyString/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyString/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyStringClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for BodyTimeClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/constantParam/package.json
+++ b/packages/autorest.typescript/test/integration/generated/constantParam/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for GeneratedClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PetStore.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-http-compat": "^1.2.0",

--- a/packages/autorest.typescript/test/integration/generated/customUrl/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrl/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for CustomUrlClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for CustomUrlMoreOptionsClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for CustomUrlPagingClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/integration/generated/datafactory/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DataFactoryClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DataLakeStorageClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/datasearch/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datasearch/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DataSearchClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-http-compat": "^1.2.0",

--- a/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DeviceProvisioningClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/domainservices/package.json
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DomainServicesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
+++ b/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ExtensibleEnumsClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/header/package.json
+++ b/packages/autorest.typescript/test/integration/generated/header/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for HeaderClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
+++ b/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for HeaderPrefixClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for HealthCareApisClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
+++ b/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for HttpInfrastructureClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
+++ b/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for IoTSpacesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-auth": "^1.3.0",

--- a/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for LicenseHeaderClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lro/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for LROClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for LroParametrizedEndpointsClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MapperRequiredClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MediaTypesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MediaTypesV3Client.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MediaTypesV3LROClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MediaTypesWithTracingClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
+++ b/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ModelFlatteningClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
+++ b/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MultipleInheritanceClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SearchClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for NoLicenseHeaderClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/noMappers/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noMappers/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for NoMappersClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/noOperation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noOperation/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for NoOperationsClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for NonStringEnumClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/objectType/package.json
+++ b/packages/autorest.typescript/test/integration/generated/objectType/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ObjectTypeClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
+++ b/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ODataDiscriminatorClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
+++ b/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for OperationGroupClashClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
+++ b/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for OptionalNullClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/paging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/paging/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PagingClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
+++ b/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PagingNoIteratorsClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/integration/generated/patterntest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/patterntest/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PatternTestClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-http-compat": "^1.2.0",

--- a/packages/autorest.typescript/test/integration/generated/petstore/package.json
+++ b/packages/autorest.typescript/test/integration/generated/petstore/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PetStore.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for KeyVaultClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
+++ b/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for RegexConstraint.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/report/package.json
+++ b/packages/autorest.typescript/test/integration/generated/report/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ReportClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
+++ b/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for RequiredOptionalClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/resources/package.json
+++ b/packages/autorest.typescript/test/integration/generated/resources/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ResourcesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-auth": "^1.3.0",

--- a/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SealedChoiceClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/storageblob/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storageblob/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for StorageBlobClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for StorageFileShareClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
+++ b/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SubscriptionIdApiVersionClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
+++ b/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for GeneratedClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/url/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for UrlClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/url2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url2/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for UrlClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
+++ b/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for UrlMultiClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for UserAgentCoreV1Client.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": { "@azure/core-http": "^2.0.0", "tslib": "^2.2.0" },
   "keywords": ["node", "azure", "typescript", "browser", "isomorphic"],
   "license": "MIT",

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for UserAgentCoreV2Client.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/uuid/package.json
+++ b/packages/autorest.typescript/test/integration/generated/uuid/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for UuidClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/validation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/validation/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ValidationClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for XmlServiceClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for XmsErrorResponsesClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ReportClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/report/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/report/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ReportClient.",
   "version": "1.0.0-preview1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-rest-pipeline": "^1.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && dev-tool run bundle",
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for DeploymentScriptsClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-features-2015-12/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-features-2015-12/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for FeatureClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-links-2016-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-links-2016-09/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ManagementLinkClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-locks-2016-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-locks-2016-09/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ManagementLockClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ApplicationClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-policy-2019-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-policy-2019-09/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for PolicyClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ResourceManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SubscriptionClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ComputeManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for CosmosDBManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/graphrbac-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/graphrbac-data-plane/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for GraphRbacManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for KeyVaultManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/monitor-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/monitor-data-plane/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for MonitorClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-client": "^1.5.0",
     "@azure/core-auth": "^1.3.0",

--- a/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for ManagedServiceIdentityClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-paging": "^1.2.0",
     "@azure/core-client": "^1.5.0",

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for NetworkManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for SqlManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for StorageManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
@@ -4,7 +4,7 @@
   "author": "Microsoft Corporation",
   "description": "A generated SDK for WebSiteManagementClient.",
   "version": "1.0.0-beta.1",
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "dependencies": {
     "@azure/core-lro": "^2.2.0",
     "@azure/abort-controller": "^1.0.0",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
@@ -25,7 +25,7 @@
       { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "7.18.11",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "mkdirp": "^1.0.4",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
@@ -25,7 +25,7 @@
       { "path": "swagger/README.md", "prefix": "package-version" }
     ]
   },
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -67,7 +67,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "7.18.11",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^7.15.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/authentication/apiKey/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/authentication/apiKey/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/dictionary/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/dictionary/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/extensibleEnums/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/extensibleEnums/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/hello/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/hello/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/models/inheritance/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/models/inheritance/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/models/propertyOptional/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/models/propertyOptional/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/models/propertyTypes/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/models/propertyTypes/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/models/readonlyProperties/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/models/readonlyProperties/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/models/usage/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/models/usage/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/resiliency/devDriven/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/resiliency/devDriven/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/resiliency/srvDriven1/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/resiliency/srvDriven1/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-emitter/test/integration/generated/resiliency/srvDriven2/package.json
+++ b/packages/cadl-rlc-emitter/test/integration/generated/resiliency/srvDriven2/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-test/test/authoring/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/authoring/cadl-output/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "tsc -p . && cross-env ONLY_BROWSER=true rollup -c 2>&1",
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -61,7 +61,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/cadl-rlc-test/test/playfab/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/playfab/cadl-output/package.json
@@ -19,7 +19,7 @@
     "LICENSE",
     "review/*"
   ],
-  "engines": { "node": ">=12.0.0" },
+  "engines": { "node": ">=14.0.0" },
   "scripts": {
     "audit": "node ../../../common/scripts/rush-audit.js && rimraf node_modules package-lock.json && npm i --package-lock-only 2>&1 && npm audit",
     "build:browser": "echo skipped.",
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.31.1",
     "autorest": "latest",
-    "@types/node": "^12.0.0",
+    "@types/node": "^14.0.0",
     "dotenv": "^8.2.0",
     "eslint": "^8.0.0",
     "mkdirp": "^1.0.4",

--- a/packages/rlc-codegen/src/metadata/buildPackageFile.ts
+++ b/packages/rlc-codegen/src/metadata/buildPackageFile.ts
@@ -86,7 +86,7 @@ function restLevelPackage(model: RLCModel, hasSamplesGenerated: boolean) {
       "review/*"
     ],
     engines: {
-      node: ">=12.0.0"
+      node: ">=14.0.0"
     },
     scripts: {
       audit:
@@ -139,7 +139,7 @@ function restLevelPackage(model: RLCModel, hasSamplesGenerated: boolean) {
     devDependencies: {
       "@microsoft/api-extractor": "^7.31.1",
       autorest: "latest",
-      "@types/node": "^12.0.0",
+      "@types/node": "^14.0.0",
       dotenv: "^8.2.0",
       eslint: "^8.0.0",
       mkdirp: "^1.0.4",


### PR DESCRIPTION
We are planning to drop NodeJS v12 support.  This PR updates codegen to use v14 as template.