### PR TITLE
upgrade `prettier` version in the template to be `^2.5.1`

### DIFF
--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyComplexRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFileRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyFormDataRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/customUrlRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/headerRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -63,7 +63,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/lroRest/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/mediaTypesRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleInheritanceRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -63,7 +63,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/pagingRest/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -63,7 +63,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -63,7 +63,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-mv-rest/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/purview-administration-rest/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-initial/package.json
@@ -71,7 +71,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^7.15.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typedoc": "0.15.2",

--- a/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
+++ b/packages/autorest.typescript/test/version-tolerance/generated/rlc-updated/package.json
@@ -71,7 +71,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^7.15.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typedoc": "0.15.2",

--- a/packages/cadl-rlc-test/test/anomalyDetector/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/anomalyDetector/cadl-output/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/authoring/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/authoring/cadl-output/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/batch/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/batch/cadl-output/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/confidentialLedger/cadl-output/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/contoso/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/contoso/cadl-output/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/customWrapper/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/customWrapper/cadl-output/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/multiclient/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/multiclient/cadl-output/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/openai/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/openai/cadl-output/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/parametrizedHost/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/parametrizedHost/cadl-output/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-rlc-test/test/playfab/cadl-output/package.json
+++ b/packages/cadl-rlc-test/test/playfab/cadl-output/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/authentication/apiKey/package.json
+++ b/packages/cadl-typescript/test/integration/generated/authentication/apiKey/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/dictionary/package.json
+++ b/packages/cadl-typescript/test/integration/generated/dictionary/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/enums/extensible/package.json
+++ b/packages/cadl-typescript/test/integration/generated/enums/extensible/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/enums/fixed/package.json
+++ b/packages/cadl-typescript/test/integration/generated/enums/fixed/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/hello/package.json
+++ b/packages/cadl-typescript/test/integration/generated/hello/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/lro/lroBasic/package.json
+++ b/packages/cadl-typescript/test/integration/generated/lro/lroBasic/package.json
@@ -66,7 +66,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/models/inheritance/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/inheritance/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/models/propertyOptional/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/propertyOptional/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/models/propertyTypes/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/propertyTypes/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/models/usage/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/usage/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/models/visibility/package.json
+++ b/packages/cadl-typescript/test/integration/generated/models/visibility/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/resiliency/devDriven/package.json
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/devDriven/package.json
@@ -65,7 +65,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven1/package.json
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven1/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven2/package.json
+++ b/packages/cadl-typescript/test/integration/generated/resiliency/srvDriven2/package.json
@@ -64,7 +64,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
     "mkdirp": "^2.1.2",
-    "prettier": "2.2.1",
+    "prettier": "^2.5.1",
     "rimraf": "^3.0.0",
     "source-map-support": "^0.5.9",
     "typescript": "~4.8.0",

--- a/packages/rlc-common/src/metadata/buildPackageFile.ts
+++ b/packages/rlc-common/src/metadata/buildPackageFile.ts
@@ -152,7 +152,7 @@ function restLevelPackage(model: RLCModel, hasSamplesGenerated: boolean) {
       dotenv: "^16.0.0",
       eslint: "^8.0.0",
       mkdirp: "^2.1.2",
-      prettier: "2.2.1",
+      prettier: "^2.5.1",
       rimraf: "^3.0.0",
       "source-map-support": "^0.5.9",
       typescript: "~4.8.0"


### PR DESCRIPTION
the version currently in the azure-sdk-for-js repository.