### PR TITLE
Update readme generation

### DIFF
--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/README.md
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/README.md
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/README.md
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/README.md
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/README.md
@@ -13,7 +13,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -50,7 +50,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/unit/restLevelClient/files/case-rlcReadme.md
+++ b/packages/autorest.typescript/test/unit/restLevelClient/files/case-rlcReadme.md
@@ -16,7 +16,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -53,7 +53,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/README.md
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/README.md
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-rlc-test/test/authoring/cadl-output/README.md
+++ b/packages/cadl-rlc-test/test/authoring/cadl-output/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/README.md
+++ b/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-rlc-test/test/playfab/cadl-output/README.md
+++ b/packages/cadl-rlc-test/test/playfab/cadl-output/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/authentication/apiKey/README.md
+++ b/packages/cadl-typescript/test/integration/generated/authentication/apiKey/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/dictionary/README.md
+++ b/packages/cadl-typescript/test/integration/generated/dictionary/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/extensibleEnums/README.md
+++ b/packages/cadl-typescript/test/integration/generated/extensibleEnums/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/hello/README.md
+++ b/packages/cadl-typescript/test/integration/generated/hello/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/models/inheritance/README.md
+++ b/packages/cadl-typescript/test/integration/generated/models/inheritance/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/models/propertyOptional/README.md
+++ b/packages/cadl-typescript/test/integration/generated/models/propertyOptional/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/models/propertyTypes/README.md
+++ b/packages/cadl-typescript/test/integration/generated/models/propertyTypes/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/models/readonlyProperties/README.md
+++ b/packages/cadl-typescript/test/integration/generated/models/readonlyProperties/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/models/usage/README.md
+++ b/packages/cadl-typescript/test/integration/generated/models/usage/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/resiliency/devDriven/README.md
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/devDriven/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven1/README.md
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven1/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven2/README.md
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven2/README.md
@@ -12,7 +12,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -48,7 +48,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the `AZURE_LOG_LEVEL` environment variable to `info`. Alternatively, logging can be enabled at runtime by calling `setLogLevel` in the `@azure/logger`:
 
 ```javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 ```

--- a/packages/rlc-common/src/metadata/buildReadmeFile.ts
+++ b/packages/rlc-common/src/metadata/buildReadmeFile.ts
@@ -35,7 +35,7 @@ Key links:
 
 ### Currently supported environments
 
-- Node.js version 14.x.x or higher
+- LTS versions of Node.js
 
 ### Prerequisites
 
@@ -72,7 +72,7 @@ AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_CLIENT_SECRET
 Enabling logging may help uncover useful information about failures. In order to see a log of HTTP requests and responses, set the \`AZURE_LOG_LEVEL\` environment variable to \`info\`. Alternatively, logging can be enabled at runtime by calling \`setLogLevel\` in the \`@azure/logger\`:
 
 \`\`\`javascript
-import { setLogLevel } from "@azure/logger";
+const { setLogLevel } = require("@azure/logger");
 
 setLogLevel("info");
 \`\`\`


### PR DESCRIPTION
- to not mention NodeJS version
- to use `require` in logger code snippets