### PR TITLE
Upgrade to TypeScript 4.8

### DIFF
--- a/packages/autorest.typescript/package.json
+++ b/packages/autorest.typescript/package.json
@@ -114,7 +114,7 @@
         "sinon": "^10.0.0",
         "source-map-loader": "^1.0.0",
         "ts-node": "^8.5.2",
-        "typescript": "^4.3.4",
+        "typescript": "~4.8.0",
         "wait-port": "^0.2.6",
         "webpack": "^5.72.0",
         "webpack-cli": "^4.9.2",

--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -116,7 +116,7 @@ function regularAutorestPackage(
       mkdirp: "^1.0.4",
       rollup: "^2.66.1",
       "rollup-plugin-sourcemaps": "^0.6.3",
-      typescript: "~4.6.0",
+      typescript: "~4.8.0",
       "uglify-js": "^3.4.9",
       rimraf: "^3.0.0"
     },

--- a/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/attestation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/attestation/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureReport/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyString/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyString/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/constantParam/package.json
+++ b/packages/autorest.typescript/test/integration/generated/constantParam/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/customUrl/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrl/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/datafactory/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/datasearch/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datasearch/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/domainservices/package.json
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
+++ b/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/header/package.json
+++ b/packages/autorest.typescript/test/integration/generated/header/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
+++ b/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
+++ b/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
+++ b/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lro/package.json
@@ -27,7 +27,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
+++ b/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
+++ b/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/noMappers/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noMappers/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/noOperation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noOperation/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/objectType/package.json
+++ b/packages/autorest.typescript/test/integration/generated/objectType/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
+++ b/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
+++ b/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
+++ b/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/paging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/paging/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
+++ b/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/patterntest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/patterntest/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/integration/generated/petstore/package.json
+++ b/packages/autorest.typescript/test/integration/generated/petstore/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
+++ b/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/report/package.json
+++ b/packages/autorest.typescript/test/integration/generated/report/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
+++ b/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/resources/package.json
+++ b/packages/autorest.typescript/test/integration/generated/resources/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/storageblob/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storageblob/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
+++ b/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
+++ b/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/url/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/url2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url2/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
+++ b/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
@@ -20,7 +20,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/uuid/package.json
+++ b/packages/autorest.typescript/test/integration/generated/uuid/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/validation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/validation/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -68,7 +68,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -66,7 +66,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
@@ -68,7 +68,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -66,7 +66,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
@@ -69,7 +69,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/report/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/report/package.json
@@ -24,7 +24,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -66,7 +66,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -66,7 +66,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@azure/dev-tool": "^1.0.0",
     "@azure/eslint-plugin-azure-sdk": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -69,7 +69,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -69,7 +69,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-deploymentscripts-2019-10-preview/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-features-2015-12/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-features-2015-12/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-links-2016-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-links-2016-09/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-locks-2016-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-locks-2016-09/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-managedapplications-2018-06/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-policy-2019-09/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-policy-2019-09/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-resources-2019-08/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/cosmos-db-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/graphrbac-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/graphrbac-data-plane/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/smoke/generated/monitor-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/monitor-data-plane/package.json
@@ -25,7 +25,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0"
   },

--- a/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
@@ -26,7 +26,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
@@ -68,7 +68,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
@@ -28,7 +28,7 @@
     "mkdirp": "^1.0.4",
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "uglify-js": "^3.4.9",
     "rimraf": "^3.0.0",
     "@azure/identity": "^2.0.1",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typedoc": "0.15.2",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
@@ -75,7 +75,7 @@
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typedoc": "0.15.2",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-rlc-test/package.json
+++ b/packages/cadl-rlc-test/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "ts-node": "^8.5.2",
     "@types/node": "^18.0.0",
-    "typescript": "^4.3.4",
+    "typescript": "~4.8.0",
     "@types/mocha": "^5.2.7"
   },
   "scripts": {

--- a/packages/cadl-rlc-test/test/authoring/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/authoring/cadl-output/package.json
@@ -69,7 +69,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/package.json
@@ -68,7 +68,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-rlc-test/test/playfab/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/playfab/cadl-output/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/package.json
+++ b/packages/cadl-typescript/package.json
@@ -32,7 +32,7 @@
     "mocha": "^9.2.2",
     "rimraf": "^3.0.2",
     "ts-node": "^10.7.0",
-    "typescript": "^4.6.3",
+    "typescript": "~4.8.0",
     "prettier": "~2.7.1",
     "@azure-tools/cadl-ranch-specs": "~0.4.3",
     "@cadl-lang/versioning": "0.9.0",

--- a/packages/cadl-typescript/test/integration/generated/authentication/apiKey/package.json
+++ b/packages/cadl-typescript/test/integration/generated/authentication/apiKey/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/dictionary/package.json
+++ b/packages/cadl-typescript/test/integration/generated/dictionary/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/extensibleEnums/package.json
+++ b/packages/cadl-typescript/test/integration/generated/extensibleEnums/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/hello/package.json
+++ b/packages/cadl-typescript/test/integration/generated/hello/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/lro/lroBasic/package.json
+++ b/packages/cadl-typescript/test/integration/generated/lro/lroBasic/package.json
@@ -68,7 +68,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/models/inheritance/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/inheritance/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/models/propertyOptional/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/propertyOptional/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/models/propertyTypes/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/propertyTypes/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/models/readonlyProperties/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/readonlyProperties/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/models/usage/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/usage/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/resiliency/devDriven/package.json
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/devDriven/package.json
@@ -68,7 +68,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven1/package.json
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven1/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven2/package.json
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven2/package.json
@@ -67,7 +67,7 @@
     "prettier": "2.2.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
-    "typescript": "~4.6.0",
+    "typescript": "~4.8.0",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-multi-entry": "^4.1.0",

--- a/packages/rlc-common/package.json
+++ b/packages/rlc-common/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@types/node": "^18.0.0",
     "prettier": "~2.7.1",
-    "typescript": "^4.6.3",
+    "typescript": "~4.8.0",
     "rimraf": "^3.0.2",
     "@types/lodash": "^4.14.182",
     "fs-extra": "^10.0.0",

--- a/packages/rlc-common/src/metadata/buildPackageFile.ts
+++ b/packages/rlc-common/src/metadata/buildPackageFile.ts
@@ -146,7 +146,7 @@ function restLevelPackage(model: RLCModel, hasSamplesGenerated: boolean) {
       prettier: "2.2.1",
       rimraf: "^3.0.0",
       "source-map-support": "^0.5.9",
-      typescript: "~4.6.0"
+      typescript: "~4.8.0"
     }
   };
 


### PR DESCRIPTION
This PR updates our TS dependencies for all generator packages and newly generated packages.