### PR TITLE
[Modular] Generate API operations

### DIFF
--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Account.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Account.ts
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  AccountListSupportedImagesResult,
+  PoolNodeCountsListResult,
+} from "./models.js";
+
+export interface Accountlistsupportedimagesoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-support-images.
+   */
+  $filter?: string;
+}
+
+/** Lists all Virtual Machine Images supported by the Azure Batch service. */
+export async function listSupportedImages(
+  context: Client,
+  options: Accountlistsupportedimagesoptions = { requestOptions: {} }
+): Promise<AccountListSupportedImagesResult> {
+  const result = await context.path("/supportedimages").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      nodeAgentSKUId: p["nodeAgentSKUId"],
+      imageReference: {
+        publisher: p.imageReference["publisher"],
+        offer: p.imageReference["offer"],
+        sku: p.imageReference["sku"],
+        version: p.imageReference["version"],
+        virtualMachineImageId: p.imageReference["virtualMachineImageId"],
+        exactVersion: p.imageReference["exactVersion"],
+      },
+      osType: p["osType"],
+      capabilities: p["capabilities"],
+      batchSupportEndOfLife: new Date(p["batchSupportEndOfLife"] ?? ""),
+      verificationType: p["verificationType"],
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Accountlistpoolnodecountsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-support-images.
+   */
+  $filter?: string;
+}
+
+/**
+ * Gets the number of Compute Nodes in each state, grouped by Pool. Note that the
+ * numbers returned may not always be up to date. If you need exact node counts,
+ * use a list query.
+ */
+export async function listPoolNodeCounts(
+  context: Client,
+  options: Accountlistpoolnodecountsoptions = { requestOptions: {} }
+): Promise<PoolNodeCountsListResult> {
+  const result = await context.path("/nodecounts").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      poolId: p["poolId"],
+      dedicated: !p.dedicated
+        ? undefined
+        : {
+            creating: p.dedicated?.["creating"],
+            idle: p.dedicated?.["idle"],
+            offline: p.dedicated?.["offline"],
+            preempted: p.dedicated?.["preempted"],
+            rebooting: p.dedicated?.["rebooting"],
+            reimaging: p.dedicated?.["reimaging"],
+            running: p.dedicated?.["running"],
+            starting: p.dedicated?.["starting"],
+            startTaskFailed: p.dedicated?.["startTaskFailed"],
+            leavingPool: p.dedicated?.["leavingPool"],
+            unknown: p.dedicated?.["unknown"],
+            unusable: p.dedicated?.["unusable"],
+            waitingForStartTask: p.dedicated?.["waitingForStartTask"],
+            total: p.dedicated?.["total"],
+          },
+      lowPriority: !p.lowPriority
+        ? undefined
+        : {
+            creating: p.lowPriority?.["creating"],
+            idle: p.lowPriority?.["idle"],
+            offline: p.lowPriority?.["offline"],
+            preempted: p.lowPriority?.["preempted"],
+            rebooting: p.lowPriority?.["rebooting"],
+            reimaging: p.lowPriority?.["reimaging"],
+            running: p.lowPriority?.["running"],
+            starting: p.lowPriority?.["starting"],
+            startTaskFailed: p.lowPriority?.["startTaskFailed"],
+            leavingPool: p.lowPriority?.["leavingPool"],
+            unknown: p.lowPriority?.["unknown"],
+            unusable: p.lowPriority?.["unusable"],
+            waitingForStartTask: p.lowPriority?.["waitingForStartTask"],
+            total: p.lowPriority?.["total"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Account.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Account.ts
@@ -8,7 +8,7 @@ import {
   PoolNodeCountsListResult,
 } from "./models.js";
 
-export interface Accountlistsupportedimagesoptions extends RequestOptions {
+export interface AccountListSupportedImagesOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -42,7 +42,7 @@ export interface Accountlistsupportedimagesoptions extends RequestOptions {
 /** Lists all Virtual Machine Images supported by the Azure Batch service. */
 export async function listSupportedImages(
   context: Client,
-  options: Accountlistsupportedimagesoptions = { requestOptions: {} }
+  options: AccountListSupportedImagesOptions = { requestOptions: {} }
 ): Promise<AccountListSupportedImagesResult> {
   const result = await context.path("/supportedimages").get({
     headers: {
@@ -86,7 +86,7 @@ export async function listSupportedImages(
   };
 }
 
-export interface Accountlistpoolnodecountsoptions extends RequestOptions {
+export interface AccountListPoolNodeCountsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -124,7 +124,7 @@ export interface Accountlistpoolnodecountsoptions extends RequestOptions {
  */
 export async function listPoolNodeCounts(
   context: Client,
-  options: Accountlistpoolnodecountsoptions = { requestOptions: {} }
+  options: AccountListPoolNodeCountsOptions = { requestOptions: {} }
 ): Promise<PoolNodeCountsListResult> {
   const result = await context.path("/nodecounts").get({
     headers: {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Applications.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Applications.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import { ApplicationListResult, Application } from "./models.js";
+
+export interface Applicationslistapplicationsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+}
+
+/**
+ * This operation returns only Applications and versions that are available for
+ * use on Compute Nodes; that is, that can be used in an Package reference. For
+ * administrator information about applications and versions that are not yet
+ * available to Compute Nodes, use the Azure portal or the Azure Resource Manager
+ * API.
+ */
+export async function listApplications(
+  context: Client,
+  options: Applicationslistapplicationsoptions = { requestOptions: {} }
+): Promise<ApplicationListResult> {
+  const result = await context.path("/applications").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      displayName: p["displayName"],
+      versions: p["versions"],
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Applicationsgetoptions extends RequestOptions {}
+
+/**
+ * This operation returns only Applications and versions that are available for
+ * use on Compute Nodes; that is, that can be used in an Package reference. For
+ * administrator information about Applications and versions that are not yet
+ * available to Compute Nodes, use the Azure portal or the Azure Resource Manager
+ * API.
+ */
+export async function get(
+  context: Client,
+  applicationId: string,
+  options: Applicationsgetoptions = { requestOptions: {} }
+): Promise<Application> {
+  const result = await context
+    .path("/applications/{applicationId}", applicationId)
+    .get({
+      headers: {
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    displayName: result.body["displayName"],
+    versions: result.body["versions"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Applications.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Applications.ts
@@ -5,7 +5,7 @@ import { RequestOptions } from "../common/interfaces.js";
 import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
 import { ApplicationListResult, Application } from "./models.js";
 
-export interface Applicationslistapplicationsoptions extends RequestOptions {
+export interface ApplicationsListApplicationsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -40,7 +40,7 @@ export interface Applicationslistapplicationsoptions extends RequestOptions {
  */
 export async function listApplications(
   context: Client,
-  options: Applicationslistapplicationsoptions = { requestOptions: {} }
+  options: ApplicationsListApplicationsOptions = { requestOptions: {} }
 ): Promise<ApplicationListResult> {
   const result = await context.path("/applications").get({
     headers: {
@@ -73,7 +73,7 @@ export async function listApplications(
   };
 }
 
-export interface Applicationsgetoptions extends RequestOptions {}
+export interface ApplicationsGetOptions extends RequestOptions {}
 
 /**
  * This operation returns only Applications and versions that are available for
@@ -85,7 +85,7 @@ export interface Applicationsgetoptions extends RequestOptions {}
 export async function get(
   context: Client,
   applicationId: string,
-  options: Applicationsgetoptions = { requestOptions: {} }
+  options: ApplicationsGetOptions = { requestOptions: {} }
 ): Promise<Application> {
   const result = await context
     .path("/applications/{applicationId}", applicationId)

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Certificates.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Certificates.ts
@@ -1,0 +1,400 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  Certificate,
+  CertificateState,
+  DeleteCertificateError,
+  CertificateFormat,
+  CertificateListResult,
+} from "./models.js";
+
+export interface Certificatesaddcertificateoptions extends RequestOptions {
+  /**
+   * The X.509 thumbprint of the Certificate. This is a sequence of up to 40 hex
+   * digits.
+   */
+  thumbprint?: string;
+  /** The algorithm used to derive the thumbprint. */
+  thumbprintAlgorithm?: string;
+  /** The URL of the Certificate. */
+  url?: string;
+  /** The state of the Certificate. */
+  state?: CertificateState;
+  /** The time at which the Certificate entered its current state. */
+  stateTransitionTime?: Date;
+  /** This property is not set if the Certificate is in its initial active state. */
+  previousState?: CertificateState;
+  /** This property is not set if the Certificate is in its initial Active state. */
+  previousStateTransitionTime?: Date;
+  /** The public part of the Certificate as a base-64 encoded .cer file. */
+  publicData?: string;
+  /** This property is set only if the Certificate is in the DeleteFailed state. */
+  deleteCertificateError?: DeleteCertificateError;
+  /** The base64-encoded contents of the Certificate. The maximum size is 10KB. */
+  data?: string;
+  /** The format of the Certificate data. */
+  certificateFormat?: CertificateFormat;
+  /** This must be omitted if the Certificate format is cer. */
+  password?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/** Adds a Certificate to the specified Account. */
+export async function addCertificate(
+  context: Client,
+  options: Certificatesaddcertificateoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/certificates").post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.thumbprint && { thumbprint: options.thumbprint }),
+      ...(options.thumbprintAlgorithm && {
+        thumbprintAlgorithm: options.thumbprintAlgorithm,
+      }),
+      ...(options.data && { data: options.data }),
+      ...(options.certificateFormat && {
+        certificateFormat: options.certificateFormat,
+      }),
+      ...(options.password && { password: options.password }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Certificateslistcertificatesoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-certificates.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** Lists all of the Certificates that have been added to the specified Account. */
+export async function listCertificates(
+  context: Client,
+  options: Certificateslistcertificatesoptions = { requestOptions: {} }
+): Promise<CertificateListResult> {
+  const result = await context.path("/certificates").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+      ...(options.$select && { $select: options.$select }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      thumbprint: p["thumbprint"],
+      thumbprintAlgorithm: p["thumbprintAlgorithm"],
+      url: p["url"],
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      previousState: p["previousState"],
+      previousStateTransitionTime: new Date(
+        p["previousStateTransitionTime"] ?? ""
+      ),
+      publicData: p["publicData"],
+      deleteCertificateError: !p.deleteCertificateError
+        ? undefined
+        : {
+            code: p.deleteCertificateError?.["code"],
+            message: p.deleteCertificateError?.["message"],
+            values: (p.deleteCertificateError?.["values"] ?? []).map((p) => ({
+              name: p["name"],
+              value: p["value"],
+            })),
+          },
+      data: p["data"],
+      certificateFormat: p["certificateFormat"],
+      password: p["password"],
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Certificatescancelcertificatedeletionoptions
+  extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * If you try to delete a Certificate that is being used by a Pool or Compute
+ * Node, the status of the Certificate changes to deleteFailed. If you decide that
+ * you want to continue using the Certificate, you can use this operation to set
+ * the status of the Certificate back to active. If you intend to delete the
+ * Certificate, you do not need to run this operation after the deletion failed.
+ * You must make sure that the Certificate is not being used by any resources, and
+ * then you can try again to delete the Certificate.
+ */
+export async function cancelCertificateDeletion(
+  context: Client,
+  thumbprintAlgorithm: string,
+  thumbprint: string,
+  options: Certificatescancelcertificatedeletionoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})/canceldelete",
+      thumbprintAlgorithm,
+      thumbprint
+    )
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Certificatesdeletecertificateoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * You cannot delete a Certificate if a resource (Pool or Compute Node) is using
+ * it. Before you can delete a Certificate, you must therefore make sure that the
+ * Certificate is not associated with any existing Pools, the Certificate is not
+ * installed on any Nodes (even if you remove a Certificate from a Pool, it is not
+ * removed from existing Compute Nodes in that Pool until they restart), and no
+ * running Tasks depend on the Certificate. If you try to delete a Certificate
+ * that is in use, the deletion fails. The Certificate status changes to
+ * deleteFailed. You can use Cancel Delete Certificate to set the status back to
+ * active if you decide that you want to continue using the Certificate.
+ */
+export async function deleteCertificate(
+  context: Client,
+  thumbprintAlgorithm: string,
+  thumbprint: string,
+  options: Certificatesdeletecertificateoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})",
+      thumbprintAlgorithm,
+      thumbprint
+    )
+    .delete({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Certificatesgetcertificateoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** Gets information about the specified Certificate. */
+export async function getCertificate(
+  context: Client,
+  thumbprintAlgorithm: string,
+  thumbprint: string,
+  options: Certificatesgetcertificateoptions = { requestOptions: {} }
+): Promise<Certificate> {
+  const result = await context
+    .path(
+      "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})",
+      thumbprintAlgorithm,
+      thumbprint
+    )
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    thumbprint: result.body["thumbprint"],
+    thumbprintAlgorithm: result.body["thumbprintAlgorithm"],
+    url: result.body["url"],
+    state: result.body["state"],
+    stateTransitionTime: new Date(result.body["stateTransitionTime"] ?? ""),
+    previousState: result.body["previousState"],
+    previousStateTransitionTime: new Date(
+      result.body["previousStateTransitionTime"] ?? ""
+    ),
+    publicData: result.body["publicData"],
+    deleteCertificateError: !result.body.deleteCertificateError
+      ? undefined
+      : {
+          code: result.body.deleteCertificateError?.["code"],
+          message: result.body.deleteCertificateError?.["message"],
+          values: (result.body.deleteCertificateError?.["values"] ?? []).map(
+            (p) => ({ name: p["name"], value: p["value"] })
+          ),
+        },
+    data: result.body["data"],
+    certificateFormat: result.body["certificateFormat"],
+    password: result.body["password"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Certificates.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Certificates.ts
@@ -11,7 +11,7 @@ import {
   CertificateListResult,
 } from "./models.js";
 
-export interface Certificatesaddcertificateoptions extends RequestOptions {
+export interface CertificatesAddCertificateOptions extends RequestOptions {
   /**
    * The X.509 thumbprint of the Certificate. This is a sequence of up to 40 hex
    * digits.
@@ -64,7 +64,7 @@ export interface Certificatesaddcertificateoptions extends RequestOptions {
 /** Adds a Certificate to the specified Account. */
 export async function addCertificate(
   context: Client,
-  options: Certificatesaddcertificateoptions = { requestOptions: {} }
+  options: CertificatesAddCertificateOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/certificates").post({
     headers: {
@@ -98,7 +98,7 @@ export async function addCertificate(
   return;
 }
 
-export interface Certificateslistcertificatesoptions extends RequestOptions {
+export interface CertificatesListCertificatesOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -134,7 +134,7 @@ export interface Certificateslistcertificatesoptions extends RequestOptions {
 /** Lists all of the Certificates that have been added to the specified Account. */
 export async function listCertificates(
   context: Client,
-  options: Certificateslistcertificatesoptions = { requestOptions: {} }
+  options: CertificatesListCertificatesOptions = { requestOptions: {} }
 ): Promise<CertificateListResult> {
   const result = await context.path("/certificates").get({
     headers: {
@@ -189,7 +189,7 @@ export async function listCertificates(
   };
 }
 
-export interface Certificatescancelcertificatedeletionoptions
+export interface CertificatesCancelCertificateDeletionOptions
   extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
@@ -224,7 +224,7 @@ export async function cancelCertificateDeletion(
   context: Client,
   thumbprintAlgorithm: string,
   thumbprint: string,
-  options: Certificatescancelcertificatedeletionoptions = { requestOptions: {} }
+  options: CertificatesCancelCertificateDeletionOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -252,7 +252,7 @@ export async function cancelCertificateDeletion(
   return;
 }
 
-export interface Certificatesdeletecertificateoptions extends RequestOptions {
+export interface CertificatesDeleteCertificateOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -288,7 +288,7 @@ export async function deleteCertificate(
   context: Client,
   thumbprintAlgorithm: string,
   thumbprint: string,
-  options: Certificatesdeletecertificateoptions = { requestOptions: {} }
+  options: CertificatesDeleteCertificateOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -316,7 +316,7 @@ export async function deleteCertificate(
   return;
 }
 
-export interface Certificatesgetcertificateoptions extends RequestOptions {
+export interface CertificatesGetCertificateOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -344,7 +344,7 @@ export async function getCertificate(
   context: Client,
   thumbprintAlgorithm: string,
   thumbprint: string,
-  options: Certificatesgetcertificateoptions = { requestOptions: {} }
+  options: CertificatesGetCertificateOptions = { requestOptions: {} }
 ): Promise<Certificate> {
   const result = await context
     .path(

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodeExtensions.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodeExtensions.ts
@@ -1,0 +1,214 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import { NodeVMExtension, NodeVMExtensionList } from "./models.js";
+
+export interface Computenodeextensionsgetcomputenodeextensionsoptions
+  extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** Gets information about the specified Compute Node Extension. */
+export async function getComputeNodeExtensions(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  extensionName: string,
+  options: Computenodeextensionsgetcomputenodeextensionsoptions = {
+    requestOptions: {},
+  }
+): Promise<NodeVMExtension> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/extensions/{extensionName}",
+      poolId,
+      nodeId,
+      extensionName
+    )
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    provisioningState: result.body["provisioningState"],
+    vmExtension: !result.body.vmExtension
+      ? undefined
+      : {
+          name: result.body.vmExtension?.["name"],
+          publisher: result.body.vmExtension?.["publisher"],
+          type: result.body.vmExtension?.["type"],
+          typeHandlerVersion: result.body.vmExtension?.["typeHandlerVersion"],
+          autoUpgradeMinorVersion:
+            result.body.vmExtension?.["autoUpgradeMinorVersion"],
+          settings: !result.body.vmExtension?.settings ? undefined : {},
+          protectedSettings: !result.body.vmExtension?.protectedSettings
+            ? undefined
+            : {},
+          provisionAfterExtensions:
+            result.body.vmExtension?.["provisionAfterExtensions"],
+        },
+    instanceView: !result.body.instanceView
+      ? undefined
+      : {
+          name: result.body.instanceView?.["name"],
+          statuses: (result.body.instanceView?.["statuses"] ?? []).map((p) => ({
+            code: p["code"],
+            displayStatus: p["displayStatus"],
+            level: p["level"],
+            message: p["message"],
+            time: p["time"],
+          })),
+          subStatuses: (result.body.instanceView?.["subStatuses"] ?? []).map(
+            (p) => ({
+              code: p["code"],
+              displayStatus: p["displayStatus"],
+              level: p["level"],
+              message: p["message"],
+              time: p["time"],
+            })
+          ),
+        },
+  };
+}
+
+export interface Computenodeextensionslistcomputenodeextensionsoptions
+  extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** Lists the Compute Nodes Extensions in the specified Pool. */
+export async function listComputeNodeExtensions(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodeextensionslistcomputenodeextensionsoptions = {
+    requestOptions: {},
+  }
+): Promise<NodeVMExtensionList> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/extensions", poolId, nodeId)
+    .get({
+      headers: {
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.maxresults && { maxresults: options.maxresults }),
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      provisioningState: p["provisioningState"],
+      vmExtension: !p.vmExtension
+        ? undefined
+        : {
+            name: p.vmExtension?.["name"],
+            publisher: p.vmExtension?.["publisher"],
+            type: p.vmExtension?.["type"],
+            typeHandlerVersion: p.vmExtension?.["typeHandlerVersion"],
+            autoUpgradeMinorVersion: p.vmExtension?.["autoUpgradeMinorVersion"],
+            settings: !p.vmExtension?.settings ? undefined : {},
+            protectedSettings: !p.vmExtension?.protectedSettings
+              ? undefined
+              : {},
+            provisionAfterExtensions:
+              p.vmExtension?.["provisionAfterExtensions"],
+          },
+      instanceView: !p.instanceView
+        ? undefined
+        : {
+            name: p.instanceView?.["name"],
+            statuses: (p.instanceView?.["statuses"] ?? []).map((p) => ({
+              code: p["code"],
+              displayStatus: p["displayStatus"],
+              level: p["level"],
+              message: p["message"],
+              time: p["time"],
+            })),
+            subStatuses: (p.instanceView?.["subStatuses"] ?? []).map((p) => ({
+              code: p["code"],
+              displayStatus: p["displayStatus"],
+              level: p["level"],
+              message: p["message"],
+              time: p["time"],
+            })),
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodeExtensions.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodeExtensions.ts
@@ -5,7 +5,7 @@ import { RequestOptions } from "../common/interfaces.js";
 import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
 import { NodeVMExtension, NodeVMExtensionList } from "./models.js";
 
-export interface Computenodeextensionsgetcomputenodeextensionsoptions
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsOptions
   extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
@@ -35,7 +35,7 @@ export async function getComputeNodeExtensions(
   poolId: string,
   nodeId: string,
   extensionName: string,
-  options: Computenodeextensionsgetcomputenodeextensionsoptions = {
+  options: ComputeNodeExtensionsGetComputeNodeExtensionsOptions = {
     requestOptions: {},
   }
 ): Promise<NodeVMExtension> {
@@ -109,7 +109,7 @@ export async function getComputeNodeExtensions(
   };
 }
 
-export interface Computenodeextensionslistcomputenodeextensionsoptions
+export interface ComputeNodeExtensionsListComputeNodeExtensionsOptions
   extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
@@ -143,7 +143,7 @@ export async function listComputeNodeExtensions(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodeextensionslistcomputenodeextensionsoptions = {
+  options: ComputeNodeExtensionsListComputeNodeExtensionsOptions = {
     requestOptions: {},
   }
 ): Promise<NodeVMExtensionList> {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodes.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodes.ts
@@ -14,7 +14,7 @@ import {
   ComputeNodeListResult,
 } from "./models.js";
 
-export interface Computenodesadduseroptions extends RequestOptions {
+export interface ComputeNodesAddUserOptions extends RequestOptions {
   /** The default value is false. */
   isAdmin?: boolean;
   /**
@@ -68,7 +68,7 @@ export async function addUser(
   name: string,
   poolId: string,
   nodeId: string,
-  options: Computenodesadduseroptions = { requestOptions: {} }
+  options: ComputeNodesAddUserOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/users", poolId, nodeId)
@@ -100,7 +100,7 @@ export async function addUser(
   return;
 }
 
-export interface Computenodesdeleteuseroptions extends RequestOptions {
+export interface ComputeNodesDeleteUserOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -130,7 +130,7 @@ export async function deleteUser(
   poolId: string,
   nodeId: string,
   userName: string,
-  options: Computenodesdeleteuseroptions = { requestOptions: {} }
+  options: ComputeNodesDeleteUserOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -159,7 +159,7 @@ export async function deleteUser(
   return;
 }
 
-export interface Computenodesupdateuseroptions extends RequestOptions {
+export interface ComputeNodesUpdateUserOptions extends RequestOptions {
   /**
    * The password is required for Windows Compute Nodes (those created with
    * 'cloudServiceConfiguration', or created with 'virtualMachineConfiguration'
@@ -214,7 +214,7 @@ export async function updateUser(
   poolId: string,
   nodeId: string,
   userName: string,
-  options: Computenodesupdateuseroptions = { requestOptions: {} }
+  options: ComputeNodesUpdateUserOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -249,7 +249,7 @@ export async function updateUser(
   return;
 }
 
-export interface Computenodesgetcomputenodeoptions extends RequestOptions {
+export interface ComputeNodesGetComputeNodeOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -277,7 +277,7 @@ export async function getComputeNode(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesgetcomputenodeoptions = { requestOptions: {} }
+  options: ComputeNodesGetComputeNodeOptions = { requestOptions: {} }
 ): Promise<ComputeNode> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}", poolId, nodeId)
@@ -530,7 +530,7 @@ export async function getComputeNode(
   };
 }
 
-export interface Computenodesrebootcomputenodeoptions extends RequestOptions {
+export interface ComputeNodesRebootComputeNodeOptions extends RequestOptions {
   /** The default value is requeue. */
   nodeRebootOption?: ComputeNodeRebootOption;
   /**
@@ -560,7 +560,7 @@ export async function rebootComputeNode(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesrebootcomputenodeoptions = { requestOptions: {} }
+  options: ComputeNodesRebootComputeNodeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/reboot", poolId, nodeId)
@@ -590,7 +590,7 @@ export async function rebootComputeNode(
   return;
 }
 
-export interface Computenodesreimagecomputenodeoptions extends RequestOptions {
+export interface ComputeNodesReimageComputeNodeOptions extends RequestOptions {
   /** The default value is requeue. */
   nodeReimageOption?: ComputeNodeReimageOption;
   /**
@@ -624,7 +624,7 @@ export async function reimageComputeNode(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesreimagecomputenodeoptions = { requestOptions: {} }
+  options: ComputeNodesReimageComputeNodeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/reimage", poolId, nodeId)
@@ -654,7 +654,7 @@ export async function reimageComputeNode(
   return;
 }
 
-export interface Computenodesdisableschedulingoptions extends RequestOptions {
+export interface ComputeNodesDisableSchedulingOptions extends RequestOptions {
   /** The default value is requeue. */
   nodeDisableSchedulingOption?: DisableComputeNodeSchedulingOption;
   /**
@@ -687,7 +687,7 @@ export async function disableScheduling(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesdisableschedulingoptions = { requestOptions: {} }
+  options: ComputeNodesDisableSchedulingOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/disablescheduling", poolId, nodeId)
@@ -717,7 +717,7 @@ export async function disableScheduling(
   return;
 }
 
-export interface Computenodesenableschedulingoptions extends RequestOptions {
+export interface ComputeNodesEnableSchedulingOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -746,7 +746,7 @@ export async function enableScheduling(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesenableschedulingoptions = { requestOptions: {} }
+  options: ComputeNodesEnableSchedulingOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/enablescheduling", poolId, nodeId)
@@ -770,7 +770,7 @@ export async function enableScheduling(
   return;
 }
 
-export interface Computenodesgetremoteloginsettingsoptions
+export interface ComputeNodesGetRemoteLoginSettingsOptions
   extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
@@ -803,7 +803,7 @@ export async function getRemoteLoginSettings(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesgetremoteloginsettingsoptions = { requestOptions: {} }
+  options: ComputeNodesGetRemoteLoginSettingsOptions = { requestOptions: {} }
 ): Promise<ComputeNodeGetRemoteLoginSettingsResult> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/remoteloginsettings", poolId, nodeId)
@@ -831,7 +831,7 @@ export async function getRemoteLoginSettings(
   };
 }
 
-export interface Computenodesgetremotedesktopoptions extends RequestOptions {
+export interface ComputeNodesGetRemoteDesktopOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -862,7 +862,7 @@ export async function getRemoteDesktop(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Computenodesgetremotedesktopoptions = { requestOptions: {} }
+  options: ComputeNodesGetRemoteDesktopOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/rdp", poolId, nodeId)
@@ -887,7 +887,7 @@ export async function getRemoteDesktop(
   return;
 }
 
-export interface Computenodesuploadbatchservicelogsoptions
+export interface ComputeNodesUploadBatchServiceLogsOptions
   extends RequestOptions {
   /**
    * Any log file containing a log message in the time range will be uploaded. This
@@ -933,7 +933,7 @@ export async function uploadBatchServiceLogs(
   startTime: Date,
   poolId: string,
   nodeId: string,
-  options: Computenodesuploadbatchservicelogsoptions = { requestOptions: {} }
+  options: ComputeNodesUploadBatchServiceLogsOptions = { requestOptions: {} }
 ): Promise<UploadBatchServiceLogsResult> {
   const result = await context
     .path(
@@ -974,7 +974,7 @@ export async function uploadBatchServiceLogs(
   };
 }
 
-export interface Computenodeslistoptions extends RequestOptions {
+export interface ComputeNodesListOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1011,7 +1011,7 @@ export interface Computenodeslistoptions extends RequestOptions {
 export async function list(
   context: Client,
   poolId: string,
-  options: Computenodeslistoptions = { requestOptions: {} }
+  options: ComputeNodesListOptions = { requestOptions: {} }
 ): Promise<ComputeNodeListResult> {
   const result = await context.path("/pools/{poolId}/nodes", poolId).get({
     headers: {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodes.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/ComputeNodes.ts
@@ -1,0 +1,1248 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  ComputeNodeIdentityReference,
+  ComputeNode,
+  ComputeNodeRebootOption,
+  ComputeNodeReimageOption,
+  DisableComputeNodeSchedulingOption,
+  ComputeNodeGetRemoteLoginSettingsResult,
+  UploadBatchServiceLogsResult,
+  ComputeNodeListResult,
+} from "./models.js";
+
+export interface Computenodesadduseroptions extends RequestOptions {
+  /** The default value is false. */
+  isAdmin?: boolean;
+  /**
+   * If omitted, the default is 1 day from the current time. For Linux Compute
+   * Nodes, the expiryTime has a precision up to a day.
+   */
+  expiryTime?: Date;
+  /**
+   * The password is required for Windows Compute Nodes (those created with
+   * 'cloudServiceConfiguration', or created with 'virtualMachineConfiguration'
+   * using a Windows Image reference). For Linux Compute Nodes, the password can
+   * optionally be specified along with the sshPublicKey property.
+   */
+  password?: string;
+  /**
+   * The public key should be compatible with OpenSSH encoding and should be base 64
+   * encoded. This property can be specified only for Linux Compute Nodes. If this
+   * is specified for a Windows Compute Node, then the Batch service rejects the
+   * request; if you are calling the REST API directly, the HTTP status code is 400
+   * (Bad Request).
+   */
+  sshPublicKey?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * You can add a user Account to a Compute Node only when it is in the idle or
+ * running state.
+ */
+export async function addUser(
+  context: Client,
+  name: string,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesadduseroptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/users", poolId, nodeId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        name: name,
+        ...(options.isAdmin && { isAdmin: options.isAdmin }),
+        ...(options.expiryTime && { expiryTime: options.expiryTime }),
+        ...(options.password && { password: options.password }),
+        ...(options.sshPublicKey && { sshPublicKey: options.sshPublicKey }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesdeleteuseroptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * You can delete a user Account to a Compute Node only when it is in the idle or
+ * running state.
+ */
+export async function deleteUser(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  userName: string,
+  options: Computenodesdeleteuseroptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/users/{userName}",
+      poolId,
+      nodeId,
+      userName
+    )
+    .delete({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesupdateuseroptions extends RequestOptions {
+  /**
+   * The password is required for Windows Compute Nodes (those created with
+   * 'cloudServiceConfiguration', or created with 'virtualMachineConfiguration'
+   * using a Windows Image reference). For Linux Compute Nodes, the password can
+   * optionally be specified along with the sshPublicKey property. If omitted, any
+   * existing password is removed.
+   */
+  password?: string;
+  /**
+   * If omitted, the default is 1 day from the current time. For Linux Compute
+   * Nodes, the expiryTime has a precision up to a day.
+   */
+  expiryTime?: Date;
+  /**
+   * The public key should be compatible with OpenSSH encoding and should be base 64
+   * encoded. This property can be specified only for Linux Compute Nodes. If this
+   * is specified for a Windows Compute Node, then the Batch service rejects the
+   * request; if you are calling the REST API directly, the HTTP status code is 400
+   * (Bad Request). If omitted, any existing SSH public key is removed.
+   */
+  sshPublicKey?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This operation replaces of all the updatable properties of the Account. For
+ * example, if the expiryTime element is not specified, the current value is
+ * replaced with the default value, not left unmodified. You can update a user
+ * Account on a Compute Node only when it is in the idle or running state.
+ */
+export async function updateUser(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  userName: string,
+  options: Computenodesupdateuseroptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/users/{userName}",
+      poolId,
+      nodeId,
+      userName
+    )
+    .put({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.password && { password: options.password }),
+        ...(options.expiryTime && { expiryTime: options.expiryTime }),
+        ...(options.sshPublicKey && { sshPublicKey: options.sshPublicKey }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesgetcomputenodeoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** Gets information about the specified Compute Node. */
+export async function getComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesgetcomputenodeoptions = { requestOptions: {} }
+): Promise<ComputeNode> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}", poolId, nodeId)
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    url: result.body["url"],
+    state: result.body["state"],
+    schedulingState: result.body["schedulingState"],
+    stateTransitionTime: new Date(result.body["stateTransitionTime"] ?? ""),
+    lastBootTime: new Date(result.body["lastBootTime"] ?? ""),
+    allocationTime: new Date(result.body["allocationTime"] ?? ""),
+    ipAddress: result.body["ipAddress"],
+    affinityId: result.body["affinityId"],
+    vmSize: result.body["vmSize"],
+    totalTasksRun: result.body["totalTasksRun"],
+    runningTasksCount: result.body["runningTasksCount"],
+    runningTaskSlotsCount: result.body["runningTaskSlotsCount"],
+    totalTasksSucceeded: result.body["totalTasksSucceeded"],
+    recentTasks: (result.body["recentTasks"] ?? []).map((p) => ({
+      taskUrl: p["taskUrl"],
+      jobId: p["jobId"],
+      taskId: p["taskId"],
+      subtaskId: p["subtaskId"],
+      taskState: p["taskState"],
+      executionInfo: !p.executionInfo
+        ? undefined
+        : {
+            startTime: new Date(p.executionInfo?.["startTime"] ?? ""),
+            endTime: new Date(p.executionInfo?.["endTime"] ?? ""),
+            exitCode: p.executionInfo?.["exitCode"],
+            containerInfo: !p.executionInfo?.containerInfo
+              ? undefined
+              : {
+                  containerId: p.executionInfo?.containerInfo?.["containerId"],
+                  state: p.executionInfo?.containerInfo?.["state"],
+                  error: p.executionInfo?.containerInfo?.["error"],
+                },
+            failureInfo: !p.executionInfo?.failureInfo
+              ? undefined
+              : {
+                  category: p.executionInfo?.failureInfo?.["category"],
+                  code: p.executionInfo?.failureInfo?.["code"],
+                  message: p.executionInfo?.failureInfo?.["message"],
+                  details: (
+                    p.executionInfo?.failureInfo?.["details"] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            retryCount: p.executionInfo?.["retryCount"],
+            lastRetryTime: new Date(p.executionInfo?.["lastRetryTime"] ?? ""),
+            requeueCount: p.executionInfo?.["requeueCount"],
+            lastRequeueTime: new Date(
+              p.executionInfo?.["lastRequeueTime"] ?? ""
+            ),
+            result: p.executionInfo?.["result"],
+          },
+    })),
+    startTask: !result.body.startTask
+      ? undefined
+      : {
+          commandLine: result.body.startTask?.["commandLine"],
+          containerSettings: !result.body.startTask?.containerSettings
+            ? undefined
+            : {
+                containerRunOptions:
+                  result.body.startTask?.containerSettings?.[
+                    "containerRunOptions"
+                  ],
+                imageName:
+                  result.body.startTask?.containerSettings?.["imageName"],
+                registry: !result.body.startTask?.containerSettings?.registry
+                  ? undefined
+                  : {
+                      username:
+                        result.body.startTask?.containerSettings?.registry?.[
+                          "username"
+                        ],
+                      password:
+                        result.body.startTask?.containerSettings?.registry?.[
+                          "password"
+                        ],
+                      registryServer:
+                        result.body.startTask?.containerSettings?.registry?.[
+                          "registryServer"
+                        ],
+                      identityReference: !result.body.startTask
+                        ?.containerSettings?.registry?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              result.body.startTask?.containerSettings?.registry
+                                ?.identityReference?.["resourceId"],
+                          },
+                    },
+                workingDirectory:
+                  result.body.startTask?.containerSettings?.[
+                    "workingDirectory"
+                  ],
+              },
+          resourceFiles: (result.body.startTask?.["resourceFiles"] ?? []).map(
+            (p) => ({
+              autoStorageContainerName: p["autoStorageContainerName"],
+              storageContainerUrl: p["storageContainerUrl"],
+              httpUrl: p["httpUrl"],
+              blobPrefix: p["blobPrefix"],
+              filePath: p["filePath"],
+              fileMode: p["fileMode"],
+              identityReference: !p.identityReference
+                ? undefined
+                : { resourceId: p.identityReference?.["resourceId"] },
+            })
+          ),
+          environmentSettings: (
+            result.body.startTask?.["environmentSettings"] ?? []
+          ).map((p) => ({ name: p["name"], value: p["value"] })),
+          userIdentity: !result.body.startTask?.userIdentity
+            ? undefined
+            : {
+                username: result.body.startTask?.userIdentity?.["username"],
+                autoUser: !result.body.startTask?.userIdentity?.autoUser
+                  ? undefined
+                  : {
+                      scope:
+                        result.body.startTask?.userIdentity?.autoUser?.[
+                          "scope"
+                        ],
+                      elevationLevel:
+                        result.body.startTask?.userIdentity?.autoUser?.[
+                          "elevationLevel"
+                        ],
+                    },
+              },
+          maxTaskRetryCount: result.body.startTask?.["maxTaskRetryCount"],
+          waitForSuccess: result.body.startTask?.["waitForSuccess"],
+        },
+    startTaskInfo: !result.body.startTaskInfo
+      ? undefined
+      : {
+          state: result.body.startTaskInfo?.["state"],
+          startTime: new Date(result.body.startTaskInfo?.["startTime"] ?? ""),
+          endTime: new Date(result.body.startTaskInfo?.["endTime"] ?? ""),
+          exitCode: result.body.startTaskInfo?.["exitCode"],
+          containerInfo: !result.body.startTaskInfo?.containerInfo
+            ? undefined
+            : {
+                containerId:
+                  result.body.startTaskInfo?.containerInfo?.["containerId"],
+                state: result.body.startTaskInfo?.containerInfo?.["state"],
+                error: result.body.startTaskInfo?.containerInfo?.["error"],
+              },
+          failureInfo: !result.body.startTaskInfo?.failureInfo
+            ? undefined
+            : {
+                category: result.body.startTaskInfo?.failureInfo?.["category"],
+                code: result.body.startTaskInfo?.failureInfo?.["code"],
+                message: result.body.startTaskInfo?.failureInfo?.["message"],
+                details: (
+                  result.body.startTaskInfo?.failureInfo?.["details"] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+              },
+          retryCount: result.body.startTaskInfo?.["retryCount"],
+          lastRetryTime: new Date(
+            result.body.startTaskInfo?.["lastRetryTime"] ?? ""
+          ),
+          result: result.body.startTaskInfo?.["result"],
+        },
+    certificateReferences: (result.body["certificateReferences"] ?? []).map(
+      (p) => ({
+        thumbprint: p["thumbprint"],
+        thumbprintAlgorithm: p["thumbprintAlgorithm"],
+        storeLocation: p["storeLocation"],
+        storeName: p["storeName"],
+        visibility: p["visibility"],
+      })
+    ),
+    errors: (result.body["errors"] ?? []).map((p) => ({
+      code: p["code"],
+      message: p["message"],
+      errorDetails: (p["errorDetails"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+    })),
+    isDedicated: result.body["isDedicated"],
+    endpointConfiguration: !result.body.endpointConfiguration
+      ? undefined
+      : {
+          inboundEndpoints: (
+            result.body.endpointConfiguration?.["inboundEndpoints"] ?? []
+          ).map((p) => ({
+            name: p["name"],
+            protocol: p["protocol"],
+            publicIPAddress: p["publicIPAddress"],
+            publicFQDN: p["publicFQDN"],
+            frontendPort: p["frontendPort"],
+            backendPort: p["backendPort"],
+          })),
+        },
+    nodeAgentInfo: !result.body.nodeAgentInfo
+      ? undefined
+      : {
+          version: result.body.nodeAgentInfo?.["version"],
+          lastUpdateTime: new Date(
+            result.body.nodeAgentInfo?.["lastUpdateTime"] ?? ""
+          ),
+        },
+    virtualMachineInfo: !result.body.virtualMachineInfo
+      ? undefined
+      : {
+          imageReference: !result.body.virtualMachineInfo?.imageReference
+            ? undefined
+            : {
+                publisher:
+                  result.body.virtualMachineInfo?.imageReference?.["publisher"],
+                offer:
+                  result.body.virtualMachineInfo?.imageReference?.["offer"],
+                sku: result.body.virtualMachineInfo?.imageReference?.["sku"],
+                version:
+                  result.body.virtualMachineInfo?.imageReference?.["version"],
+                virtualMachineImageId:
+                  result.body.virtualMachineInfo?.imageReference?.[
+                    "virtualMachineImageId"
+                  ],
+                exactVersion:
+                  result.body.virtualMachineInfo?.imageReference?.[
+                    "exactVersion"
+                  ],
+              },
+        },
+  };
+}
+
+export interface Computenodesrebootcomputenodeoptions extends RequestOptions {
+  /** The default value is requeue. */
+  nodeRebootOption?: ComputeNodeRebootOption;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/** You can restart a Compute Node only if it is in an idle or running state. */
+export async function rebootComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesrebootcomputenodeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/reboot", poolId, nodeId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.nodeRebootOption && {
+          nodeRebootOption: options.nodeRebootOption,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesreimagecomputenodeoptions extends RequestOptions {
+  /** The default value is requeue. */
+  nodeReimageOption?: ComputeNodeReimageOption;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * You can reinstall the operating system on a Compute Node only if it is in an
+ * idle or running state. This API can be invoked only on Pools created with the
+ * cloud service configuration property.
+ */
+export async function reimageComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesreimagecomputenodeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/reimage", poolId, nodeId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.nodeReimageOption && {
+          nodeReimageOption: options.nodeReimageOption,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesdisableschedulingoptions extends RequestOptions {
+  /** The default value is requeue. */
+  nodeDisableSchedulingOption?: DisableComputeNodeSchedulingOption;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * You can disable Task scheduling on a Compute Node only if its current
+ * scheduling state is enabled.
+ */
+export async function disableScheduling(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesdisableschedulingoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/disablescheduling", poolId, nodeId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.nodeDisableSchedulingOption && {
+          nodeDisableSchedulingOption: options.nodeDisableSchedulingOption,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesenableschedulingoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * You can enable Task scheduling on a Compute Node only if its current scheduling
+ * state is disabled
+ */
+export async function enableScheduling(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesenableschedulingoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/enablescheduling", poolId, nodeId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesgetremoteloginsettingsoptions
+  extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * Before you can remotely login to a Compute Node using the remote login
+ * settings, you must create a user Account on the Compute Node. This API can be
+ * invoked only on Pools created with the virtual machine configuration property.
+ * For Pools created with a cloud service configuration, see the GetRemoteDesktop
+ * API.
+ */
+export async function getRemoteLoginSettings(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesgetremoteloginsettingsoptions = { requestOptions: {} }
+): Promise<ComputeNodeGetRemoteLoginSettingsResult> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/remoteloginsettings", poolId, nodeId)
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    remoteLoginIPAddress: result.body["remoteLoginIPAddress"],
+    remoteLoginPort: result.body["remoteLoginPort"],
+  };
+}
+
+export interface Computenodesgetremotedesktopoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * Before you can access a Compute Node by using the RDP file, you must create a
+ * user Account on the Compute Node. This API can only be invoked on Pools created
+ * with a cloud service configuration. For Pools created with a virtual machine
+ * configuration, see the GetRemoteLoginSettings API.
+ */
+export async function getRemoteDesktop(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesgetremotedesktopoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/rdp", poolId, nodeId)
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Computenodesuploadbatchservicelogsoptions
+  extends RequestOptions {
+  /**
+   * Any log file containing a log message in the time range will be uploaded. This
+   * means that the operation might retrieve more logs than have been requested
+   * since the entire log file is always uploaded, but the operation should not
+   * retrieve fewer logs than have been requested. If omitted, the default is to
+   * upload all logs available after the startTime.
+   */
+  endTime?: Date;
+  /** The identity must have write access to the Azure Blob Storage container. */
+  identityReference?: ComputeNodeIdentityReference;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This is for gathering Azure Batch service log files in an automated fashion
+ * from Compute Nodes if you are experiencing an error and wish to escalate to
+ * Azure support. The Azure Batch service log files should be shared with Azure
+ * support to aid in debugging issues with the Batch service.
+ */
+export async function uploadBatchServiceLogs(
+  context: Client,
+  containerUrl: string,
+  startTime: Date,
+  poolId: string,
+  nodeId: string,
+  options: Computenodesuploadbatchservicelogsoptions = { requestOptions: {} }
+): Promise<UploadBatchServiceLogsResult> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/uploadbatchservicelogs",
+      poolId,
+      nodeId
+    )
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        containerUrl: containerUrl,
+        startTime: startTime,
+        ...(options.endTime && { endTime: options.endTime }),
+        ...(options.identityReference && {
+          identityReference: options.identityReference,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    virtualDirectoryName: result.body["virtualDirectoryName"],
+    numberOfFilesUploaded: result.body["numberOfFilesUploaded"],
+  };
+}
+
+export interface Computenodeslistoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-nodes-in-a-pool.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** Lists the Compute Nodes in the specified Pool. */
+export async function list(
+  context: Client,
+  poolId: string,
+  options: Computenodeslistoptions = { requestOptions: {} }
+): Promise<ComputeNodeListResult> {
+  const result = await context.path("/pools/{poolId}/nodes", poolId).get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+      ...(options.$select && { $select: options.$select }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      url: p["url"],
+      state: p["state"],
+      schedulingState: p["schedulingState"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      lastBootTime: new Date(p["lastBootTime"] ?? ""),
+      allocationTime: new Date(p["allocationTime"] ?? ""),
+      ipAddress: p["ipAddress"],
+      affinityId: p["affinityId"],
+      vmSize: p["vmSize"],
+      totalTasksRun: p["totalTasksRun"],
+      runningTasksCount: p["runningTasksCount"],
+      runningTaskSlotsCount: p["runningTaskSlotsCount"],
+      totalTasksSucceeded: p["totalTasksSucceeded"],
+      recentTasks: (p["recentTasks"] ?? []).map((p) => ({
+        taskUrl: p["taskUrl"],
+        jobId: p["jobId"],
+        taskId: p["taskId"],
+        subtaskId: p["subtaskId"],
+        taskState: p["taskState"],
+        executionInfo: !p.executionInfo
+          ? undefined
+          : {
+              startTime: new Date(p.executionInfo?.["startTime"] ?? ""),
+              endTime: new Date(p.executionInfo?.["endTime"] ?? ""),
+              exitCode: p.executionInfo?.["exitCode"],
+              containerInfo: !p.executionInfo?.containerInfo
+                ? undefined
+                : {
+                    containerId:
+                      p.executionInfo?.containerInfo?.["containerId"],
+                    state: p.executionInfo?.containerInfo?.["state"],
+                    error: p.executionInfo?.containerInfo?.["error"],
+                  },
+              failureInfo: !p.executionInfo?.failureInfo
+                ? undefined
+                : {
+                    category: p.executionInfo?.failureInfo?.["category"],
+                    code: p.executionInfo?.failureInfo?.["code"],
+                    message: p.executionInfo?.failureInfo?.["message"],
+                    details: (
+                      p.executionInfo?.failureInfo?.["details"] ?? []
+                    ).map((p) => ({ name: p["name"], value: p["value"] })),
+                  },
+              retryCount: p.executionInfo?.["retryCount"],
+              lastRetryTime: new Date(p.executionInfo?.["lastRetryTime"] ?? ""),
+              requeueCount: p.executionInfo?.["requeueCount"],
+              lastRequeueTime: new Date(
+                p.executionInfo?.["lastRequeueTime"] ?? ""
+              ),
+              result: p.executionInfo?.["result"],
+            },
+      })),
+      startTask: !p.startTask
+        ? undefined
+        : {
+            commandLine: p.startTask?.["commandLine"],
+            containerSettings: !p.startTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.startTask?.containerSettings?.["containerRunOptions"],
+                  imageName: p.startTask?.containerSettings?.["imageName"],
+                  registry: !p.startTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.startTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.startTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.startTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.startTask?.containerSettings
+                          ?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.startTask?.containerSettings?.registry
+                                  ?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.startTask?.containerSettings?.["workingDirectory"],
+                },
+            resourceFiles: (p.startTask?.["resourceFiles"] ?? []).map((p) => ({
+              autoStorageContainerName: p["autoStorageContainerName"],
+              storageContainerUrl: p["storageContainerUrl"],
+              httpUrl: p["httpUrl"],
+              blobPrefix: p["blobPrefix"],
+              filePath: p["filePath"],
+              fileMode: p["fileMode"],
+              identityReference: !p.identityReference
+                ? undefined
+                : { resourceId: p.identityReference?.["resourceId"] },
+            })),
+            environmentSettings: (
+              p.startTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            userIdentity: !p.startTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.startTask?.userIdentity?.["username"],
+                  autoUser: !p.startTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope: p.startTask?.userIdentity?.autoUser?.["scope"],
+                        elevationLevel:
+                          p.startTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+            maxTaskRetryCount: p.startTask?.["maxTaskRetryCount"],
+            waitForSuccess: p.startTask?.["waitForSuccess"],
+          },
+      startTaskInfo: !p.startTaskInfo
+        ? undefined
+        : {
+            state: p.startTaskInfo?.["state"],
+            startTime: new Date(p.startTaskInfo?.["startTime"] ?? ""),
+            endTime: new Date(p.startTaskInfo?.["endTime"] ?? ""),
+            exitCode: p.startTaskInfo?.["exitCode"],
+            containerInfo: !p.startTaskInfo?.containerInfo
+              ? undefined
+              : {
+                  containerId: p.startTaskInfo?.containerInfo?.["containerId"],
+                  state: p.startTaskInfo?.containerInfo?.["state"],
+                  error: p.startTaskInfo?.containerInfo?.["error"],
+                },
+            failureInfo: !p.startTaskInfo?.failureInfo
+              ? undefined
+              : {
+                  category: p.startTaskInfo?.failureInfo?.["category"],
+                  code: p.startTaskInfo?.failureInfo?.["code"],
+                  message: p.startTaskInfo?.failureInfo?.["message"],
+                  details: (
+                    p.startTaskInfo?.failureInfo?.["details"] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            retryCount: p.startTaskInfo?.["retryCount"],
+            lastRetryTime: new Date(p.startTaskInfo?.["lastRetryTime"] ?? ""),
+            result: p.startTaskInfo?.["result"],
+          },
+      certificateReferences: (p["certificateReferences"] ?? []).map((p) => ({
+        thumbprint: p["thumbprint"],
+        thumbprintAlgorithm: p["thumbprintAlgorithm"],
+        storeLocation: p["storeLocation"],
+        storeName: p["storeName"],
+        visibility: p["visibility"],
+      })),
+      errors: (p["errors"] ?? []).map((p) => ({
+        code: p["code"],
+        message: p["message"],
+        errorDetails: (p["errorDetails"] ?? []).map((p) => ({
+          name: p["name"],
+          value: p["value"],
+        })),
+      })),
+      isDedicated: p["isDedicated"],
+      endpointConfiguration: !p.endpointConfiguration
+        ? undefined
+        : {
+            inboundEndpoints: (
+              p.endpointConfiguration?.["inboundEndpoints"] ?? []
+            ).map((p) => ({
+              name: p["name"],
+              protocol: p["protocol"],
+              publicIPAddress: p["publicIPAddress"],
+              publicFQDN: p["publicFQDN"],
+              frontendPort: p["frontendPort"],
+              backendPort: p["backendPort"],
+            })),
+          },
+      nodeAgentInfo: !p.nodeAgentInfo
+        ? undefined
+        : {
+            version: p.nodeAgentInfo?.["version"],
+            lastUpdateTime: new Date(p.nodeAgentInfo?.["lastUpdateTime"] ?? ""),
+          },
+      virtualMachineInfo: !p.virtualMachineInfo
+        ? undefined
+        : {
+            imageReference: !p.virtualMachineInfo?.imageReference
+              ? undefined
+              : {
+                  publisher:
+                    p.virtualMachineInfo?.imageReference?.["publisher"],
+                  offer: p.virtualMachineInfo?.imageReference?.["offer"],
+                  sku: p.virtualMachineInfo?.imageReference?.["sku"],
+                  version: p.virtualMachineInfo?.imageReference?.["version"],
+                  virtualMachineImageId:
+                    p.virtualMachineInfo?.imageReference?.[
+                      "virtualMachineImageId"
+                    ],
+                  exactVersion:
+                    p.virtualMachineInfo?.imageReference?.["exactVersion"],
+                },
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/File.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/File.ts
@@ -5,7 +5,7 @@ import { RequestOptions } from "../common/interfaces.js";
 import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
 import { NodeFileListResult } from "./models.js";
 
-export interface Filedeletefromtaskoptions extends RequestOptions {
+export interface FileDeleteFromTaskOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -39,7 +39,7 @@ export async function deleteFromTask(
   jobId: string,
   taskId: string,
   filePath: string,
-  options: Filedeletefromtaskoptions = { requestOptions: {} }
+  options: FileDeleteFromTaskOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -71,7 +71,7 @@ export async function deleteFromTask(
   return;
 }
 
-export interface Filegetfromtaskoptions extends RequestOptions {
+export interface FileGetFromTaskOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -115,7 +115,7 @@ export async function getFromTask(
   jobId: string,
   taskId: string,
   filePath: string,
-  options: Filegetfromtaskoptions = { requestOptions: {} }
+  options: FileGetFromTaskOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -152,7 +152,7 @@ export async function getFromTask(
   return;
 }
 
-export interface Filegetpropertiesfromtaskoptions extends RequestOptions {
+export interface FileGetPropertiesFromTaskOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -191,7 +191,7 @@ export async function getPropertiesFromTask(
   jobId: string,
   taskId: string,
   filePath: string,
-  options: Filegetpropertiesfromtaskoptions = { requestOptions: {} }
+  options: FileGetPropertiesFromTaskOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -226,7 +226,7 @@ export async function getPropertiesFromTask(
   return;
 }
 
-export interface Filedeletefromcomputenodeoptions extends RequestOptions {
+export interface FileDeleteFromComputeNodeOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -260,7 +260,7 @@ export async function deleteFromComputeNode(
   poolId: string,
   nodeId: string,
   filePath: string,
-  options: Filedeletefromcomputenodeoptions = { requestOptions: {} }
+  options: FileDeleteFromComputeNodeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -292,7 +292,7 @@ export async function deleteFromComputeNode(
   return;
 }
 
-export interface Filegetfromcomputenodeoptions extends RequestOptions {
+export interface FileGetFromComputeNodeOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -336,7 +336,7 @@ export async function getFromComputeNode(
   poolId: string,
   nodeId: string,
   filePath: string,
-  options: Filegetfromcomputenodeoptions = { requestOptions: {} }
+  options: FileGetFromComputeNodeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -373,7 +373,7 @@ export async function getFromComputeNode(
   return;
 }
 
-export interface Filegetpropertiesfromcomputenodeoptions
+export interface FileGetPropertiesFromComputeNodeOptions
   extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
@@ -413,7 +413,7 @@ export async function getPropertiesFromComputeNode(
   poolId: string,
   nodeId: string,
   filePath: string,
-  options: Filegetpropertiesfromcomputenodeoptions = { requestOptions: {} }
+  options: FileGetPropertiesFromComputeNodeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path(
@@ -448,7 +448,7 @@ export async function getPropertiesFromComputeNode(
   return;
 }
 
-export interface Filelistfromtaskoptions extends RequestOptions {
+export interface FileListFromTaskOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -489,7 +489,7 @@ export async function listFromTask(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Filelistfromtaskoptions = { requestOptions: {} }
+  options: FileListFromTaskOptions = { requestOptions: {} }
 ): Promise<NodeFileListResult> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}/files", jobId, taskId)
@@ -535,7 +535,7 @@ export async function listFromTask(
   };
 }
 
-export interface Filelistfromcomputenodeoptions extends RequestOptions {
+export interface FileListFromComputeNodeOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -573,7 +573,7 @@ export async function listFromComputeNode(
   context: Client,
   poolId: string,
   nodeId: string,
-  options: Filelistfromcomputenodeoptions = { requestOptions: {} }
+  options: FileListFromComputeNodeOptions = { requestOptions: {} }
 ): Promise<NodeFileListResult> {
   const result = await context
     .path("/pools/{poolId}/nodes/{nodeId}/files", poolId, nodeId)

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/File.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/File.ts
@@ -1,0 +1,620 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import { NodeFileListResult } from "./models.js";
+
+export interface Filedeletefromtaskoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * Whether to delete children of a directory. If the filePath parameter represents
+   * a directory instead of a file, you can set recursive to true to delete the
+   * directory and all of the files and subdirectories in it. If recursive is false
+   * then the directory must be empty or deletion will fail.
+   */
+  recursive?: boolean;
+}
+
+/** Deletes the specified Task file from the Compute Node where the Task ran. */
+export async function deleteFromTask(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  filePath: string,
+  options: Filedeletefromtaskoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/jobs/{jobId}/tasks/{taskId}/files/{filePath}",
+      jobId,
+      taskId,
+      filePath
+    )
+    .delete({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.recursive && { recursive: options.recursive }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Filegetfromtaskoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /**
+   * The byte range to be retrieved. The default is to retrieve the entire file. The
+   * format is bytes=startRange-endRange.
+   */
+  ocpRange?: string;
+}
+
+/** Returns the content of the specified Task file. */
+export async function getFromTask(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  filePath: string,
+  options: Filegetfromtaskoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/jobs/{jobId}/tasks/{taskId}/files/{filePath}",
+      jobId,
+      taskId,
+      filePath
+    )
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.ocpRange && { "ocp-range": options.ocpRange }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Filegetpropertiesfromtaskoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** Gets the properties of the specified Task file. */
+export async function getPropertiesFromTask(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  filePath: string,
+  options: Filegetpropertiesfromtaskoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/jobs/{jobId}/tasks/{taskId}/files/{filePath}",
+      jobId,
+      taskId,
+      filePath
+    )
+    .head({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Filedeletefromcomputenodeoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * Whether to delete children of a directory. If the filePath parameter represents
+   * a directory instead of a file, you can set recursive to true to delete the
+   * directory and all of the files and subdirectories in it. If recursive is false
+   * then the directory must be empty or deletion will fail.
+   */
+  recursive?: boolean;
+}
+
+/** Deletes the specified file from the Compute Node. */
+export async function deleteFromComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  filePath: string,
+  options: Filedeletefromcomputenodeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/files/{filePath}",
+      poolId,
+      nodeId,
+      filePath
+    )
+    .delete({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.recursive && { recursive: options.recursive }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Filegetfromcomputenodeoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /**
+   * The byte range to be retrieved. The default is to retrieve the entire file. The
+   * format is bytes=startRange-endRange.
+   */
+  ocpRange?: string;
+}
+
+/** Returns the content of the specified Compute Node file. */
+export async function getFromComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  filePath: string,
+  options: Filegetfromcomputenodeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/files/{filePath}",
+      poolId,
+      nodeId,
+      filePath
+    )
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.ocpRange && { "ocp-range": options.ocpRange }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Filegetpropertiesfromcomputenodeoptions
+  extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** Gets the properties of the specified Compute Node file. */
+export async function getPropertiesFromComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  filePath: string,
+  options: Filegetpropertiesfromcomputenodeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path(
+      "/pools/{poolId}/nodes/{nodeId}/files/{filePath}",
+      poolId,
+      nodeId,
+      filePath
+    )
+    .head({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Filelistfromtaskoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-task-files.
+   */
+  $filter?: string;
+  /**
+   * Whether to list children of the Task directory. This parameter can be used in
+   * combination with the filter parameter to list specific type of files.
+   */
+  recursive?: boolean;
+}
+
+/** Lists the files in a Task's directory on its Compute Node. */
+export async function listFromTask(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Filelistfromtaskoptions = { requestOptions: {} }
+): Promise<NodeFileListResult> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}/files", jobId, taskId)
+    .get({
+      headers: {
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.maxresults && { maxresults: options.maxresults }),
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$filter && { $filter: options.$filter }),
+        ...(options.recursive && { recursive: options.recursive }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      name: p["name"],
+      url: p["url"],
+      isDirectory: p["isDirectory"],
+      properties: !p.properties
+        ? undefined
+        : {
+            creationTime: new Date(p.properties?.["creationTime"] ?? ""),
+            lastModified: new Date(p.properties?.["lastModified"] ?? ""),
+            contentLength: p.properties?.["contentLength"],
+            contentType: p.properties?.["contentType"],
+            fileMode: p.properties?.["fileMode"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Filelistfromcomputenodeoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-compute-node-files.
+   */
+  $filter?: string;
+  /** Whether to list children of a directory. */
+  recursive?: boolean;
+}
+
+/** Lists all of the files in Task directories on the specified Compute Node. */
+export async function listFromComputeNode(
+  context: Client,
+  poolId: string,
+  nodeId: string,
+  options: Filelistfromcomputenodeoptions = { requestOptions: {} }
+): Promise<NodeFileListResult> {
+  const result = await context
+    .path("/pools/{poolId}/nodes/{nodeId}/files", poolId, nodeId)
+    .get({
+      headers: {
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.maxresults && { maxresults: options.maxresults }),
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$filter && { $filter: options.$filter }),
+        ...(options.recursive && { recursive: options.recursive }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      name: p["name"],
+      url: p["url"],
+      isDirectory: p["isDirectory"],
+      properties: !p.properties
+        ? undefined
+        : {
+            creationTime: new Date(p.properties?.["creationTime"] ?? ""),
+            lastModified: new Date(p.properties?.["lastModified"] ?? ""),
+            contentLength: p.properties?.["contentLength"],
+            contentType: p.properties?.["contentType"],
+            fileMode: p.properties?.["fileMode"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Job.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Job.ts
@@ -1,0 +1,4406 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  EnvironmentSetting,
+  MetadataItem,
+  JobStatistics,
+  BatchJob,
+  JobState,
+  JobConstraints,
+  JobManagerTask,
+  JobPreparationTask,
+  JobReleaseTask,
+  PoolInformation,
+  OnAllTasksComplete,
+  OnTaskFailure,
+  JobNetworkConfiguration,
+  JobExecutionInformation,
+  DisableJobOption,
+  BatchJobListResult,
+  BatchJobListPreparationAndReleaseTaskStatusResult,
+  TaskCountsResult,
+} from "./models.js";
+
+export interface Jobgetalllifetimestatisticsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * Statistics are aggregated across all Jobs that have ever existed in the
+ * Account, from Account creation to the last update time of the statistics. The
+ * statistics may not be immediately available. The Batch service performs
+ * periodic roll-up of statistics. The typical delay is about 30 minutes.
+ */
+export async function getAllLifetimeStatistics(
+  context: Client,
+  options: Jobgetalllifetimestatisticsoptions = { requestOptions: {} }
+): Promise<JobStatistics> {
+  const result = await context.path("/lifetimejobstats").get({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    url: result.body["url"],
+    startTime: new Date(result.body["startTime"] ?? ""),
+    lastUpdateTime: new Date(result.body["lastUpdateTime"] ?? ""),
+    userCPUTime: result.body["userCPUTime"],
+    kernelCPUTime: result.body["kernelCPUTime"],
+    wallClockTime: result.body["wallClockTime"],
+    readIOps: result.body["readIOps"],
+    writeIOps: result.body["writeIOps"],
+    readIOGiB: result.body["readIOGiB"],
+    writeIOGiB: result.body["writeIOGiB"],
+    numSucceededTasks: result.body["numSucceededTasks"],
+    numFailedTasks: result.body["numFailedTasks"],
+    numTaskRetries: result.body["numTaskRetries"],
+    waitTime: result.body["waitTime"],
+  };
+}
+
+export interface Jobdeletejoboptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * Deleting a Job also deletes all Tasks that are part of that Job, and all Job
+ * statistics. This also overrides the retention period for Task data; that is, if
+ * the Job contains Tasks which are still retained on Compute Nodes, the Batch
+ * services deletes those Tasks' working directories and all their contents.  When
+ * a Delete Job request is received, the Batch service sets the Job to the
+ * deleting state. All update operations on a Job that is in deleting state will
+ * fail with status code 409 (Conflict), with additional information indicating
+ * that the Job is being deleted.
+ */
+export async function deleteJob(
+  context: Client,
+  jobId: string,
+  options: Jobdeletejoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}", jobId).delete({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobgetjoboptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Gets information about the specified Job. */
+export async function getJob(
+  context: Client,
+  jobId: string,
+  options: Jobgetjoboptions = { requestOptions: {} }
+): Promise<BatchJob> {
+  const result = await context.path("/jobs/{jobId}", jobId).get({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$select && { $select: options.$select }),
+      ...(options.$expand && { $expand: options.$expand }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    displayName: result.body["displayName"],
+    usesTaskDependencies: result.body["usesTaskDependencies"],
+    url: result.body["url"],
+    eTag: result.body["eTag"],
+    lastModified: new Date(result.body["lastModified"] ?? ""),
+    creationTime: new Date(result.body["creationTime"] ?? ""),
+    state: result.body["state"],
+    stateTransitionTime: new Date(result.body["stateTransitionTime"] ?? ""),
+    previousState: result.body["previousState"],
+    previousStateTransitionTime: new Date(
+      result.body["previousStateTransitionTime"] ?? ""
+    ),
+    priority: result.body["priority"],
+    allowTaskPreemption: result.body["allowTaskPreemption"],
+    maxParallelTasks: result.body["maxParallelTasks"],
+    constraints: !result.body.constraints
+      ? undefined
+      : {
+          maxWallClockTime: result.body.constraints?.["maxWallClockTime"],
+          maxTaskRetryCount: result.body.constraints?.["maxTaskRetryCount"],
+        },
+    jobManagerTask: !result.body.jobManagerTask
+      ? undefined
+      : {
+          id: result.body.jobManagerTask?.["id"],
+          displayName: result.body.jobManagerTask?.["displayName"],
+          commandLine: result.body.jobManagerTask?.["commandLine"],
+          containerSettings: !result.body.jobManagerTask?.containerSettings
+            ? undefined
+            : {
+                containerRunOptions:
+                  result.body.jobManagerTask?.containerSettings?.[
+                    "containerRunOptions"
+                  ],
+                imageName:
+                  result.body.jobManagerTask?.containerSettings?.["imageName"],
+                registry: !result.body.jobManagerTask?.containerSettings
+                  ?.registry
+                  ? undefined
+                  : {
+                      username:
+                        result.body.jobManagerTask?.containerSettings
+                          ?.registry?.["username"],
+                      password:
+                        result.body.jobManagerTask?.containerSettings
+                          ?.registry?.["password"],
+                      registryServer:
+                        result.body.jobManagerTask?.containerSettings
+                          ?.registry?.["registryServer"],
+                      identityReference: !result.body.jobManagerTask
+                        ?.containerSettings?.registry?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              result.body.jobManagerTask?.containerSettings
+                                ?.registry?.identityReference?.["resourceId"],
+                          },
+                    },
+                workingDirectory:
+                  result.body.jobManagerTask?.containerSettings?.[
+                    "workingDirectory"
+                  ],
+              },
+          resourceFiles: (
+            result.body.jobManagerTask?.["resourceFiles"] ?? []
+          ).map((p) => ({
+            autoStorageContainerName: p["autoStorageContainerName"],
+            storageContainerUrl: p["storageContainerUrl"],
+            httpUrl: p["httpUrl"],
+            blobPrefix: p["blobPrefix"],
+            filePath: p["filePath"],
+            fileMode: p["fileMode"],
+            identityReference: !p.identityReference
+              ? undefined
+              : { resourceId: p.identityReference?.["resourceId"] },
+          })),
+          outputFiles: (result.body.jobManagerTask?.["outputFiles"] ?? []).map(
+            (p) => ({
+              filePattern: p["filePattern"],
+              destination: {
+                container: !p.destination.container
+                  ? undefined
+                  : {
+                      path: p.destination.container?.["path"],
+                      containerUrl: p.destination.container?.["containerUrl"],
+                      identityReference: !p.destination.container
+                        ?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              p.destination.container?.identityReference?.[
+                                "resourceId"
+                              ],
+                          },
+                      uploadHeaders: (
+                        p.destination.container?.["uploadHeaders"] ?? []
+                      ).map((p) => ({ name: p["name"], value: p["value"] })),
+                    },
+              },
+              uploadOptions: {
+                uploadCondition: p.uploadOptions["uploadCondition"],
+              },
+            })
+          ),
+          environmentSettings: (
+            result.body.jobManagerTask?.["environmentSettings"] ?? []
+          ).map((p) => ({ name: p["name"], value: p["value"] })),
+          constraints: !result.body.jobManagerTask?.constraints
+            ? undefined
+            : {
+                maxWallClockTime:
+                  result.body.jobManagerTask?.constraints?.["maxWallClockTime"],
+                retentionTime:
+                  result.body.jobManagerTask?.constraints?.["retentionTime"],
+                maxTaskRetryCount:
+                  result.body.jobManagerTask?.constraints?.[
+                    "maxTaskRetryCount"
+                  ],
+              },
+          requiredSlots: result.body.jobManagerTask?.["requiredSlots"],
+          killJobOnCompletion:
+            result.body.jobManagerTask?.["killJobOnCompletion"],
+          userIdentity: !result.body.jobManagerTask?.userIdentity
+            ? undefined
+            : {
+                username:
+                  result.body.jobManagerTask?.userIdentity?.["username"],
+                autoUser: !result.body.jobManagerTask?.userIdentity?.autoUser
+                  ? undefined
+                  : {
+                      scope:
+                        result.body.jobManagerTask?.userIdentity?.autoUser?.[
+                          "scope"
+                        ],
+                      elevationLevel:
+                        result.body.jobManagerTask?.userIdentity?.autoUser?.[
+                          "elevationLevel"
+                        ],
+                    },
+              },
+          runExclusive: result.body.jobManagerTask?.["runExclusive"],
+          applicationPackageReferences: (
+            result.body.jobManagerTask?.["applicationPackageReferences"] ?? []
+          ).map((p) => ({
+            applicationId: p["applicationId"],
+            version: p["version"],
+          })),
+          authenticationTokenSettings: !result.body.jobManagerTask
+            ?.authenticationTokenSettings
+            ? undefined
+            : {
+                access:
+                  result.body.jobManagerTask?.authenticationTokenSettings?.[
+                    "access"
+                  ],
+              },
+          allowLowPriorityNode:
+            result.body.jobManagerTask?.["allowLowPriorityNode"],
+        },
+    jobPreparationTask: !result.body.jobPreparationTask
+      ? undefined
+      : {
+          id: result.body.jobPreparationTask?.["id"],
+          commandLine: result.body.jobPreparationTask?.["commandLine"],
+          containerSettings: !result.body.jobPreparationTask?.containerSettings
+            ? undefined
+            : {
+                containerRunOptions:
+                  result.body.jobPreparationTask?.containerSettings?.[
+                    "containerRunOptions"
+                  ],
+                imageName:
+                  result.body.jobPreparationTask?.containerSettings?.[
+                    "imageName"
+                  ],
+                registry: !result.body.jobPreparationTask?.containerSettings
+                  ?.registry
+                  ? undefined
+                  : {
+                      username:
+                        result.body.jobPreparationTask?.containerSettings
+                          ?.registry?.["username"],
+                      password:
+                        result.body.jobPreparationTask?.containerSettings
+                          ?.registry?.["password"],
+                      registryServer:
+                        result.body.jobPreparationTask?.containerSettings
+                          ?.registry?.["registryServer"],
+                      identityReference: !result.body.jobPreparationTask
+                        ?.containerSettings?.registry?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              result.body.jobPreparationTask?.containerSettings
+                                ?.registry?.identityReference?.["resourceId"],
+                          },
+                    },
+                workingDirectory:
+                  result.body.jobPreparationTask?.containerSettings?.[
+                    "workingDirectory"
+                  ],
+              },
+          resourceFiles: (
+            result.body.jobPreparationTask?.["resourceFiles"] ?? []
+          ).map((p) => ({
+            autoStorageContainerName: p["autoStorageContainerName"],
+            storageContainerUrl: p["storageContainerUrl"],
+            httpUrl: p["httpUrl"],
+            blobPrefix: p["blobPrefix"],
+            filePath: p["filePath"],
+            fileMode: p["fileMode"],
+            identityReference: !p.identityReference
+              ? undefined
+              : { resourceId: p.identityReference?.["resourceId"] },
+          })),
+          environmentSettings: (
+            result.body.jobPreparationTask?.["environmentSettings"] ?? []
+          ).map((p) => ({ name: p["name"], value: p["value"] })),
+          constraints: !result.body.jobPreparationTask?.constraints
+            ? undefined
+            : {
+                maxWallClockTime:
+                  result.body.jobPreparationTask?.constraints?.[
+                    "maxWallClockTime"
+                  ],
+                retentionTime:
+                  result.body.jobPreparationTask?.constraints?.[
+                    "retentionTime"
+                  ],
+                maxTaskRetryCount:
+                  result.body.jobPreparationTask?.constraints?.[
+                    "maxTaskRetryCount"
+                  ],
+              },
+          waitForSuccess: result.body.jobPreparationTask?.["waitForSuccess"],
+          userIdentity: !result.body.jobPreparationTask?.userIdentity
+            ? undefined
+            : {
+                username:
+                  result.body.jobPreparationTask?.userIdentity?.["username"],
+                autoUser: !result.body.jobPreparationTask?.userIdentity
+                  ?.autoUser
+                  ? undefined
+                  : {
+                      scope:
+                        result.body.jobPreparationTask?.userIdentity
+                          ?.autoUser?.["scope"],
+                      elevationLevel:
+                        result.body.jobPreparationTask?.userIdentity
+                          ?.autoUser?.["elevationLevel"],
+                    },
+              },
+          rerunOnNodeRebootAfterSuccess:
+            result.body.jobPreparationTask?.["rerunOnNodeRebootAfterSuccess"],
+        },
+    jobReleaseTask: !result.body.jobReleaseTask
+      ? undefined
+      : {
+          id: result.body.jobReleaseTask?.["id"],
+          commandLine: result.body.jobReleaseTask?.["commandLine"],
+          containerSettings: !result.body.jobReleaseTask?.containerSettings
+            ? undefined
+            : {
+                containerRunOptions:
+                  result.body.jobReleaseTask?.containerSettings?.[
+                    "containerRunOptions"
+                  ],
+                imageName:
+                  result.body.jobReleaseTask?.containerSettings?.["imageName"],
+                registry: !result.body.jobReleaseTask?.containerSettings
+                  ?.registry
+                  ? undefined
+                  : {
+                      username:
+                        result.body.jobReleaseTask?.containerSettings
+                          ?.registry?.["username"],
+                      password:
+                        result.body.jobReleaseTask?.containerSettings
+                          ?.registry?.["password"],
+                      registryServer:
+                        result.body.jobReleaseTask?.containerSettings
+                          ?.registry?.["registryServer"],
+                      identityReference: !result.body.jobReleaseTask
+                        ?.containerSettings?.registry?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              result.body.jobReleaseTask?.containerSettings
+                                ?.registry?.identityReference?.["resourceId"],
+                          },
+                    },
+                workingDirectory:
+                  result.body.jobReleaseTask?.containerSettings?.[
+                    "workingDirectory"
+                  ],
+              },
+          resourceFiles: (
+            result.body.jobReleaseTask?.["resourceFiles"] ?? []
+          ).map((p) => ({
+            autoStorageContainerName: p["autoStorageContainerName"],
+            storageContainerUrl: p["storageContainerUrl"],
+            httpUrl: p["httpUrl"],
+            blobPrefix: p["blobPrefix"],
+            filePath: p["filePath"],
+            fileMode: p["fileMode"],
+            identityReference: !p.identityReference
+              ? undefined
+              : { resourceId: p.identityReference?.["resourceId"] },
+          })),
+          environmentSettings: (
+            result.body.jobReleaseTask?.["environmentSettings"] ?? []
+          ).map((p) => ({ name: p["name"], value: p["value"] })),
+          maxWallClockTime: result.body.jobReleaseTask?.["maxWallClockTime"],
+          retentionTime: result.body.jobReleaseTask?.["retentionTime"],
+          userIdentity: !result.body.jobReleaseTask?.userIdentity
+            ? undefined
+            : {
+                username:
+                  result.body.jobReleaseTask?.userIdentity?.["username"],
+                autoUser: !result.body.jobReleaseTask?.userIdentity?.autoUser
+                  ? undefined
+                  : {
+                      scope:
+                        result.body.jobReleaseTask?.userIdentity?.autoUser?.[
+                          "scope"
+                        ],
+                      elevationLevel:
+                        result.body.jobReleaseTask?.userIdentity?.autoUser?.[
+                          "elevationLevel"
+                        ],
+                    },
+              },
+        },
+    commonEnvironmentSettings: (
+      result.body["commonEnvironmentSettings"] ?? []
+    ).map((p) => ({ name: p["name"], value: p["value"] })),
+    poolInfo: !result.body.poolInfo
+      ? undefined
+      : {
+          poolId: result.body.poolInfo?.["poolId"],
+          autoPoolSpecification: !result.body.poolInfo?.autoPoolSpecification
+            ? undefined
+            : {
+                autoPoolIdPrefix:
+                  result.body.poolInfo?.autoPoolSpecification?.[
+                    "autoPoolIdPrefix"
+                  ],
+                poolLifetimeOption:
+                  result.body.poolInfo?.autoPoolSpecification?.[
+                    "poolLifetimeOption"
+                  ],
+                keepAlive:
+                  result.body.poolInfo?.autoPoolSpecification?.["keepAlive"],
+                pool: !result.body.poolInfo?.autoPoolSpecification?.pool
+                  ? undefined
+                  : {
+                      displayName:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "displayName"
+                        ],
+                      vmSize:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "vmSize"
+                        ],
+                      cloudServiceConfiguration: !result.body.poolInfo
+                        ?.autoPoolSpecification?.pool?.cloudServiceConfiguration
+                        ? undefined
+                        : {
+                            osFamily:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.cloudServiceConfiguration?.["osFamily"],
+                            osVersion:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.cloudServiceConfiguration?.["osVersion"],
+                          },
+                      virtualMachineConfiguration: !result.body.poolInfo
+                        ?.autoPoolSpecification?.pool
+                        ?.virtualMachineConfiguration
+                        ? undefined
+                        : {
+                            imageReference: {
+                              publisher:
+                                result.body.poolInfo?.autoPoolSpecification
+                                  ?.pool?.virtualMachineConfiguration
+                                  ?.imageReference["publisher"],
+                              offer:
+                                result.body.poolInfo?.autoPoolSpecification
+                                  ?.pool?.virtualMachineConfiguration
+                                  ?.imageReference["offer"],
+                              sku: result.body.poolInfo?.autoPoolSpecification
+                                ?.pool?.virtualMachineConfiguration
+                                ?.imageReference["sku"],
+                              version:
+                                result.body.poolInfo?.autoPoolSpecification
+                                  ?.pool?.virtualMachineConfiguration
+                                  ?.imageReference["version"],
+                              virtualMachineImageId:
+                                result.body.poolInfo?.autoPoolSpecification
+                                  ?.pool?.virtualMachineConfiguration
+                                  ?.imageReference["virtualMachineImageId"],
+                              exactVersion:
+                                result.body.poolInfo?.autoPoolSpecification
+                                  ?.pool?.virtualMachineConfiguration
+                                  ?.imageReference["exactVersion"],
+                            },
+                            nodeAgentSKUId:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.[
+                                "nodeAgentSKUId"
+                              ],
+                            windowsConfiguration: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool
+                              ?.virtualMachineConfiguration
+                              ?.windowsConfiguration
+                              ? undefined
+                              : {
+                                  enableAutomaticUpdates:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.windowsConfiguration?.[
+                                      "enableAutomaticUpdates"
+                                    ],
+                                },
+                            dataDisks: (
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.["dataDisks"] ??
+                              []
+                            ).map((p) => ({
+                              lun: p["lun"],
+                              caching: p["caching"],
+                              diskSizeGB: p["diskSizeGB"],
+                              storageAccountType: p["storageAccountType"],
+                            })),
+                            licenseType:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.["licenseType"],
+                            containerConfiguration: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool
+                              ?.virtualMachineConfiguration
+                              ?.containerConfiguration
+                              ? undefined
+                              : {
+                                  type: result.body.poolInfo
+                                    ?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.containerConfiguration?.["type"],
+                                  containerImageNames:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.containerConfiguration?.[
+                                      "containerImageNames"
+                                    ],
+                                  containerRegistries: (
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.containerConfiguration?.[
+                                      "containerRegistries"
+                                    ] ?? []
+                                  ).map((p) => ({
+                                    username: p["username"],
+                                    password: p["password"],
+                                    registryServer: p["registryServer"],
+                                    identityReference: !p.identityReference
+                                      ? undefined
+                                      : {
+                                          resourceId:
+                                            p.identityReference?.["resourceId"],
+                                        },
+                                  })),
+                                },
+                            diskEncryptionConfiguration: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool
+                              ?.virtualMachineConfiguration
+                              ?.diskEncryptionConfiguration
+                              ? undefined
+                              : {
+                                  targets:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.diskEncryptionConfiguration?.[
+                                      "targets"
+                                    ],
+                                },
+                            nodePlacementConfiguration: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool
+                              ?.virtualMachineConfiguration
+                              ?.nodePlacementConfiguration
+                              ? undefined
+                              : {
+                                  policy:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.nodePlacementConfiguration?.["policy"],
+                                },
+                            extensions: (
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.["extensions"] ??
+                              []
+                            ).map((p) => ({
+                              name: p["name"],
+                              publisher: p["publisher"],
+                              type: p["type"],
+                              typeHandlerVersion: p["typeHandlerVersion"],
+                              autoUpgradeMinorVersion:
+                                p["autoUpgradeMinorVersion"],
+                              settings: !p.settings ? undefined : {},
+                              protectedSettings: !p.protectedSettings
+                                ? undefined
+                                : {},
+                              provisionAfterExtensions:
+                                p["provisionAfterExtensions"],
+                            })),
+                            osDisk: !result.body.poolInfo?.autoPoolSpecification
+                              ?.pool?.virtualMachineConfiguration?.osDisk
+                              ? undefined
+                              : {
+                                  ephemeralOSDiskSettings: !result.body.poolInfo
+                                    ?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration?.osDisk
+                                    ?.ephemeralOSDiskSettings
+                                    ? undefined
+                                    : {
+                                        placement:
+                                          result.body.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.virtualMachineConfiguration
+                                            ?.osDisk?.ephemeralOSDiskSettings?.[
+                                            "placement"
+                                          ],
+                                      },
+                                },
+                          },
+                      taskSlotsPerNode:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "taskSlotsPerNode"
+                        ],
+                      taskSchedulingPolicy: !result.body.poolInfo
+                        ?.autoPoolSpecification?.pool?.taskSchedulingPolicy
+                        ? undefined
+                        : {
+                            nodeFillType:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.taskSchedulingPolicy?.["nodeFillType"],
+                          },
+                      resizeTimeout:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "resizeTimeout"
+                        ],
+                      targetDedicatedNodes:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "targetDedicatedNodes"
+                        ],
+                      targetLowPriorityNodes:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "targetLowPriorityNodes"
+                        ],
+                      enableAutoScale:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "enableAutoScale"
+                        ],
+                      autoScaleFormula:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "autoScaleFormula"
+                        ],
+                      autoScaleEvaluationInterval:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "autoScaleEvaluationInterval"
+                        ],
+                      enableInterNodeCommunication:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "enableInterNodeCommunication"
+                        ],
+                      networkConfiguration: !result.body.poolInfo
+                        ?.autoPoolSpecification?.pool?.networkConfiguration
+                        ? undefined
+                        : {
+                            subnetId:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.networkConfiguration?.["subnetId"],
+                            dynamicVNetAssignmentScope:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.networkConfiguration?.[
+                                "dynamicVNetAssignmentScope"
+                              ],
+                            endpointConfiguration: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool
+                              ?.networkConfiguration?.endpointConfiguration
+                              ? undefined
+                              : {
+                                  inboundNATPools: (
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.networkConfiguration
+                                      ?.endpointConfiguration?.[
+                                      "inboundNATPools"
+                                    ] ?? []
+                                  ).map((p) => ({
+                                    name: p["name"],
+                                    protocol: p["protocol"],
+                                    backendPort: p["backendPort"],
+                                    frontendPortRangeStart:
+                                      p["frontendPortRangeStart"],
+                                    frontendPortRangeEnd:
+                                      p["frontendPortRangeEnd"],
+                                    networkSecurityGroupRules: (
+                                      p["networkSecurityGroupRules"] ?? []
+                                    ).map((p) => ({
+                                      priority: p["priority"],
+                                      access: p["access"],
+                                      sourceAddressPrefix:
+                                        p["sourceAddressPrefix"],
+                                      sourcePortRanges: p["sourcePortRanges"],
+                                    })),
+                                  })),
+                                },
+                            publicIPAddressConfiguration: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool
+                              ?.networkConfiguration
+                              ?.publicIPAddressConfiguration
+                              ? undefined
+                              : {
+                                  provision:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.networkConfiguration
+                                      ?.publicIPAddressConfiguration?.[
+                                      "provision"
+                                    ],
+                                  ipAddressIds:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.networkConfiguration
+                                      ?.publicIPAddressConfiguration?.[
+                                      "ipAddressIds"
+                                    ],
+                                },
+                          },
+                      startTask: !result.body.poolInfo?.autoPoolSpecification
+                        ?.pool?.startTask
+                        ? undefined
+                        : {
+                            commandLine:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.startTask?.["commandLine"],
+                            containerSettings: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool?.startTask
+                              ?.containerSettings
+                              ? undefined
+                              : {
+                                  containerRunOptions:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.containerSettings?.[
+                                      "containerRunOptions"
+                                    ],
+                                  imageName:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.containerSettings?.[
+                                      "imageName"
+                                    ],
+                                  registry: !result.body.poolInfo
+                                    ?.autoPoolSpecification?.pool?.startTask
+                                    ?.containerSettings?.registry
+                                    ? undefined
+                                    : {
+                                        username:
+                                          result.body.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.containerSettings
+                                            ?.registry?.["username"],
+                                        password:
+                                          result.body.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.containerSettings
+                                            ?.registry?.["password"],
+                                        registryServer:
+                                          result.body.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.containerSettings
+                                            ?.registry?.["registryServer"],
+                                        identityReference: !result.body.poolInfo
+                                          ?.autoPoolSpecification?.pool
+                                          ?.startTask?.containerSettings
+                                          ?.registry?.identityReference
+                                          ? undefined
+                                          : {
+                                              resourceId:
+                                                result.body.poolInfo
+                                                  ?.autoPoolSpecification?.pool
+                                                  ?.startTask?.containerSettings
+                                                  ?.registry
+                                                  ?.identityReference?.[
+                                                  "resourceId"
+                                                ],
+                                            },
+                                      },
+                                  workingDirectory:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.containerSettings?.[
+                                      "workingDirectory"
+                                    ],
+                                },
+                            resourceFiles: (
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.startTask?.["resourceFiles"] ?? []
+                            ).map((p) => ({
+                              autoStorageContainerName:
+                                p["autoStorageContainerName"],
+                              storageContainerUrl: p["storageContainerUrl"],
+                              httpUrl: p["httpUrl"],
+                              blobPrefix: p["blobPrefix"],
+                              filePath: p["filePath"],
+                              fileMode: p["fileMode"],
+                              identityReference: !p.identityReference
+                                ? undefined
+                                : {
+                                    resourceId:
+                                      p.identityReference?.["resourceId"],
+                                  },
+                            })),
+                            environmentSettings: (
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.startTask?.["environmentSettings"] ?? []
+                            ).map((p) => ({
+                              name: p["name"],
+                              value: p["value"],
+                            })),
+                            userIdentity: !result.body.poolInfo
+                              ?.autoPoolSpecification?.pool?.startTask
+                              ?.userIdentity
+                              ? undefined
+                              : {
+                                  username:
+                                    result.body.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.userIdentity?.[
+                                      "username"
+                                    ],
+                                  autoUser: !result.body.poolInfo
+                                    ?.autoPoolSpecification?.pool?.startTask
+                                    ?.userIdentity?.autoUser
+                                    ? undefined
+                                    : {
+                                        scope:
+                                          result.body.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.userIdentity
+                                            ?.autoUser?.["scope"],
+                                        elevationLevel:
+                                          result.body.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.userIdentity
+                                            ?.autoUser?.["elevationLevel"],
+                                      },
+                                },
+                            maxTaskRetryCount:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.startTask?.["maxTaskRetryCount"],
+                            waitForSuccess:
+                              result.body.poolInfo?.autoPoolSpecification?.pool
+                                ?.startTask?.["waitForSuccess"],
+                          },
+                      certificateReferences: (
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "certificateReferences"
+                        ] ?? []
+                      ).map((p) => ({
+                        thumbprint: p["thumbprint"],
+                        thumbprintAlgorithm: p["thumbprintAlgorithm"],
+                        storeLocation: p["storeLocation"],
+                        storeName: p["storeName"],
+                        visibility: p["visibility"],
+                      })),
+                      applicationPackageReferences: (
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "applicationPackageReferences"
+                        ] ?? []
+                      ).map((p) => ({
+                        applicationId: p["applicationId"],
+                        version: p["version"],
+                      })),
+                      applicationLicenses:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "applicationLicenses"
+                        ],
+                      userAccounts: (
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "userAccounts"
+                        ] ?? []
+                      ).map((p) => ({
+                        name: p["name"],
+                        password: p["password"],
+                        elevationLevel: p["elevationLevel"],
+                        linuxUserConfiguration: !p.linuxUserConfiguration
+                          ? undefined
+                          : {
+                              uid: p.linuxUserConfiguration?.["uid"],
+                              gid: p.linuxUserConfiguration?.["gid"],
+                              sshPrivateKey:
+                                p.linuxUserConfiguration?.["sshPrivateKey"],
+                            },
+                        windowsUserConfiguration: !p.windowsUserConfiguration
+                          ? undefined
+                          : {
+                              loginMode:
+                                p.windowsUserConfiguration?.["loginMode"],
+                            },
+                      })),
+                      metadata: (
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "metadata"
+                        ] ?? []
+                      ).map((p) => ({ name: p["name"], value: p["value"] })),
+                      mountConfiguration: (
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "mountConfiguration"
+                        ] ?? []
+                      ).map((p) => ({
+                        azureBlobFileSystemConfiguration:
+                          !p.azureBlobFileSystemConfiguration
+                            ? undefined
+                            : {
+                                accountName:
+                                  p.azureBlobFileSystemConfiguration?.[
+                                    "accountName"
+                                  ],
+                                containerName:
+                                  p.azureBlobFileSystemConfiguration?.[
+                                    "containerName"
+                                  ],
+                                accountKey:
+                                  p.azureBlobFileSystemConfiguration?.[
+                                    "accountKey"
+                                  ],
+                                sasKey:
+                                  p.azureBlobFileSystemConfiguration?.[
+                                    "sasKey"
+                                  ],
+                                blobfuseOptions:
+                                  p.azureBlobFileSystemConfiguration?.[
+                                    "blobfuseOptions"
+                                  ],
+                                relativeMountPath:
+                                  p.azureBlobFileSystemConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                identityReference: !p
+                                  .azureBlobFileSystemConfiguration
+                                  ?.identityReference
+                                  ? undefined
+                                  : {
+                                      resourceId:
+                                        p.azureBlobFileSystemConfiguration
+                                          ?.identityReference?.["resourceId"],
+                                    },
+                              },
+                        nfsMountConfiguration: !p.nfsMountConfiguration
+                          ? undefined
+                          : {
+                              source: p.nfsMountConfiguration?.["source"],
+                              relativeMountPath:
+                                p.nfsMountConfiguration?.["relativeMountPath"],
+                              mountOptions:
+                                p.nfsMountConfiguration?.["mountOptions"],
+                            },
+                        cifsMountConfiguration: !p.cifsMountConfiguration
+                          ? undefined
+                          : {
+                              username: p.cifsMountConfiguration?.["username"],
+                              source: p.cifsMountConfiguration?.["source"],
+                              relativeMountPath:
+                                p.cifsMountConfiguration?.["relativeMountPath"],
+                              mountOptions:
+                                p.cifsMountConfiguration?.["mountOptions"],
+                              password: p.cifsMountConfiguration?.["password"],
+                            },
+                        azureFileShareConfiguration:
+                          !p.azureFileShareConfiguration
+                            ? undefined
+                            : {
+                                accountName:
+                                  p.azureFileShareConfiguration?.[
+                                    "accountName"
+                                  ],
+                                azureFileUrl:
+                                  p.azureFileShareConfiguration?.[
+                                    "azureFileUrl"
+                                  ],
+                                accountKey:
+                                  p.azureFileShareConfiguration?.["accountKey"],
+                                relativeMountPath:
+                                  p.azureFileShareConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.azureFileShareConfiguration?.[
+                                    "mountOptions"
+                                  ],
+                              },
+                      })),
+                      targetNodeCommunicationMode:
+                        result.body.poolInfo?.autoPoolSpecification?.pool?.[
+                          "targetNodeCommunicationMode"
+                        ],
+                    },
+              },
+        },
+    onAllTasksComplete: result.body["onAllTasksComplete"],
+    onTaskFailure: result.body["onTaskFailure"],
+    networkConfiguration: !result.body.networkConfiguration
+      ? undefined
+      : { subnetId: result.body.networkConfiguration?.["subnetId"] },
+    metadata: (result.body["metadata"] ?? []).map((p) => ({
+      name: p["name"],
+      value: p["value"],
+    })),
+    executionInfo: !result.body.executionInfo
+      ? undefined
+      : {
+          startTime: new Date(result.body.executionInfo?.["startTime"] ?? ""),
+          endTime: new Date(result.body.executionInfo?.["endTime"] ?? ""),
+          poolId: result.body.executionInfo?.["poolId"],
+          schedulingError: !result.body.executionInfo?.schedulingError
+            ? undefined
+            : {
+                category:
+                  result.body.executionInfo?.schedulingError?.["category"],
+                code: result.body.executionInfo?.schedulingError?.["code"],
+                message:
+                  result.body.executionInfo?.schedulingError?.["message"],
+                details: (
+                  result.body.executionInfo?.schedulingError?.["details"] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+              },
+          terminateReason: result.body.executionInfo?.["terminateReason"],
+        },
+    stats: !result.body.stats
+      ? undefined
+      : {
+          url: result.body.stats?.["url"],
+          startTime: new Date(result.body.stats?.["startTime"] ?? ""),
+          lastUpdateTime: new Date(result.body.stats?.["lastUpdateTime"] ?? ""),
+          userCPUTime: result.body.stats?.["userCPUTime"],
+          kernelCPUTime: result.body.stats?.["kernelCPUTime"],
+          wallClockTime: result.body.stats?.["wallClockTime"],
+          readIOps: result.body.stats?.["readIOps"],
+          writeIOps: result.body.stats?.["writeIOps"],
+          readIOGiB: result.body.stats?.["readIOGiB"],
+          writeIOGiB: result.body.stats?.["writeIOGiB"],
+          numSucceededTasks: result.body.stats?.["numSucceededTasks"],
+          numFailedTasks: result.body.stats?.["numFailedTasks"],
+          numTaskRetries: result.body.stats?.["numTaskRetries"],
+          waitTime: result.body.stats?.["waitTime"],
+        },
+  };
+}
+
+export interface Jobpatchjoboptions extends RequestOptions {
+  /**
+   * The ID is case-preserving and case-insensitive (that is, you may not have two
+   * IDs within an Account that differ only by case).
+   */
+  id?: string;
+  /** The display name for the Job. */
+  displayName?: string;
+  /**
+   * Whether Tasks in the Job can define dependencies on each other. The default is
+   * false.
+   */
+  usesTaskDependencies?: boolean;
+  /** The URL of the Job. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Job has changed
+   * between requests. In particular, you can be pass the ETag when updating a Job
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Job in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the Job level data, such as the Job state or
+   * priority, changed. It does not factor in task-level changes such as adding new
+   * Tasks or Tasks changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Job. */
+  creationTime?: Date;
+  /** The state of the Job. */
+  state?: JobState;
+  /** The time at which the Job entered its current state. */
+  stateTransitionTime?: Date;
+  /** This property is not set if the Job is in its initial Active state. */
+  previousState?: JobState;
+  /** This property is not set if the Job is in its initial Active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * Priority values can range from -1000 to 1000, with -1000 being the lowest
+   * priority and 1000 being the highest priority. The default value is 0.
+   */
+  priority?: number;
+  /**
+   * If the value is set to True, other high priority jobs submitted to the system
+   * will take precedence and will be able requeue tasks from this job. You can
+   * update a job's allowTaskPreemption after it has been created using the update
+   * job API.
+   */
+  allowTaskPreemption?: boolean;
+  /**
+   * The value of maxParallelTasks must be -1 or greater than 0 if specified. If not
+   * specified, the default value is -1, which means there's no limit to the number
+   * of tasks that can be run at once. You can update a job's maxParallelTasks after
+   * it has been created using the update job API.
+   */
+  maxParallelTasks?: number;
+  /** The execution constraints for a Job. */
+  constraints?: JobConstraints;
+  /**
+   * The Job Manager Task is automatically started when the Job is created. The
+   * Batch service tries to schedule the Job Manager Task before any other Tasks in
+   * the Job. When shrinking a Pool, the Batch service tries to preserve Nodes where
+   * Job Manager Tasks are running for as long as possible (that is, Compute Nodes
+   * running 'normal' Tasks are removed before Compute Nodes running Job Manager
+   * Tasks). When a Job Manager Task fails and needs to be restarted, the system
+   * tries to schedule it at the highest priority. If there are no idle Compute
+   * Nodes available, the system may terminate one of the running Tasks in the Pool
+   * and return it to the queue in order to make room for the Job Manager Task to
+   * restart. Note that a Job Manager Task in one Job does not have priority over
+   * Tasks in other Jobs. Across Jobs, only Job level priorities are observed. For
+   * example, if a Job Manager in a priority 0 Job needs to be restarted, it will
+   * not displace Tasks of a priority 1 Job. Batch will retry Tasks when a recovery
+   * operation is triggered on a Node. Examples of recovery operations include (but
+   * are not limited to) when an unhealthy Node is rebooted or a Compute Node
+   * disappeared due to host failure. Retries due to recovery operations are
+   * independent of and are not counted against the maxTaskRetryCount. Even if the
+   * maxTaskRetryCount is 0, an internal retry due to a recovery operation may
+   * occur. Because of this, all Tasks should be idempotent. This means Tasks need
+   * to tolerate being interrupted and restarted without causing any corruption or
+   * duplicate data. The best practice for long running Tasks is to use some form of
+   * checkpointing.
+   */
+  jobManagerTask?: JobManagerTask;
+  /**
+   * The Job Preparation Task is a special Task run on each Compute Node before any
+   * other Task of the Job.
+   */
+  jobPreparationTask?: JobPreparationTask;
+  /**
+   * The Job Release Task is a special Task run at the end of the Job on each
+   * Compute Node that has run any other Task of the Job.
+   */
+  jobReleaseTask?: JobReleaseTask;
+  /**
+   * Individual Tasks can override an environment setting specified here by
+   * specifying the same setting name with a different value.
+   */
+  commonEnvironmentSettings?: EnvironmentSetting[];
+  /** Specifies how a Job should be assigned to a Pool. */
+  poolInfo?: PoolInformation;
+  /** The default is noaction. */
+  onAllTasksComplete?: OnAllTasksComplete;
+  /**
+   * A Task is considered to have failed if has a failureInfo. A failureInfo is set
+   * if the Task completes with a non-zero exit code after exhausting its retry
+   * count, or if there was an error starting the Task, for example due to a
+   * resource file download error. The default is noaction.
+   */
+  onTaskFailure?: OnTaskFailure;
+  /** The network configuration for the Job. */
+  networkConfiguration?: JobNetworkConfiguration;
+  /**
+   * The Batch service does not assign any meaning to metadata; it is solely for the
+   * use of user code.
+   */
+  metadata?: MetadataItem[];
+  /** Contains information about the execution of a Job in the Azure Batch service. */
+  executionInfo?: JobExecutionInformation;
+  /**
+   * This property is populated only if the CloudJob was retrieved with an expand
+   * clause including the 'stats' attribute; otherwise it is null. The statistics
+   * may not be immediately available. The Batch service performs periodic roll-up
+   * of statistics. The typical delay is about 30 minutes.
+   */
+  stats?: JobStatistics;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This replaces only the Job properties specified in the request. For example, if
+ * the Job has constraints, and a request does not specify the constraints
+ * element, then the Job keeps the existing constraints.
+ */
+export async function patchJob(
+  context: Client,
+  jobId: string,
+  options: Jobpatchjoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}", jobId).patch({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.priority && { priority: options.priority }),
+      ...(options.allowTaskPreemption && {
+        allowTaskPreemption: options.allowTaskPreemption,
+      }),
+      ...(options.maxParallelTasks && {
+        maxParallelTasks: options.maxParallelTasks,
+      }),
+      ...(options.constraints && { constraints: options.constraints }),
+      ...(options.poolInfo && { poolInfo: options.poolInfo }),
+      ...(options.onAllTasksComplete && {
+        onAllTasksComplete: options.onAllTasksComplete,
+      }),
+      ...(options.metadata && { metadata: options.metadata }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobupdatejoboptions extends RequestOptions {
+  /**
+   * The ID is case-preserving and case-insensitive (that is, you may not have two
+   * IDs within an Account that differ only by case).
+   */
+  id?: string;
+  /** The display name for the Job. */
+  displayName?: string;
+  /**
+   * Whether Tasks in the Job can define dependencies on each other. The default is
+   * false.
+   */
+  usesTaskDependencies?: boolean;
+  /** The URL of the Job. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Job has changed
+   * between requests. In particular, you can be pass the ETag when updating a Job
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Job in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the Job level data, such as the Job state or
+   * priority, changed. It does not factor in task-level changes such as adding new
+   * Tasks or Tasks changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Job. */
+  creationTime?: Date;
+  /** The state of the Job. */
+  state?: JobState;
+  /** The time at which the Job entered its current state. */
+  stateTransitionTime?: Date;
+  /** This property is not set if the Job is in its initial Active state. */
+  previousState?: JobState;
+  /** This property is not set if the Job is in its initial Active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * Priority values can range from -1000 to 1000, with -1000 being the lowest
+   * priority and 1000 being the highest priority. The default value is 0.
+   */
+  priority?: number;
+  /**
+   * If the value is set to True, other high priority jobs submitted to the system
+   * will take precedence and will be able requeue tasks from this job. You can
+   * update a job's allowTaskPreemption after it has been created using the update
+   * job API.
+   */
+  allowTaskPreemption?: boolean;
+  /**
+   * The value of maxParallelTasks must be -1 or greater than 0 if specified. If not
+   * specified, the default value is -1, which means there's no limit to the number
+   * of tasks that can be run at once. You can update a job's maxParallelTasks after
+   * it has been created using the update job API.
+   */
+  maxParallelTasks?: number;
+  /** The execution constraints for a Job. */
+  constraints?: JobConstraints;
+  /**
+   * The Job Manager Task is automatically started when the Job is created. The
+   * Batch service tries to schedule the Job Manager Task before any other Tasks in
+   * the Job. When shrinking a Pool, the Batch service tries to preserve Nodes where
+   * Job Manager Tasks are running for as long as possible (that is, Compute Nodes
+   * running 'normal' Tasks are removed before Compute Nodes running Job Manager
+   * Tasks). When a Job Manager Task fails and needs to be restarted, the system
+   * tries to schedule it at the highest priority. If there are no idle Compute
+   * Nodes available, the system may terminate one of the running Tasks in the Pool
+   * and return it to the queue in order to make room for the Job Manager Task to
+   * restart. Note that a Job Manager Task in one Job does not have priority over
+   * Tasks in other Jobs. Across Jobs, only Job level priorities are observed. For
+   * example, if a Job Manager in a priority 0 Job needs to be restarted, it will
+   * not displace Tasks of a priority 1 Job. Batch will retry Tasks when a recovery
+   * operation is triggered on a Node. Examples of recovery operations include (but
+   * are not limited to) when an unhealthy Node is rebooted or a Compute Node
+   * disappeared due to host failure. Retries due to recovery operations are
+   * independent of and are not counted against the maxTaskRetryCount. Even if the
+   * maxTaskRetryCount is 0, an internal retry due to a recovery operation may
+   * occur. Because of this, all Tasks should be idempotent. This means Tasks need
+   * to tolerate being interrupted and restarted without causing any corruption or
+   * duplicate data. The best practice for long running Tasks is to use some form of
+   * checkpointing.
+   */
+  jobManagerTask?: JobManagerTask;
+  /**
+   * The Job Preparation Task is a special Task run on each Compute Node before any
+   * other Task of the Job.
+   */
+  jobPreparationTask?: JobPreparationTask;
+  /**
+   * The Job Release Task is a special Task run at the end of the Job on each
+   * Compute Node that has run any other Task of the Job.
+   */
+  jobReleaseTask?: JobReleaseTask;
+  /**
+   * Individual Tasks can override an environment setting specified here by
+   * specifying the same setting name with a different value.
+   */
+  commonEnvironmentSettings?: EnvironmentSetting[];
+  /** Specifies how a Job should be assigned to a Pool. */
+  poolInfo?: PoolInformation;
+  /** The default is noaction. */
+  onAllTasksComplete?: OnAllTasksComplete;
+  /**
+   * A Task is considered to have failed if has a failureInfo. A failureInfo is set
+   * if the Task completes with a non-zero exit code after exhausting its retry
+   * count, or if there was an error starting the Task, for example due to a
+   * resource file download error. The default is noaction.
+   */
+  onTaskFailure?: OnTaskFailure;
+  /** The network configuration for the Job. */
+  networkConfiguration?: JobNetworkConfiguration;
+  /**
+   * The Batch service does not assign any meaning to metadata; it is solely for the
+   * use of user code.
+   */
+  metadata?: MetadataItem[];
+  /** Contains information about the execution of a Job in the Azure Batch service. */
+  executionInfo?: JobExecutionInformation;
+  /**
+   * This property is populated only if the CloudJob was retrieved with an expand
+   * clause including the 'stats' attribute; otherwise it is null. The statistics
+   * may not be immediately available. The Batch service performs periodic roll-up
+   * of statistics. The typical delay is about 30 minutes.
+   */
+  stats?: JobStatistics;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This fully replaces all the updatable properties of the Job. For example, if
+ * the Job has constraints associated with it and if constraints is not specified
+ * with this request, then the Batch service will remove the existing constraints.
+ */
+export async function updateJob(
+  context: Client,
+  jobId: string,
+  options: Jobupdatejoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}", jobId).put({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.priority && { priority: options.priority }),
+      ...(options.allowTaskPreemption && {
+        allowTaskPreemption: options.allowTaskPreemption,
+      }),
+      ...(options.maxParallelTasks && {
+        maxParallelTasks: options.maxParallelTasks,
+      }),
+      ...(options.constraints && { constraints: options.constraints }),
+      ...(options.poolInfo && { poolInfo: options.poolInfo }),
+      ...(options.onAllTasksComplete && {
+        onAllTasksComplete: options.onAllTasksComplete,
+      }),
+      ...(options.metadata && { metadata: options.metadata }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobdisablejoboptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * The Batch Service immediately moves the Job to the disabling state. Batch then
+ * uses the disableTasks parameter to determine what to do with the currently
+ * running Tasks of the Job. The Job remains in the disabling state until the
+ * disable operation is completed and all Tasks have been dealt with according to
+ * the disableTasks option; the Job then moves to the disabled state. No new Tasks
+ * are started under the Job until it moves back to active state. If you try to
+ * disable a Job that is in any state other than active, disabling, or disabled,
+ * the request fails with status code 409.
+ */
+export async function disableJob(
+  context: Client,
+  disableTasks: DisableJobOption,
+  jobId: string,
+  options: Jobdisablejoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}/disable", jobId).post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: { disableTasks: disableTasks },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobenablejoboptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * When you call this API, the Batch service sets a disabled Job to the enabling
+ * state. After the this operation is completed, the Job moves to the active
+ * state, and scheduling of new Tasks under the Job resumes. The Batch service
+ * does not allow a Task to remain in the active state for more than 180 days.
+ * Therefore, if you enable a Job containing active Tasks which were added more
+ * than 180 days ago, those Tasks will not run.
+ */
+export async function enableJob(
+  context: Client,
+  jobId: string,
+  options: Jobenablejoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}/enable", jobId).post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobterminatejoboptions extends RequestOptions {
+  /**
+   * The text you want to appear as the Job's TerminateReason. The default is
+   * 'UserTerminate'.
+   */
+  terminateReason?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * When a Terminate Job request is received, the Batch service sets the Job to the
+ * terminating state. The Batch service then terminates any running Tasks
+ * associated with the Job and runs any required Job release Tasks. Then the Job
+ * moves into the completed state. If there are any Tasks in the Job in the active
+ * state, they will remain in the active state. Once a Job is terminated, new
+ * Tasks cannot be added and any remaining active Tasks will not be scheduled.
+ */
+export async function terminateJob(
+  context: Client,
+  jobId: string,
+  options: Jobterminatejoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}/terminate", jobId).post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.terminateReason && {
+        terminateReason: options.terminateReason,
+      }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobaddjoboptions extends RequestOptions {
+  /**
+   * The ID is case-preserving and case-insensitive (that is, you may not have two
+   * IDs within an Account that differ only by case).
+   */
+  id?: string;
+  /** The display name for the Job. */
+  displayName?: string;
+  /**
+   * Whether Tasks in the Job can define dependencies on each other. The default is
+   * false.
+   */
+  usesTaskDependencies?: boolean;
+  /** The URL of the Job. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Job has changed
+   * between requests. In particular, you can be pass the ETag when updating a Job
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Job in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the Job level data, such as the Job state or
+   * priority, changed. It does not factor in task-level changes such as adding new
+   * Tasks or Tasks changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Job. */
+  creationTime?: Date;
+  /** The state of the Job. */
+  state?: JobState;
+  /** The time at which the Job entered its current state. */
+  stateTransitionTime?: Date;
+  /** This property is not set if the Job is in its initial Active state. */
+  previousState?: JobState;
+  /** This property is not set if the Job is in its initial Active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * Priority values can range from -1000 to 1000, with -1000 being the lowest
+   * priority and 1000 being the highest priority. The default value is 0.
+   */
+  priority?: number;
+  /**
+   * If the value is set to True, other high priority jobs submitted to the system
+   * will take precedence and will be able requeue tasks from this job. You can
+   * update a job's allowTaskPreemption after it has been created using the update
+   * job API.
+   */
+  allowTaskPreemption?: boolean;
+  /**
+   * The value of maxParallelTasks must be -1 or greater than 0 if specified. If not
+   * specified, the default value is -1, which means there's no limit to the number
+   * of tasks that can be run at once. You can update a job's maxParallelTasks after
+   * it has been created using the update job API.
+   */
+  maxParallelTasks?: number;
+  /** The execution constraints for a Job. */
+  constraints?: JobConstraints;
+  /**
+   * The Job Manager Task is automatically started when the Job is created. The
+   * Batch service tries to schedule the Job Manager Task before any other Tasks in
+   * the Job. When shrinking a Pool, the Batch service tries to preserve Nodes where
+   * Job Manager Tasks are running for as long as possible (that is, Compute Nodes
+   * running 'normal' Tasks are removed before Compute Nodes running Job Manager
+   * Tasks). When a Job Manager Task fails and needs to be restarted, the system
+   * tries to schedule it at the highest priority. If there are no idle Compute
+   * Nodes available, the system may terminate one of the running Tasks in the Pool
+   * and return it to the queue in order to make room for the Job Manager Task to
+   * restart. Note that a Job Manager Task in one Job does not have priority over
+   * Tasks in other Jobs. Across Jobs, only Job level priorities are observed. For
+   * example, if a Job Manager in a priority 0 Job needs to be restarted, it will
+   * not displace Tasks of a priority 1 Job. Batch will retry Tasks when a recovery
+   * operation is triggered on a Node. Examples of recovery operations include (but
+   * are not limited to) when an unhealthy Node is rebooted or a Compute Node
+   * disappeared due to host failure. Retries due to recovery operations are
+   * independent of and are not counted against the maxTaskRetryCount. Even if the
+   * maxTaskRetryCount is 0, an internal retry due to a recovery operation may
+   * occur. Because of this, all Tasks should be idempotent. This means Tasks need
+   * to tolerate being interrupted and restarted without causing any corruption or
+   * duplicate data. The best practice for long running Tasks is to use some form of
+   * checkpointing.
+   */
+  jobManagerTask?: JobManagerTask;
+  /**
+   * The Job Preparation Task is a special Task run on each Compute Node before any
+   * other Task of the Job.
+   */
+  jobPreparationTask?: JobPreparationTask;
+  /**
+   * The Job Release Task is a special Task run at the end of the Job on each
+   * Compute Node that has run any other Task of the Job.
+   */
+  jobReleaseTask?: JobReleaseTask;
+  /**
+   * Individual Tasks can override an environment setting specified here by
+   * specifying the same setting name with a different value.
+   */
+  commonEnvironmentSettings?: EnvironmentSetting[];
+  /** Specifies how a Job should be assigned to a Pool. */
+  poolInfo?: PoolInformation;
+  /** The default is noaction. */
+  onAllTasksComplete?: OnAllTasksComplete;
+  /**
+   * A Task is considered to have failed if has a failureInfo. A failureInfo is set
+   * if the Task completes with a non-zero exit code after exhausting its retry
+   * count, or if there was an error starting the Task, for example due to a
+   * resource file download error. The default is noaction.
+   */
+  onTaskFailure?: OnTaskFailure;
+  /** The network configuration for the Job. */
+  networkConfiguration?: JobNetworkConfiguration;
+  /**
+   * The Batch service does not assign any meaning to metadata; it is solely for the
+   * use of user code.
+   */
+  metadata?: MetadataItem[];
+  /** Contains information about the execution of a Job in the Azure Batch service. */
+  executionInfo?: JobExecutionInformation;
+  /**
+   * This property is populated only if the CloudJob was retrieved with an expand
+   * clause including the 'stats' attribute; otherwise it is null. The statistics
+   * may not be immediately available. The Batch service performs periodic roll-up
+   * of statistics. The typical delay is about 30 minutes.
+   */
+  stats?: JobStatistics;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * The Batch service supports two ways to control the work done as part of a Job.
+ * In the first approach, the user specifies a Job Manager Task. The Batch service
+ * launches this Task when it is ready to start the Job. The Job Manager Task
+ * controls all other Tasks that run under this Job, by using the Task APIs. In
+ * the second approach, the user directly controls the execution of Tasks under an
+ * active Job, by using the Task APIs. Also note: when naming Jobs, avoid
+ * including sensitive information such as user names or secret project names.
+ * This information may appear in telemetry logs accessible to Microsoft Support
+ * engineers.
+ */
+export async function addJob(
+  context: Client,
+  options: Jobaddjoboptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs").post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.priority && { priority: options.priority }),
+      ...(options.allowTaskPreemption && {
+        allowTaskPreemption: options.allowTaskPreemption,
+      }),
+      ...(options.maxParallelTasks && {
+        maxParallelTasks: options.maxParallelTasks,
+      }),
+      ...(options.constraints && { constraints: options.constraints }),
+      ...(options.poolInfo && { poolInfo: options.poolInfo }),
+      ...(options.onAllTasksComplete && {
+        onAllTasksComplete: options.onAllTasksComplete,
+      }),
+      ...(options.metadata && { metadata: options.metadata }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Joblistjobsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-jobs.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Lists all of the Jobs in the specified Account. */
+export async function listJobs(
+  context: Client,
+  options: Joblistjobsoptions = { requestOptions: {} }
+): Promise<BatchJobListResult> {
+  const result = await context.path("/jobs").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+      ...(options.$select && { $select: options.$select }),
+      ...(options.$expand && { $expand: options.$expand }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      displayName: p["displayName"],
+      usesTaskDependencies: p["usesTaskDependencies"],
+      url: p["url"],
+      eTag: p["eTag"],
+      lastModified: new Date(p["lastModified"] ?? ""),
+      creationTime: new Date(p["creationTime"] ?? ""),
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      previousState: p["previousState"],
+      previousStateTransitionTime: new Date(
+        p["previousStateTransitionTime"] ?? ""
+      ),
+      priority: p["priority"],
+      allowTaskPreemption: p["allowTaskPreemption"],
+      maxParallelTasks: p["maxParallelTasks"],
+      constraints: !p.constraints
+        ? undefined
+        : {
+            maxWallClockTime: p.constraints?.["maxWallClockTime"],
+            maxTaskRetryCount: p.constraints?.["maxTaskRetryCount"],
+          },
+      jobManagerTask: !p.jobManagerTask
+        ? undefined
+        : {
+            id: p.jobManagerTask?.["id"],
+            displayName: p.jobManagerTask?.["displayName"],
+            commandLine: p.jobManagerTask?.["commandLine"],
+            containerSettings: !p.jobManagerTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.jobManagerTask?.containerSettings?.[
+                      "containerRunOptions"
+                    ],
+                  imageName: p.jobManagerTask?.containerSettings?.["imageName"],
+                  registry: !p.jobManagerTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.jobManagerTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.jobManagerTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.jobManagerTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.jobManagerTask?.containerSettings
+                          ?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.jobManagerTask?.containerSettings?.registry
+                                  ?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.jobManagerTask?.containerSettings?.["workingDirectory"],
+                },
+            resourceFiles: (p.jobManagerTask?.["resourceFiles"] ?? []).map(
+              (p) => ({
+                autoStorageContainerName: p["autoStorageContainerName"],
+                storageContainerUrl: p["storageContainerUrl"],
+                httpUrl: p["httpUrl"],
+                blobPrefix: p["blobPrefix"],
+                filePath: p["filePath"],
+                fileMode: p["fileMode"],
+                identityReference: !p.identityReference
+                  ? undefined
+                  : { resourceId: p.identityReference?.["resourceId"] },
+              })
+            ),
+            outputFiles: (p.jobManagerTask?.["outputFiles"] ?? []).map((p) => ({
+              filePattern: p["filePattern"],
+              destination: {
+                container: !p.destination.container
+                  ? undefined
+                  : {
+                      path: p.destination.container?.["path"],
+                      containerUrl: p.destination.container?.["containerUrl"],
+                      identityReference: !p.destination.container
+                        ?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              p.destination.container?.identityReference?.[
+                                "resourceId"
+                              ],
+                          },
+                      uploadHeaders: (
+                        p.destination.container?.["uploadHeaders"] ?? []
+                      ).map((p) => ({ name: p["name"], value: p["value"] })),
+                    },
+              },
+              uploadOptions: {
+                uploadCondition: p.uploadOptions["uploadCondition"],
+              },
+            })),
+            environmentSettings: (
+              p.jobManagerTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            constraints: !p.jobManagerTask?.constraints
+              ? undefined
+              : {
+                  maxWallClockTime:
+                    p.jobManagerTask?.constraints?.["maxWallClockTime"],
+                  retentionTime:
+                    p.jobManagerTask?.constraints?.["retentionTime"],
+                  maxTaskRetryCount:
+                    p.jobManagerTask?.constraints?.["maxTaskRetryCount"],
+                },
+            requiredSlots: p.jobManagerTask?.["requiredSlots"],
+            killJobOnCompletion: p.jobManagerTask?.["killJobOnCompletion"],
+            userIdentity: !p.jobManagerTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.jobManagerTask?.userIdentity?.["username"],
+                  autoUser: !p.jobManagerTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope:
+                          p.jobManagerTask?.userIdentity?.autoUser?.["scope"],
+                        elevationLevel:
+                          p.jobManagerTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+            runExclusive: p.jobManagerTask?.["runExclusive"],
+            applicationPackageReferences: (
+              p.jobManagerTask?.["applicationPackageReferences"] ?? []
+            ).map((p) => ({
+              applicationId: p["applicationId"],
+              version: p["version"],
+            })),
+            authenticationTokenSettings: !p.jobManagerTask
+              ?.authenticationTokenSettings
+              ? undefined
+              : {
+                  access:
+                    p.jobManagerTask?.authenticationTokenSettings?.["access"],
+                },
+            allowLowPriorityNode: p.jobManagerTask?.["allowLowPriorityNode"],
+          },
+      jobPreparationTask: !p.jobPreparationTask
+        ? undefined
+        : {
+            id: p.jobPreparationTask?.["id"],
+            commandLine: p.jobPreparationTask?.["commandLine"],
+            containerSettings: !p.jobPreparationTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.jobPreparationTask?.containerSettings?.[
+                      "containerRunOptions"
+                    ],
+                  imageName:
+                    p.jobPreparationTask?.containerSettings?.["imageName"],
+                  registry: !p.jobPreparationTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.jobPreparationTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.jobPreparationTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.jobPreparationTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.jobPreparationTask
+                          ?.containerSettings?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.jobPreparationTask?.containerSettings
+                                  ?.registry?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.jobPreparationTask?.containerSettings?.[
+                      "workingDirectory"
+                    ],
+                },
+            resourceFiles: (p.jobPreparationTask?.["resourceFiles"] ?? []).map(
+              (p) => ({
+                autoStorageContainerName: p["autoStorageContainerName"],
+                storageContainerUrl: p["storageContainerUrl"],
+                httpUrl: p["httpUrl"],
+                blobPrefix: p["blobPrefix"],
+                filePath: p["filePath"],
+                fileMode: p["fileMode"],
+                identityReference: !p.identityReference
+                  ? undefined
+                  : { resourceId: p.identityReference?.["resourceId"] },
+              })
+            ),
+            environmentSettings: (
+              p.jobPreparationTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            constraints: !p.jobPreparationTask?.constraints
+              ? undefined
+              : {
+                  maxWallClockTime:
+                    p.jobPreparationTask?.constraints?.["maxWallClockTime"],
+                  retentionTime:
+                    p.jobPreparationTask?.constraints?.["retentionTime"],
+                  maxTaskRetryCount:
+                    p.jobPreparationTask?.constraints?.["maxTaskRetryCount"],
+                },
+            waitForSuccess: p.jobPreparationTask?.["waitForSuccess"],
+            userIdentity: !p.jobPreparationTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.jobPreparationTask?.userIdentity?.["username"],
+                  autoUser: !p.jobPreparationTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope:
+                          p.jobPreparationTask?.userIdentity?.autoUser?.[
+                            "scope"
+                          ],
+                        elevationLevel:
+                          p.jobPreparationTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+            rerunOnNodeRebootAfterSuccess:
+              p.jobPreparationTask?.["rerunOnNodeRebootAfterSuccess"],
+          },
+      jobReleaseTask: !p.jobReleaseTask
+        ? undefined
+        : {
+            id: p.jobReleaseTask?.["id"],
+            commandLine: p.jobReleaseTask?.["commandLine"],
+            containerSettings: !p.jobReleaseTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.jobReleaseTask?.containerSettings?.[
+                      "containerRunOptions"
+                    ],
+                  imageName: p.jobReleaseTask?.containerSettings?.["imageName"],
+                  registry: !p.jobReleaseTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.jobReleaseTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.jobReleaseTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.jobReleaseTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.jobReleaseTask?.containerSettings
+                          ?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.jobReleaseTask?.containerSettings?.registry
+                                  ?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.jobReleaseTask?.containerSettings?.["workingDirectory"],
+                },
+            resourceFiles: (p.jobReleaseTask?.["resourceFiles"] ?? []).map(
+              (p) => ({
+                autoStorageContainerName: p["autoStorageContainerName"],
+                storageContainerUrl: p["storageContainerUrl"],
+                httpUrl: p["httpUrl"],
+                blobPrefix: p["blobPrefix"],
+                filePath: p["filePath"],
+                fileMode: p["fileMode"],
+                identityReference: !p.identityReference
+                  ? undefined
+                  : { resourceId: p.identityReference?.["resourceId"] },
+              })
+            ),
+            environmentSettings: (
+              p.jobReleaseTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            maxWallClockTime: p.jobReleaseTask?.["maxWallClockTime"],
+            retentionTime: p.jobReleaseTask?.["retentionTime"],
+            userIdentity: !p.jobReleaseTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.jobReleaseTask?.userIdentity?.["username"],
+                  autoUser: !p.jobReleaseTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope:
+                          p.jobReleaseTask?.userIdentity?.autoUser?.["scope"],
+                        elevationLevel:
+                          p.jobReleaseTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+          },
+      commonEnvironmentSettings: (p["commonEnvironmentSettings"] ?? []).map(
+        (p) => ({ name: p["name"], value: p["value"] })
+      ),
+      poolInfo: !p.poolInfo
+        ? undefined
+        : {
+            poolId: p.poolInfo?.["poolId"],
+            autoPoolSpecification: !p.poolInfo?.autoPoolSpecification
+              ? undefined
+              : {
+                  autoPoolIdPrefix:
+                    p.poolInfo?.autoPoolSpecification?.["autoPoolIdPrefix"],
+                  poolLifetimeOption:
+                    p.poolInfo?.autoPoolSpecification?.["poolLifetimeOption"],
+                  keepAlive: p.poolInfo?.autoPoolSpecification?.["keepAlive"],
+                  pool: !p.poolInfo?.autoPoolSpecification?.pool
+                    ? undefined
+                    : {
+                        displayName:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "displayName"
+                          ],
+                        vmSize:
+                          p.poolInfo?.autoPoolSpecification?.pool?.["vmSize"],
+                        cloudServiceConfiguration: !p.poolInfo
+                          ?.autoPoolSpecification?.pool
+                          ?.cloudServiceConfiguration
+                          ? undefined
+                          : {
+                              osFamily:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.cloudServiceConfiguration?.["osFamily"],
+                              osVersion:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.cloudServiceConfiguration?.["osVersion"],
+                            },
+                        virtualMachineConfiguration: !p.poolInfo
+                          ?.autoPoolSpecification?.pool
+                          ?.virtualMachineConfiguration
+                          ? undefined
+                          : {
+                              imageReference: {
+                                publisher:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["publisher"],
+                                offer:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["offer"],
+                                sku: p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.imageReference[
+                                  "sku"
+                                ],
+                                version:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["version"],
+                                virtualMachineImageId:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["virtualMachineImageId"],
+                                exactVersion:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["exactVersion"],
+                              },
+                              nodeAgentSKUId:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "nodeAgentSKUId"
+                                ],
+                              windowsConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.windowsConfiguration
+                                ? undefined
+                                : {
+                                    enableAutomaticUpdates:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.windowsConfiguration?.[
+                                        "enableAutomaticUpdates"
+                                      ],
+                                  },
+                              dataDisks: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "dataDisks"
+                                ] ?? []
+                              ).map((p) => ({
+                                lun: p["lun"],
+                                caching: p["caching"],
+                                diskSizeGB: p["diskSizeGB"],
+                                storageAccountType: p["storageAccountType"],
+                              })),
+                              licenseType:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "licenseType"
+                                ],
+                              containerConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.containerConfiguration
+                                ? undefined
+                                : {
+                                    type: p.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.containerConfiguration?.["type"],
+                                    containerImageNames:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.[
+                                        "containerImageNames"
+                                      ],
+                                    containerRegistries: (
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.[
+                                        "containerRegistries"
+                                      ] ?? []
+                                    ).map((p) => ({
+                                      username: p["username"],
+                                      password: p["password"],
+                                      registryServer: p["registryServer"],
+                                      identityReference: !p.identityReference
+                                        ? undefined
+                                        : {
+                                            resourceId:
+                                              p.identityReference?.[
+                                                "resourceId"
+                                              ],
+                                          },
+                                    })),
+                                  },
+                              diskEncryptionConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.diskEncryptionConfiguration
+                                ? undefined
+                                : {
+                                    targets:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.diskEncryptionConfiguration?.[
+                                        "targets"
+                                      ],
+                                  },
+                              nodePlacementConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.nodePlacementConfiguration
+                                ? undefined
+                                : {
+                                    policy:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.nodePlacementConfiguration?.[
+                                        "policy"
+                                      ],
+                                  },
+                              extensions: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "extensions"
+                                ] ?? []
+                              ).map((p) => ({
+                                name: p["name"],
+                                publisher: p["publisher"],
+                                type: p["type"],
+                                typeHandlerVersion: p["typeHandlerVersion"],
+                                autoUpgradeMinorVersion:
+                                  p["autoUpgradeMinorVersion"],
+                                settings: !p.settings ? undefined : {},
+                                protectedSettings: !p.protectedSettings
+                                  ? undefined
+                                  : {},
+                                provisionAfterExtensions:
+                                  p["provisionAfterExtensions"],
+                              })),
+                              osDisk: !p.poolInfo?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.osDisk
+                                ? undefined
+                                : {
+                                    ephemeralOSDiskSettings: !p.poolInfo
+                                      ?.autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration?.osDisk
+                                      ?.ephemeralOSDiskSettings
+                                      ? undefined
+                                      : {
+                                          placement:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool
+                                              ?.virtualMachineConfiguration
+                                              ?.osDisk
+                                              ?.ephemeralOSDiskSettings?.[
+                                              "placement"
+                                            ],
+                                        },
+                                  },
+                            },
+                        taskSlotsPerNode:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "taskSlotsPerNode"
+                          ],
+                        taskSchedulingPolicy: !p.poolInfo?.autoPoolSpecification
+                          ?.pool?.taskSchedulingPolicy
+                          ? undefined
+                          : {
+                              nodeFillType:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.taskSchedulingPolicy?.["nodeFillType"],
+                            },
+                        resizeTimeout:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "resizeTimeout"
+                          ],
+                        targetDedicatedNodes:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "targetDedicatedNodes"
+                          ],
+                        targetLowPriorityNodes:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "targetLowPriorityNodes"
+                          ],
+                        enableAutoScale:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "enableAutoScale"
+                          ],
+                        autoScaleFormula:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "autoScaleFormula"
+                          ],
+                        autoScaleEvaluationInterval:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "autoScaleEvaluationInterval"
+                          ],
+                        enableInterNodeCommunication:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "enableInterNodeCommunication"
+                          ],
+                        networkConfiguration: !p.poolInfo?.autoPoolSpecification
+                          ?.pool?.networkConfiguration
+                          ? undefined
+                          : {
+                              subnetId:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.["subnetId"],
+                              dynamicVNetAssignmentScope:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.[
+                                  "dynamicVNetAssignmentScope"
+                                ],
+                              endpointConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.networkConfiguration?.endpointConfiguration
+                                ? undefined
+                                : {
+                                    inboundNATPools: (
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.endpointConfiguration?.[
+                                        "inboundNATPools"
+                                      ] ?? []
+                                    ).map((p) => ({
+                                      name: p["name"],
+                                      protocol: p["protocol"],
+                                      backendPort: p["backendPort"],
+                                      frontendPortRangeStart:
+                                        p["frontendPortRangeStart"],
+                                      frontendPortRangeEnd:
+                                        p["frontendPortRangeEnd"],
+                                      networkSecurityGroupRules: (
+                                        p["networkSecurityGroupRules"] ?? []
+                                      ).map((p) => ({
+                                        priority: p["priority"],
+                                        access: p["access"],
+                                        sourceAddressPrefix:
+                                          p["sourceAddressPrefix"],
+                                        sourcePortRanges: p["sourcePortRanges"],
+                                      })),
+                                    })),
+                                  },
+                              publicIPAddressConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.networkConfiguration
+                                ?.publicIPAddressConfiguration
+                                ? undefined
+                                : {
+                                    provision:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.publicIPAddressConfiguration?.[
+                                        "provision"
+                                      ],
+                                    ipAddressIds:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.publicIPAddressConfiguration?.[
+                                        "ipAddressIds"
+                                      ],
+                                  },
+                            },
+                        startTask: !p.poolInfo?.autoPoolSpecification?.pool
+                          ?.startTask
+                          ? undefined
+                          : {
+                              commandLine:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["commandLine"],
+                              containerSettings: !p.poolInfo
+                                ?.autoPoolSpecification?.pool?.startTask
+                                ?.containerSettings
+                                ? undefined
+                                : {
+                                    containerRunOptions:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.containerSettings?.[
+                                        "containerRunOptions"
+                                      ],
+                                    imageName:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.containerSettings?.[
+                                        "imageName"
+                                      ],
+                                    registry: !p.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.containerSettings
+                                      ?.registry
+                                      ? undefined
+                                      : {
+                                          username:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "username"
+                                            ],
+                                          password:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "password"
+                                            ],
+                                          registryServer:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "registryServer"
+                                            ],
+                                          identityReference: !p.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.containerSettings
+                                            ?.registry?.identityReference
+                                            ? undefined
+                                            : {
+                                                resourceId:
+                                                  p.poolInfo
+                                                    ?.autoPoolSpecification
+                                                    ?.pool?.startTask
+                                                    ?.containerSettings
+                                                    ?.registry
+                                                    ?.identityReference?.[
+                                                    "resourceId"
+                                                  ],
+                                              },
+                                        },
+                                    workingDirectory:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.containerSettings?.[
+                                        "workingDirectory"
+                                      ],
+                                  },
+                              resourceFiles: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["resourceFiles"] ?? []
+                              ).map((p) => ({
+                                autoStorageContainerName:
+                                  p["autoStorageContainerName"],
+                                storageContainerUrl: p["storageContainerUrl"],
+                                httpUrl: p["httpUrl"],
+                                blobPrefix: p["blobPrefix"],
+                                filePath: p["filePath"],
+                                fileMode: p["fileMode"],
+                                identityReference: !p.identityReference
+                                  ? undefined
+                                  : {
+                                      resourceId:
+                                        p.identityReference?.["resourceId"],
+                                    },
+                              })),
+                              environmentSettings: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["environmentSettings"] ?? []
+                              ).map((p) => ({
+                                name: p["name"],
+                                value: p["value"],
+                              })),
+                              userIdentity: !p.poolInfo?.autoPoolSpecification
+                                ?.pool?.startTask?.userIdentity
+                                ? undefined
+                                : {
+                                    username:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.userIdentity?.["username"],
+                                    autoUser: !p.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.userIdentity?.autoUser
+                                      ? undefined
+                                      : {
+                                          scope:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask?.userIdentity
+                                              ?.autoUser?.["scope"],
+                                          elevationLevel:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask?.userIdentity
+                                              ?.autoUser?.["elevationLevel"],
+                                        },
+                                  },
+                              maxTaskRetryCount:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["maxTaskRetryCount"],
+                              waitForSuccess:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["waitForSuccess"],
+                            },
+                        certificateReferences: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "certificateReferences"
+                          ] ?? []
+                        ).map((p) => ({
+                          thumbprint: p["thumbprint"],
+                          thumbprintAlgorithm: p["thumbprintAlgorithm"],
+                          storeLocation: p["storeLocation"],
+                          storeName: p["storeName"],
+                          visibility: p["visibility"],
+                        })),
+                        applicationPackageReferences: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "applicationPackageReferences"
+                          ] ?? []
+                        ).map((p) => ({
+                          applicationId: p["applicationId"],
+                          version: p["version"],
+                        })),
+                        applicationLicenses:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "applicationLicenses"
+                          ],
+                        userAccounts: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "userAccounts"
+                          ] ?? []
+                        ).map((p) => ({
+                          name: p["name"],
+                          password: p["password"],
+                          elevationLevel: p["elevationLevel"],
+                          linuxUserConfiguration: !p.linuxUserConfiguration
+                            ? undefined
+                            : {
+                                uid: p.linuxUserConfiguration?.["uid"],
+                                gid: p.linuxUserConfiguration?.["gid"],
+                                sshPrivateKey:
+                                  p.linuxUserConfiguration?.["sshPrivateKey"],
+                              },
+                          windowsUserConfiguration: !p.windowsUserConfiguration
+                            ? undefined
+                            : {
+                                loginMode:
+                                  p.windowsUserConfiguration?.["loginMode"],
+                              },
+                        })),
+                        metadata: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "metadata"
+                          ] ?? []
+                        ).map((p) => ({ name: p["name"], value: p["value"] })),
+                        mountConfiguration: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "mountConfiguration"
+                          ] ?? []
+                        ).map((p) => ({
+                          azureBlobFileSystemConfiguration:
+                            !p.azureBlobFileSystemConfiguration
+                              ? undefined
+                              : {
+                                  accountName:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "accountName"
+                                    ],
+                                  containerName:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "containerName"
+                                    ],
+                                  accountKey:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "accountKey"
+                                    ],
+                                  sasKey:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "sasKey"
+                                    ],
+                                  blobfuseOptions:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "blobfuseOptions"
+                                    ],
+                                  relativeMountPath:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  identityReference: !p
+                                    .azureBlobFileSystemConfiguration
+                                    ?.identityReference
+                                    ? undefined
+                                    : {
+                                        resourceId:
+                                          p.azureBlobFileSystemConfiguration
+                                            ?.identityReference?.["resourceId"],
+                                      },
+                                },
+                          nfsMountConfiguration: !p.nfsMountConfiguration
+                            ? undefined
+                            : {
+                                source: p.nfsMountConfiguration?.["source"],
+                                relativeMountPath:
+                                  p.nfsMountConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.nfsMountConfiguration?.["mountOptions"],
+                              },
+                          cifsMountConfiguration: !p.cifsMountConfiguration
+                            ? undefined
+                            : {
+                                username:
+                                  p.cifsMountConfiguration?.["username"],
+                                source: p.cifsMountConfiguration?.["source"],
+                                relativeMountPath:
+                                  p.cifsMountConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.cifsMountConfiguration?.["mountOptions"],
+                                password:
+                                  p.cifsMountConfiguration?.["password"],
+                              },
+                          azureFileShareConfiguration:
+                            !p.azureFileShareConfiguration
+                              ? undefined
+                              : {
+                                  accountName:
+                                    p.azureFileShareConfiguration?.[
+                                      "accountName"
+                                    ],
+                                  azureFileUrl:
+                                    p.azureFileShareConfiguration?.[
+                                      "azureFileUrl"
+                                    ],
+                                  accountKey:
+                                    p.azureFileShareConfiguration?.[
+                                      "accountKey"
+                                    ],
+                                  relativeMountPath:
+                                    p.azureFileShareConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  mountOptions:
+                                    p.azureFileShareConfiguration?.[
+                                      "mountOptions"
+                                    ],
+                                },
+                        })),
+                        targetNodeCommunicationMode:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "targetNodeCommunicationMode"
+                          ],
+                      },
+                },
+          },
+      onAllTasksComplete: p["onAllTasksComplete"],
+      onTaskFailure: p["onTaskFailure"],
+      networkConfiguration: !p.networkConfiguration
+        ? undefined
+        : { subnetId: p.networkConfiguration?.["subnetId"] },
+      metadata: (p["metadata"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+      executionInfo: !p.executionInfo
+        ? undefined
+        : {
+            startTime: new Date(p.executionInfo?.["startTime"] ?? ""),
+            endTime: new Date(p.executionInfo?.["endTime"] ?? ""),
+            poolId: p.executionInfo?.["poolId"],
+            schedulingError: !p.executionInfo?.schedulingError
+              ? undefined
+              : {
+                  category: p.executionInfo?.schedulingError?.["category"],
+                  code: p.executionInfo?.schedulingError?.["code"],
+                  message: p.executionInfo?.schedulingError?.["message"],
+                  details: (
+                    p.executionInfo?.schedulingError?.["details"] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            terminateReason: p.executionInfo?.["terminateReason"],
+          },
+      stats: !p.stats
+        ? undefined
+        : {
+            url: p.stats?.["url"],
+            startTime: new Date(p.stats?.["startTime"] ?? ""),
+            lastUpdateTime: new Date(p.stats?.["lastUpdateTime"] ?? ""),
+            userCPUTime: p.stats?.["userCPUTime"],
+            kernelCPUTime: p.stats?.["kernelCPUTime"],
+            wallClockTime: p.stats?.["wallClockTime"],
+            readIOps: p.stats?.["readIOps"],
+            writeIOps: p.stats?.["writeIOps"],
+            readIOGiB: p.stats?.["readIOGiB"],
+            writeIOGiB: p.stats?.["writeIOGiB"],
+            numSucceededTasks: p.stats?.["numSucceededTasks"],
+            numFailedTasks: p.stats?.["numFailedTasks"],
+            numTaskRetries: p.stats?.["numTaskRetries"],
+            waitTime: p.stats?.["waitTime"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Joblistfromjobscheduleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-jobs-in-a-job-schedule.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Lists the Jobs that have been created under the specified Job Schedule. */
+export async function listFromJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Joblistfromjobscheduleoptions = { requestOptions: {} }
+): Promise<BatchJobListResult> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}/jobs", jobScheduleId)
+    .get({
+      headers: {
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.maxresults && { maxresults: options.maxresults }),
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$filter && { $filter: options.$filter }),
+        ...(options.$select && { $select: options.$select }),
+        ...(options.$expand && { $expand: options.$expand }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      displayName: p["displayName"],
+      usesTaskDependencies: p["usesTaskDependencies"],
+      url: p["url"],
+      eTag: p["eTag"],
+      lastModified: new Date(p["lastModified"] ?? ""),
+      creationTime: new Date(p["creationTime"] ?? ""),
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      previousState: p["previousState"],
+      previousStateTransitionTime: new Date(
+        p["previousStateTransitionTime"] ?? ""
+      ),
+      priority: p["priority"],
+      allowTaskPreemption: p["allowTaskPreemption"],
+      maxParallelTasks: p["maxParallelTasks"],
+      constraints: !p.constraints
+        ? undefined
+        : {
+            maxWallClockTime: p.constraints?.["maxWallClockTime"],
+            maxTaskRetryCount: p.constraints?.["maxTaskRetryCount"],
+          },
+      jobManagerTask: !p.jobManagerTask
+        ? undefined
+        : {
+            id: p.jobManagerTask?.["id"],
+            displayName: p.jobManagerTask?.["displayName"],
+            commandLine: p.jobManagerTask?.["commandLine"],
+            containerSettings: !p.jobManagerTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.jobManagerTask?.containerSettings?.[
+                      "containerRunOptions"
+                    ],
+                  imageName: p.jobManagerTask?.containerSettings?.["imageName"],
+                  registry: !p.jobManagerTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.jobManagerTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.jobManagerTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.jobManagerTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.jobManagerTask?.containerSettings
+                          ?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.jobManagerTask?.containerSettings?.registry
+                                  ?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.jobManagerTask?.containerSettings?.["workingDirectory"],
+                },
+            resourceFiles: (p.jobManagerTask?.["resourceFiles"] ?? []).map(
+              (p) => ({
+                autoStorageContainerName: p["autoStorageContainerName"],
+                storageContainerUrl: p["storageContainerUrl"],
+                httpUrl: p["httpUrl"],
+                blobPrefix: p["blobPrefix"],
+                filePath: p["filePath"],
+                fileMode: p["fileMode"],
+                identityReference: !p.identityReference
+                  ? undefined
+                  : { resourceId: p.identityReference?.["resourceId"] },
+              })
+            ),
+            outputFiles: (p.jobManagerTask?.["outputFiles"] ?? []).map((p) => ({
+              filePattern: p["filePattern"],
+              destination: {
+                container: !p.destination.container
+                  ? undefined
+                  : {
+                      path: p.destination.container?.["path"],
+                      containerUrl: p.destination.container?.["containerUrl"],
+                      identityReference: !p.destination.container
+                        ?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              p.destination.container?.identityReference?.[
+                                "resourceId"
+                              ],
+                          },
+                      uploadHeaders: (
+                        p.destination.container?.["uploadHeaders"] ?? []
+                      ).map((p) => ({ name: p["name"], value: p["value"] })),
+                    },
+              },
+              uploadOptions: {
+                uploadCondition: p.uploadOptions["uploadCondition"],
+              },
+            })),
+            environmentSettings: (
+              p.jobManagerTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            constraints: !p.jobManagerTask?.constraints
+              ? undefined
+              : {
+                  maxWallClockTime:
+                    p.jobManagerTask?.constraints?.["maxWallClockTime"],
+                  retentionTime:
+                    p.jobManagerTask?.constraints?.["retentionTime"],
+                  maxTaskRetryCount:
+                    p.jobManagerTask?.constraints?.["maxTaskRetryCount"],
+                },
+            requiredSlots: p.jobManagerTask?.["requiredSlots"],
+            killJobOnCompletion: p.jobManagerTask?.["killJobOnCompletion"],
+            userIdentity: !p.jobManagerTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.jobManagerTask?.userIdentity?.["username"],
+                  autoUser: !p.jobManagerTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope:
+                          p.jobManagerTask?.userIdentity?.autoUser?.["scope"],
+                        elevationLevel:
+                          p.jobManagerTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+            runExclusive: p.jobManagerTask?.["runExclusive"],
+            applicationPackageReferences: (
+              p.jobManagerTask?.["applicationPackageReferences"] ?? []
+            ).map((p) => ({
+              applicationId: p["applicationId"],
+              version: p["version"],
+            })),
+            authenticationTokenSettings: !p.jobManagerTask
+              ?.authenticationTokenSettings
+              ? undefined
+              : {
+                  access:
+                    p.jobManagerTask?.authenticationTokenSettings?.["access"],
+                },
+            allowLowPriorityNode: p.jobManagerTask?.["allowLowPriorityNode"],
+          },
+      jobPreparationTask: !p.jobPreparationTask
+        ? undefined
+        : {
+            id: p.jobPreparationTask?.["id"],
+            commandLine: p.jobPreparationTask?.["commandLine"],
+            containerSettings: !p.jobPreparationTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.jobPreparationTask?.containerSettings?.[
+                      "containerRunOptions"
+                    ],
+                  imageName:
+                    p.jobPreparationTask?.containerSettings?.["imageName"],
+                  registry: !p.jobPreparationTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.jobPreparationTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.jobPreparationTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.jobPreparationTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.jobPreparationTask
+                          ?.containerSettings?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.jobPreparationTask?.containerSettings
+                                  ?.registry?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.jobPreparationTask?.containerSettings?.[
+                      "workingDirectory"
+                    ],
+                },
+            resourceFiles: (p.jobPreparationTask?.["resourceFiles"] ?? []).map(
+              (p) => ({
+                autoStorageContainerName: p["autoStorageContainerName"],
+                storageContainerUrl: p["storageContainerUrl"],
+                httpUrl: p["httpUrl"],
+                blobPrefix: p["blobPrefix"],
+                filePath: p["filePath"],
+                fileMode: p["fileMode"],
+                identityReference: !p.identityReference
+                  ? undefined
+                  : { resourceId: p.identityReference?.["resourceId"] },
+              })
+            ),
+            environmentSettings: (
+              p.jobPreparationTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            constraints: !p.jobPreparationTask?.constraints
+              ? undefined
+              : {
+                  maxWallClockTime:
+                    p.jobPreparationTask?.constraints?.["maxWallClockTime"],
+                  retentionTime:
+                    p.jobPreparationTask?.constraints?.["retentionTime"],
+                  maxTaskRetryCount:
+                    p.jobPreparationTask?.constraints?.["maxTaskRetryCount"],
+                },
+            waitForSuccess: p.jobPreparationTask?.["waitForSuccess"],
+            userIdentity: !p.jobPreparationTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.jobPreparationTask?.userIdentity?.["username"],
+                  autoUser: !p.jobPreparationTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope:
+                          p.jobPreparationTask?.userIdentity?.autoUser?.[
+                            "scope"
+                          ],
+                        elevationLevel:
+                          p.jobPreparationTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+            rerunOnNodeRebootAfterSuccess:
+              p.jobPreparationTask?.["rerunOnNodeRebootAfterSuccess"],
+          },
+      jobReleaseTask: !p.jobReleaseTask
+        ? undefined
+        : {
+            id: p.jobReleaseTask?.["id"],
+            commandLine: p.jobReleaseTask?.["commandLine"],
+            containerSettings: !p.jobReleaseTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.jobReleaseTask?.containerSettings?.[
+                      "containerRunOptions"
+                    ],
+                  imageName: p.jobReleaseTask?.containerSettings?.["imageName"],
+                  registry: !p.jobReleaseTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.jobReleaseTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.jobReleaseTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.jobReleaseTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.jobReleaseTask?.containerSettings
+                          ?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.jobReleaseTask?.containerSettings?.registry
+                                  ?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.jobReleaseTask?.containerSettings?.["workingDirectory"],
+                },
+            resourceFiles: (p.jobReleaseTask?.["resourceFiles"] ?? []).map(
+              (p) => ({
+                autoStorageContainerName: p["autoStorageContainerName"],
+                storageContainerUrl: p["storageContainerUrl"],
+                httpUrl: p["httpUrl"],
+                blobPrefix: p["blobPrefix"],
+                filePath: p["filePath"],
+                fileMode: p["fileMode"],
+                identityReference: !p.identityReference
+                  ? undefined
+                  : { resourceId: p.identityReference?.["resourceId"] },
+              })
+            ),
+            environmentSettings: (
+              p.jobReleaseTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            maxWallClockTime: p.jobReleaseTask?.["maxWallClockTime"],
+            retentionTime: p.jobReleaseTask?.["retentionTime"],
+            userIdentity: !p.jobReleaseTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.jobReleaseTask?.userIdentity?.["username"],
+                  autoUser: !p.jobReleaseTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope:
+                          p.jobReleaseTask?.userIdentity?.autoUser?.["scope"],
+                        elevationLevel:
+                          p.jobReleaseTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+          },
+      commonEnvironmentSettings: (p["commonEnvironmentSettings"] ?? []).map(
+        (p) => ({ name: p["name"], value: p["value"] })
+      ),
+      poolInfo: !p.poolInfo
+        ? undefined
+        : {
+            poolId: p.poolInfo?.["poolId"],
+            autoPoolSpecification: !p.poolInfo?.autoPoolSpecification
+              ? undefined
+              : {
+                  autoPoolIdPrefix:
+                    p.poolInfo?.autoPoolSpecification?.["autoPoolIdPrefix"],
+                  poolLifetimeOption:
+                    p.poolInfo?.autoPoolSpecification?.["poolLifetimeOption"],
+                  keepAlive: p.poolInfo?.autoPoolSpecification?.["keepAlive"],
+                  pool: !p.poolInfo?.autoPoolSpecification?.pool
+                    ? undefined
+                    : {
+                        displayName:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "displayName"
+                          ],
+                        vmSize:
+                          p.poolInfo?.autoPoolSpecification?.pool?.["vmSize"],
+                        cloudServiceConfiguration: !p.poolInfo
+                          ?.autoPoolSpecification?.pool
+                          ?.cloudServiceConfiguration
+                          ? undefined
+                          : {
+                              osFamily:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.cloudServiceConfiguration?.["osFamily"],
+                              osVersion:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.cloudServiceConfiguration?.["osVersion"],
+                            },
+                        virtualMachineConfiguration: !p.poolInfo
+                          ?.autoPoolSpecification?.pool
+                          ?.virtualMachineConfiguration
+                          ? undefined
+                          : {
+                              imageReference: {
+                                publisher:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["publisher"],
+                                offer:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["offer"],
+                                sku: p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.imageReference[
+                                  "sku"
+                                ],
+                                version:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["version"],
+                                virtualMachineImageId:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["virtualMachineImageId"],
+                                exactVersion:
+                                  p.poolInfo?.autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["exactVersion"],
+                              },
+                              nodeAgentSKUId:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "nodeAgentSKUId"
+                                ],
+                              windowsConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.windowsConfiguration
+                                ? undefined
+                                : {
+                                    enableAutomaticUpdates:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.windowsConfiguration?.[
+                                        "enableAutomaticUpdates"
+                                      ],
+                                  },
+                              dataDisks: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "dataDisks"
+                                ] ?? []
+                              ).map((p) => ({
+                                lun: p["lun"],
+                                caching: p["caching"],
+                                diskSizeGB: p["diskSizeGB"],
+                                storageAccountType: p["storageAccountType"],
+                              })),
+                              licenseType:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "licenseType"
+                                ],
+                              containerConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.containerConfiguration
+                                ? undefined
+                                : {
+                                    type: p.poolInfo?.autoPoolSpecification
+                                      ?.pool?.virtualMachineConfiguration
+                                      ?.containerConfiguration?.["type"],
+                                    containerImageNames:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.[
+                                        "containerImageNames"
+                                      ],
+                                    containerRegistries: (
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.[
+                                        "containerRegistries"
+                                      ] ?? []
+                                    ).map((p) => ({
+                                      username: p["username"],
+                                      password: p["password"],
+                                      registryServer: p["registryServer"],
+                                      identityReference: !p.identityReference
+                                        ? undefined
+                                        : {
+                                            resourceId:
+                                              p.identityReference?.[
+                                                "resourceId"
+                                              ],
+                                          },
+                                    })),
+                                  },
+                              diskEncryptionConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.diskEncryptionConfiguration
+                                ? undefined
+                                : {
+                                    targets:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.diskEncryptionConfiguration?.[
+                                        "targets"
+                                      ],
+                                  },
+                              nodePlacementConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.nodePlacementConfiguration
+                                ? undefined
+                                : {
+                                    policy:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.nodePlacementConfiguration?.[
+                                        "policy"
+                                      ],
+                                  },
+                              extensions: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "extensions"
+                                ] ?? []
+                              ).map((p) => ({
+                                name: p["name"],
+                                publisher: p["publisher"],
+                                type: p["type"],
+                                typeHandlerVersion: p["typeHandlerVersion"],
+                                autoUpgradeMinorVersion:
+                                  p["autoUpgradeMinorVersion"],
+                                settings: !p.settings ? undefined : {},
+                                protectedSettings: !p.protectedSettings
+                                  ? undefined
+                                  : {},
+                                provisionAfterExtensions:
+                                  p["provisionAfterExtensions"],
+                              })),
+                              osDisk: !p.poolInfo?.autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.osDisk
+                                ? undefined
+                                : {
+                                    ephemeralOSDiskSettings: !p.poolInfo
+                                      ?.autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration?.osDisk
+                                      ?.ephemeralOSDiskSettings
+                                      ? undefined
+                                      : {
+                                          placement:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool
+                                              ?.virtualMachineConfiguration
+                                              ?.osDisk
+                                              ?.ephemeralOSDiskSettings?.[
+                                              "placement"
+                                            ],
+                                        },
+                                  },
+                            },
+                        taskSlotsPerNode:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "taskSlotsPerNode"
+                          ],
+                        taskSchedulingPolicy: !p.poolInfo?.autoPoolSpecification
+                          ?.pool?.taskSchedulingPolicy
+                          ? undefined
+                          : {
+                              nodeFillType:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.taskSchedulingPolicy?.["nodeFillType"],
+                            },
+                        resizeTimeout:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "resizeTimeout"
+                          ],
+                        targetDedicatedNodes:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "targetDedicatedNodes"
+                          ],
+                        targetLowPriorityNodes:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "targetLowPriorityNodes"
+                          ],
+                        enableAutoScale:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "enableAutoScale"
+                          ],
+                        autoScaleFormula:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "autoScaleFormula"
+                          ],
+                        autoScaleEvaluationInterval:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "autoScaleEvaluationInterval"
+                          ],
+                        enableInterNodeCommunication:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "enableInterNodeCommunication"
+                          ],
+                        networkConfiguration: !p.poolInfo?.autoPoolSpecification
+                          ?.pool?.networkConfiguration
+                          ? undefined
+                          : {
+                              subnetId:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.["subnetId"],
+                              dynamicVNetAssignmentScope:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.[
+                                  "dynamicVNetAssignmentScope"
+                                ],
+                              endpointConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.networkConfiguration?.endpointConfiguration
+                                ? undefined
+                                : {
+                                    inboundNATPools: (
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.endpointConfiguration?.[
+                                        "inboundNATPools"
+                                      ] ?? []
+                                    ).map((p) => ({
+                                      name: p["name"],
+                                      protocol: p["protocol"],
+                                      backendPort: p["backendPort"],
+                                      frontendPortRangeStart:
+                                        p["frontendPortRangeStart"],
+                                      frontendPortRangeEnd:
+                                        p["frontendPortRangeEnd"],
+                                      networkSecurityGroupRules: (
+                                        p["networkSecurityGroupRules"] ?? []
+                                      ).map((p) => ({
+                                        priority: p["priority"],
+                                        access: p["access"],
+                                        sourceAddressPrefix:
+                                          p["sourceAddressPrefix"],
+                                        sourcePortRanges: p["sourcePortRanges"],
+                                      })),
+                                    })),
+                                  },
+                              publicIPAddressConfiguration: !p.poolInfo
+                                ?.autoPoolSpecification?.pool
+                                ?.networkConfiguration
+                                ?.publicIPAddressConfiguration
+                                ? undefined
+                                : {
+                                    provision:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.publicIPAddressConfiguration?.[
+                                        "provision"
+                                      ],
+                                    ipAddressIds:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.publicIPAddressConfiguration?.[
+                                        "ipAddressIds"
+                                      ],
+                                  },
+                            },
+                        startTask: !p.poolInfo?.autoPoolSpecification?.pool
+                          ?.startTask
+                          ? undefined
+                          : {
+                              commandLine:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["commandLine"],
+                              containerSettings: !p.poolInfo
+                                ?.autoPoolSpecification?.pool?.startTask
+                                ?.containerSettings
+                                ? undefined
+                                : {
+                                    containerRunOptions:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.containerSettings?.[
+                                        "containerRunOptions"
+                                      ],
+                                    imageName:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.containerSettings?.[
+                                        "imageName"
+                                      ],
+                                    registry: !p.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.containerSettings
+                                      ?.registry
+                                      ? undefined
+                                      : {
+                                          username:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "username"
+                                            ],
+                                          password:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "password"
+                                            ],
+                                          registryServer:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "registryServer"
+                                            ],
+                                          identityReference: !p.poolInfo
+                                            ?.autoPoolSpecification?.pool
+                                            ?.startTask?.containerSettings
+                                            ?.registry?.identityReference
+                                            ? undefined
+                                            : {
+                                                resourceId:
+                                                  p.poolInfo
+                                                    ?.autoPoolSpecification
+                                                    ?.pool?.startTask
+                                                    ?.containerSettings
+                                                    ?.registry
+                                                    ?.identityReference?.[
+                                                    "resourceId"
+                                                  ],
+                                              },
+                                        },
+                                    workingDirectory:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.containerSettings?.[
+                                        "workingDirectory"
+                                      ],
+                                  },
+                              resourceFiles: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["resourceFiles"] ?? []
+                              ).map((p) => ({
+                                autoStorageContainerName:
+                                  p["autoStorageContainerName"],
+                                storageContainerUrl: p["storageContainerUrl"],
+                                httpUrl: p["httpUrl"],
+                                blobPrefix: p["blobPrefix"],
+                                filePath: p["filePath"],
+                                fileMode: p["fileMode"],
+                                identityReference: !p.identityReference
+                                  ? undefined
+                                  : {
+                                      resourceId:
+                                        p.identityReference?.["resourceId"],
+                                    },
+                              })),
+                              environmentSettings: (
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["environmentSettings"] ?? []
+                              ).map((p) => ({
+                                name: p["name"],
+                                value: p["value"],
+                              })),
+                              userIdentity: !p.poolInfo?.autoPoolSpecification
+                                ?.pool?.startTask?.userIdentity
+                                ? undefined
+                                : {
+                                    username:
+                                      p.poolInfo?.autoPoolSpecification?.pool
+                                        ?.startTask?.userIdentity?.["username"],
+                                    autoUser: !p.poolInfo?.autoPoolSpecification
+                                      ?.pool?.startTask?.userIdentity?.autoUser
+                                      ? undefined
+                                      : {
+                                          scope:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask?.userIdentity
+                                              ?.autoUser?.["scope"],
+                                          elevationLevel:
+                                            p.poolInfo?.autoPoolSpecification
+                                              ?.pool?.startTask?.userIdentity
+                                              ?.autoUser?.["elevationLevel"],
+                                        },
+                                  },
+                              maxTaskRetryCount:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["maxTaskRetryCount"],
+                              waitForSuccess:
+                                p.poolInfo?.autoPoolSpecification?.pool
+                                  ?.startTask?.["waitForSuccess"],
+                            },
+                        certificateReferences: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "certificateReferences"
+                          ] ?? []
+                        ).map((p) => ({
+                          thumbprint: p["thumbprint"],
+                          thumbprintAlgorithm: p["thumbprintAlgorithm"],
+                          storeLocation: p["storeLocation"],
+                          storeName: p["storeName"],
+                          visibility: p["visibility"],
+                        })),
+                        applicationPackageReferences: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "applicationPackageReferences"
+                          ] ?? []
+                        ).map((p) => ({
+                          applicationId: p["applicationId"],
+                          version: p["version"],
+                        })),
+                        applicationLicenses:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "applicationLicenses"
+                          ],
+                        userAccounts: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "userAccounts"
+                          ] ?? []
+                        ).map((p) => ({
+                          name: p["name"],
+                          password: p["password"],
+                          elevationLevel: p["elevationLevel"],
+                          linuxUserConfiguration: !p.linuxUserConfiguration
+                            ? undefined
+                            : {
+                                uid: p.linuxUserConfiguration?.["uid"],
+                                gid: p.linuxUserConfiguration?.["gid"],
+                                sshPrivateKey:
+                                  p.linuxUserConfiguration?.["sshPrivateKey"],
+                              },
+                          windowsUserConfiguration: !p.windowsUserConfiguration
+                            ? undefined
+                            : {
+                                loginMode:
+                                  p.windowsUserConfiguration?.["loginMode"],
+                              },
+                        })),
+                        metadata: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "metadata"
+                          ] ?? []
+                        ).map((p) => ({ name: p["name"], value: p["value"] })),
+                        mountConfiguration: (
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "mountConfiguration"
+                          ] ?? []
+                        ).map((p) => ({
+                          azureBlobFileSystemConfiguration:
+                            !p.azureBlobFileSystemConfiguration
+                              ? undefined
+                              : {
+                                  accountName:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "accountName"
+                                    ],
+                                  containerName:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "containerName"
+                                    ],
+                                  accountKey:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "accountKey"
+                                    ],
+                                  sasKey:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "sasKey"
+                                    ],
+                                  blobfuseOptions:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "blobfuseOptions"
+                                    ],
+                                  relativeMountPath:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  identityReference: !p
+                                    .azureBlobFileSystemConfiguration
+                                    ?.identityReference
+                                    ? undefined
+                                    : {
+                                        resourceId:
+                                          p.azureBlobFileSystemConfiguration
+                                            ?.identityReference?.["resourceId"],
+                                      },
+                                },
+                          nfsMountConfiguration: !p.nfsMountConfiguration
+                            ? undefined
+                            : {
+                                source: p.nfsMountConfiguration?.["source"],
+                                relativeMountPath:
+                                  p.nfsMountConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.nfsMountConfiguration?.["mountOptions"],
+                              },
+                          cifsMountConfiguration: !p.cifsMountConfiguration
+                            ? undefined
+                            : {
+                                username:
+                                  p.cifsMountConfiguration?.["username"],
+                                source: p.cifsMountConfiguration?.["source"],
+                                relativeMountPath:
+                                  p.cifsMountConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.cifsMountConfiguration?.["mountOptions"],
+                                password:
+                                  p.cifsMountConfiguration?.["password"],
+                              },
+                          azureFileShareConfiguration:
+                            !p.azureFileShareConfiguration
+                              ? undefined
+                              : {
+                                  accountName:
+                                    p.azureFileShareConfiguration?.[
+                                      "accountName"
+                                    ],
+                                  azureFileUrl:
+                                    p.azureFileShareConfiguration?.[
+                                      "azureFileUrl"
+                                    ],
+                                  accountKey:
+                                    p.azureFileShareConfiguration?.[
+                                      "accountKey"
+                                    ],
+                                  relativeMountPath:
+                                    p.azureFileShareConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  mountOptions:
+                                    p.azureFileShareConfiguration?.[
+                                      "mountOptions"
+                                    ],
+                                },
+                        })),
+                        targetNodeCommunicationMode:
+                          p.poolInfo?.autoPoolSpecification?.pool?.[
+                            "targetNodeCommunicationMode"
+                          ],
+                      },
+                },
+          },
+      onAllTasksComplete: p["onAllTasksComplete"],
+      onTaskFailure: p["onTaskFailure"],
+      networkConfiguration: !p.networkConfiguration
+        ? undefined
+        : { subnetId: p.networkConfiguration?.["subnetId"] },
+      metadata: (p["metadata"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+      executionInfo: !p.executionInfo
+        ? undefined
+        : {
+            startTime: new Date(p.executionInfo?.["startTime"] ?? ""),
+            endTime: new Date(p.executionInfo?.["endTime"] ?? ""),
+            poolId: p.executionInfo?.["poolId"],
+            schedulingError: !p.executionInfo?.schedulingError
+              ? undefined
+              : {
+                  category: p.executionInfo?.schedulingError?.["category"],
+                  code: p.executionInfo?.schedulingError?.["code"],
+                  message: p.executionInfo?.schedulingError?.["message"],
+                  details: (
+                    p.executionInfo?.schedulingError?.["details"] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            terminateReason: p.executionInfo?.["terminateReason"],
+          },
+      stats: !p.stats
+        ? undefined
+        : {
+            url: p.stats?.["url"],
+            startTime: new Date(p.stats?.["startTime"] ?? ""),
+            lastUpdateTime: new Date(p.stats?.["lastUpdateTime"] ?? ""),
+            userCPUTime: p.stats?.["userCPUTime"],
+            kernelCPUTime: p.stats?.["kernelCPUTime"],
+            wallClockTime: p.stats?.["wallClockTime"],
+            readIOps: p.stats?.["readIOps"],
+            writeIOps: p.stats?.["writeIOps"],
+            readIOGiB: p.stats?.["readIOGiB"],
+            writeIOGiB: p.stats?.["writeIOGiB"],
+            numSucceededTasks: p.stats?.["numSucceededTasks"],
+            numFailedTasks: p.stats?.["numFailedTasks"],
+            numTaskRetries: p.stats?.["numTaskRetries"],
+            waitTime: p.stats?.["waitTime"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Joblistpreparationandreleasetaskstatusoptions
+  extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-job-preparation-and-release-status.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/**
+ * This API returns the Job Preparation and Job Release Task status on all Compute
+ * Nodes that have run the Job Preparation or Job Release Task. This includes
+ * Compute Nodes which have since been removed from the Pool. If this API is
+ * invoked on a Job which has no Job Preparation or Job Release Task, the Batch
+ * service returns HTTP status code 409 (Conflict) with an error code of
+ * JobPreparationTaskNotSpecified.
+ */
+export async function listPreparationAndReleaseTaskStatus(
+  context: Client,
+  jobId: string,
+  options: Joblistpreparationandreleasetaskstatusoptions = {
+    requestOptions: {},
+  }
+): Promise<BatchJobListPreparationAndReleaseTaskStatusResult> {
+  const result = await context
+    .path("/jobs/{jobId}/jobpreparationandreleasetaskstatus", jobId)
+    .get({
+      headers: {
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.maxresults && { maxresults: options.maxresults }),
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$filter && { $filter: options.$filter }),
+        ...(options.$select && { $select: options.$select }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      poolId: p["poolId"],
+      nodeId: p["nodeId"],
+      nodeUrl: p["nodeUrl"],
+      jobPreparationTaskExecutionInfo: !p.jobPreparationTaskExecutionInfo
+        ? undefined
+        : {
+            startTime: new Date(
+              p.jobPreparationTaskExecutionInfo?.["startTime"] ?? ""
+            ),
+            endTime: new Date(
+              p.jobPreparationTaskExecutionInfo?.["endTime"] ?? ""
+            ),
+            state: p.jobPreparationTaskExecutionInfo?.["state"],
+            taskRootDirectory:
+              p.jobPreparationTaskExecutionInfo?.["taskRootDirectory"],
+            taskRootDirectoryUrl:
+              p.jobPreparationTaskExecutionInfo?.["taskRootDirectoryUrl"],
+            exitCode: p.jobPreparationTaskExecutionInfo?.["exitCode"],
+            containerInfo: !p.jobPreparationTaskExecutionInfo?.containerInfo
+              ? undefined
+              : {
+                  containerId:
+                    p.jobPreparationTaskExecutionInfo?.containerInfo?.[
+                      "containerId"
+                    ],
+                  state:
+                    p.jobPreparationTaskExecutionInfo?.containerInfo?.["state"],
+                  error:
+                    p.jobPreparationTaskExecutionInfo?.containerInfo?.["error"],
+                },
+            failureInfo: !p.jobPreparationTaskExecutionInfo?.failureInfo
+              ? undefined
+              : {
+                  category:
+                    p.jobPreparationTaskExecutionInfo?.failureInfo?.[
+                      "category"
+                    ],
+                  code: p.jobPreparationTaskExecutionInfo?.failureInfo?.[
+                    "code"
+                  ],
+                  message:
+                    p.jobPreparationTaskExecutionInfo?.failureInfo?.["message"],
+                  details: (
+                    p.jobPreparationTaskExecutionInfo?.failureInfo?.[
+                      "details"
+                    ] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            retryCount: p.jobPreparationTaskExecutionInfo?.["retryCount"],
+            lastRetryTime: new Date(
+              p.jobPreparationTaskExecutionInfo?.["lastRetryTime"] ?? ""
+            ),
+            result: p.jobPreparationTaskExecutionInfo?.["result"],
+          },
+      jobReleaseTaskExecutionInfo: !p.jobReleaseTaskExecutionInfo
+        ? undefined
+        : {
+            startTime: new Date(
+              p.jobReleaseTaskExecutionInfo?.["startTime"] ?? ""
+            ),
+            endTime: new Date(p.jobReleaseTaskExecutionInfo?.["endTime"] ?? ""),
+            state: p.jobReleaseTaskExecutionInfo?.["state"],
+            taskRootDirectory:
+              p.jobReleaseTaskExecutionInfo?.["taskRootDirectory"],
+            taskRootDirectoryUrl:
+              p.jobReleaseTaskExecutionInfo?.["taskRootDirectoryUrl"],
+            exitCode: p.jobReleaseTaskExecutionInfo?.["exitCode"],
+            containerInfo: !p.jobReleaseTaskExecutionInfo?.containerInfo
+              ? undefined
+              : {
+                  containerId:
+                    p.jobReleaseTaskExecutionInfo?.containerInfo?.[
+                      "containerId"
+                    ],
+                  state:
+                    p.jobReleaseTaskExecutionInfo?.containerInfo?.["state"],
+                  error:
+                    p.jobReleaseTaskExecutionInfo?.containerInfo?.["error"],
+                },
+            failureInfo: !p.jobReleaseTaskExecutionInfo?.failureInfo
+              ? undefined
+              : {
+                  category:
+                    p.jobReleaseTaskExecutionInfo?.failureInfo?.["category"],
+                  code: p.jobReleaseTaskExecutionInfo?.failureInfo?.["code"],
+                  message:
+                    p.jobReleaseTaskExecutionInfo?.failureInfo?.["message"],
+                  details: (
+                    p.jobReleaseTaskExecutionInfo?.failureInfo?.["details"] ??
+                    []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            result: p.jobReleaseTaskExecutionInfo?.["result"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Jobgettaskcountsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * Task counts provide a count of the Tasks by active, running or completed Task
+ * state, and a count of Tasks which succeeded or failed. Tasks in the preparing
+ * state are counted as running. Note that the numbers returned may not always be
+ * up to date. If you need exact task counts, use a list query.
+ */
+export async function getTaskCounts(
+  context: Client,
+  jobId: string,
+  options: Jobgettaskcountsoptions = { requestOptions: {} }
+): Promise<TaskCountsResult> {
+  const result = await context.path("/jobs/{jobId}/taskcounts", jobId).get({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    taskCounts: {
+      active: result.body.taskCounts["active"],
+      running: result.body.taskCounts["running"],
+      completed: result.body.taskCounts["completed"],
+      succeeded: result.body.taskCounts["succeeded"],
+      failed: result.body.taskCounts["failed"],
+    },
+    taskSlotCounts: {
+      active: result.body.taskSlotCounts["active"],
+      running: result.body.taskSlotCounts["running"],
+      completed: result.body.taskSlotCounts["completed"],
+      succeeded: result.body.taskSlotCounts["succeeded"],
+      failed: result.body.taskSlotCounts["failed"],
+    },
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Job.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Job.ts
@@ -24,7 +24,7 @@ import {
   TaskCountsResult,
 } from "./models.js";
 
-export interface Jobgetalllifetimestatisticsoptions extends RequestOptions {
+export interface JobGetAllLifetimeStatisticsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -53,7 +53,7 @@ export interface Jobgetalllifetimestatisticsoptions extends RequestOptions {
  */
 export async function getAllLifetimeStatistics(
   context: Client,
-  options: Jobgetalllifetimestatisticsoptions = { requestOptions: {} }
+  options: JobGetAllLifetimeStatisticsOptions = { requestOptions: {} }
 ): Promise<JobStatistics> {
   const result = await context.path("/lifetimejobstats").get({
     headers: {
@@ -91,7 +91,7 @@ export async function getAllLifetimeStatistics(
   };
 }
 
-export interface Jobdeletejoboptions extends RequestOptions {
+export interface JobDeleteJobOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -149,7 +149,7 @@ export interface Jobdeletejoboptions extends RequestOptions {
 export async function deleteJob(
   context: Client,
   jobId: string,
-  options: Jobdeletejoboptions = { requestOptions: {} }
+  options: JobDeleteJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}", jobId).delete({
     headers: {
@@ -179,7 +179,7 @@ export async function deleteJob(
   return;
 }
 
-export interface Jobgetjoboptions extends RequestOptions {
+export interface JobGetJobOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -232,7 +232,7 @@ export interface Jobgetjoboptions extends RequestOptions {
 export async function getJob(
   context: Client,
   jobId: string,
-  options: Jobgetjoboptions = { requestOptions: {} }
+  options: JobGetJobOptions = { requestOptions: {} }
 ): Promise<BatchJob> {
   const result = await context.path("/jobs/{jobId}", jobId).get({
     headers: {
@@ -1218,7 +1218,7 @@ export async function getJob(
   };
 }
 
-export interface Jobpatchjoboptions extends RequestOptions {
+export interface JobPatchJobOptions extends RequestOptions {
   /**
    * The ID is case-preserving and case-insensitive (that is, you may not have two
    * IDs within an Account that differ only by case).
@@ -1398,7 +1398,7 @@ export interface Jobpatchjoboptions extends RequestOptions {
 export async function patchJob(
   context: Client,
   jobId: string,
-  options: Jobpatchjoboptions = { requestOptions: {} }
+  options: JobPatchJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}", jobId).patch({
     headers: {
@@ -1444,7 +1444,7 @@ export async function patchJob(
   return;
 }
 
-export interface Jobupdatejoboptions extends RequestOptions {
+export interface JobUpdateJobOptions extends RequestOptions {
   /**
    * The ID is case-preserving and case-insensitive (that is, you may not have two
    * IDs within an Account that differ only by case).
@@ -1624,7 +1624,7 @@ export interface Jobupdatejoboptions extends RequestOptions {
 export async function updateJob(
   context: Client,
   jobId: string,
-  options: Jobupdatejoboptions = { requestOptions: {} }
+  options: JobUpdateJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}", jobId).put({
     headers: {
@@ -1670,7 +1670,7 @@ export async function updateJob(
   return;
 }
 
-export interface Jobdisablejoboptions extends RequestOptions {
+export interface JobDisableJobOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1731,7 +1731,7 @@ export async function disableJob(
   context: Client,
   disableTasks: DisableJobOption,
   jobId: string,
-  options: Jobdisablejoboptions = { requestOptions: {} }
+  options: JobDisableJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}/disable", jobId).post({
     headers: {
@@ -1763,7 +1763,7 @@ export async function disableJob(
   return;
 }
 
-export interface Jobenablejoboptions extends RequestOptions {
+export interface JobEnableJobOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1819,7 +1819,7 @@ export interface Jobenablejoboptions extends RequestOptions {
 export async function enableJob(
   context: Client,
   jobId: string,
-  options: Jobenablejoboptions = { requestOptions: {} }
+  options: JobEnableJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}/enable", jobId).post({
     headers: {
@@ -1849,7 +1849,7 @@ export async function enableJob(
   return;
 }
 
-export interface Jobterminatejoboptions extends RequestOptions {
+export interface JobTerminateJobOptions extends RequestOptions {
   /**
    * The text you want to appear as the Job's TerminateReason. The default is
    * 'UserTerminate'.
@@ -1912,7 +1912,7 @@ export interface Jobterminatejoboptions extends RequestOptions {
 export async function terminateJob(
   context: Client,
   jobId: string,
-  options: Jobterminatejoboptions = { requestOptions: {} }
+  options: JobTerminateJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}/terminate", jobId).post({
     headers: {
@@ -1948,7 +1948,7 @@ export async function terminateJob(
   return;
 }
 
-export interface Jobaddjoboptions extends RequestOptions {
+export interface JobAddJobOptions extends RequestOptions {
   /**
    * The ID is case-preserving and case-insensitive (that is, you may not have two
    * IDs within an Account that differ only by case).
@@ -2109,7 +2109,7 @@ export interface Jobaddjoboptions extends RequestOptions {
  */
 export async function addJob(
   context: Client,
-  options: Jobaddjoboptions = { requestOptions: {} }
+  options: JobAddJobOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs").post({
     headers: {
@@ -2147,7 +2147,7 @@ export async function addJob(
   return;
 }
 
-export interface Joblistjobsoptions extends RequestOptions {
+export interface JobListJobsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2185,7 +2185,7 @@ export interface Joblistjobsoptions extends RequestOptions {
 /** Lists all of the Jobs in the specified Account. */
 export async function listJobs(
   context: Client,
-  options: Joblistjobsoptions = { requestOptions: {} }
+  options: JobListJobsOptions = { requestOptions: {} }
 ): Promise<BatchJobListResult> {
   const result = await context.path("/jobs").get({
     headers: {
@@ -3153,7 +3153,7 @@ export async function listJobs(
   };
 }
 
-export interface Joblistfromjobscheduleoptions extends RequestOptions {
+export interface JobListFromJobScheduleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3192,7 +3192,7 @@ export interface Joblistfromjobscheduleoptions extends RequestOptions {
 export async function listFromJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Joblistfromjobscheduleoptions = { requestOptions: {} }
+  options: JobListFromJobScheduleOptions = { requestOptions: {} }
 ): Promise<BatchJobListResult> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}/jobs", jobScheduleId)
@@ -4162,7 +4162,7 @@ export async function listFromJobSchedule(
   };
 }
 
-export interface Joblistpreparationandreleasetaskstatusoptions
+export interface JobListPreparationAndReleaseTaskStatusOptions
   extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
@@ -4207,7 +4207,7 @@ export interface Joblistpreparationandreleasetaskstatusoptions
 export async function listPreparationAndReleaseTaskStatus(
   context: Client,
   jobId: string,
-  options: Joblistpreparationandreleasetaskstatusoptions = {
+  options: JobListPreparationAndReleaseTaskStatusOptions = {
     requestOptions: {},
   }
 ): Promise<BatchJobListPreparationAndReleaseTaskStatusResult> {
@@ -4337,7 +4337,7 @@ export async function listPreparationAndReleaseTaskStatus(
   };
 }
 
-export interface Jobgettaskcountsoptions extends RequestOptions {
+export interface JobGetTaskCountsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -4367,7 +4367,7 @@ export interface Jobgettaskcountsoptions extends RequestOptions {
 export async function getTaskCounts(
   context: Client,
   jobId: string,
-  options: Jobgettaskcountsoptions = { requestOptions: {} }
+  options: JobGetTaskCountsOptions = { requestOptions: {} }
 ): Promise<TaskCountsResult> {
   const result = await context.path("/jobs/{jobId}/taskcounts", jobId).get({
     headers: {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/JobSchedule.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/JobSchedule.ts
@@ -14,7 +14,7 @@ import {
   BatchJobScheduleListResult,
 } from "./models.js";
 
-export interface Jobschedulejobscheduleexistsoptions extends RequestOptions {
+export interface JobScheduleJobScheduleExistsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -63,7 +63,7 @@ export interface Jobschedulejobscheduleexistsoptions extends RequestOptions {
 export async function jobScheduleExists(
   context: Client,
   jobScheduleId: string,
-  options: Jobschedulejobscheduleexistsoptions = { requestOptions: {} }
+  options: JobScheduleJobScheduleExistsOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}", jobScheduleId)
@@ -95,7 +95,7 @@ export async function jobScheduleExists(
   return;
 }
 
-export interface Jobscheduledeletejobscheduleoptions extends RequestOptions {
+export interface JobScheduleDeleteJobScheduleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -150,7 +150,7 @@ export interface Jobscheduledeletejobscheduleoptions extends RequestOptions {
 export async function deleteJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobscheduledeletejobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleDeleteJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}", jobScheduleId)
@@ -182,7 +182,7 @@ export async function deleteJobSchedule(
   return;
 }
 
-export interface Jobschedulegetjobscheduleoptions extends RequestOptions {
+export interface JobScheduleGetJobScheduleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -235,7 +235,7 @@ export interface Jobschedulegetjobscheduleoptions extends RequestOptions {
 export async function getJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobschedulegetjobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleGetJobScheduleOptions = { requestOptions: {} }
 ): Promise<BatchJobSchedule> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}", jobScheduleId)
@@ -1386,7 +1386,7 @@ export async function getJobSchedule(
   };
 }
 
-export interface Jobschedulepatchjobscheduleoptions extends RequestOptions {
+export interface JobSchedulePatchJobScheduleOptions extends RequestOptions {
   /** A string that uniquely identifies the schedule within the Account. */
   id?: string;
   /** The display name for the schedule. */
@@ -1491,7 +1491,7 @@ export interface Jobschedulepatchjobscheduleoptions extends RequestOptions {
 export async function patchJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobschedulepatchjobscheduleoptions = { requestOptions: {} }
+  options: JobSchedulePatchJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}", jobScheduleId)
@@ -1531,7 +1531,7 @@ export async function patchJobSchedule(
   return;
 }
 
-export interface Jobscheduleupdatejobscheduleoptions extends RequestOptions {
+export interface JobScheduleUpdateJobScheduleOptions extends RequestOptions {
   /** A string that uniquely identifies the schedule within the Account. */
   id?: string;
   /** The display name for the schedule. */
@@ -1636,7 +1636,7 @@ export interface Jobscheduleupdatejobscheduleoptions extends RequestOptions {
 export async function updateJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobscheduleupdatejobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleUpdateJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}", jobScheduleId)
@@ -1676,7 +1676,7 @@ export async function updateJobSchedule(
   return;
 }
 
-export interface Jobscheduledisablejobscheduleoptions extends RequestOptions {
+export interface JobScheduleDisableJobScheduleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1725,7 +1725,7 @@ export interface Jobscheduledisablejobscheduleoptions extends RequestOptions {
 export async function disableJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobscheduledisablejobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleDisableJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}/disable", jobScheduleId)
@@ -1757,7 +1757,7 @@ export async function disableJobSchedule(
   return;
 }
 
-export interface Jobscheduleenablejobscheduleoptions extends RequestOptions {
+export interface JobScheduleEnableJobScheduleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1806,7 +1806,7 @@ export interface Jobscheduleenablejobscheduleoptions extends RequestOptions {
 export async function enableJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobscheduleenablejobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleEnableJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}/enable", jobScheduleId)
@@ -1838,7 +1838,7 @@ export async function enableJobSchedule(
   return;
 }
 
-export interface Jobscheduleterminatejobscheduleoptions extends RequestOptions {
+export interface JobScheduleTerminateJobScheduleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1887,7 +1887,7 @@ export interface Jobscheduleterminatejobscheduleoptions extends RequestOptions {
 export async function terminateJobSchedule(
   context: Client,
   jobScheduleId: string,
-  options: Jobscheduleterminatejobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleTerminateJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobschedules/{jobScheduleId}/terminate", jobScheduleId)
@@ -1919,7 +1919,7 @@ export async function terminateJobSchedule(
   return;
 }
 
-export interface Jobscheduleaddjobscheduleoptions extends RequestOptions {
+export interface JobScheduleAddJobScheduleOptions extends RequestOptions {
   /** A string that uniquely identifies the schedule within the Account. */
   id?: string;
   /** The display name for the schedule. */
@@ -1993,7 +1993,7 @@ export interface Jobscheduleaddjobscheduleoptions extends RequestOptions {
 /** Adds a Job Schedule to the specified Account. */
 export async function addJobSchedule(
   context: Client,
-  options: Jobscheduleaddjobscheduleoptions = { requestOptions: {} }
+  options: JobScheduleAddJobScheduleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobschedules").post({
     headers: {
@@ -2023,7 +2023,7 @@ export async function addJobSchedule(
   return;
 }
 
-export interface Jobschedulelistjobschedulesoptions extends RequestOptions {
+export interface JobScheduleListJobSchedulesOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2061,7 +2061,7 @@ export interface Jobschedulelistjobschedulesoptions extends RequestOptions {
 /** Lists all of the Job Schedules in the specified Account. */
 export async function listJobSchedules(
   context: Client,
-  options: Jobschedulelistjobschedulesoptions = { requestOptions: {} }
+  options: JobScheduleListJobSchedulesOptions = { requestOptions: {} }
 ): Promise<BatchJobScheduleListResult> {
   const result = await context.path("/jobschedules").get({
     headers: {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/JobSchedule.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/JobSchedule.ts
@@ -1,0 +1,3156 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  MetadataItem,
+  BatchJobSchedule,
+  JobScheduleState,
+  Schedule,
+  JobSpecification,
+  JobScheduleExecutionInformation,
+  JobScheduleStatistics,
+  BatchJobScheduleListResult,
+} from "./models.js";
+
+export interface Jobschedulejobscheduleexistsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** Checks the specified Job Schedule exists. */
+export async function jobScheduleExists(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobschedulejobscheduleexistsoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}", jobScheduleId)
+    .head({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobscheduledeletejobscheduleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * When you delete a Job Schedule, this also deletes all Jobs and Tasks under that
+ * schedule. When Tasks are deleted, all the files in their working directories on
+ * the Compute Nodes are also deleted (the retention period is ignored). The Job
+ * Schedule statistics are no longer accessible once the Job Schedule is deleted,
+ * though they are still counted towards Account lifetime statistics.
+ */
+export async function deleteJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobscheduledeletejobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}", jobScheduleId)
+    .delete({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobschedulegetjobscheduleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Gets information about the specified Job Schedule. */
+export async function getJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobschedulegetjobscheduleoptions = { requestOptions: {} }
+): Promise<BatchJobSchedule> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}", jobScheduleId)
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+        ...(options.$expand && { $expand: options.$expand }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    displayName: result.body["displayName"],
+    url: result.body["url"],
+    eTag: result.body["eTag"],
+    lastModified: new Date(result.body["lastModified"] ?? ""),
+    creationTime: new Date(result.body["creationTime"] ?? ""),
+    state: result.body["state"],
+    stateTransitionTime: new Date(result.body["stateTransitionTime"] ?? ""),
+    previousState: result.body["previousState"],
+    previousStateTransitionTime: new Date(
+      result.body["previousStateTransitionTime"] ?? ""
+    ),
+    schedule: !result.body.schedule
+      ? undefined
+      : {
+          doNotRunUntil: new Date(
+            result.body.schedule?.["doNotRunUntil"] ?? ""
+          ),
+          doNotRunAfter: new Date(
+            result.body.schedule?.["doNotRunAfter"] ?? ""
+          ),
+          startWindow: result.body.schedule?.["startWindow"],
+          recurrenceInterval: result.body.schedule?.["recurrenceInterval"],
+        },
+    jobSpecification: !result.body.jobSpecification
+      ? undefined
+      : {
+          priority: result.body.jobSpecification?.["priority"],
+          allowTaskPreemption:
+            result.body.jobSpecification?.["allowTaskPreemption"],
+          maxParallelTasks: result.body.jobSpecification?.["maxParallelTasks"],
+          displayName: result.body.jobSpecification?.["displayName"],
+          usesTaskDependencies:
+            result.body.jobSpecification?.["usesTaskDependencies"],
+          onAllTasksComplete:
+            result.body.jobSpecification?.["onAllTasksComplete"],
+          onTaskFailure: result.body.jobSpecification?.["onTaskFailure"],
+          networkConfiguration: !result.body.jobSpecification
+            ?.networkConfiguration
+            ? undefined
+            : {
+                subnetId:
+                  result.body.jobSpecification?.networkConfiguration?.[
+                    "subnetId"
+                  ],
+              },
+          constraints: !result.body.jobSpecification?.constraints
+            ? undefined
+            : {
+                maxWallClockTime:
+                  result.body.jobSpecification?.constraints?.[
+                    "maxWallClockTime"
+                  ],
+                maxTaskRetryCount:
+                  result.body.jobSpecification?.constraints?.[
+                    "maxTaskRetryCount"
+                  ],
+              },
+          jobManagerTask: !result.body.jobSpecification?.jobManagerTask
+            ? undefined
+            : {
+                id: result.body.jobSpecification?.jobManagerTask?.["id"],
+                displayName:
+                  result.body.jobSpecification?.jobManagerTask?.["displayName"],
+                commandLine:
+                  result.body.jobSpecification?.jobManagerTask?.["commandLine"],
+                containerSettings: !result.body.jobSpecification?.jobManagerTask
+                  ?.containerSettings
+                  ? undefined
+                  : {
+                      containerRunOptions:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.containerSettings?.["containerRunOptions"],
+                      imageName:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.containerSettings?.["imageName"],
+                      registry: !result.body.jobSpecification?.jobManagerTask
+                        ?.containerSettings?.registry
+                        ? undefined
+                        : {
+                            username:
+                              result.body.jobSpecification?.jobManagerTask
+                                ?.containerSettings?.registry?.["username"],
+                            password:
+                              result.body.jobSpecification?.jobManagerTask
+                                ?.containerSettings?.registry?.["password"],
+                            registryServer:
+                              result.body.jobSpecification?.jobManagerTask
+                                ?.containerSettings?.registry?.[
+                                "registryServer"
+                              ],
+                            identityReference: !result.body.jobSpecification
+                              ?.jobManagerTask?.containerSettings?.registry
+                              ?.identityReference
+                              ? undefined
+                              : {
+                                  resourceId:
+                                    result.body.jobSpecification?.jobManagerTask
+                                      ?.containerSettings?.registry
+                                      ?.identityReference?.["resourceId"],
+                                },
+                          },
+                      workingDirectory:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.containerSettings?.["workingDirectory"],
+                    },
+                resourceFiles: (
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "resourceFiles"
+                  ] ?? []
+                ).map((p) => ({
+                  autoStorageContainerName: p["autoStorageContainerName"],
+                  storageContainerUrl: p["storageContainerUrl"],
+                  httpUrl: p["httpUrl"],
+                  blobPrefix: p["blobPrefix"],
+                  filePath: p["filePath"],
+                  fileMode: p["fileMode"],
+                  identityReference: !p.identityReference
+                    ? undefined
+                    : { resourceId: p.identityReference?.["resourceId"] },
+                })),
+                outputFiles: (
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "outputFiles"
+                  ] ?? []
+                ).map((p) => ({
+                  filePattern: p["filePattern"],
+                  destination: {
+                    container: !p.destination.container
+                      ? undefined
+                      : {
+                          path: p.destination.container?.["path"],
+                          containerUrl:
+                            p.destination.container?.["containerUrl"],
+                          identityReference: !p.destination.container
+                            ?.identityReference
+                            ? undefined
+                            : {
+                                resourceId:
+                                  p.destination.container?.identityReference?.[
+                                    "resourceId"
+                                  ],
+                              },
+                          uploadHeaders: (
+                            p.destination.container?.["uploadHeaders"] ?? []
+                          ).map((p) => ({
+                            name: p["name"],
+                            value: p["value"],
+                          })),
+                        },
+                  },
+                  uploadOptions: {
+                    uploadCondition: p.uploadOptions["uploadCondition"],
+                  },
+                })),
+                environmentSettings: (
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "environmentSettings"
+                  ] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+                constraints: !result.body.jobSpecification?.jobManagerTask
+                  ?.constraints
+                  ? undefined
+                  : {
+                      maxWallClockTime:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.constraints?.["maxWallClockTime"],
+                      retentionTime:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.constraints?.["retentionTime"],
+                      maxTaskRetryCount:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.constraints?.["maxTaskRetryCount"],
+                    },
+                requiredSlots:
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "requiredSlots"
+                  ],
+                killJobOnCompletion:
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "killJobOnCompletion"
+                  ],
+                userIdentity: !result.body.jobSpecification?.jobManagerTask
+                  ?.userIdentity
+                  ? undefined
+                  : {
+                      username:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.userIdentity?.["username"],
+                      autoUser: !result.body.jobSpecification?.jobManagerTask
+                        ?.userIdentity?.autoUser
+                        ? undefined
+                        : {
+                            scope:
+                              result.body.jobSpecification?.jobManagerTask
+                                ?.userIdentity?.autoUser?.["scope"],
+                            elevationLevel:
+                              result.body.jobSpecification?.jobManagerTask
+                                ?.userIdentity?.autoUser?.["elevationLevel"],
+                          },
+                    },
+                runExclusive:
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "runExclusive"
+                  ],
+                applicationPackageReferences: (
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "applicationPackageReferences"
+                  ] ?? []
+                ).map((p) => ({
+                  applicationId: p["applicationId"],
+                  version: p["version"],
+                })),
+                authenticationTokenSettings: !result.body.jobSpecification
+                  ?.jobManagerTask?.authenticationTokenSettings
+                  ? undefined
+                  : {
+                      access:
+                        result.body.jobSpecification?.jobManagerTask
+                          ?.authenticationTokenSettings?.["access"],
+                    },
+                allowLowPriorityNode:
+                  result.body.jobSpecification?.jobManagerTask?.[
+                    "allowLowPriorityNode"
+                  ],
+              },
+          jobPreparationTask: !result.body.jobSpecification?.jobPreparationTask
+            ? undefined
+            : {
+                id: result.body.jobSpecification?.jobPreparationTask?.["id"],
+                commandLine:
+                  result.body.jobSpecification?.jobPreparationTask?.[
+                    "commandLine"
+                  ],
+                containerSettings: !result.body.jobSpecification
+                  ?.jobPreparationTask?.containerSettings
+                  ? undefined
+                  : {
+                      containerRunOptions:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.containerSettings?.["containerRunOptions"],
+                      imageName:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.containerSettings?.["imageName"],
+                      registry: !result.body.jobSpecification
+                        ?.jobPreparationTask?.containerSettings?.registry
+                        ? undefined
+                        : {
+                            username:
+                              result.body.jobSpecification?.jobPreparationTask
+                                ?.containerSettings?.registry?.["username"],
+                            password:
+                              result.body.jobSpecification?.jobPreparationTask
+                                ?.containerSettings?.registry?.["password"],
+                            registryServer:
+                              result.body.jobSpecification?.jobPreparationTask
+                                ?.containerSettings?.registry?.[
+                                "registryServer"
+                              ],
+                            identityReference: !result.body.jobSpecification
+                              ?.jobPreparationTask?.containerSettings?.registry
+                              ?.identityReference
+                              ? undefined
+                              : {
+                                  resourceId:
+                                    result.body.jobSpecification
+                                      ?.jobPreparationTask?.containerSettings
+                                      ?.registry?.identityReference?.[
+                                      "resourceId"
+                                    ],
+                                },
+                          },
+                      workingDirectory:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.containerSettings?.["workingDirectory"],
+                    },
+                resourceFiles: (
+                  result.body.jobSpecification?.jobPreparationTask?.[
+                    "resourceFiles"
+                  ] ?? []
+                ).map((p) => ({
+                  autoStorageContainerName: p["autoStorageContainerName"],
+                  storageContainerUrl: p["storageContainerUrl"],
+                  httpUrl: p["httpUrl"],
+                  blobPrefix: p["blobPrefix"],
+                  filePath: p["filePath"],
+                  fileMode: p["fileMode"],
+                  identityReference: !p.identityReference
+                    ? undefined
+                    : { resourceId: p.identityReference?.["resourceId"] },
+                })),
+                environmentSettings: (
+                  result.body.jobSpecification?.jobPreparationTask?.[
+                    "environmentSettings"
+                  ] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+                constraints: !result.body.jobSpecification?.jobPreparationTask
+                  ?.constraints
+                  ? undefined
+                  : {
+                      maxWallClockTime:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.constraints?.["maxWallClockTime"],
+                      retentionTime:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.constraints?.["retentionTime"],
+                      maxTaskRetryCount:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.constraints?.["maxTaskRetryCount"],
+                    },
+                waitForSuccess:
+                  result.body.jobSpecification?.jobPreparationTask?.[
+                    "waitForSuccess"
+                  ],
+                userIdentity: !result.body.jobSpecification?.jobPreparationTask
+                  ?.userIdentity
+                  ? undefined
+                  : {
+                      username:
+                        result.body.jobSpecification?.jobPreparationTask
+                          ?.userIdentity?.["username"],
+                      autoUser: !result.body.jobSpecification
+                        ?.jobPreparationTask?.userIdentity?.autoUser
+                        ? undefined
+                        : {
+                            scope:
+                              result.body.jobSpecification?.jobPreparationTask
+                                ?.userIdentity?.autoUser?.["scope"],
+                            elevationLevel:
+                              result.body.jobSpecification?.jobPreparationTask
+                                ?.userIdentity?.autoUser?.["elevationLevel"],
+                          },
+                    },
+                rerunOnNodeRebootAfterSuccess:
+                  result.body.jobSpecification?.jobPreparationTask?.[
+                    "rerunOnNodeRebootAfterSuccess"
+                  ],
+              },
+          jobReleaseTask: !result.body.jobSpecification?.jobReleaseTask
+            ? undefined
+            : {
+                id: result.body.jobSpecification?.jobReleaseTask?.["id"],
+                commandLine:
+                  result.body.jobSpecification?.jobReleaseTask?.["commandLine"],
+                containerSettings: !result.body.jobSpecification?.jobReleaseTask
+                  ?.containerSettings
+                  ? undefined
+                  : {
+                      containerRunOptions:
+                        result.body.jobSpecification?.jobReleaseTask
+                          ?.containerSettings?.["containerRunOptions"],
+                      imageName:
+                        result.body.jobSpecification?.jobReleaseTask
+                          ?.containerSettings?.["imageName"],
+                      registry: !result.body.jobSpecification?.jobReleaseTask
+                        ?.containerSettings?.registry
+                        ? undefined
+                        : {
+                            username:
+                              result.body.jobSpecification?.jobReleaseTask
+                                ?.containerSettings?.registry?.["username"],
+                            password:
+                              result.body.jobSpecification?.jobReleaseTask
+                                ?.containerSettings?.registry?.["password"],
+                            registryServer:
+                              result.body.jobSpecification?.jobReleaseTask
+                                ?.containerSettings?.registry?.[
+                                "registryServer"
+                              ],
+                            identityReference: !result.body.jobSpecification
+                              ?.jobReleaseTask?.containerSettings?.registry
+                              ?.identityReference
+                              ? undefined
+                              : {
+                                  resourceId:
+                                    result.body.jobSpecification?.jobReleaseTask
+                                      ?.containerSettings?.registry
+                                      ?.identityReference?.["resourceId"],
+                                },
+                          },
+                      workingDirectory:
+                        result.body.jobSpecification?.jobReleaseTask
+                          ?.containerSettings?.["workingDirectory"],
+                    },
+                resourceFiles: (
+                  result.body.jobSpecification?.jobReleaseTask?.[
+                    "resourceFiles"
+                  ] ?? []
+                ).map((p) => ({
+                  autoStorageContainerName: p["autoStorageContainerName"],
+                  storageContainerUrl: p["storageContainerUrl"],
+                  httpUrl: p["httpUrl"],
+                  blobPrefix: p["blobPrefix"],
+                  filePath: p["filePath"],
+                  fileMode: p["fileMode"],
+                  identityReference: !p.identityReference
+                    ? undefined
+                    : { resourceId: p.identityReference?.["resourceId"] },
+                })),
+                environmentSettings: (
+                  result.body.jobSpecification?.jobReleaseTask?.[
+                    "environmentSettings"
+                  ] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+                maxWallClockTime:
+                  result.body.jobSpecification?.jobReleaseTask?.[
+                    "maxWallClockTime"
+                  ],
+                retentionTime:
+                  result.body.jobSpecification?.jobReleaseTask?.[
+                    "retentionTime"
+                  ],
+                userIdentity: !result.body.jobSpecification?.jobReleaseTask
+                  ?.userIdentity
+                  ? undefined
+                  : {
+                      username:
+                        result.body.jobSpecification?.jobReleaseTask
+                          ?.userIdentity?.["username"],
+                      autoUser: !result.body.jobSpecification?.jobReleaseTask
+                        ?.userIdentity?.autoUser
+                        ? undefined
+                        : {
+                            scope:
+                              result.body.jobSpecification?.jobReleaseTask
+                                ?.userIdentity?.autoUser?.["scope"],
+                            elevationLevel:
+                              result.body.jobSpecification?.jobReleaseTask
+                                ?.userIdentity?.autoUser?.["elevationLevel"],
+                          },
+                    },
+              },
+          commonEnvironmentSettings: (
+            result.body.jobSpecification?.["commonEnvironmentSettings"] ?? []
+          ).map((p) => ({ name: p["name"], value: p["value"] })),
+          poolInfo: {
+            poolId: result.body.jobSpecification?.poolInfo["poolId"],
+            autoPoolSpecification: !result.body.jobSpecification?.poolInfo
+              .autoPoolSpecification
+              ? undefined
+              : {
+                  autoPoolIdPrefix:
+                    result.body.jobSpecification?.poolInfo
+                      .autoPoolSpecification?.["autoPoolIdPrefix"],
+                  poolLifetimeOption:
+                    result.body.jobSpecification?.poolInfo
+                      .autoPoolSpecification?.["poolLifetimeOption"],
+                  keepAlive:
+                    result.body.jobSpecification?.poolInfo
+                      .autoPoolSpecification?.["keepAlive"],
+                  pool: !result.body.jobSpecification?.poolInfo
+                    .autoPoolSpecification?.pool
+                    ? undefined
+                    : {
+                        displayName:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["displayName"],
+                        vmSize:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["vmSize"],
+                        cloudServiceConfiguration: !result.body.jobSpecification
+                          ?.poolInfo.autoPoolSpecification?.pool
+                          ?.cloudServiceConfiguration
+                          ? undefined
+                          : {
+                              osFamily:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.cloudServiceConfiguration?.["osFamily"],
+                              osVersion:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.cloudServiceConfiguration?.["osVersion"],
+                            },
+                        virtualMachineConfiguration: !result.body
+                          .jobSpecification?.poolInfo.autoPoolSpecification
+                          ?.pool?.virtualMachineConfiguration
+                          ? undefined
+                          : {
+                              imageReference: {
+                                publisher:
+                                  result.body.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["publisher"],
+                                offer:
+                                  result.body.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["offer"],
+                                sku: result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.imageReference[
+                                  "sku"
+                                ],
+                                version:
+                                  result.body.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["version"],
+                                virtualMachineImageId:
+                                  result.body.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["virtualMachineImageId"],
+                                exactVersion:
+                                  result.body.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["exactVersion"],
+                              },
+                              nodeAgentSKUId:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "nodeAgentSKUId"
+                                ],
+                              windowsConfiguration: !result.body
+                                .jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.windowsConfiguration
+                                ? undefined
+                                : {
+                                    enableAutomaticUpdates:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.windowsConfiguration?.[
+                                        "enableAutomaticUpdates"
+                                      ],
+                                  },
+                              dataDisks: (
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "dataDisks"
+                                ] ?? []
+                              ).map((p) => ({
+                                lun: p["lun"],
+                                caching: p["caching"],
+                                diskSizeGB: p["diskSizeGB"],
+                                storageAccountType: p["storageAccountType"],
+                              })),
+                              licenseType:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "licenseType"
+                                ],
+                              containerConfiguration: !result.body
+                                .jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.containerConfiguration
+                                ? undefined
+                                : {
+                                    type: result.body.jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration
+                                      ?.containerConfiguration?.["type"],
+                                    containerImageNames:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.[
+                                        "containerImageNames"
+                                      ],
+                                    containerRegistries: (
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.[
+                                        "containerRegistries"
+                                      ] ?? []
+                                    ).map((p) => ({
+                                      username: p["username"],
+                                      password: p["password"],
+                                      registryServer: p["registryServer"],
+                                      identityReference: !p.identityReference
+                                        ? undefined
+                                        : {
+                                            resourceId:
+                                              p.identityReference?.[
+                                                "resourceId"
+                                              ],
+                                          },
+                                    })),
+                                  },
+                              diskEncryptionConfiguration: !result.body
+                                .jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.diskEncryptionConfiguration
+                                ? undefined
+                                : {
+                                    targets:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.diskEncryptionConfiguration?.[
+                                        "targets"
+                                      ],
+                                  },
+                              nodePlacementConfiguration: !result.body
+                                .jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration
+                                ?.nodePlacementConfiguration
+                                ? undefined
+                                : {
+                                    policy:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.nodePlacementConfiguration?.[
+                                        "policy"
+                                      ],
+                                  },
+                              extensions: (
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.[
+                                  "extensions"
+                                ] ?? []
+                              ).map((p) => ({
+                                name: p["name"],
+                                publisher: p["publisher"],
+                                type: p["type"],
+                                typeHandlerVersion: p["typeHandlerVersion"],
+                                autoUpgradeMinorVersion:
+                                  p["autoUpgradeMinorVersion"],
+                                settings: !p.settings ? undefined : {},
+                                protectedSettings: !p.protectedSettings
+                                  ? undefined
+                                  : {},
+                                provisionAfterExtensions:
+                                  p["provisionAfterExtensions"],
+                              })),
+                              osDisk: !result.body.jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.virtualMachineConfiguration?.osDisk
+                                ? undefined
+                                : {
+                                    ephemeralOSDiskSettings: !result.body
+                                      .jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration?.osDisk
+                                      ?.ephemeralOSDiskSettings
+                                      ? undefined
+                                      : {
+                                          placement:
+                                            result.body.jobSpecification
+                                              ?.poolInfo.autoPoolSpecification
+                                              ?.pool
+                                              ?.virtualMachineConfiguration
+                                              ?.osDisk
+                                              ?.ephemeralOSDiskSettings?.[
+                                              "placement"
+                                            ],
+                                        },
+                                  },
+                            },
+                        taskSlotsPerNode:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["taskSlotsPerNode"],
+                        taskSchedulingPolicy: !result.body.jobSpecification
+                          ?.poolInfo.autoPoolSpecification?.pool
+                          ?.taskSchedulingPolicy
+                          ? undefined
+                          : {
+                              nodeFillType:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.taskSchedulingPolicy?.["nodeFillType"],
+                            },
+                        resizeTimeout:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["resizeTimeout"],
+                        targetDedicatedNodes:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "targetDedicatedNodes"
+                          ],
+                        targetLowPriorityNodes:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "targetLowPriorityNodes"
+                          ],
+                        enableAutoScale:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["enableAutoScale"],
+                        autoScaleFormula:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["autoScaleFormula"],
+                        autoScaleEvaluationInterval:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "autoScaleEvaluationInterval"
+                          ],
+                        enableInterNodeCommunication:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "enableInterNodeCommunication"
+                          ],
+                        networkConfiguration: !result.body.jobSpecification
+                          ?.poolInfo.autoPoolSpecification?.pool
+                          ?.networkConfiguration
+                          ? undefined
+                          : {
+                              subnetId:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.["subnetId"],
+                              dynamicVNetAssignmentScope:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.[
+                                  "dynamicVNetAssignmentScope"
+                                ],
+                              endpointConfiguration: !result.body
+                                .jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.networkConfiguration?.endpointConfiguration
+                                ? undefined
+                                : {
+                                    inboundNATPools: (
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.endpointConfiguration?.[
+                                        "inboundNATPools"
+                                      ] ?? []
+                                    ).map((p) => ({
+                                      name: p["name"],
+                                      protocol: p["protocol"],
+                                      backendPort: p["backendPort"],
+                                      frontendPortRangeStart:
+                                        p["frontendPortRangeStart"],
+                                      frontendPortRangeEnd:
+                                        p["frontendPortRangeEnd"],
+                                      networkSecurityGroupRules: (
+                                        p["networkSecurityGroupRules"] ?? []
+                                      ).map((p) => ({
+                                        priority: p["priority"],
+                                        access: p["access"],
+                                        sourceAddressPrefix:
+                                          p["sourceAddressPrefix"],
+                                        sourcePortRanges: p["sourcePortRanges"],
+                                      })),
+                                    })),
+                                  },
+                              publicIPAddressConfiguration: !result.body
+                                .jobSpecification?.poolInfo
+                                .autoPoolSpecification?.pool
+                                ?.networkConfiguration
+                                ?.publicIPAddressConfiguration
+                                ? undefined
+                                : {
+                                    provision:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.publicIPAddressConfiguration?.[
+                                        "provision"
+                                      ],
+                                    ipAddressIds:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.networkConfiguration
+                                        ?.publicIPAddressConfiguration?.[
+                                        "ipAddressIds"
+                                      ],
+                                  },
+                            },
+                        startTask: !result.body.jobSpecification?.poolInfo
+                          .autoPoolSpecification?.pool?.startTask
+                          ? undefined
+                          : {
+                              commandLine:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask?.[
+                                  "commandLine"
+                                ],
+                              containerSettings: !result.body.jobSpecification
+                                ?.poolInfo.autoPoolSpecification?.pool
+                                ?.startTask?.containerSettings
+                                ? undefined
+                                : {
+                                    containerRunOptions:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool?.startTask
+                                        ?.containerSettings?.[
+                                        "containerRunOptions"
+                                      ],
+                                    imageName:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool?.startTask
+                                        ?.containerSettings?.["imageName"],
+                                    registry: !result.body.jobSpecification
+                                      ?.poolInfo.autoPoolSpecification?.pool
+                                      ?.startTask?.containerSettings?.registry
+                                      ? undefined
+                                      : {
+                                          username:
+                                            result.body.jobSpecification
+                                              ?.poolInfo.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "username"
+                                            ],
+                                          password:
+                                            result.body.jobSpecification
+                                              ?.poolInfo.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "password"
+                                            ],
+                                          registryServer:
+                                            result.body.jobSpecification
+                                              ?.poolInfo.autoPoolSpecification
+                                              ?.pool?.startTask
+                                              ?.containerSettings?.registry?.[
+                                              "registryServer"
+                                            ],
+                                          identityReference: !result.body
+                                            .jobSpecification?.poolInfo
+                                            .autoPoolSpecification?.pool
+                                            ?.startTask?.containerSettings
+                                            ?.registry?.identityReference
+                                            ? undefined
+                                            : {
+                                                resourceId:
+                                                  result.body.jobSpecification
+                                                    ?.poolInfo
+                                                    .autoPoolSpecification?.pool
+                                                    ?.startTask
+                                                    ?.containerSettings
+                                                    ?.registry
+                                                    ?.identityReference?.[
+                                                    "resourceId"
+                                                  ],
+                                              },
+                                        },
+                                    workingDirectory:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool?.startTask
+                                        ?.containerSettings?.[
+                                        "workingDirectory"
+                                      ],
+                                  },
+                              resourceFiles: (
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask?.[
+                                  "resourceFiles"
+                                ] ?? []
+                              ).map((p) => ({
+                                autoStorageContainerName:
+                                  p["autoStorageContainerName"],
+                                storageContainerUrl: p["storageContainerUrl"],
+                                httpUrl: p["httpUrl"],
+                                blobPrefix: p["blobPrefix"],
+                                filePath: p["filePath"],
+                                fileMode: p["fileMode"],
+                                identityReference: !p.identityReference
+                                  ? undefined
+                                  : {
+                                      resourceId:
+                                        p.identityReference?.["resourceId"],
+                                    },
+                              })),
+                              environmentSettings: (
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask?.[
+                                  "environmentSettings"
+                                ] ?? []
+                              ).map((p) => ({
+                                name: p["name"],
+                                value: p["value"],
+                              })),
+                              userIdentity: !result.body.jobSpecification
+                                ?.poolInfo.autoPoolSpecification?.pool
+                                ?.startTask?.userIdentity
+                                ? undefined
+                                : {
+                                    username:
+                                      result.body.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool?.startTask
+                                        ?.userIdentity?.["username"],
+                                    autoUser: !result.body.jobSpecification
+                                      ?.poolInfo.autoPoolSpecification?.pool
+                                      ?.startTask?.userIdentity?.autoUser
+                                      ? undefined
+                                      : {
+                                          scope:
+                                            result.body.jobSpecification
+                                              ?.poolInfo.autoPoolSpecification
+                                              ?.pool?.startTask?.userIdentity
+                                              ?.autoUser?.["scope"],
+                                          elevationLevel:
+                                            result.body.jobSpecification
+                                              ?.poolInfo.autoPoolSpecification
+                                              ?.pool?.startTask?.userIdentity
+                                              ?.autoUser?.["elevationLevel"],
+                                        },
+                                  },
+                              maxTaskRetryCount:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask?.[
+                                  "maxTaskRetryCount"
+                                ],
+                              waitForSuccess:
+                                result.body.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask?.[
+                                  "waitForSuccess"
+                                ],
+                            },
+                        certificateReferences: (
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "certificateReferences"
+                          ] ?? []
+                        ).map((p) => ({
+                          thumbprint: p["thumbprint"],
+                          thumbprintAlgorithm: p["thumbprintAlgorithm"],
+                          storeLocation: p["storeLocation"],
+                          storeName: p["storeName"],
+                          visibility: p["visibility"],
+                        })),
+                        applicationPackageReferences: (
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "applicationPackageReferences"
+                          ] ?? []
+                        ).map((p) => ({
+                          applicationId: p["applicationId"],
+                          version: p["version"],
+                        })),
+                        applicationLicenses:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "applicationLicenses"
+                          ],
+                        userAccounts: (
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["userAccounts"] ?? []
+                        ).map((p) => ({
+                          name: p["name"],
+                          password: p["password"],
+                          elevationLevel: p["elevationLevel"],
+                          linuxUserConfiguration: !p.linuxUserConfiguration
+                            ? undefined
+                            : {
+                                uid: p.linuxUserConfiguration?.["uid"],
+                                gid: p.linuxUserConfiguration?.["gid"],
+                                sshPrivateKey:
+                                  p.linuxUserConfiguration?.["sshPrivateKey"],
+                              },
+                          windowsUserConfiguration: !p.windowsUserConfiguration
+                            ? undefined
+                            : {
+                                loginMode:
+                                  p.windowsUserConfiguration?.["loginMode"],
+                              },
+                        })),
+                        metadata: (
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.["metadata"] ?? []
+                        ).map((p) => ({ name: p["name"], value: p["value"] })),
+                        mountConfiguration: (
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "mountConfiguration"
+                          ] ?? []
+                        ).map((p) => ({
+                          azureBlobFileSystemConfiguration:
+                            !p.azureBlobFileSystemConfiguration
+                              ? undefined
+                              : {
+                                  accountName:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "accountName"
+                                    ],
+                                  containerName:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "containerName"
+                                    ],
+                                  accountKey:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "accountKey"
+                                    ],
+                                  sasKey:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "sasKey"
+                                    ],
+                                  blobfuseOptions:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "blobfuseOptions"
+                                    ],
+                                  relativeMountPath:
+                                    p.azureBlobFileSystemConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  identityReference: !p
+                                    .azureBlobFileSystemConfiguration
+                                    ?.identityReference
+                                    ? undefined
+                                    : {
+                                        resourceId:
+                                          p.azureBlobFileSystemConfiguration
+                                            ?.identityReference?.["resourceId"],
+                                      },
+                                },
+                          nfsMountConfiguration: !p.nfsMountConfiguration
+                            ? undefined
+                            : {
+                                source: p.nfsMountConfiguration?.["source"],
+                                relativeMountPath:
+                                  p.nfsMountConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.nfsMountConfiguration?.["mountOptions"],
+                              },
+                          cifsMountConfiguration: !p.cifsMountConfiguration
+                            ? undefined
+                            : {
+                                username:
+                                  p.cifsMountConfiguration?.["username"],
+                                source: p.cifsMountConfiguration?.["source"],
+                                relativeMountPath:
+                                  p.cifsMountConfiguration?.[
+                                    "relativeMountPath"
+                                  ],
+                                mountOptions:
+                                  p.cifsMountConfiguration?.["mountOptions"],
+                                password:
+                                  p.cifsMountConfiguration?.["password"],
+                              },
+                          azureFileShareConfiguration:
+                            !p.azureFileShareConfiguration
+                              ? undefined
+                              : {
+                                  accountName:
+                                    p.azureFileShareConfiguration?.[
+                                      "accountName"
+                                    ],
+                                  azureFileUrl:
+                                    p.azureFileShareConfiguration?.[
+                                      "azureFileUrl"
+                                    ],
+                                  accountKey:
+                                    p.azureFileShareConfiguration?.[
+                                      "accountKey"
+                                    ],
+                                  relativeMountPath:
+                                    p.azureFileShareConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  mountOptions:
+                                    p.azureFileShareConfiguration?.[
+                                      "mountOptions"
+                                    ],
+                                },
+                        })),
+                        targetNodeCommunicationMode:
+                          result.body.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.[
+                            "targetNodeCommunicationMode"
+                          ],
+                      },
+                },
+          },
+          metadata: (result.body.jobSpecification?.["metadata"] ?? []).map(
+            (p) => ({ name: p["name"], value: p["value"] })
+          ),
+        },
+    executionInfo: !result.body.executionInfo
+      ? undefined
+      : {
+          nextRunTime: new Date(
+            result.body.executionInfo?.["nextRunTime"] ?? ""
+          ),
+          recentJob: !result.body.executionInfo?.recentJob
+            ? undefined
+            : {
+                id: result.body.executionInfo?.recentJob?.["id"],
+                url: result.body.executionInfo?.recentJob?.["url"],
+              },
+          endTime: new Date(result.body.executionInfo?.["endTime"] ?? ""),
+        },
+    metadata: (result.body["metadata"] ?? []).map((p) => ({
+      name: p["name"],
+      value: p["value"],
+    })),
+    stats: !result.body.stats
+      ? undefined
+      : {
+          url: result.body.stats?.["url"],
+          startTime: new Date(result.body.stats?.["startTime"] ?? ""),
+          lastUpdateTime: new Date(result.body.stats?.["lastUpdateTime"] ?? ""),
+          userCPUTime: result.body.stats?.["userCPUTime"],
+          kernelCPUTime: result.body.stats?.["kernelCPUTime"],
+          wallClockTime: result.body.stats?.["wallClockTime"],
+          readIOps: result.body.stats?.["readIOps"],
+          writeIOps: result.body.stats?.["writeIOps"],
+          readIOGiB: result.body.stats?.["readIOGiB"],
+          writeIOGiB: result.body.stats?.["writeIOGiB"],
+          numSucceededTasks: result.body.stats?.["numSucceededTasks"],
+          numFailedTasks: result.body.stats?.["numFailedTasks"],
+          numTaskRetries: result.body.stats?.["numTaskRetries"],
+          waitTime: result.body.stats?.["waitTime"],
+        },
+  };
+}
+
+export interface Jobschedulepatchjobscheduleoptions extends RequestOptions {
+  /** A string that uniquely identifies the schedule within the Account. */
+  id?: string;
+  /** The display name for the schedule. */
+  displayName?: string;
+  /** The URL of the Job Schedule. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Job Schedule has
+   * changed between requests. In particular, you can be pass the ETag with an
+   * Update Job Schedule request to specify that your changes should take effect
+   * only if nobody else has modified the schedule in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the schedule level data, such as the Job
+   * specification or recurrence information, changed. It does not factor in
+   * job-level changes such as new Jobs being created or Jobs changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Job Schedule. */
+  creationTime?: Date;
+  /** The state of the Job Schedule. */
+  state?: JobScheduleState;
+  /** The time at which the Job Schedule entered the current state. */
+  stateTransitionTime?: Date;
+  /** This property is not present if the Job Schedule is in its initial active state. */
+  previousState?: JobScheduleState;
+  /** This property is not present if the Job Schedule is in its initial active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * All times are fixed respective to UTC and are not impacted by daylight saving
+   * time.
+   */
+  schedule?: Schedule;
+  /** Specifies details of the Jobs to be created on a schedule. */
+  jobSpecification?: JobSpecification;
+  /**
+   * Contains information about Jobs that have been and will be run under a Job
+   * Schedule.
+   */
+  executionInfo?: JobScheduleExecutionInformation;
+  /**
+   * The Batch service does not assign any meaning to metadata; it is solely for the
+   * use of user code.
+   */
+  metadata?: MetadataItem[];
+  /** Resource usage statistics for a Job Schedule. */
+  stats?: JobScheduleStatistics;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This replaces only the Job Schedule properties specified in the request. For
+ * example, if the schedule property is not specified with this request, then the
+ * Batch service will keep the existing schedule. Changes to a Job Schedule only
+ * impact Jobs created by the schedule after the update has taken place; currently
+ * running Jobs are unaffected.
+ */
+export async function patchJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobschedulepatchjobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}", jobScheduleId)
+    .patch({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.schedule && { schedule: options.schedule }),
+        ...(options.jobSpecification && {
+          jobSpecification: options.jobSpecification,
+        }),
+        ...(options.metadata && { metadata: options.metadata }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobscheduleupdatejobscheduleoptions extends RequestOptions {
+  /** A string that uniquely identifies the schedule within the Account. */
+  id?: string;
+  /** The display name for the schedule. */
+  displayName?: string;
+  /** The URL of the Job Schedule. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Job Schedule has
+   * changed between requests. In particular, you can be pass the ETag with an
+   * Update Job Schedule request to specify that your changes should take effect
+   * only if nobody else has modified the schedule in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the schedule level data, such as the Job
+   * specification or recurrence information, changed. It does not factor in
+   * job-level changes such as new Jobs being created or Jobs changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Job Schedule. */
+  creationTime?: Date;
+  /** The state of the Job Schedule. */
+  state?: JobScheduleState;
+  /** The time at which the Job Schedule entered the current state. */
+  stateTransitionTime?: Date;
+  /** This property is not present if the Job Schedule is in its initial active state. */
+  previousState?: JobScheduleState;
+  /** This property is not present if the Job Schedule is in its initial active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * All times are fixed respective to UTC and are not impacted by daylight saving
+   * time.
+   */
+  schedule?: Schedule;
+  /** Specifies details of the Jobs to be created on a schedule. */
+  jobSpecification?: JobSpecification;
+  /**
+   * Contains information about Jobs that have been and will be run under a Job
+   * Schedule.
+   */
+  executionInfo?: JobScheduleExecutionInformation;
+  /**
+   * The Batch service does not assign any meaning to metadata; it is solely for the
+   * use of user code.
+   */
+  metadata?: MetadataItem[];
+  /** Resource usage statistics for a Job Schedule. */
+  stats?: JobScheduleStatistics;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This fully replaces all the updatable properties of the Job Schedule. For
+ * example, if the schedule property is not specified with this request, then the
+ * Batch service will remove the existing schedule. Changes to a Job Schedule only
+ * impact Jobs created by the schedule after the update has taken place; currently
+ * running Jobs are unaffected.
+ */
+export async function updateJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobscheduleupdatejobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}", jobScheduleId)
+    .put({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.schedule && { schedule: options.schedule }),
+        ...(options.jobSpecification && {
+          jobSpecification: options.jobSpecification,
+        }),
+        ...(options.metadata && { metadata: options.metadata }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobscheduledisablejobscheduleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** No new Jobs will be created until the Job Schedule is enabled again. */
+export async function disableJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobscheduledisablejobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}/disable", jobScheduleId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobscheduleenablejobscheduleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** Enables a Job Schedule. */
+export async function enableJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobscheduleenablejobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}/enable", jobScheduleId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobscheduleterminatejobscheduleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** Terminates a Job Schedule. */
+export async function terminateJobSchedule(
+  context: Client,
+  jobScheduleId: string,
+  options: Jobscheduleterminatejobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobschedules/{jobScheduleId}/terminate", jobScheduleId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobscheduleaddjobscheduleoptions extends RequestOptions {
+  /** A string that uniquely identifies the schedule within the Account. */
+  id?: string;
+  /** The display name for the schedule. */
+  displayName?: string;
+  /** The URL of the Job Schedule. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Job Schedule has
+   * changed between requests. In particular, you can be pass the ETag with an
+   * Update Job Schedule request to specify that your changes should take effect
+   * only if nobody else has modified the schedule in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the schedule level data, such as the Job
+   * specification or recurrence information, changed. It does not factor in
+   * job-level changes such as new Jobs being created or Jobs changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Job Schedule. */
+  creationTime?: Date;
+  /** The state of the Job Schedule. */
+  state?: JobScheduleState;
+  /** The time at which the Job Schedule entered the current state. */
+  stateTransitionTime?: Date;
+  /** This property is not present if the Job Schedule is in its initial active state. */
+  previousState?: JobScheduleState;
+  /** This property is not present if the Job Schedule is in its initial active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * All times are fixed respective to UTC and are not impacted by daylight saving
+   * time.
+   */
+  schedule?: Schedule;
+  /** Specifies details of the Jobs to be created on a schedule. */
+  jobSpecification?: JobSpecification;
+  /**
+   * Contains information about Jobs that have been and will be run under a Job
+   * Schedule.
+   */
+  executionInfo?: JobScheduleExecutionInformation;
+  /**
+   * The Batch service does not assign any meaning to metadata; it is solely for the
+   * use of user code.
+   */
+  metadata?: MetadataItem[];
+  /** Resource usage statistics for a Job Schedule. */
+  stats?: JobScheduleStatistics;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/** Adds a Job Schedule to the specified Account. */
+export async function addJobSchedule(
+  context: Client,
+  options: Jobscheduleaddjobscheduleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobschedules").post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.schedule && { schedule: options.schedule }),
+      ...(options.jobSpecification && {
+        jobSpecification: options.jobSpecification,
+      }),
+      ...(options.metadata && { metadata: options.metadata }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Jobschedulelistjobschedulesoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-job-schedules.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Lists all of the Job Schedules in the specified Account. */
+export async function listJobSchedules(
+  context: Client,
+  options: Jobschedulelistjobschedulesoptions = { requestOptions: {} }
+): Promise<BatchJobScheduleListResult> {
+  const result = await context.path("/jobschedules").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+      ...(options.$select && { $select: options.$select }),
+      ...(options.$expand && { $expand: options.$expand }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      displayName: p["displayName"],
+      url: p["url"],
+      eTag: p["eTag"],
+      lastModified: new Date(p["lastModified"] ?? ""),
+      creationTime: new Date(p["creationTime"] ?? ""),
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      previousState: p["previousState"],
+      previousStateTransitionTime: new Date(
+        p["previousStateTransitionTime"] ?? ""
+      ),
+      schedule: !p.schedule
+        ? undefined
+        : {
+            doNotRunUntil: new Date(p.schedule?.["doNotRunUntil"] ?? ""),
+            doNotRunAfter: new Date(p.schedule?.["doNotRunAfter"] ?? ""),
+            startWindow: p.schedule?.["startWindow"],
+            recurrenceInterval: p.schedule?.["recurrenceInterval"],
+          },
+      jobSpecification: !p.jobSpecification
+        ? undefined
+        : {
+            priority: p.jobSpecification?.["priority"],
+            allowTaskPreemption: p.jobSpecification?.["allowTaskPreemption"],
+            maxParallelTasks: p.jobSpecification?.["maxParallelTasks"],
+            displayName: p.jobSpecification?.["displayName"],
+            usesTaskDependencies: p.jobSpecification?.["usesTaskDependencies"],
+            onAllTasksComplete: p.jobSpecification?.["onAllTasksComplete"],
+            onTaskFailure: p.jobSpecification?.["onTaskFailure"],
+            networkConfiguration: !p.jobSpecification?.networkConfiguration
+              ? undefined
+              : {
+                  subnetId:
+                    p.jobSpecification?.networkConfiguration?.["subnetId"],
+                },
+            constraints: !p.jobSpecification?.constraints
+              ? undefined
+              : {
+                  maxWallClockTime:
+                    p.jobSpecification?.constraints?.["maxWallClockTime"],
+                  maxTaskRetryCount:
+                    p.jobSpecification?.constraints?.["maxTaskRetryCount"],
+                },
+            jobManagerTask: !p.jobSpecification?.jobManagerTask
+              ? undefined
+              : {
+                  id: p.jobSpecification?.jobManagerTask?.["id"],
+                  displayName:
+                    p.jobSpecification?.jobManagerTask?.["displayName"],
+                  commandLine:
+                    p.jobSpecification?.jobManagerTask?.["commandLine"],
+                  containerSettings: !p.jobSpecification?.jobManagerTask
+                    ?.containerSettings
+                    ? undefined
+                    : {
+                        containerRunOptions:
+                          p.jobSpecification?.jobManagerTask
+                            ?.containerSettings?.["containerRunOptions"],
+                        imageName:
+                          p.jobSpecification?.jobManagerTask
+                            ?.containerSettings?.["imageName"],
+                        registry: !p.jobSpecification?.jobManagerTask
+                          ?.containerSettings?.registry
+                          ? undefined
+                          : {
+                              username:
+                                p.jobSpecification?.jobManagerTask
+                                  ?.containerSettings?.registry?.["username"],
+                              password:
+                                p.jobSpecification?.jobManagerTask
+                                  ?.containerSettings?.registry?.["password"],
+                              registryServer:
+                                p.jobSpecification?.jobManagerTask
+                                  ?.containerSettings?.registry?.[
+                                  "registryServer"
+                                ],
+                              identityReference: !p.jobSpecification
+                                ?.jobManagerTask?.containerSettings?.registry
+                                ?.identityReference
+                                ? undefined
+                                : {
+                                    resourceId:
+                                      p.jobSpecification?.jobManagerTask
+                                        ?.containerSettings?.registry
+                                        ?.identityReference?.["resourceId"],
+                                  },
+                            },
+                        workingDirectory:
+                          p.jobSpecification?.jobManagerTask
+                            ?.containerSettings?.["workingDirectory"],
+                      },
+                  resourceFiles: (
+                    p.jobSpecification?.jobManagerTask?.["resourceFiles"] ?? []
+                  ).map((p) => ({
+                    autoStorageContainerName: p["autoStorageContainerName"],
+                    storageContainerUrl: p["storageContainerUrl"],
+                    httpUrl: p["httpUrl"],
+                    blobPrefix: p["blobPrefix"],
+                    filePath: p["filePath"],
+                    fileMode: p["fileMode"],
+                    identityReference: !p.identityReference
+                      ? undefined
+                      : { resourceId: p.identityReference?.["resourceId"] },
+                  })),
+                  outputFiles: (
+                    p.jobSpecification?.jobManagerTask?.["outputFiles"] ?? []
+                  ).map((p) => ({
+                    filePattern: p["filePattern"],
+                    destination: {
+                      container: !p.destination.container
+                        ? undefined
+                        : {
+                            path: p.destination.container?.["path"],
+                            containerUrl:
+                              p.destination.container?.["containerUrl"],
+                            identityReference: !p.destination.container
+                              ?.identityReference
+                              ? undefined
+                              : {
+                                  resourceId:
+                                    p.destination.container
+                                      ?.identityReference?.["resourceId"],
+                                },
+                            uploadHeaders: (
+                              p.destination.container?.["uploadHeaders"] ?? []
+                            ).map((p) => ({
+                              name: p["name"],
+                              value: p["value"],
+                            })),
+                          },
+                    },
+                    uploadOptions: {
+                      uploadCondition: p.uploadOptions["uploadCondition"],
+                    },
+                  })),
+                  environmentSettings: (
+                    p.jobSpecification?.jobManagerTask?.[
+                      "environmentSettings"
+                    ] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                  constraints: !p.jobSpecification?.jobManagerTask?.constraints
+                    ? undefined
+                    : {
+                        maxWallClockTime:
+                          p.jobSpecification?.jobManagerTask?.constraints?.[
+                            "maxWallClockTime"
+                          ],
+                        retentionTime:
+                          p.jobSpecification?.jobManagerTask?.constraints?.[
+                            "retentionTime"
+                          ],
+                        maxTaskRetryCount:
+                          p.jobSpecification?.jobManagerTask?.constraints?.[
+                            "maxTaskRetryCount"
+                          ],
+                      },
+                  requiredSlots:
+                    p.jobSpecification?.jobManagerTask?.["requiredSlots"],
+                  killJobOnCompletion:
+                    p.jobSpecification?.jobManagerTask?.["killJobOnCompletion"],
+                  userIdentity: !p.jobSpecification?.jobManagerTask
+                    ?.userIdentity
+                    ? undefined
+                    : {
+                        username:
+                          p.jobSpecification?.jobManagerTask?.userIdentity?.[
+                            "username"
+                          ],
+                        autoUser: !p.jobSpecification?.jobManagerTask
+                          ?.userIdentity?.autoUser
+                          ? undefined
+                          : {
+                              scope:
+                                p.jobSpecification?.jobManagerTask?.userIdentity
+                                  ?.autoUser?.["scope"],
+                              elevationLevel:
+                                p.jobSpecification?.jobManagerTask?.userIdentity
+                                  ?.autoUser?.["elevationLevel"],
+                            },
+                      },
+                  runExclusive:
+                    p.jobSpecification?.jobManagerTask?.["runExclusive"],
+                  applicationPackageReferences: (
+                    p.jobSpecification?.jobManagerTask?.[
+                      "applicationPackageReferences"
+                    ] ?? []
+                  ).map((p) => ({
+                    applicationId: p["applicationId"],
+                    version: p["version"],
+                  })),
+                  authenticationTokenSettings: !p.jobSpecification
+                    ?.jobManagerTask?.authenticationTokenSettings
+                    ? undefined
+                    : {
+                        access:
+                          p.jobSpecification?.jobManagerTask
+                            ?.authenticationTokenSettings?.["access"],
+                      },
+                  allowLowPriorityNode:
+                    p.jobSpecification?.jobManagerTask?.[
+                      "allowLowPriorityNode"
+                    ],
+                },
+            jobPreparationTask: !p.jobSpecification?.jobPreparationTask
+              ? undefined
+              : {
+                  id: p.jobSpecification?.jobPreparationTask?.["id"],
+                  commandLine:
+                    p.jobSpecification?.jobPreparationTask?.["commandLine"],
+                  containerSettings: !p.jobSpecification?.jobPreparationTask
+                    ?.containerSettings
+                    ? undefined
+                    : {
+                        containerRunOptions:
+                          p.jobSpecification?.jobPreparationTask
+                            ?.containerSettings?.["containerRunOptions"],
+                        imageName:
+                          p.jobSpecification?.jobPreparationTask
+                            ?.containerSettings?.["imageName"],
+                        registry: !p.jobSpecification?.jobPreparationTask
+                          ?.containerSettings?.registry
+                          ? undefined
+                          : {
+                              username:
+                                p.jobSpecification?.jobPreparationTask
+                                  ?.containerSettings?.registry?.["username"],
+                              password:
+                                p.jobSpecification?.jobPreparationTask
+                                  ?.containerSettings?.registry?.["password"],
+                              registryServer:
+                                p.jobSpecification?.jobPreparationTask
+                                  ?.containerSettings?.registry?.[
+                                  "registryServer"
+                                ],
+                              identityReference: !p.jobSpecification
+                                ?.jobPreparationTask?.containerSettings
+                                ?.registry?.identityReference
+                                ? undefined
+                                : {
+                                    resourceId:
+                                      p.jobSpecification?.jobPreparationTask
+                                        ?.containerSettings?.registry
+                                        ?.identityReference?.["resourceId"],
+                                  },
+                            },
+                        workingDirectory:
+                          p.jobSpecification?.jobPreparationTask
+                            ?.containerSettings?.["workingDirectory"],
+                      },
+                  resourceFiles: (
+                    p.jobSpecification?.jobPreparationTask?.["resourceFiles"] ??
+                    []
+                  ).map((p) => ({
+                    autoStorageContainerName: p["autoStorageContainerName"],
+                    storageContainerUrl: p["storageContainerUrl"],
+                    httpUrl: p["httpUrl"],
+                    blobPrefix: p["blobPrefix"],
+                    filePath: p["filePath"],
+                    fileMode: p["fileMode"],
+                    identityReference: !p.identityReference
+                      ? undefined
+                      : { resourceId: p.identityReference?.["resourceId"] },
+                  })),
+                  environmentSettings: (
+                    p.jobSpecification?.jobPreparationTask?.[
+                      "environmentSettings"
+                    ] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                  constraints: !p.jobSpecification?.jobPreparationTask
+                    ?.constraints
+                    ? undefined
+                    : {
+                        maxWallClockTime:
+                          p.jobSpecification?.jobPreparationTask?.constraints?.[
+                            "maxWallClockTime"
+                          ],
+                        retentionTime:
+                          p.jobSpecification?.jobPreparationTask?.constraints?.[
+                            "retentionTime"
+                          ],
+                        maxTaskRetryCount:
+                          p.jobSpecification?.jobPreparationTask?.constraints?.[
+                            "maxTaskRetryCount"
+                          ],
+                      },
+                  waitForSuccess:
+                    p.jobSpecification?.jobPreparationTask?.["waitForSuccess"],
+                  userIdentity: !p.jobSpecification?.jobPreparationTask
+                    ?.userIdentity
+                    ? undefined
+                    : {
+                        username:
+                          p.jobSpecification?.jobPreparationTask
+                            ?.userIdentity?.["username"],
+                        autoUser: !p.jobSpecification?.jobPreparationTask
+                          ?.userIdentity?.autoUser
+                          ? undefined
+                          : {
+                              scope:
+                                p.jobSpecification?.jobPreparationTask
+                                  ?.userIdentity?.autoUser?.["scope"],
+                              elevationLevel:
+                                p.jobSpecification?.jobPreparationTask
+                                  ?.userIdentity?.autoUser?.["elevationLevel"],
+                            },
+                      },
+                  rerunOnNodeRebootAfterSuccess:
+                    p.jobSpecification?.jobPreparationTask?.[
+                      "rerunOnNodeRebootAfterSuccess"
+                    ],
+                },
+            jobReleaseTask: !p.jobSpecification?.jobReleaseTask
+              ? undefined
+              : {
+                  id: p.jobSpecification?.jobReleaseTask?.["id"],
+                  commandLine:
+                    p.jobSpecification?.jobReleaseTask?.["commandLine"],
+                  containerSettings: !p.jobSpecification?.jobReleaseTask
+                    ?.containerSettings
+                    ? undefined
+                    : {
+                        containerRunOptions:
+                          p.jobSpecification?.jobReleaseTask
+                            ?.containerSettings?.["containerRunOptions"],
+                        imageName:
+                          p.jobSpecification?.jobReleaseTask
+                            ?.containerSettings?.["imageName"],
+                        registry: !p.jobSpecification?.jobReleaseTask
+                          ?.containerSettings?.registry
+                          ? undefined
+                          : {
+                              username:
+                                p.jobSpecification?.jobReleaseTask
+                                  ?.containerSettings?.registry?.["username"],
+                              password:
+                                p.jobSpecification?.jobReleaseTask
+                                  ?.containerSettings?.registry?.["password"],
+                              registryServer:
+                                p.jobSpecification?.jobReleaseTask
+                                  ?.containerSettings?.registry?.[
+                                  "registryServer"
+                                ],
+                              identityReference: !p.jobSpecification
+                                ?.jobReleaseTask?.containerSettings?.registry
+                                ?.identityReference
+                                ? undefined
+                                : {
+                                    resourceId:
+                                      p.jobSpecification?.jobReleaseTask
+                                        ?.containerSettings?.registry
+                                        ?.identityReference?.["resourceId"],
+                                  },
+                            },
+                        workingDirectory:
+                          p.jobSpecification?.jobReleaseTask
+                            ?.containerSettings?.["workingDirectory"],
+                      },
+                  resourceFiles: (
+                    p.jobSpecification?.jobReleaseTask?.["resourceFiles"] ?? []
+                  ).map((p) => ({
+                    autoStorageContainerName: p["autoStorageContainerName"],
+                    storageContainerUrl: p["storageContainerUrl"],
+                    httpUrl: p["httpUrl"],
+                    blobPrefix: p["blobPrefix"],
+                    filePath: p["filePath"],
+                    fileMode: p["fileMode"],
+                    identityReference: !p.identityReference
+                      ? undefined
+                      : { resourceId: p.identityReference?.["resourceId"] },
+                  })),
+                  environmentSettings: (
+                    p.jobSpecification?.jobReleaseTask?.[
+                      "environmentSettings"
+                    ] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                  maxWallClockTime:
+                    p.jobSpecification?.jobReleaseTask?.["maxWallClockTime"],
+                  retentionTime:
+                    p.jobSpecification?.jobReleaseTask?.["retentionTime"],
+                  userIdentity: !p.jobSpecification?.jobReleaseTask
+                    ?.userIdentity
+                    ? undefined
+                    : {
+                        username:
+                          p.jobSpecification?.jobReleaseTask?.userIdentity?.[
+                            "username"
+                          ],
+                        autoUser: !p.jobSpecification?.jobReleaseTask
+                          ?.userIdentity?.autoUser
+                          ? undefined
+                          : {
+                              scope:
+                                p.jobSpecification?.jobReleaseTask?.userIdentity
+                                  ?.autoUser?.["scope"],
+                              elevationLevel:
+                                p.jobSpecification?.jobReleaseTask?.userIdentity
+                                  ?.autoUser?.["elevationLevel"],
+                            },
+                      },
+                },
+            commonEnvironmentSettings: (
+              p.jobSpecification?.["commonEnvironmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            poolInfo: {
+              poolId: p.jobSpecification?.poolInfo["poolId"],
+              autoPoolSpecification: !p.jobSpecification?.poolInfo
+                .autoPoolSpecification
+                ? undefined
+                : {
+                    autoPoolIdPrefix:
+                      p.jobSpecification?.poolInfo.autoPoolSpecification?.[
+                        "autoPoolIdPrefix"
+                      ],
+                    poolLifetimeOption:
+                      p.jobSpecification?.poolInfo.autoPoolSpecification?.[
+                        "poolLifetimeOption"
+                      ],
+                    keepAlive:
+                      p.jobSpecification?.poolInfo.autoPoolSpecification?.[
+                        "keepAlive"
+                      ],
+                    pool: !p.jobSpecification?.poolInfo.autoPoolSpecification
+                      ?.pool
+                      ? undefined
+                      : {
+                          displayName:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["displayName"],
+                          vmSize:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["vmSize"],
+                          cloudServiceConfiguration: !p.jobSpecification
+                            ?.poolInfo.autoPoolSpecification?.pool
+                            ?.cloudServiceConfiguration
+                            ? undefined
+                            : {
+                                osFamily:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.cloudServiceConfiguration?.["osFamily"],
+                                osVersion:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.cloudServiceConfiguration?.["osVersion"],
+                              },
+                          virtualMachineConfiguration: !p.jobSpecification
+                            ?.poolInfo.autoPoolSpecification?.pool
+                            ?.virtualMachineConfiguration
+                            ? undefined
+                            : {
+                                imageReference: {
+                                  publisher:
+                                    p.jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration
+                                      ?.imageReference["publisher"],
+                                  offer:
+                                    p.jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration
+                                      ?.imageReference["offer"],
+                                  sku: p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration
+                                    ?.imageReference["sku"],
+                                  version:
+                                    p.jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration
+                                      ?.imageReference["version"],
+                                  virtualMachineImageId:
+                                    p.jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration
+                                      ?.imageReference["virtualMachineImageId"],
+                                  exactVersion:
+                                    p.jobSpecification?.poolInfo
+                                      .autoPoolSpecification?.pool
+                                      ?.virtualMachineConfiguration
+                                      ?.imageReference["exactVersion"],
+                                },
+                                nodeAgentSKUId:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration?.[
+                                    "nodeAgentSKUId"
+                                  ],
+                                windowsConfiguration: !p.jobSpecification
+                                  ?.poolInfo.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration
+                                  ?.windowsConfiguration
+                                  ? undefined
+                                  : {
+                                      enableAutomaticUpdates:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.virtualMachineConfiguration
+                                          ?.windowsConfiguration?.[
+                                          "enableAutomaticUpdates"
+                                        ],
+                                    },
+                                dataDisks: (
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration?.[
+                                    "dataDisks"
+                                  ] ?? []
+                                ).map((p) => ({
+                                  lun: p["lun"],
+                                  caching: p["caching"],
+                                  diskSizeGB: p["diskSizeGB"],
+                                  storageAccountType: p["storageAccountType"],
+                                })),
+                                licenseType:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration?.[
+                                    "licenseType"
+                                  ],
+                                containerConfiguration: !p.jobSpecification
+                                  ?.poolInfo.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration
+                                  ?.containerConfiguration
+                                  ? undefined
+                                  : {
+                                      type: p.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration
+                                        ?.containerConfiguration?.["type"],
+                                      containerImageNames:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.virtualMachineConfiguration
+                                          ?.containerConfiguration?.[
+                                          "containerImageNames"
+                                        ],
+                                      containerRegistries: (
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.virtualMachineConfiguration
+                                          ?.containerConfiguration?.[
+                                          "containerRegistries"
+                                        ] ?? []
+                                      ).map((p) => ({
+                                        username: p["username"],
+                                        password: p["password"],
+                                        registryServer: p["registryServer"],
+                                        identityReference: !p.identityReference
+                                          ? undefined
+                                          : {
+                                              resourceId:
+                                                p.identityReference?.[
+                                                  "resourceId"
+                                                ],
+                                            },
+                                      })),
+                                    },
+                                diskEncryptionConfiguration: !p.jobSpecification
+                                  ?.poolInfo.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration
+                                  ?.diskEncryptionConfiguration
+                                  ? undefined
+                                  : {
+                                      targets:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.virtualMachineConfiguration
+                                          ?.diskEncryptionConfiguration?.[
+                                          "targets"
+                                        ],
+                                    },
+                                nodePlacementConfiguration: !p.jobSpecification
+                                  ?.poolInfo.autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration
+                                  ?.nodePlacementConfiguration
+                                  ? undefined
+                                  : {
+                                      policy:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.virtualMachineConfiguration
+                                          ?.nodePlacementConfiguration?.[
+                                          "policy"
+                                        ],
+                                    },
+                                extensions: (
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.virtualMachineConfiguration?.[
+                                    "extensions"
+                                  ] ?? []
+                                ).map((p) => ({
+                                  name: p["name"],
+                                  publisher: p["publisher"],
+                                  type: p["type"],
+                                  typeHandlerVersion: p["typeHandlerVersion"],
+                                  autoUpgradeMinorVersion:
+                                    p["autoUpgradeMinorVersion"],
+                                  settings: !p.settings ? undefined : {},
+                                  protectedSettings: !p.protectedSettings
+                                    ? undefined
+                                    : {},
+                                  provisionAfterExtensions:
+                                    p["provisionAfterExtensions"],
+                                })),
+                                osDisk: !p.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.virtualMachineConfiguration?.osDisk
+                                  ? undefined
+                                  : {
+                                      ephemeralOSDiskSettings: !p
+                                        .jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool
+                                        ?.virtualMachineConfiguration?.osDisk
+                                        ?.ephemeralOSDiskSettings
+                                        ? undefined
+                                        : {
+                                            placement:
+                                              p.jobSpecification?.poolInfo
+                                                .autoPoolSpecification?.pool
+                                                ?.virtualMachineConfiguration
+                                                ?.osDisk
+                                                ?.ephemeralOSDiskSettings?.[
+                                                "placement"
+                                              ],
+                                          },
+                                    },
+                              },
+                          taskSlotsPerNode:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["taskSlotsPerNode"],
+                          taskSchedulingPolicy: !p.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.taskSchedulingPolicy
+                            ? undefined
+                            : {
+                                nodeFillType:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.taskSchedulingPolicy?.["nodeFillType"],
+                              },
+                          resizeTimeout:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["resizeTimeout"],
+                          targetDedicatedNodes:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["targetDedicatedNodes"],
+                          targetLowPriorityNodes:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["targetLowPriorityNodes"],
+                          enableAutoScale:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["enableAutoScale"],
+                          autoScaleFormula:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["autoScaleFormula"],
+                          autoScaleEvaluationInterval:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["autoScaleEvaluationInterval"],
+                          enableInterNodeCommunication:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["enableInterNodeCommunication"],
+                          networkConfiguration: !p.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.networkConfiguration
+                            ? undefined
+                            : {
+                                subnetId:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.networkConfiguration?.["subnetId"],
+                                dynamicVNetAssignmentScope:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool
+                                    ?.networkConfiguration?.[
+                                    "dynamicVNetAssignmentScope"
+                                  ],
+                                endpointConfiguration: !p.jobSpecification
+                                  ?.poolInfo.autoPoolSpecification?.pool
+                                  ?.networkConfiguration?.endpointConfiguration
+                                  ? undefined
+                                  : {
+                                      inboundNATPools: (
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.networkConfiguration
+                                          ?.endpointConfiguration?.[
+                                          "inboundNATPools"
+                                        ] ?? []
+                                      ).map((p) => ({
+                                        name: p["name"],
+                                        protocol: p["protocol"],
+                                        backendPort: p["backendPort"],
+                                        frontendPortRangeStart:
+                                          p["frontendPortRangeStart"],
+                                        frontendPortRangeEnd:
+                                          p["frontendPortRangeEnd"],
+                                        networkSecurityGroupRules: (
+                                          p["networkSecurityGroupRules"] ?? []
+                                        ).map((p) => ({
+                                          priority: p["priority"],
+                                          access: p["access"],
+                                          sourceAddressPrefix:
+                                            p["sourceAddressPrefix"],
+                                          sourcePortRanges:
+                                            p["sourcePortRanges"],
+                                        })),
+                                      })),
+                                    },
+                                publicIPAddressConfiguration: !p
+                                  .jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool
+                                  ?.networkConfiguration
+                                  ?.publicIPAddressConfiguration
+                                  ? undefined
+                                  : {
+                                      provision:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.networkConfiguration
+                                          ?.publicIPAddressConfiguration?.[
+                                          "provision"
+                                        ],
+                                      ipAddressIds:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.networkConfiguration
+                                          ?.publicIPAddressConfiguration?.[
+                                          "ipAddressIds"
+                                        ],
+                                    },
+                              },
+                          startTask: !p.jobSpecification?.poolInfo
+                            .autoPoolSpecification?.pool?.startTask
+                            ? undefined
+                            : {
+                                commandLine:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool?.startTask?.[
+                                    "commandLine"
+                                  ],
+                                containerSettings: !p.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask
+                                  ?.containerSettings
+                                  ? undefined
+                                  : {
+                                      containerRunOptions:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.startTask?.containerSettings?.[
+                                          "containerRunOptions"
+                                        ],
+                                      imageName:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.startTask?.containerSettings?.[
+                                          "imageName"
+                                        ],
+                                      registry: !p.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool?.startTask
+                                        ?.containerSettings?.registry
+                                        ? undefined
+                                        : {
+                                            username:
+                                              p.jobSpecification?.poolInfo
+                                                .autoPoolSpecification?.pool
+                                                ?.startTask?.containerSettings
+                                                ?.registry?.["username"],
+                                            password:
+                                              p.jobSpecification?.poolInfo
+                                                .autoPoolSpecification?.pool
+                                                ?.startTask?.containerSettings
+                                                ?.registry?.["password"],
+                                            registryServer:
+                                              p.jobSpecification?.poolInfo
+                                                .autoPoolSpecification?.pool
+                                                ?.startTask?.containerSettings
+                                                ?.registry?.["registryServer"],
+                                            identityReference: !p
+                                              .jobSpecification?.poolInfo
+                                              .autoPoolSpecification?.pool
+                                              ?.startTask?.containerSettings
+                                              ?.registry?.identityReference
+                                              ? undefined
+                                              : {
+                                                  resourceId:
+                                                    p.jobSpecification?.poolInfo
+                                                      .autoPoolSpecification
+                                                      ?.pool?.startTask
+                                                      ?.containerSettings
+                                                      ?.registry
+                                                      ?.identityReference?.[
+                                                      "resourceId"
+                                                    ],
+                                                },
+                                          },
+                                      workingDirectory:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.startTask?.containerSettings?.[
+                                          "workingDirectory"
+                                        ],
+                                    },
+                                resourceFiles: (
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool?.startTask?.[
+                                    "resourceFiles"
+                                  ] ?? []
+                                ).map((p) => ({
+                                  autoStorageContainerName:
+                                    p["autoStorageContainerName"],
+                                  storageContainerUrl: p["storageContainerUrl"],
+                                  httpUrl: p["httpUrl"],
+                                  blobPrefix: p["blobPrefix"],
+                                  filePath: p["filePath"],
+                                  fileMode: p["fileMode"],
+                                  identityReference: !p.identityReference
+                                    ? undefined
+                                    : {
+                                        resourceId:
+                                          p.identityReference?.["resourceId"],
+                                      },
+                                })),
+                                environmentSettings: (
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool?.startTask?.[
+                                    "environmentSettings"
+                                  ] ?? []
+                                ).map((p) => ({
+                                  name: p["name"],
+                                  value: p["value"],
+                                })),
+                                userIdentity: !p.jobSpecification?.poolInfo
+                                  .autoPoolSpecification?.pool?.startTask
+                                  ?.userIdentity
+                                  ? undefined
+                                  : {
+                                      username:
+                                        p.jobSpecification?.poolInfo
+                                          .autoPoolSpecification?.pool
+                                          ?.startTask?.userIdentity?.[
+                                          "username"
+                                        ],
+                                      autoUser: !p.jobSpecification?.poolInfo
+                                        .autoPoolSpecification?.pool?.startTask
+                                        ?.userIdentity?.autoUser
+                                        ? undefined
+                                        : {
+                                            scope:
+                                              p.jobSpecification?.poolInfo
+                                                .autoPoolSpecification?.pool
+                                                ?.startTask?.userIdentity
+                                                ?.autoUser?.["scope"],
+                                            elevationLevel:
+                                              p.jobSpecification?.poolInfo
+                                                .autoPoolSpecification?.pool
+                                                ?.startTask?.userIdentity
+                                                ?.autoUser?.["elevationLevel"],
+                                          },
+                                    },
+                                maxTaskRetryCount:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool?.startTask?.[
+                                    "maxTaskRetryCount"
+                                  ],
+                                waitForSuccess:
+                                  p.jobSpecification?.poolInfo
+                                    .autoPoolSpecification?.pool?.startTask?.[
+                                    "waitForSuccess"
+                                  ],
+                              },
+                          certificateReferences: (
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["certificateReferences"] ?? []
+                          ).map((p) => ({
+                            thumbprint: p["thumbprint"],
+                            thumbprintAlgorithm: p["thumbprintAlgorithm"],
+                            storeLocation: p["storeLocation"],
+                            storeName: p["storeName"],
+                            visibility: p["visibility"],
+                          })),
+                          applicationPackageReferences: (
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["applicationPackageReferences"] ?? []
+                          ).map((p) => ({
+                            applicationId: p["applicationId"],
+                            version: p["version"],
+                          })),
+                          applicationLicenses:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["applicationLicenses"],
+                          userAccounts: (
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["userAccounts"] ?? []
+                          ).map((p) => ({
+                            name: p["name"],
+                            password: p["password"],
+                            elevationLevel: p["elevationLevel"],
+                            linuxUserConfiguration: !p.linuxUserConfiguration
+                              ? undefined
+                              : {
+                                  uid: p.linuxUserConfiguration?.["uid"],
+                                  gid: p.linuxUserConfiguration?.["gid"],
+                                  sshPrivateKey:
+                                    p.linuxUserConfiguration?.["sshPrivateKey"],
+                                },
+                            windowsUserConfiguration:
+                              !p.windowsUserConfiguration
+                                ? undefined
+                                : {
+                                    loginMode:
+                                      p.windowsUserConfiguration?.["loginMode"],
+                                  },
+                          })),
+                          metadata: (
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["metadata"] ?? []
+                          ).map((p) => ({
+                            name: p["name"],
+                            value: p["value"],
+                          })),
+                          mountConfiguration: (
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["mountConfiguration"] ?? []
+                          ).map((p) => ({
+                            azureBlobFileSystemConfiguration:
+                              !p.azureBlobFileSystemConfiguration
+                                ? undefined
+                                : {
+                                    accountName:
+                                      p.azureBlobFileSystemConfiguration?.[
+                                        "accountName"
+                                      ],
+                                    containerName:
+                                      p.azureBlobFileSystemConfiguration?.[
+                                        "containerName"
+                                      ],
+                                    accountKey:
+                                      p.azureBlobFileSystemConfiguration?.[
+                                        "accountKey"
+                                      ],
+                                    sasKey:
+                                      p.azureBlobFileSystemConfiguration?.[
+                                        "sasKey"
+                                      ],
+                                    blobfuseOptions:
+                                      p.azureBlobFileSystemConfiguration?.[
+                                        "blobfuseOptions"
+                                      ],
+                                    relativeMountPath:
+                                      p.azureBlobFileSystemConfiguration?.[
+                                        "relativeMountPath"
+                                      ],
+                                    identityReference: !p
+                                      .azureBlobFileSystemConfiguration
+                                      ?.identityReference
+                                      ? undefined
+                                      : {
+                                          resourceId:
+                                            p.azureBlobFileSystemConfiguration
+                                              ?.identityReference?.[
+                                              "resourceId"
+                                            ],
+                                        },
+                                  },
+                            nfsMountConfiguration: !p.nfsMountConfiguration
+                              ? undefined
+                              : {
+                                  source: p.nfsMountConfiguration?.["source"],
+                                  relativeMountPath:
+                                    p.nfsMountConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  mountOptions:
+                                    p.nfsMountConfiguration?.["mountOptions"],
+                                },
+                            cifsMountConfiguration: !p.cifsMountConfiguration
+                              ? undefined
+                              : {
+                                  username:
+                                    p.cifsMountConfiguration?.["username"],
+                                  source: p.cifsMountConfiguration?.["source"],
+                                  relativeMountPath:
+                                    p.cifsMountConfiguration?.[
+                                      "relativeMountPath"
+                                    ],
+                                  mountOptions:
+                                    p.cifsMountConfiguration?.["mountOptions"],
+                                  password:
+                                    p.cifsMountConfiguration?.["password"],
+                                },
+                            azureFileShareConfiguration:
+                              !p.azureFileShareConfiguration
+                                ? undefined
+                                : {
+                                    accountName:
+                                      p.azureFileShareConfiguration?.[
+                                        "accountName"
+                                      ],
+                                    azureFileUrl:
+                                      p.azureFileShareConfiguration?.[
+                                        "azureFileUrl"
+                                      ],
+                                    accountKey:
+                                      p.azureFileShareConfiguration?.[
+                                        "accountKey"
+                                      ],
+                                    relativeMountPath:
+                                      p.azureFileShareConfiguration?.[
+                                        "relativeMountPath"
+                                      ],
+                                    mountOptions:
+                                      p.azureFileShareConfiguration?.[
+                                        "mountOptions"
+                                      ],
+                                  },
+                          })),
+                          targetNodeCommunicationMode:
+                            p.jobSpecification?.poolInfo.autoPoolSpecification
+                              ?.pool?.["targetNodeCommunicationMode"],
+                        },
+                  },
+            },
+            metadata: (p.jobSpecification?.["metadata"] ?? []).map((p) => ({
+              name: p["name"],
+              value: p["value"],
+            })),
+          },
+      executionInfo: !p.executionInfo
+        ? undefined
+        : {
+            nextRunTime: new Date(p.executionInfo?.["nextRunTime"] ?? ""),
+            recentJob: !p.executionInfo?.recentJob
+              ? undefined
+              : {
+                  id: p.executionInfo?.recentJob?.["id"],
+                  url: p.executionInfo?.recentJob?.["url"],
+                },
+            endTime: new Date(p.executionInfo?.["endTime"] ?? ""),
+          },
+      metadata: (p["metadata"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+      stats: !p.stats
+        ? undefined
+        : {
+            url: p.stats?.["url"],
+            startTime: new Date(p.stats?.["startTime"] ?? ""),
+            lastUpdateTime: new Date(p.stats?.["lastUpdateTime"] ?? ""),
+            userCPUTime: p.stats?.["userCPUTime"],
+            kernelCPUTime: p.stats?.["kernelCPUTime"],
+            wallClockTime: p.stats?.["wallClockTime"],
+            readIOps: p.stats?.["readIOps"],
+            writeIOps: p.stats?.["writeIOps"],
+            readIOGiB: p.stats?.["readIOGiB"],
+            writeIOGiB: p.stats?.["writeIOGiB"],
+            numSucceededTasks: p.stats?.["numSucceededTasks"],
+            numFailedTasks: p.stats?.["numFailedTasks"],
+            numTaskRetries: p.stats?.["numTaskRetries"],
+            waitTime: p.stats?.["waitTime"],
+          },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Pool.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Pool.ts
@@ -27,7 +27,7 @@ import {
   ComputeNodeDeallocationOption,
 } from "./models.js";
 
-export interface Poollistusagemetricsoptions extends RequestOptions {}
+export interface PoolListUsageMetricsOptions extends RequestOptions {}
 
 /**
  * If you do not specify a $filter clause including a poolId, the response
@@ -39,7 +39,7 @@ export interface Poollistusagemetricsoptions extends RequestOptions {}
  */
 export async function listUsageMetrics(
   context: Client,
-  options: Poollistusagemetricsoptions = { requestOptions: {} }
+  options: PoolListUsageMetricsOptions = { requestOptions: {} }
 ): Promise<CustomPagePoolUsageMetrics> {
   const result = await context.path("/poolusagemetrics").get({
     headers: { Accept: "application/json", ...options.requestOptions?.headers },
@@ -60,7 +60,7 @@ export async function listUsageMetrics(
   };
 }
 
-export interface Poolgetalllifetimestatisticsoptions extends RequestOptions {
+export interface PoolGetAllLifetimeStatisticsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -89,7 +89,7 @@ export interface Poolgetalllifetimestatisticsoptions extends RequestOptions {
  */
 export async function getAllLifetimeStatistics(
   context: Client,
-  options: Poolgetalllifetimestatisticsoptions = { requestOptions: {} }
+  options: PoolGetAllLifetimeStatisticsOptions = { requestOptions: {} }
 ): Promise<PoolStatistics> {
   const result = await context.path("/lifetimepoolstats").get({
     headers: {
@@ -144,7 +144,7 @@ export async function getAllLifetimeStatistics(
   };
 }
 
-export interface Pooladdpooloptions extends RequestOptions {
+export interface PoolAddPoolOptions extends RequestOptions {
   /**
    * The ID can contain any combination of alphanumeric characters including hyphens
    * and underscores, and cannot contain more than 64 characters. The ID is
@@ -347,7 +347,7 @@ export interface Pooladdpooloptions extends RequestOptions {
  */
 export async function addPool(
   context: Client,
-  options: Pooladdpooloptions = { requestOptions: {} }
+  options: PoolAddPoolOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/pools").post({
     headers: {
@@ -383,7 +383,7 @@ export async function addPool(
   return;
 }
 
-export interface Poollistpoolsoptions extends RequestOptions {
+export interface PoolListPoolsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -421,7 +421,7 @@ export interface Poollistpoolsoptions extends RequestOptions {
 /** Lists all of the Pools in the specified Account. */
 export async function listPools(
   context: Client,
-  options: Poollistpoolsoptions = { requestOptions: {} }
+  options: PoolListPoolsOptions = { requestOptions: {} }
 ): Promise<BatchPoolListResult> {
   const result = await context.path("/pools").get({
     headers: {
@@ -858,7 +858,7 @@ export async function listPools(
   };
 }
 
-export interface Pooldeletepooloptions extends RequestOptions {
+export interface PoolDeletePoolOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -920,7 +920,7 @@ export interface Pooldeletepooloptions extends RequestOptions {
 export async function deletePool(
   context: Client,
   poolId: string,
-  options: Pooldeletepooloptions = { requestOptions: {} }
+  options: PoolDeletePoolOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/pools/{poolId}", poolId).delete({
     headers: {
@@ -950,7 +950,7 @@ export async function deletePool(
   return;
 }
 
-export interface Poolexistsoptions extends RequestOptions {
+export interface PoolExistsOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -999,7 +999,7 @@ export interface Poolexistsoptions extends RequestOptions {
 export async function exists(
   context: Client,
   poolId: string,
-  options: Poolexistsoptions = { requestOptions: {} }
+  options: PoolExistsOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/pools/{poolId}", poolId).head({
     headers: {
@@ -1029,7 +1029,7 @@ export async function exists(
   return;
 }
 
-export interface Poolgetpooloptions extends RequestOptions {
+export interface PoolGetPoolOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1082,7 +1082,7 @@ export interface Poolgetpooloptions extends RequestOptions {
 export async function getPool(
   context: Client,
   poolId: string,
-  options: Poolgetpooloptions = { requestOptions: {} }
+  options: PoolGetPoolOptions = { requestOptions: {} }
 ): Promise<BatchPool> {
   const result = await context.path("/pools/{poolId}", poolId).get({
     headers: {
@@ -1545,7 +1545,7 @@ export async function getPool(
   };
 }
 
-export interface Poolpatchpooloptions extends RequestOptions {
+export interface PoolPatchPoolOptions extends RequestOptions {
   /**
    * The ID can contain any combination of alphanumeric characters including hyphens
    * and underscores, and cannot contain more than 64 characters. The ID is
@@ -1773,7 +1773,7 @@ export interface Poolpatchpooloptions extends RequestOptions {
 export async function patchPool(
   context: Client,
   poolId: string,
-  options: Poolpatchpooloptions = { requestOptions: {} }
+  options: PoolPatchPoolOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/pools/{poolId}", poolId).patch({
     headers: {
@@ -1817,7 +1817,7 @@ export async function patchPool(
   return;
 }
 
-export interface Pooldisableautoscaleoptions extends RequestOptions {
+export interface PoolDisableAutoScaleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1842,7 +1842,7 @@ export interface Pooldisableautoscaleoptions extends RequestOptions {
 export async function disableAutoScale(
   context: Client,
   poolId: string,
-  options: Pooldisableautoscaleoptions = { requestOptions: {} }
+  options: PoolDisableAutoScaleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/disableautoscale", poolId)
@@ -1866,7 +1866,7 @@ export async function disableAutoScale(
   return;
 }
 
-export interface Poolenableautoscaleoptions extends RequestOptions {
+export interface PoolEnableAutoScaleOptions extends RequestOptions {
   /**
    * The formula is checked for validity before it is applied to the Pool. If the
    * formula is not valid, the Batch service rejects the request with detailed error
@@ -1943,7 +1943,7 @@ export interface Poolenableautoscaleoptions extends RequestOptions {
 export async function enableAutoScale(
   context: Client,
   poolId: string,
-  options: Poolenableautoscaleoptions = { requestOptions: {} }
+  options: PoolEnableAutoScaleOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/enableautoscale", poolId)
@@ -1984,7 +1984,7 @@ export async function enableAutoScale(
   return;
 }
 
-export interface Poolevaluateautoscaleoptions extends RequestOptions {
+export interface PoolEvaluateAutoScaleOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2016,7 +2016,7 @@ export async function evaluateAutoScale(
   context: Client,
   autoScaleFormula: string,
   poolId: string,
-  options: Poolevaluateautoscaleoptions = { requestOptions: {} }
+  options: PoolEvaluateAutoScaleOptions = { requestOptions: {} }
 ): Promise<AutoScaleRun> {
   const result = await context
     .path("/pools/{poolId}/evaluateautoscale", poolId)
@@ -2056,7 +2056,7 @@ export async function evaluateAutoScale(
   };
 }
 
-export interface Poolresizeoptions extends RequestOptions {
+export interface PoolResizeOptions extends RequestOptions {
   /** The desired number of dedicated Compute Nodes in the Pool. */
   targetDedicatedNodes?: number;
   /** The desired number of Spot/Low-priority Compute Nodes in the Pool. */
@@ -2127,7 +2127,7 @@ export interface Poolresizeoptions extends RequestOptions {
 export async function resize(
   context: Client,
   poolId: string,
-  options: Poolresizeoptions = { requestOptions: {} }
+  options: PoolResizeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/pools/{poolId}/resize", poolId).post({
     headers: {
@@ -2170,7 +2170,7 @@ export async function resize(
   return;
 }
 
-export interface Poolstopresizeoptions extends RequestOptions {
+export interface PoolStopResizeOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2227,7 +2227,7 @@ export interface Poolstopresizeoptions extends RequestOptions {
 export async function stopResize(
   context: Client,
   poolId: string,
-  options: Poolstopresizeoptions = { requestOptions: {} }
+  options: PoolStopResizeOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/pools/{poolId}/stopresize", poolId).post({
     headers: {
@@ -2257,7 +2257,7 @@ export async function stopResize(
   return;
 }
 
-export interface Poolupdatepropertiesoptions extends RequestOptions {
+export interface PoolUpdatePropertiesOptions extends RequestOptions {
   /**
    * The ID can contain any combination of alphanumeric characters including hyphens
    * and underscores, and cannot contain more than 64 characters. The ID is
@@ -2461,7 +2461,7 @@ export interface Poolupdatepropertiesoptions extends RequestOptions {
 export async function updateProperties(
   context: Client,
   poolId: string,
-  options: Poolupdatepropertiesoptions = { requestOptions: {} }
+  options: PoolUpdatePropertiesOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/updateproperties", poolId)
@@ -2499,7 +2499,7 @@ export async function updateProperties(
   return;
 }
 
-export interface Poolremovenodesoptions extends RequestOptions {
+export interface PoolRemoveNodesOptions extends RequestOptions {
   /**
    * The default value is 15 minutes. The minimum value is 5 minutes. If you specify
    * a value less than 5 minutes, the Batch service returns an error; if you are
@@ -2563,7 +2563,7 @@ export async function removeNodes(
   context: Client,
   nodeList: string[],
   poolId: string,
-  options: Poolremovenodesoptions = { requestOptions: {} }
+  options: PoolRemoveNodesOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/pools/{poolId}/removenodes", poolId)

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Pool.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Pool.ts
@@ -1,0 +1,2604 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  CustomPagePoolUsageMetrics,
+  PoolStatistics,
+  BatchPool,
+  PoolState,
+  AllocationState,
+  CloudServiceConfiguration,
+  VirtualMachineConfiguration,
+  ResizeError,
+  AutoScaleRun,
+  NetworkConfiguration,
+  StartTask,
+  CertificateReference,
+  ApplicationPackageReference,
+  TaskSchedulingPolicy,
+  UserAccount,
+  MetadataItem,
+  MountConfiguration,
+  BatchPoolIdentity,
+  NodeCommunicationMode,
+  BatchPoolListResult,
+  ComputeNodeDeallocationOption,
+} from "./models.js";
+
+export interface Poollistusagemetricsoptions extends RequestOptions {}
+
+/**
+ * If you do not specify a $filter clause including a poolId, the response
+ * includes all Pools that existed in the Account in the time range of the
+ * returned aggregation intervals. If you do not specify a $filter clause
+ * including a startTime or endTime these filters default to the start and end
+ * times of the last aggregation interval currently available; that is, only the
+ * last aggregation interval is returned.
+ */
+export async function listUsageMetrics(
+  context: Client,
+  options: Poollistusagemetricsoptions = { requestOptions: {} }
+): Promise<CustomPagePoolUsageMetrics> {
+  const result = await context.path("/poolusagemetrics").get({
+    headers: { Accept: "application/json", ...options.requestOptions?.headers },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      poolId: p["poolId"],
+      startTime: new Date(p["startTime"] ?? ""),
+      endTime: new Date(p["endTime"] ?? ""),
+      vmSize: p["vmSize"],
+      totalCoreHours: p["totalCoreHours"],
+    })),
+    nextLink: result.body["nextLink"],
+  };
+}
+
+export interface Poolgetalllifetimestatisticsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/**
+ * Statistics are aggregated across all Pools that have ever existed in the
+ * Account, from Account creation to the last update time of the statistics. The
+ * statistics may not be immediately available. The Batch service performs
+ * periodic roll-up of statistics. The typical delay is about 30 minutes.
+ */
+export async function getAllLifetimeStatistics(
+  context: Client,
+  options: Poolgetalllifetimestatisticsoptions = { requestOptions: {} }
+): Promise<PoolStatistics> {
+  const result = await context.path("/lifetimepoolstats").get({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    url: result.body["url"],
+    startTime: new Date(result.body["startTime"] ?? ""),
+    lastUpdateTime: new Date(result.body["lastUpdateTime"] ?? ""),
+    usageStats: !result.body.usageStats
+      ? undefined
+      : {
+          startTime: new Date(result.body.usageStats?.["startTime"] ?? ""),
+          lastUpdateTime: new Date(
+            result.body.usageStats?.["lastUpdateTime"] ?? ""
+          ),
+          dedicatedCoreTime: result.body.usageStats?.["dedicatedCoreTime"],
+        },
+    resourceStats: !result.body.resourceStats
+      ? undefined
+      : {
+          startTime: new Date(result.body.resourceStats?.["startTime"] ?? ""),
+          lastUpdateTime: new Date(
+            result.body.resourceStats?.["lastUpdateTime"] ?? ""
+          ),
+          avgCPUPercentage: result.body.resourceStats?.["avgCPUPercentage"],
+          avgMemoryGiB: result.body.resourceStats?.["avgMemoryGiB"],
+          peakMemoryGiB: result.body.resourceStats?.["peakMemoryGiB"],
+          avgDiskGiB: result.body.resourceStats?.["avgDiskGiB"],
+          peakDiskGiB: result.body.resourceStats?.["peakDiskGiB"],
+          diskReadIOps: result.body.resourceStats?.["diskReadIOps"],
+          diskWriteIOps: result.body.resourceStats?.["diskWriteIOps"],
+          diskReadGiB: result.body.resourceStats?.["diskReadGiB"],
+          diskWriteGiB: result.body.resourceStats?.["diskWriteGiB"],
+          networkReadGiB: result.body.resourceStats?.["networkReadGiB"],
+          networkWriteGiB: result.body.resourceStats?.["networkWriteGiB"],
+        },
+  };
+}
+
+export interface Pooladdpooloptions extends RequestOptions {
+  /**
+   * The ID can contain any combination of alphanumeric characters including hyphens
+   * and underscores, and cannot contain more than 64 characters. The ID is
+   * case-preserving and case-insensitive (that is, you may not have two IDs within
+   * an Account that differ only by case).
+   */
+  id?: string;
+  /**
+   * The display name need not be unique and can contain any Unicode characters up
+   * to a maximum length of 1024.
+   */
+  displayName?: string;
+  /** The URL of the Pool. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Pool has changed
+   * between requests. In particular, you can be pass the ETag when updating a Pool
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Pool in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the Pool level data, such as the
+   * targetDedicatedNodes or enableAutoscale settings, changed. It does not factor
+   * in node-level changes such as a Compute Node changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Pool. */
+  creationTime?: Date;
+  /** The current state of the Pool. */
+  state?: PoolState;
+  /** The time at which the Pool entered its current state. */
+  stateTransitionTime?: Date;
+  /** Whether the Pool is resizing. */
+  allocationState?: AllocationState;
+  /** The time at which the Pool entered its current allocation state. */
+  allocationStateTransitionTime?: Date;
+  /**
+   * For information about available sizes of virtual machines in Pools, see Choose
+   * a VM size for Compute Nodes in an Azure Batch Pool
+   * (https://docs.microsoft.com/azure/batch/batch-pool-vm-sizes).
+   */
+  vmSize?: string;
+  /**
+   * This property and virtualMachineConfiguration are mutually exclusive and one of
+   * the properties must be specified. This property cannot be specified if the
+   * Batch Account was created with its poolAllocationMode property set to
+   * 'UserSubscription'.
+   */
+  cloudServiceConfiguration?: CloudServiceConfiguration;
+  /**
+   * This property and cloudServiceConfiguration are mutually exclusive and one of
+   * the properties must be specified.
+   */
+  virtualMachineConfiguration?: VirtualMachineConfiguration;
+  /**
+   * This is the timeout for the most recent resize operation. (The initial sizing
+   * when the Pool is created counts as a resize.) The default value is 15 minutes.
+   */
+  resizeTimeout?: string;
+  /**
+   * This property is set only if one or more errors occurred during the last Pool
+   * resize, and only when the Pool allocationState is Steady.
+   */
+  resizeErrors?: ResizeError[];
+  /** The number of dedicated Compute Nodes currently in the Pool. */
+  currentDedicatedNodes?: number;
+  /**
+   * Spot/Low-priority Compute Nodes which have been preempted are included in this
+   * count.
+   */
+  currentLowPriorityNodes?: number;
+  /** The desired number of dedicated Compute Nodes in the Pool. */
+  targetDedicatedNodes?: number;
+  /** The desired number of Spot/Low-priority Compute Nodes in the Pool. */
+  targetLowPriorityNodes?: number;
+  /**
+   * If false, at least one of targetDedicatedNodes and targetLowPriorityNodes must
+   * be specified. If true, the autoScaleFormula property is required and the Pool
+   * automatically resizes according to the formula. The default value is false.
+   */
+  enableAutoScale?: boolean;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleFormula?: string;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleEvaluationInterval?: string;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleRun?: AutoScaleRun;
+  /**
+   * This imposes restrictions on which Compute Nodes can be assigned to the Pool.
+   * Specifying this value can reduce the chance of the requested number of Compute
+   * Nodes to be allocated in the Pool.
+   */
+  enableInterNodeCommunication?: boolean;
+  /** The network configuration for a Pool. */
+  networkConfiguration?: NetworkConfiguration;
+  /**
+   * Batch will retry Tasks when a recovery operation is triggered on a Node.
+   * Examples of recovery operations include (but are not limited to) when an
+   * unhealthy Node is rebooted or a Compute Node disappeared due to host failure.
+   * Retries due to recovery operations are independent of and are not counted
+   * against the maxTaskRetryCount. Even if the maxTaskRetryCount is 0, an internal
+   * retry due to a recovery operation may occur. Because of this, all Tasks should
+   * be idempotent. This means Tasks need to tolerate being interrupted and
+   * restarted without causing any corruption or duplicate data. The best practice
+   * for long running Tasks is to use some form of checkpointing. In some cases the
+   * StartTask may be re-run even though the Compute Node was not rebooted. Special
+   * care should be taken to avoid StartTasks which create breakaway process or
+   * install/launch services from the StartTask working directory, as this will
+   * block Batch from being able to re-run the StartTask.
+   */
+  startTask?: StartTask;
+  /**
+   * For Windows Nodes, the Batch service installs the Certificates to the specified
+   * Certificate store and location. For Linux Compute Nodes, the Certificates are
+   * stored in a directory inside the Task working directory and an environment
+   * variable AZ_BATCH_CERTIFICATES_DIR is supplied to the Task to query for this
+   * location. For Certificates with visibility of 'remoteUser', a 'certs' directory
+   * is created in the user's home directory (e.g., /home/{user-name}/certs) and
+   * Certificates are placed in that directory.
+   */
+  certificateReferences?: CertificateReference[];
+  /**
+   * Changes to Package references affect all new Nodes joining the Pool, but do not
+   * affect Compute Nodes that are already in the Pool until they are rebooted or
+   * reimaged. There is a maximum of 10 Package references on any given Pool.
+   */
+  applicationPackageReferences?: ApplicationPackageReference[];
+  /**
+   * The list of application licenses must be a subset of available Batch service
+   * application licenses. If a license is requested which is not supported, Pool
+   * creation will fail.
+   */
+  applicationLicenses?: string[];
+  /**
+   * The default value is 1. The maximum value is the smaller of 4 times the number
+   * of cores of the vmSize of the pool or 256.
+   */
+  taskSlotsPerNode?: number;
+  /** If not specified, the default is spread. */
+  taskSchedulingPolicy?: TaskSchedulingPolicy;
+  /** The list of user Accounts to be created on each Compute Node in the Pool. */
+  userAccounts?: UserAccount[];
+  /** A list of name-value pairs associated with the Pool as metadata. */
+  metadata?: MetadataItem[];
+  /**
+   * This property is populated only if the CloudPool was retrieved with an expand
+   * clause including the 'stats' attribute; otherwise it is null. The statistics
+   * may not be immediately available. The Batch service performs periodic roll-up
+   * of statistics. The typical delay is about 30 minutes.
+   */
+  stats?: PoolStatistics;
+  /** This supports Azure Files, NFS, CIFS/SMB, and Blobfuse. */
+  mountConfiguration?: MountConfiguration[];
+  /**
+   * The list of user identities associated with the Batch pool. The user identity
+   * dictionary key references will be ARM resource ids in the form:
+   * '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
+   */
+  identity?: BatchPoolIdentity;
+  /** If omitted, the default value is Default. */
+  targetNodeCommunicationMode?: NodeCommunicationMode;
+  /** Determines how a pool communicates with the Batch service. */
+  currentNodeCommunicationMode?: NodeCommunicationMode;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * When naming Pools, avoid including sensitive information such as user names or
+ * secret project names. This information may appear in telemetry logs accessible
+ * to Microsoft Support engineers.
+ */
+export async function addPool(
+  context: Client,
+  options: Pooladdpooloptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/pools").post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.startTask && { startTask: options.startTask }),
+      ...(options.certificateReferences && {
+        certificateReferences: options.certificateReferences,
+      }),
+      ...(options.applicationPackageReferences && {
+        applicationPackageReferences: options.applicationPackageReferences,
+      }),
+      ...(options.metadata && { metadata: options.metadata }),
+      ...(options.targetNodeCommunicationMode && {
+        targetNodeCommunicationMode: options.targetNodeCommunicationMode,
+      }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poollistpoolsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-pools.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Lists all of the Pools in the specified Account. */
+export async function listPools(
+  context: Client,
+  options: Poollistpoolsoptions = { requestOptions: {} }
+): Promise<BatchPoolListResult> {
+  const result = await context.path("/pools").get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+      ...(options.$select && { $select: options.$select }),
+      ...(options.$expand && { $expand: options.$expand }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      displayName: p["displayName"],
+      url: p["url"],
+      eTag: p["eTag"],
+      lastModified: new Date(p["lastModified"] ?? ""),
+      creationTime: new Date(p["creationTime"] ?? ""),
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      allocationState: p["allocationState"],
+      allocationStateTransitionTime: new Date(
+        p["allocationStateTransitionTime"] ?? ""
+      ),
+      vmSize: p["vmSize"],
+      cloudServiceConfiguration: !p.cloudServiceConfiguration
+        ? undefined
+        : {
+            osFamily: p.cloudServiceConfiguration?.["osFamily"],
+            osVersion: p.cloudServiceConfiguration?.["osVersion"],
+          },
+      virtualMachineConfiguration: !p.virtualMachineConfiguration
+        ? undefined
+        : {
+            imageReference: {
+              publisher:
+                p.virtualMachineConfiguration?.imageReference["publisher"],
+              offer: p.virtualMachineConfiguration?.imageReference["offer"],
+              sku: p.virtualMachineConfiguration?.imageReference["sku"],
+              version: p.virtualMachineConfiguration?.imageReference["version"],
+              virtualMachineImageId:
+                p.virtualMachineConfiguration?.imageReference[
+                  "virtualMachineImageId"
+                ],
+              exactVersion:
+                p.virtualMachineConfiguration?.imageReference["exactVersion"],
+            },
+            nodeAgentSKUId: p.virtualMachineConfiguration?.["nodeAgentSKUId"],
+            windowsConfiguration: !p.virtualMachineConfiguration
+              ?.windowsConfiguration
+              ? undefined
+              : {
+                  enableAutomaticUpdates:
+                    p.virtualMachineConfiguration?.windowsConfiguration?.[
+                      "enableAutomaticUpdates"
+                    ],
+                },
+            dataDisks: (p.virtualMachineConfiguration?.["dataDisks"] ?? []).map(
+              (p) => ({
+                lun: p["lun"],
+                caching: p["caching"],
+                diskSizeGB: p["diskSizeGB"],
+                storageAccountType: p["storageAccountType"],
+              })
+            ),
+            licenseType: p.virtualMachineConfiguration?.["licenseType"],
+            containerConfiguration: !p.virtualMachineConfiguration
+              ?.containerConfiguration
+              ? undefined
+              : {
+                  type: p.virtualMachineConfiguration?.containerConfiguration?.[
+                    "type"
+                  ],
+                  containerImageNames:
+                    p.virtualMachineConfiguration?.containerConfiguration?.[
+                      "containerImageNames"
+                    ],
+                  containerRegistries: (
+                    p.virtualMachineConfiguration?.containerConfiguration?.[
+                      "containerRegistries"
+                    ] ?? []
+                  ).map((p) => ({
+                    username: p["username"],
+                    password: p["password"],
+                    registryServer: p["registryServer"],
+                    identityReference: !p.identityReference
+                      ? undefined
+                      : { resourceId: p.identityReference?.["resourceId"] },
+                  })),
+                },
+            diskEncryptionConfiguration: !p.virtualMachineConfiguration
+              ?.diskEncryptionConfiguration
+              ? undefined
+              : {
+                  targets:
+                    p.virtualMachineConfiguration
+                      ?.diskEncryptionConfiguration?.["targets"],
+                },
+            nodePlacementConfiguration: !p.virtualMachineConfiguration
+              ?.nodePlacementConfiguration
+              ? undefined
+              : {
+                  policy:
+                    p.virtualMachineConfiguration?.nodePlacementConfiguration?.[
+                      "policy"
+                    ],
+                },
+            extensions: (
+              p.virtualMachineConfiguration?.["extensions"] ?? []
+            ).map((p) => ({
+              name: p["name"],
+              publisher: p["publisher"],
+              type: p["type"],
+              typeHandlerVersion: p["typeHandlerVersion"],
+              autoUpgradeMinorVersion: p["autoUpgradeMinorVersion"],
+              settings: !p.settings ? undefined : {},
+              protectedSettings: !p.protectedSettings ? undefined : {},
+              provisionAfterExtensions: p["provisionAfterExtensions"],
+            })),
+            osDisk: !p.virtualMachineConfiguration?.osDisk
+              ? undefined
+              : {
+                  ephemeralOSDiskSettings: !p.virtualMachineConfiguration
+                    ?.osDisk?.ephemeralOSDiskSettings
+                    ? undefined
+                    : {
+                        placement:
+                          p.virtualMachineConfiguration?.osDisk
+                            ?.ephemeralOSDiskSettings?.["placement"],
+                      },
+                },
+          },
+      resizeTimeout: p["resizeTimeout"],
+      resizeErrors: (p["resizeErrors"] ?? []).map((p) => ({
+        code: p["code"],
+        message: p["message"],
+        values: (p["values"] ?? []).map((p) => ({
+          name: p["name"],
+          value: p["value"],
+        })),
+      })),
+      currentDedicatedNodes: p["currentDedicatedNodes"],
+      currentLowPriorityNodes: p["currentLowPriorityNodes"],
+      targetDedicatedNodes: p["targetDedicatedNodes"],
+      targetLowPriorityNodes: p["targetLowPriorityNodes"],
+      enableAutoScale: p["enableAutoScale"],
+      autoScaleFormula: p["autoScaleFormula"],
+      autoScaleEvaluationInterval: p["autoScaleEvaluationInterval"],
+      autoScaleRun: !p.autoScaleRun
+        ? undefined
+        : {
+            timestamp: new Date(p.autoScaleRun?.["timestamp"] ?? ""),
+            results: p.autoScaleRun?.["results"],
+            error: !p.autoScaleRun?.error
+              ? undefined
+              : {
+                  code: p.autoScaleRun?.error?.["code"],
+                  message: p.autoScaleRun?.error?.["message"],
+                  values: (p.autoScaleRun?.error?.["values"] ?? []).map(
+                    (p) => ({ name: p["name"], value: p["value"] })
+                  ),
+                },
+          },
+      enableInterNodeCommunication: p["enableInterNodeCommunication"],
+      networkConfiguration: !p.networkConfiguration
+        ? undefined
+        : {
+            subnetId: p.networkConfiguration?.["subnetId"],
+            dynamicVNetAssignmentScope:
+              p.networkConfiguration?.["dynamicVNetAssignmentScope"],
+            endpointConfiguration: !p.networkConfiguration
+              ?.endpointConfiguration
+              ? undefined
+              : {
+                  inboundNATPools: (
+                    p.networkConfiguration?.endpointConfiguration?.[
+                      "inboundNATPools"
+                    ] ?? []
+                  ).map((p) => ({
+                    name: p["name"],
+                    protocol: p["protocol"],
+                    backendPort: p["backendPort"],
+                    frontendPortRangeStart: p["frontendPortRangeStart"],
+                    frontendPortRangeEnd: p["frontendPortRangeEnd"],
+                    networkSecurityGroupRules: (
+                      p["networkSecurityGroupRules"] ?? []
+                    ).map((p) => ({
+                      priority: p["priority"],
+                      access: p["access"],
+                      sourceAddressPrefix: p["sourceAddressPrefix"],
+                      sourcePortRanges: p["sourcePortRanges"],
+                    })),
+                  })),
+                },
+            publicIPAddressConfiguration: !p.networkConfiguration
+              ?.publicIPAddressConfiguration
+              ? undefined
+              : {
+                  provision:
+                    p.networkConfiguration?.publicIPAddressConfiguration?.[
+                      "provision"
+                    ],
+                  ipAddressIds:
+                    p.networkConfiguration?.publicIPAddressConfiguration?.[
+                      "ipAddressIds"
+                    ],
+                },
+          },
+      startTask: !p.startTask
+        ? undefined
+        : {
+            commandLine: p.startTask?.["commandLine"],
+            containerSettings: !p.startTask?.containerSettings
+              ? undefined
+              : {
+                  containerRunOptions:
+                    p.startTask?.containerSettings?.["containerRunOptions"],
+                  imageName: p.startTask?.containerSettings?.["imageName"],
+                  registry: !p.startTask?.containerSettings?.registry
+                    ? undefined
+                    : {
+                        username:
+                          p.startTask?.containerSettings?.registry?.[
+                            "username"
+                          ],
+                        password:
+                          p.startTask?.containerSettings?.registry?.[
+                            "password"
+                          ],
+                        registryServer:
+                          p.startTask?.containerSettings?.registry?.[
+                            "registryServer"
+                          ],
+                        identityReference: !p.startTask?.containerSettings
+                          ?.registry?.identityReference
+                          ? undefined
+                          : {
+                              resourceId:
+                                p.startTask?.containerSettings?.registry
+                                  ?.identityReference?.["resourceId"],
+                            },
+                      },
+                  workingDirectory:
+                    p.startTask?.containerSettings?.["workingDirectory"],
+                },
+            resourceFiles: (p.startTask?.["resourceFiles"] ?? []).map((p) => ({
+              autoStorageContainerName: p["autoStorageContainerName"],
+              storageContainerUrl: p["storageContainerUrl"],
+              httpUrl: p["httpUrl"],
+              blobPrefix: p["blobPrefix"],
+              filePath: p["filePath"],
+              fileMode: p["fileMode"],
+              identityReference: !p.identityReference
+                ? undefined
+                : { resourceId: p.identityReference?.["resourceId"] },
+            })),
+            environmentSettings: (
+              p.startTask?.["environmentSettings"] ?? []
+            ).map((p) => ({ name: p["name"], value: p["value"] })),
+            userIdentity: !p.startTask?.userIdentity
+              ? undefined
+              : {
+                  username: p.startTask?.userIdentity?.["username"],
+                  autoUser: !p.startTask?.userIdentity?.autoUser
+                    ? undefined
+                    : {
+                        scope: p.startTask?.userIdentity?.autoUser?.["scope"],
+                        elevationLevel:
+                          p.startTask?.userIdentity?.autoUser?.[
+                            "elevationLevel"
+                          ],
+                      },
+                },
+            maxTaskRetryCount: p.startTask?.["maxTaskRetryCount"],
+            waitForSuccess: p.startTask?.["waitForSuccess"],
+          },
+      certificateReferences: (p["certificateReferences"] ?? []).map((p) => ({
+        thumbprint: p["thumbprint"],
+        thumbprintAlgorithm: p["thumbprintAlgorithm"],
+        storeLocation: p["storeLocation"],
+        storeName: p["storeName"],
+        visibility: p["visibility"],
+      })),
+      applicationPackageReferences: (
+        p["applicationPackageReferences"] ?? []
+      ).map((p) => ({
+        applicationId: p["applicationId"],
+        version: p["version"],
+      })),
+      applicationLicenses: p["applicationLicenses"],
+      taskSlotsPerNode: p["taskSlotsPerNode"],
+      taskSchedulingPolicy: !p.taskSchedulingPolicy
+        ? undefined
+        : { nodeFillType: p.taskSchedulingPolicy?.["nodeFillType"] },
+      userAccounts: (p["userAccounts"] ?? []).map((p) => ({
+        name: p["name"],
+        password: p["password"],
+        elevationLevel: p["elevationLevel"],
+        linuxUserConfiguration: !p.linuxUserConfiguration
+          ? undefined
+          : {
+              uid: p.linuxUserConfiguration?.["uid"],
+              gid: p.linuxUserConfiguration?.["gid"],
+              sshPrivateKey: p.linuxUserConfiguration?.["sshPrivateKey"],
+            },
+        windowsUserConfiguration: !p.windowsUserConfiguration
+          ? undefined
+          : { loginMode: p.windowsUserConfiguration?.["loginMode"] },
+      })),
+      metadata: (p["metadata"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+      stats: !p.stats
+        ? undefined
+        : {
+            url: p.stats?.["url"],
+            startTime: new Date(p.stats?.["startTime"] ?? ""),
+            lastUpdateTime: new Date(p.stats?.["lastUpdateTime"] ?? ""),
+            usageStats: !p.stats?.usageStats
+              ? undefined
+              : {
+                  startTime: new Date(p.stats?.usageStats?.["startTime"] ?? ""),
+                  lastUpdateTime: new Date(
+                    p.stats?.usageStats?.["lastUpdateTime"] ?? ""
+                  ),
+                  dedicatedCoreTime: p.stats?.usageStats?.["dedicatedCoreTime"],
+                },
+            resourceStats: !p.stats?.resourceStats
+              ? undefined
+              : {
+                  startTime: new Date(
+                    p.stats?.resourceStats?.["startTime"] ?? ""
+                  ),
+                  lastUpdateTime: new Date(
+                    p.stats?.resourceStats?.["lastUpdateTime"] ?? ""
+                  ),
+                  avgCPUPercentage:
+                    p.stats?.resourceStats?.["avgCPUPercentage"],
+                  avgMemoryGiB: p.stats?.resourceStats?.["avgMemoryGiB"],
+                  peakMemoryGiB: p.stats?.resourceStats?.["peakMemoryGiB"],
+                  avgDiskGiB: p.stats?.resourceStats?.["avgDiskGiB"],
+                  peakDiskGiB: p.stats?.resourceStats?.["peakDiskGiB"],
+                  diskReadIOps: p.stats?.resourceStats?.["diskReadIOps"],
+                  diskWriteIOps: p.stats?.resourceStats?.["diskWriteIOps"],
+                  diskReadGiB: p.stats?.resourceStats?.["diskReadGiB"],
+                  diskWriteGiB: p.stats?.resourceStats?.["diskWriteGiB"],
+                  networkReadGiB: p.stats?.resourceStats?.["networkReadGiB"],
+                  networkWriteGiB: p.stats?.resourceStats?.["networkWriteGiB"],
+                },
+          },
+      mountConfiguration: (p["mountConfiguration"] ?? []).map((p) => ({
+        azureBlobFileSystemConfiguration: !p.azureBlobFileSystemConfiguration
+          ? undefined
+          : {
+              accountName: p.azureBlobFileSystemConfiguration?.["accountName"],
+              containerName:
+                p.azureBlobFileSystemConfiguration?.["containerName"],
+              accountKey: p.azureBlobFileSystemConfiguration?.["accountKey"],
+              sasKey: p.azureBlobFileSystemConfiguration?.["sasKey"],
+              blobfuseOptions:
+                p.azureBlobFileSystemConfiguration?.["blobfuseOptions"],
+              relativeMountPath:
+                p.azureBlobFileSystemConfiguration?.["relativeMountPath"],
+              identityReference: !p.azureBlobFileSystemConfiguration
+                ?.identityReference
+                ? undefined
+                : {
+                    resourceId:
+                      p.azureBlobFileSystemConfiguration?.identityReference?.[
+                        "resourceId"
+                      ],
+                  },
+            },
+        nfsMountConfiguration: !p.nfsMountConfiguration
+          ? undefined
+          : {
+              source: p.nfsMountConfiguration?.["source"],
+              relativeMountPath: p.nfsMountConfiguration?.["relativeMountPath"],
+              mountOptions: p.nfsMountConfiguration?.["mountOptions"],
+            },
+        cifsMountConfiguration: !p.cifsMountConfiguration
+          ? undefined
+          : {
+              username: p.cifsMountConfiguration?.["username"],
+              source: p.cifsMountConfiguration?.["source"],
+              relativeMountPath:
+                p.cifsMountConfiguration?.["relativeMountPath"],
+              mountOptions: p.cifsMountConfiguration?.["mountOptions"],
+              password: p.cifsMountConfiguration?.["password"],
+            },
+        azureFileShareConfiguration: !p.azureFileShareConfiguration
+          ? undefined
+          : {
+              accountName: p.azureFileShareConfiguration?.["accountName"],
+              azureFileUrl: p.azureFileShareConfiguration?.["azureFileUrl"],
+              accountKey: p.azureFileShareConfiguration?.["accountKey"],
+              relativeMountPath:
+                p.azureFileShareConfiguration?.["relativeMountPath"],
+              mountOptions: p.azureFileShareConfiguration?.["mountOptions"],
+            },
+      })),
+      identity: !p.identity
+        ? undefined
+        : {
+            type: p.identity?.["type"],
+            userAssignedIdentities: (
+              p.identity?.["userAssignedIdentities"] ?? []
+            ).map((p) => ({
+              resourceId: p["resourceId"],
+              clientId: p["clientId"],
+              principalId: p["principalId"],
+            })),
+          },
+      targetNodeCommunicationMode: p["targetNodeCommunicationMode"],
+      currentNodeCommunicationMode: p["currentNodeCommunicationMode"],
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Pooldeletepooloptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * When you request that a Pool be deleted, the following actions occur: the Pool
+ * state is set to deleting; any ongoing resize operation on the Pool are stopped;
+ * the Batch service starts resizing the Pool to zero Compute Nodes; any Tasks
+ * running on existing Compute Nodes are terminated and requeued (as if a resize
+ * Pool operation had been requested with the default requeue option); finally,
+ * the Pool is removed from the system. Because running Tasks are requeued, the
+ * user can rerun these Tasks by updating their Job to target a different Pool.
+ * The Tasks can then run on the new Pool. If you want to override the requeue
+ * behavior, then you should call resize Pool explicitly to shrink the Pool to
+ * zero size before deleting the Pool. If you call an Update, Patch or Delete API
+ * on a Pool in the deleting state, it will fail with HTTP status code 409 with
+ * error code PoolBeingDeleted.
+ */
+export async function deletePool(
+  context: Client,
+  poolId: string,
+  options: Pooldeletepooloptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/pools/{poolId}", poolId).delete({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolexistsoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/** Gets basic properties of a Pool. */
+export async function exists(
+  context: Client,
+  poolId: string,
+  options: Poolexistsoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/pools/{poolId}", poolId).head({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolgetpooloptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/** Gets information about the specified Pool. */
+export async function getPool(
+  context: Client,
+  poolId: string,
+  options: Poolgetpooloptions = { requestOptions: {} }
+): Promise<BatchPool> {
+  const result = await context.path("/pools/{poolId}", poolId).get({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$select && { $select: options.$select }),
+      ...(options.$expand && { $expand: options.$expand }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    displayName: result.body["displayName"],
+    url: result.body["url"],
+    eTag: result.body["eTag"],
+    lastModified: new Date(result.body["lastModified"] ?? ""),
+    creationTime: new Date(result.body["creationTime"] ?? ""),
+    state: result.body["state"],
+    stateTransitionTime: new Date(result.body["stateTransitionTime"] ?? ""),
+    allocationState: result.body["allocationState"],
+    allocationStateTransitionTime: new Date(
+      result.body["allocationStateTransitionTime"] ?? ""
+    ),
+    vmSize: result.body["vmSize"],
+    cloudServiceConfiguration: !result.body.cloudServiceConfiguration
+      ? undefined
+      : {
+          osFamily: result.body.cloudServiceConfiguration?.["osFamily"],
+          osVersion: result.body.cloudServiceConfiguration?.["osVersion"],
+        },
+    virtualMachineConfiguration: !result.body.virtualMachineConfiguration
+      ? undefined
+      : {
+          imageReference: {
+            publisher:
+              result.body.virtualMachineConfiguration?.imageReference[
+                "publisher"
+              ],
+            offer:
+              result.body.virtualMachineConfiguration?.imageReference["offer"],
+            sku: result.body.virtualMachineConfiguration?.imageReference["sku"],
+            version:
+              result.body.virtualMachineConfiguration?.imageReference[
+                "version"
+              ],
+            virtualMachineImageId:
+              result.body.virtualMachineConfiguration?.imageReference[
+                "virtualMachineImageId"
+              ],
+            exactVersion:
+              result.body.virtualMachineConfiguration?.imageReference[
+                "exactVersion"
+              ],
+          },
+          nodeAgentSKUId:
+            result.body.virtualMachineConfiguration?.["nodeAgentSKUId"],
+          windowsConfiguration: !result.body.virtualMachineConfiguration
+            ?.windowsConfiguration
+            ? undefined
+            : {
+                enableAutomaticUpdates:
+                  result.body.virtualMachineConfiguration
+                    ?.windowsConfiguration?.["enableAutomaticUpdates"],
+              },
+          dataDisks: (
+            result.body.virtualMachineConfiguration?.["dataDisks"] ?? []
+          ).map((p) => ({
+            lun: p["lun"],
+            caching: p["caching"],
+            diskSizeGB: p["diskSizeGB"],
+            storageAccountType: p["storageAccountType"],
+          })),
+          licenseType: result.body.virtualMachineConfiguration?.["licenseType"],
+          containerConfiguration: !result.body.virtualMachineConfiguration
+            ?.containerConfiguration
+            ? undefined
+            : {
+                type: result.body.virtualMachineConfiguration
+                  ?.containerConfiguration?.["type"],
+                containerImageNames:
+                  result.body.virtualMachineConfiguration
+                    ?.containerConfiguration?.["containerImageNames"],
+                containerRegistries: (
+                  result.body.virtualMachineConfiguration
+                    ?.containerConfiguration?.["containerRegistries"] ?? []
+                ).map((p) => ({
+                  username: p["username"],
+                  password: p["password"],
+                  registryServer: p["registryServer"],
+                  identityReference: !p.identityReference
+                    ? undefined
+                    : { resourceId: p.identityReference?.["resourceId"] },
+                })),
+              },
+          diskEncryptionConfiguration: !result.body.virtualMachineConfiguration
+            ?.diskEncryptionConfiguration
+            ? undefined
+            : {
+                targets:
+                  result.body.virtualMachineConfiguration
+                    ?.diskEncryptionConfiguration?.["targets"],
+              },
+          nodePlacementConfiguration: !result.body.virtualMachineConfiguration
+            ?.nodePlacementConfiguration
+            ? undefined
+            : {
+                policy:
+                  result.body.virtualMachineConfiguration
+                    ?.nodePlacementConfiguration?.["policy"],
+              },
+          extensions: (
+            result.body.virtualMachineConfiguration?.["extensions"] ?? []
+          ).map((p) => ({
+            name: p["name"],
+            publisher: p["publisher"],
+            type: p["type"],
+            typeHandlerVersion: p["typeHandlerVersion"],
+            autoUpgradeMinorVersion: p["autoUpgradeMinorVersion"],
+            settings: !p.settings ? undefined : {},
+            protectedSettings: !p.protectedSettings ? undefined : {},
+            provisionAfterExtensions: p["provisionAfterExtensions"],
+          })),
+          osDisk: !result.body.virtualMachineConfiguration?.osDisk
+            ? undefined
+            : {
+                ephemeralOSDiskSettings: !result.body
+                  .virtualMachineConfiguration?.osDisk?.ephemeralOSDiskSettings
+                  ? undefined
+                  : {
+                      placement:
+                        result.body.virtualMachineConfiguration?.osDisk
+                          ?.ephemeralOSDiskSettings?.["placement"],
+                    },
+              },
+        },
+    resizeTimeout: result.body["resizeTimeout"],
+    resizeErrors: (result.body["resizeErrors"] ?? []).map((p) => ({
+      code: p["code"],
+      message: p["message"],
+      values: (p["values"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+    })),
+    currentDedicatedNodes: result.body["currentDedicatedNodes"],
+    currentLowPriorityNodes: result.body["currentLowPriorityNodes"],
+    targetDedicatedNodes: result.body["targetDedicatedNodes"],
+    targetLowPriorityNodes: result.body["targetLowPriorityNodes"],
+    enableAutoScale: result.body["enableAutoScale"],
+    autoScaleFormula: result.body["autoScaleFormula"],
+    autoScaleEvaluationInterval: result.body["autoScaleEvaluationInterval"],
+    autoScaleRun: !result.body.autoScaleRun
+      ? undefined
+      : {
+          timestamp: new Date(result.body.autoScaleRun?.["timestamp"] ?? ""),
+          results: result.body.autoScaleRun?.["results"],
+          error: !result.body.autoScaleRun?.error
+            ? undefined
+            : {
+                code: result.body.autoScaleRun?.error?.["code"],
+                message: result.body.autoScaleRun?.error?.["message"],
+                values: (result.body.autoScaleRun?.error?.["values"] ?? []).map(
+                  (p) => ({ name: p["name"], value: p["value"] })
+                ),
+              },
+        },
+    enableInterNodeCommunication: result.body["enableInterNodeCommunication"],
+    networkConfiguration: !result.body.networkConfiguration
+      ? undefined
+      : {
+          subnetId: result.body.networkConfiguration?.["subnetId"],
+          dynamicVNetAssignmentScope:
+            result.body.networkConfiguration?.["dynamicVNetAssignmentScope"],
+          endpointConfiguration: !result.body.networkConfiguration
+            ?.endpointConfiguration
+            ? undefined
+            : {
+                inboundNATPools: (
+                  result.body.networkConfiguration?.endpointConfiguration?.[
+                    "inboundNATPools"
+                  ] ?? []
+                ).map((p) => ({
+                  name: p["name"],
+                  protocol: p["protocol"],
+                  backendPort: p["backendPort"],
+                  frontendPortRangeStart: p["frontendPortRangeStart"],
+                  frontendPortRangeEnd: p["frontendPortRangeEnd"],
+                  networkSecurityGroupRules: (
+                    p["networkSecurityGroupRules"] ?? []
+                  ).map((p) => ({
+                    priority: p["priority"],
+                    access: p["access"],
+                    sourceAddressPrefix: p["sourceAddressPrefix"],
+                    sourcePortRanges: p["sourcePortRanges"],
+                  })),
+                })),
+              },
+          publicIPAddressConfiguration: !result.body.networkConfiguration
+            ?.publicIPAddressConfiguration
+            ? undefined
+            : {
+                provision:
+                  result.body.networkConfiguration
+                    ?.publicIPAddressConfiguration?.["provision"],
+                ipAddressIds:
+                  result.body.networkConfiguration
+                    ?.publicIPAddressConfiguration?.["ipAddressIds"],
+              },
+        },
+    startTask: !result.body.startTask
+      ? undefined
+      : {
+          commandLine: result.body.startTask?.["commandLine"],
+          containerSettings: !result.body.startTask?.containerSettings
+            ? undefined
+            : {
+                containerRunOptions:
+                  result.body.startTask?.containerSettings?.[
+                    "containerRunOptions"
+                  ],
+                imageName:
+                  result.body.startTask?.containerSettings?.["imageName"],
+                registry: !result.body.startTask?.containerSettings?.registry
+                  ? undefined
+                  : {
+                      username:
+                        result.body.startTask?.containerSettings?.registry?.[
+                          "username"
+                        ],
+                      password:
+                        result.body.startTask?.containerSettings?.registry?.[
+                          "password"
+                        ],
+                      registryServer:
+                        result.body.startTask?.containerSettings?.registry?.[
+                          "registryServer"
+                        ],
+                      identityReference: !result.body.startTask
+                        ?.containerSettings?.registry?.identityReference
+                        ? undefined
+                        : {
+                            resourceId:
+                              result.body.startTask?.containerSettings?.registry
+                                ?.identityReference?.["resourceId"],
+                          },
+                    },
+                workingDirectory:
+                  result.body.startTask?.containerSettings?.[
+                    "workingDirectory"
+                  ],
+              },
+          resourceFiles: (result.body.startTask?.["resourceFiles"] ?? []).map(
+            (p) => ({
+              autoStorageContainerName: p["autoStorageContainerName"],
+              storageContainerUrl: p["storageContainerUrl"],
+              httpUrl: p["httpUrl"],
+              blobPrefix: p["blobPrefix"],
+              filePath: p["filePath"],
+              fileMode: p["fileMode"],
+              identityReference: !p.identityReference
+                ? undefined
+                : { resourceId: p.identityReference?.["resourceId"] },
+            })
+          ),
+          environmentSettings: (
+            result.body.startTask?.["environmentSettings"] ?? []
+          ).map((p) => ({ name: p["name"], value: p["value"] })),
+          userIdentity: !result.body.startTask?.userIdentity
+            ? undefined
+            : {
+                username: result.body.startTask?.userIdentity?.["username"],
+                autoUser: !result.body.startTask?.userIdentity?.autoUser
+                  ? undefined
+                  : {
+                      scope:
+                        result.body.startTask?.userIdentity?.autoUser?.[
+                          "scope"
+                        ],
+                      elevationLevel:
+                        result.body.startTask?.userIdentity?.autoUser?.[
+                          "elevationLevel"
+                        ],
+                    },
+              },
+          maxTaskRetryCount: result.body.startTask?.["maxTaskRetryCount"],
+          waitForSuccess: result.body.startTask?.["waitForSuccess"],
+        },
+    certificateReferences: (result.body["certificateReferences"] ?? []).map(
+      (p) => ({
+        thumbprint: p["thumbprint"],
+        thumbprintAlgorithm: p["thumbprintAlgorithm"],
+        storeLocation: p["storeLocation"],
+        storeName: p["storeName"],
+        visibility: p["visibility"],
+      })
+    ),
+    applicationPackageReferences: (
+      result.body["applicationPackageReferences"] ?? []
+    ).map((p) => ({
+      applicationId: p["applicationId"],
+      version: p["version"],
+    })),
+    applicationLicenses: result.body["applicationLicenses"],
+    taskSlotsPerNode: result.body["taskSlotsPerNode"],
+    taskSchedulingPolicy: !result.body.taskSchedulingPolicy
+      ? undefined
+      : { nodeFillType: result.body.taskSchedulingPolicy?.["nodeFillType"] },
+    userAccounts: (result.body["userAccounts"] ?? []).map((p) => ({
+      name: p["name"],
+      password: p["password"],
+      elevationLevel: p["elevationLevel"],
+      linuxUserConfiguration: !p.linuxUserConfiguration
+        ? undefined
+        : {
+            uid: p.linuxUserConfiguration?.["uid"],
+            gid: p.linuxUserConfiguration?.["gid"],
+            sshPrivateKey: p.linuxUserConfiguration?.["sshPrivateKey"],
+          },
+      windowsUserConfiguration: !p.windowsUserConfiguration
+        ? undefined
+        : { loginMode: p.windowsUserConfiguration?.["loginMode"] },
+    })),
+    metadata: (result.body["metadata"] ?? []).map((p) => ({
+      name: p["name"],
+      value: p["value"],
+    })),
+    stats: !result.body.stats
+      ? undefined
+      : {
+          url: result.body.stats?.["url"],
+          startTime: new Date(result.body.stats?.["startTime"] ?? ""),
+          lastUpdateTime: new Date(result.body.stats?.["lastUpdateTime"] ?? ""),
+          usageStats: !result.body.stats?.usageStats
+            ? undefined
+            : {
+                startTime: new Date(
+                  result.body.stats?.usageStats?.["startTime"] ?? ""
+                ),
+                lastUpdateTime: new Date(
+                  result.body.stats?.usageStats?.["lastUpdateTime"] ?? ""
+                ),
+                dedicatedCoreTime:
+                  result.body.stats?.usageStats?.["dedicatedCoreTime"],
+              },
+          resourceStats: !result.body.stats?.resourceStats
+            ? undefined
+            : {
+                startTime: new Date(
+                  result.body.stats?.resourceStats?.["startTime"] ?? ""
+                ),
+                lastUpdateTime: new Date(
+                  result.body.stats?.resourceStats?.["lastUpdateTime"] ?? ""
+                ),
+                avgCPUPercentage:
+                  result.body.stats?.resourceStats?.["avgCPUPercentage"],
+                avgMemoryGiB:
+                  result.body.stats?.resourceStats?.["avgMemoryGiB"],
+                peakMemoryGiB:
+                  result.body.stats?.resourceStats?.["peakMemoryGiB"],
+                avgDiskGiB: result.body.stats?.resourceStats?.["avgDiskGiB"],
+                peakDiskGiB: result.body.stats?.resourceStats?.["peakDiskGiB"],
+                diskReadIOps:
+                  result.body.stats?.resourceStats?.["diskReadIOps"],
+                diskWriteIOps:
+                  result.body.stats?.resourceStats?.["diskWriteIOps"],
+                diskReadGiB: result.body.stats?.resourceStats?.["diskReadGiB"],
+                diskWriteGiB:
+                  result.body.stats?.resourceStats?.["diskWriteGiB"],
+                networkReadGiB:
+                  result.body.stats?.resourceStats?.["networkReadGiB"],
+                networkWriteGiB:
+                  result.body.stats?.resourceStats?.["networkWriteGiB"],
+              },
+        },
+    mountConfiguration: (result.body["mountConfiguration"] ?? []).map((p) => ({
+      azureBlobFileSystemConfiguration: !p.azureBlobFileSystemConfiguration
+        ? undefined
+        : {
+            accountName: p.azureBlobFileSystemConfiguration?.["accountName"],
+            containerName:
+              p.azureBlobFileSystemConfiguration?.["containerName"],
+            accountKey: p.azureBlobFileSystemConfiguration?.["accountKey"],
+            sasKey: p.azureBlobFileSystemConfiguration?.["sasKey"],
+            blobfuseOptions:
+              p.azureBlobFileSystemConfiguration?.["blobfuseOptions"],
+            relativeMountPath:
+              p.azureBlobFileSystemConfiguration?.["relativeMountPath"],
+            identityReference: !p.azureBlobFileSystemConfiguration
+              ?.identityReference
+              ? undefined
+              : {
+                  resourceId:
+                    p.azureBlobFileSystemConfiguration?.identityReference?.[
+                      "resourceId"
+                    ],
+                },
+          },
+      nfsMountConfiguration: !p.nfsMountConfiguration
+        ? undefined
+        : {
+            source: p.nfsMountConfiguration?.["source"],
+            relativeMountPath: p.nfsMountConfiguration?.["relativeMountPath"],
+            mountOptions: p.nfsMountConfiguration?.["mountOptions"],
+          },
+      cifsMountConfiguration: !p.cifsMountConfiguration
+        ? undefined
+        : {
+            username: p.cifsMountConfiguration?.["username"],
+            source: p.cifsMountConfiguration?.["source"],
+            relativeMountPath: p.cifsMountConfiguration?.["relativeMountPath"],
+            mountOptions: p.cifsMountConfiguration?.["mountOptions"],
+            password: p.cifsMountConfiguration?.["password"],
+          },
+      azureFileShareConfiguration: !p.azureFileShareConfiguration
+        ? undefined
+        : {
+            accountName: p.azureFileShareConfiguration?.["accountName"],
+            azureFileUrl: p.azureFileShareConfiguration?.["azureFileUrl"],
+            accountKey: p.azureFileShareConfiguration?.["accountKey"],
+            relativeMountPath:
+              p.azureFileShareConfiguration?.["relativeMountPath"],
+            mountOptions: p.azureFileShareConfiguration?.["mountOptions"],
+          },
+    })),
+    identity: !result.body.identity
+      ? undefined
+      : {
+          type: result.body.identity?.["type"],
+          userAssignedIdentities: (
+            result.body.identity?.["userAssignedIdentities"] ?? []
+          ).map((p) => ({
+            resourceId: p["resourceId"],
+            clientId: p["clientId"],
+            principalId: p["principalId"],
+          })),
+        },
+    targetNodeCommunicationMode: result.body["targetNodeCommunicationMode"],
+    currentNodeCommunicationMode: result.body["currentNodeCommunicationMode"],
+  };
+}
+
+export interface Poolpatchpooloptions extends RequestOptions {
+  /**
+   * The ID can contain any combination of alphanumeric characters including hyphens
+   * and underscores, and cannot contain more than 64 characters. The ID is
+   * case-preserving and case-insensitive (that is, you may not have two IDs within
+   * an Account that differ only by case).
+   */
+  id?: string;
+  /**
+   * The display name need not be unique and can contain any Unicode characters up
+   * to a maximum length of 1024.
+   */
+  displayName?: string;
+  /** The URL of the Pool. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Pool has changed
+   * between requests. In particular, you can be pass the ETag when updating a Pool
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Pool in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the Pool level data, such as the
+   * targetDedicatedNodes or enableAutoscale settings, changed. It does not factor
+   * in node-level changes such as a Compute Node changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Pool. */
+  creationTime?: Date;
+  /** The current state of the Pool. */
+  state?: PoolState;
+  /** The time at which the Pool entered its current state. */
+  stateTransitionTime?: Date;
+  /** Whether the Pool is resizing. */
+  allocationState?: AllocationState;
+  /** The time at which the Pool entered its current allocation state. */
+  allocationStateTransitionTime?: Date;
+  /**
+   * For information about available sizes of virtual machines in Pools, see Choose
+   * a VM size for Compute Nodes in an Azure Batch Pool
+   * (https://docs.microsoft.com/azure/batch/batch-pool-vm-sizes).
+   */
+  vmSize?: string;
+  /**
+   * This property and virtualMachineConfiguration are mutually exclusive and one of
+   * the properties must be specified. This property cannot be specified if the
+   * Batch Account was created with its poolAllocationMode property set to
+   * 'UserSubscription'.
+   */
+  cloudServiceConfiguration?: CloudServiceConfiguration;
+  /**
+   * This property and cloudServiceConfiguration are mutually exclusive and one of
+   * the properties must be specified.
+   */
+  virtualMachineConfiguration?: VirtualMachineConfiguration;
+  /**
+   * This is the timeout for the most recent resize operation. (The initial sizing
+   * when the Pool is created counts as a resize.) The default value is 15 minutes.
+   */
+  resizeTimeout?: string;
+  /**
+   * This property is set only if one or more errors occurred during the last Pool
+   * resize, and only when the Pool allocationState is Steady.
+   */
+  resizeErrors?: ResizeError[];
+  /** The number of dedicated Compute Nodes currently in the Pool. */
+  currentDedicatedNodes?: number;
+  /**
+   * Spot/Low-priority Compute Nodes which have been preempted are included in this
+   * count.
+   */
+  currentLowPriorityNodes?: number;
+  /** The desired number of dedicated Compute Nodes in the Pool. */
+  targetDedicatedNodes?: number;
+  /** The desired number of Spot/Low-priority Compute Nodes in the Pool. */
+  targetLowPriorityNodes?: number;
+  /**
+   * If false, at least one of targetDedicatedNodes and targetLowPriorityNodes must
+   * be specified. If true, the autoScaleFormula property is required and the Pool
+   * automatically resizes according to the formula. The default value is false.
+   */
+  enableAutoScale?: boolean;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleFormula?: string;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleEvaluationInterval?: string;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleRun?: AutoScaleRun;
+  /**
+   * This imposes restrictions on which Compute Nodes can be assigned to the Pool.
+   * Specifying this value can reduce the chance of the requested number of Compute
+   * Nodes to be allocated in the Pool.
+   */
+  enableInterNodeCommunication?: boolean;
+  /** The network configuration for a Pool. */
+  networkConfiguration?: NetworkConfiguration;
+  /**
+   * Batch will retry Tasks when a recovery operation is triggered on a Node.
+   * Examples of recovery operations include (but are not limited to) when an
+   * unhealthy Node is rebooted or a Compute Node disappeared due to host failure.
+   * Retries due to recovery operations are independent of and are not counted
+   * against the maxTaskRetryCount. Even if the maxTaskRetryCount is 0, an internal
+   * retry due to a recovery operation may occur. Because of this, all Tasks should
+   * be idempotent. This means Tasks need to tolerate being interrupted and
+   * restarted without causing any corruption or duplicate data. The best practice
+   * for long running Tasks is to use some form of checkpointing. In some cases the
+   * StartTask may be re-run even though the Compute Node was not rebooted. Special
+   * care should be taken to avoid StartTasks which create breakaway process or
+   * install/launch services from the StartTask working directory, as this will
+   * block Batch from being able to re-run the StartTask.
+   */
+  startTask?: StartTask;
+  /**
+   * For Windows Nodes, the Batch service installs the Certificates to the specified
+   * Certificate store and location. For Linux Compute Nodes, the Certificates are
+   * stored in a directory inside the Task working directory and an environment
+   * variable AZ_BATCH_CERTIFICATES_DIR is supplied to the Task to query for this
+   * location. For Certificates with visibility of 'remoteUser', a 'certs' directory
+   * is created in the user's home directory (e.g., /home/{user-name}/certs) and
+   * Certificates are placed in that directory.
+   */
+  certificateReferences?: CertificateReference[];
+  /**
+   * Changes to Package references affect all new Nodes joining the Pool, but do not
+   * affect Compute Nodes that are already in the Pool until they are rebooted or
+   * reimaged. There is a maximum of 10 Package references on any given Pool.
+   */
+  applicationPackageReferences?: ApplicationPackageReference[];
+  /**
+   * The list of application licenses must be a subset of available Batch service
+   * application licenses. If a license is requested which is not supported, Pool
+   * creation will fail.
+   */
+  applicationLicenses?: string[];
+  /**
+   * The default value is 1. The maximum value is the smaller of 4 times the number
+   * of cores of the vmSize of the pool or 256.
+   */
+  taskSlotsPerNode?: number;
+  /** If not specified, the default is spread. */
+  taskSchedulingPolicy?: TaskSchedulingPolicy;
+  /** The list of user Accounts to be created on each Compute Node in the Pool. */
+  userAccounts?: UserAccount[];
+  /** A list of name-value pairs associated with the Pool as metadata. */
+  metadata?: MetadataItem[];
+  /**
+   * This property is populated only if the CloudPool was retrieved with an expand
+   * clause including the 'stats' attribute; otherwise it is null. The statistics
+   * may not be immediately available. The Batch service performs periodic roll-up
+   * of statistics. The typical delay is about 30 minutes.
+   */
+  stats?: PoolStatistics;
+  /** This supports Azure Files, NFS, CIFS/SMB, and Blobfuse. */
+  mountConfiguration?: MountConfiguration[];
+  /**
+   * The list of user identities associated with the Batch pool. The user identity
+   * dictionary key references will be ARM resource ids in the form:
+   * '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
+   */
+  identity?: BatchPoolIdentity;
+  /** If omitted, the default value is Default. */
+  targetNodeCommunicationMode?: NodeCommunicationMode;
+  /** Determines how a pool communicates with the Batch service. */
+  currentNodeCommunicationMode?: NodeCommunicationMode;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This only replaces the Pool properties specified in the request. For example,
+ * if the Pool has a StartTask associated with it, and a request does not specify
+ * a StartTask element, then the Pool keeps the existing StartTask.
+ */
+export async function patchPool(
+  context: Client,
+  poolId: string,
+  options: Poolpatchpooloptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/pools/{poolId}", poolId).patch({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.startTask && { startTask: options.startTask }),
+      ...(options.certificateReferences && {
+        certificateReferences: options.certificateReferences,
+      }),
+      ...(options.applicationPackageReferences && {
+        applicationPackageReferences: options.applicationPackageReferences,
+      }),
+      ...(options.metadata && { metadata: options.metadata }),
+      ...(options.targetNodeCommunicationMode && {
+        targetNodeCommunicationMode: options.targetNodeCommunicationMode,
+      }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Pooldisableautoscaleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+}
+
+/** Disables automatic scaling for a Pool. */
+export async function disableAutoScale(
+  context: Client,
+  poolId: string,
+  options: Pooldisableautoscaleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/disableautoscale", poolId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolenableautoscaleoptions extends RequestOptions {
+  /**
+   * The formula is checked for validity before it is applied to the Pool. If the
+   * formula is not valid, the Batch service rejects the request with detailed error
+   * information. For more information about specifying this formula, see
+   * Automatically scale Compute Nodes in an Azure Batch Pool
+   * (https://azure.microsoft.com/en-us/documentation/articles/batch-automatic-scaling).
+   */
+  autoScaleFormula?: string;
+  /**
+   * The default value is 15 minutes. The minimum and maximum value are 5 minutes
+   * and 168 hours respectively. If you specify a value less than 5 minutes or
+   * greater than 168 hours, the Batch service rejects the request with an invalid
+   * property value error; if you are calling the REST API directly, the HTTP status
+   * code is 400 (Bad Request). If you specify a new interval, then the existing
+   * autoscale evaluation schedule will be stopped and a new autoscale evaluation
+   * schedule will be started, with its starting time being the time when this
+   * request was issued.
+   */
+  autoScaleEvaluationInterval?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * You cannot enable automatic scaling on a Pool if a resize operation is in
+ * progress on the Pool. If automatic scaling of the Pool is currently disabled,
+ * you must specify a valid autoscale formula as part of the request. If automatic
+ * scaling of the Pool is already enabled, you may specify a new autoscale formula
+ * and/or a new evaluation interval. You cannot call this API for the same Pool
+ * more than once every 30 seconds.
+ */
+export async function enableAutoScale(
+  context: Client,
+  poolId: string,
+  options: Poolenableautoscaleoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/enableautoscale", poolId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.autoScaleFormula && {
+          autoScaleFormula: options.autoScaleFormula,
+        }),
+        ...(options.autoScaleEvaluationInterval && {
+          autoScaleEvaluationInterval: options.autoScaleEvaluationInterval,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolevaluateautoscaleoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This API is primarily for validating an autoscale formula, as it simply returns
+ * the result without applying the formula to the Pool. The Pool must have auto
+ * scaling enabled in order to evaluate a formula.
+ */
+export async function evaluateAutoScale(
+  context: Client,
+  autoScaleFormula: string,
+  poolId: string,
+  options: Poolevaluateautoscaleoptions = { requestOptions: {} }
+): Promise<AutoScaleRun> {
+  const result = await context
+    .path("/pools/{poolId}/evaluateautoscale", poolId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: { autoScaleFormula: autoScaleFormula },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    timestamp: new Date(result.body["timestamp"] ?? ""),
+    results: result.body["results"],
+    error: !result.body.error
+      ? undefined
+      : {
+          code: result.body.error?.["code"],
+          message: result.body.error?.["message"],
+          values: (result.body.error?.["values"] ?? []).map((p) => ({
+            name: p["name"],
+            value: p["value"],
+          })),
+        },
+  };
+}
+
+export interface Poolresizeoptions extends RequestOptions {
+  /** The desired number of dedicated Compute Nodes in the Pool. */
+  targetDedicatedNodes?: number;
+  /** The desired number of Spot/Low-priority Compute Nodes in the Pool. */
+  targetLowPriorityNodes?: number;
+  /**
+   * The default value is 15 minutes. The minimum value is 5 minutes. If you specify
+   * a value less than 5 minutes, the Batch service returns an error; if you are
+   * calling the REST API directly, the HTTP status code is 400 (Bad Request).
+   */
+  resizeTimeout?: string;
+  /** The default value is requeue. */
+  nodeDeallocationOption?: ComputeNodeDeallocationOption;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * You can only resize a Pool when its allocation state is steady. If the Pool is
+ * already resizing, the request fails with status code 409. When you resize a
+ * Pool, the Pool's allocation state changes from steady to resizing. You cannot
+ * resize Pools which are configured for automatic scaling. If you try to do this,
+ * the Batch service returns an error 409. If you resize a Pool downwards, the
+ * Batch service chooses which Compute Nodes to remove. To remove specific Compute
+ * Nodes, use the Pool remove Compute Nodes API instead.
+ */
+export async function resize(
+  context: Client,
+  poolId: string,
+  options: Poolresizeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/pools/{poolId}/resize", poolId).post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.targetDedicatedNodes && {
+        targetDedicatedNodes: options.targetDedicatedNodes,
+      }),
+      ...(options.targetLowPriorityNodes && {
+        targetLowPriorityNodes: options.targetLowPriorityNodes,
+      }),
+      ...(options.resizeTimeout && { resizeTimeout: options.resizeTimeout }),
+      ...(options.nodeDeallocationOption && {
+        nodeDeallocationOption: options.nodeDeallocationOption,
+      }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolstopresizeoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * This does not restore the Pool to its previous state before the resize
+ * operation: it only stops any further changes being made, and the Pool maintains
+ * its current state. After stopping, the Pool stabilizes at the number of Compute
+ * Nodes it was at when the stop operation was done. During the stop operation,
+ * the Pool allocation state changes first to stopping and then to steady. A
+ * resize operation need not be an explicit resize Pool request; this API can also
+ * be used to halt the initial sizing of the Pool when it is created.
+ */
+export async function stopResize(
+  context: Client,
+  poolId: string,
+  options: Poolstopresizeoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/pools/{poolId}/stopresize", poolId).post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.ifMatch && { "if-match": options.ifMatch }),
+      ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+      ...(options.ifModifiedSince && {
+        "if-modified-since": options.ifModifiedSince,
+      }),
+      ...(options.ifUnmodifiedSince && {
+        "if-unmodified-since": options.ifUnmodifiedSince,
+      }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolupdatepropertiesoptions extends RequestOptions {
+  /**
+   * The ID can contain any combination of alphanumeric characters including hyphens
+   * and underscores, and cannot contain more than 64 characters. The ID is
+   * case-preserving and case-insensitive (that is, you may not have two IDs within
+   * an Account that differ only by case).
+   */
+  id?: string;
+  /**
+   * The display name need not be unique and can contain any Unicode characters up
+   * to a maximum length of 1024.
+   */
+  displayName?: string;
+  /** The URL of the Pool. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Pool has changed
+   * between requests. In particular, you can be pass the ETag when updating a Pool
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Pool in the meantime.
+   */
+  eTag?: string;
+  /**
+   * This is the last time at which the Pool level data, such as the
+   * targetDedicatedNodes or enableAutoscale settings, changed. It does not factor
+   * in node-level changes such as a Compute Node changing state.
+   */
+  lastModified?: Date;
+  /** The creation time of the Pool. */
+  creationTime?: Date;
+  /** The current state of the Pool. */
+  state?: PoolState;
+  /** The time at which the Pool entered its current state. */
+  stateTransitionTime?: Date;
+  /** Whether the Pool is resizing. */
+  allocationState?: AllocationState;
+  /** The time at which the Pool entered its current allocation state. */
+  allocationStateTransitionTime?: Date;
+  /**
+   * For information about available sizes of virtual machines in Pools, see Choose
+   * a VM size for Compute Nodes in an Azure Batch Pool
+   * (https://docs.microsoft.com/azure/batch/batch-pool-vm-sizes).
+   */
+  vmSize?: string;
+  /**
+   * This property and virtualMachineConfiguration are mutually exclusive and one of
+   * the properties must be specified. This property cannot be specified if the
+   * Batch Account was created with its poolAllocationMode property set to
+   * 'UserSubscription'.
+   */
+  cloudServiceConfiguration?: CloudServiceConfiguration;
+  /**
+   * This property and cloudServiceConfiguration are mutually exclusive and one of
+   * the properties must be specified.
+   */
+  virtualMachineConfiguration?: VirtualMachineConfiguration;
+  /**
+   * This is the timeout for the most recent resize operation. (The initial sizing
+   * when the Pool is created counts as a resize.) The default value is 15 minutes.
+   */
+  resizeTimeout?: string;
+  /**
+   * This property is set only if one or more errors occurred during the last Pool
+   * resize, and only when the Pool allocationState is Steady.
+   */
+  resizeErrors?: ResizeError[];
+  /** The number of dedicated Compute Nodes currently in the Pool. */
+  currentDedicatedNodes?: number;
+  /**
+   * Spot/Low-priority Compute Nodes which have been preempted are included in this
+   * count.
+   */
+  currentLowPriorityNodes?: number;
+  /** The desired number of dedicated Compute Nodes in the Pool. */
+  targetDedicatedNodes?: number;
+  /** The desired number of Spot/Low-priority Compute Nodes in the Pool. */
+  targetLowPriorityNodes?: number;
+  /**
+   * If false, at least one of targetDedicatedNodes and targetLowPriorityNodes must
+   * be specified. If true, the autoScaleFormula property is required and the Pool
+   * automatically resizes according to the formula. The default value is false.
+   */
+  enableAutoScale?: boolean;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleFormula?: string;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleEvaluationInterval?: string;
+  /**
+   * This property is set only if the Pool automatically scales, i.e.
+   * enableAutoScale is true.
+   */
+  autoScaleRun?: AutoScaleRun;
+  /**
+   * This imposes restrictions on which Compute Nodes can be assigned to the Pool.
+   * Specifying this value can reduce the chance of the requested number of Compute
+   * Nodes to be allocated in the Pool.
+   */
+  enableInterNodeCommunication?: boolean;
+  /** The network configuration for a Pool. */
+  networkConfiguration?: NetworkConfiguration;
+  /**
+   * Batch will retry Tasks when a recovery operation is triggered on a Node.
+   * Examples of recovery operations include (but are not limited to) when an
+   * unhealthy Node is rebooted or a Compute Node disappeared due to host failure.
+   * Retries due to recovery operations are independent of and are not counted
+   * against the maxTaskRetryCount. Even if the maxTaskRetryCount is 0, an internal
+   * retry due to a recovery operation may occur. Because of this, all Tasks should
+   * be idempotent. This means Tasks need to tolerate being interrupted and
+   * restarted without causing any corruption or duplicate data. The best practice
+   * for long running Tasks is to use some form of checkpointing. In some cases the
+   * StartTask may be re-run even though the Compute Node was not rebooted. Special
+   * care should be taken to avoid StartTasks which create breakaway process or
+   * install/launch services from the StartTask working directory, as this will
+   * block Batch from being able to re-run the StartTask.
+   */
+  startTask?: StartTask;
+  /**
+   * For Windows Nodes, the Batch service installs the Certificates to the specified
+   * Certificate store and location. For Linux Compute Nodes, the Certificates are
+   * stored in a directory inside the Task working directory and an environment
+   * variable AZ_BATCH_CERTIFICATES_DIR is supplied to the Task to query for this
+   * location. For Certificates with visibility of 'remoteUser', a 'certs' directory
+   * is created in the user's home directory (e.g., /home/{user-name}/certs) and
+   * Certificates are placed in that directory.
+   */
+  certificateReferences?: CertificateReference[];
+  /**
+   * Changes to Package references affect all new Nodes joining the Pool, but do not
+   * affect Compute Nodes that are already in the Pool until they are rebooted or
+   * reimaged. There is a maximum of 10 Package references on any given Pool.
+   */
+  applicationPackageReferences?: ApplicationPackageReference[];
+  /**
+   * The list of application licenses must be a subset of available Batch service
+   * application licenses. If a license is requested which is not supported, Pool
+   * creation will fail.
+   */
+  applicationLicenses?: string[];
+  /**
+   * The default value is 1. The maximum value is the smaller of 4 times the number
+   * of cores of the vmSize of the pool or 256.
+   */
+  taskSlotsPerNode?: number;
+  /** If not specified, the default is spread. */
+  taskSchedulingPolicy?: TaskSchedulingPolicy;
+  /** The list of user Accounts to be created on each Compute Node in the Pool. */
+  userAccounts?: UserAccount[];
+  /** A list of name-value pairs associated with the Pool as metadata. */
+  metadata?: MetadataItem[];
+  /**
+   * This property is populated only if the CloudPool was retrieved with an expand
+   * clause including the 'stats' attribute; otherwise it is null. The statistics
+   * may not be immediately available. The Batch service performs periodic roll-up
+   * of statistics. The typical delay is about 30 minutes.
+   */
+  stats?: PoolStatistics;
+  /** This supports Azure Files, NFS, CIFS/SMB, and Blobfuse. */
+  mountConfiguration?: MountConfiguration[];
+  /**
+   * The list of user identities associated with the Batch pool. The user identity
+   * dictionary key references will be ARM resource ids in the form:
+   * '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.
+   */
+  identity?: BatchPoolIdentity;
+  /** If omitted, the default value is Default. */
+  targetNodeCommunicationMode?: NodeCommunicationMode;
+  /** Determines how a pool communicates with the Batch service. */
+  currentNodeCommunicationMode?: NodeCommunicationMode;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This fully replaces all the updatable properties of the Pool. For example, if
+ * the Pool has a StartTask associated with it and if StartTask is not specified
+ * with this request, then the Batch service will remove the existing StartTask.
+ */
+export async function updateProperties(
+  context: Client,
+  poolId: string,
+  options: Poolupdatepropertiesoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/updateproperties", poolId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.startTask && { startTask: options.startTask }),
+        ...(options.certificateReferences && {
+          certificateReferences: options.certificateReferences,
+        }),
+        ...(options.applicationPackageReferences && {
+          applicationPackageReferences: options.applicationPackageReferences,
+        }),
+        ...(options.metadata && { metadata: options.metadata }),
+        ...(options.targetNodeCommunicationMode && {
+          targetNodeCommunicationMode: options.targetNodeCommunicationMode,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Poolremovenodesoptions extends RequestOptions {
+  /**
+   * The default value is 15 minutes. The minimum value is 5 minutes. If you specify
+   * a value less than 5 minutes, the Batch service returns an error; if you are
+   * calling the REST API directly, the HTTP status code is 400 (Bad Request).
+   */
+  resizeTimeout?: string;
+  /** The default value is requeue. */
+  nodeDeallocationOption?: ComputeNodeDeallocationOption;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * This operation can only run when the allocation state of the Pool is steady.
+ * When this operation runs, the allocation state changes from steady to resizing.
+ * Each request may remove up to 100 nodes.
+ */
+export async function removeNodes(
+  context: Client,
+  nodeList: string[],
+  poolId: string,
+  options: Poolremovenodesoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/pools/{poolId}/removenodes", poolId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        nodeList: nodeList,
+        ...(options.resizeTimeout && { resizeTimeout: options.resizeTimeout }),
+        ...(options.nodeDeallocationOption && {
+          nodeDeallocationOption: options.nodeDeallocationOption,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Task.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Task.ts
@@ -1,0 +1,1583 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestOptions } from "../common/interfaces.js";
+import { BatchServiceContext as Client, isUnexpected } from "../rest/index.js";
+import {
+  TaskContainerSettings,
+  ResourceFile,
+  EnvironmentSetting,
+  UserIdentity,
+  ApplicationPackageReference,
+  OutputFile,
+  TaskConstraints,
+  AuthenticationTokenSettings,
+  BatchTask,
+  ExitConditions,
+  TaskState,
+  AffinityInformation,
+  TaskExecutionInformation,
+  ComputeNodeInformation,
+  MultiInstanceSettings,
+  TaskStatistics,
+  TaskDependencies,
+  BatchTaskListResult,
+  TaskAddCollectionResult,
+  BatchTaskListSubtasksResult,
+} from "./models.js";
+
+export interface Taskaddtaskoptions extends RequestOptions {
+  /**
+   * The ID can contain any combination of alphanumeric characters including hyphens
+   * and underscores, and cannot contain more than 64 characters.
+   */
+  id?: string;
+  /**
+   * The display name need not be unique and can contain any Unicode characters up
+   * to a maximum length of 1024.
+   */
+  displayName?: string;
+  /** The URL of the Task. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Task has changed
+   * between requests. In particular, you can be pass the ETag when updating a Task
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Task in the meantime.
+   */
+  eTag?: string;
+  /** The last modified time of the Task. */
+  lastModified?: Date;
+  /** The creation time of the Task. */
+  creationTime?: Date;
+  /** How the Batch service should respond when the Task completes. */
+  exitConditions?: ExitConditions;
+  /** The state of the Task. */
+  state?: TaskState;
+  /** The time at which the Task entered its current state. */
+  stateTransitionTime?: Date;
+  /** This property is not set if the Task is in its initial Active state. */
+  previousState?: TaskState;
+  /** This property is not set if the Task is in its initial Active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * For multi-instance Tasks, the command line is executed as the primary Task,
+   * after the primary Task and all subtasks have finished executing the
+   * coordination command line. The command line does not run under a shell, and
+   * therefore cannot take advantage of shell features such as environment variable
+   * expansion. If you want to take advantage of such features, you should invoke
+   * the shell in the command line, for example using "cmd /c MyCommand" in
+   * Windows or "/bin/sh -c MyCommand" in Linux. If the command line refers to
+   * file paths, it should use a relative path (relative to the Task working
+   * directory), or use the Batch provided environment variable
+   * (https://docs.microsoft.com/en-us/azure/batch/batch-compute-node-environment-variables).
+   */
+  commandLine?: string;
+  /**
+   * If the Pool that will run this Task has containerConfiguration set, this must
+   * be set as well. If the Pool that will run this Task doesn't have
+   * containerConfiguration set, this must not be set. When this is specified, all
+   * directories recursively below the AZ_BATCH_NODE_ROOT_DIR (the root of Azure
+   * Batch directories on the node) are mapped into the container, all Task
+   * environment variables are mapped into the container, and the Task command line
+   * is executed in the container. Files produced in the container outside of
+   * AZ_BATCH_NODE_ROOT_DIR might not be reflected to the host disk, meaning that
+   * Batch file APIs will not be able to access those files.
+   */
+  containerSettings?: TaskContainerSettings;
+  /**
+   * For multi-instance Tasks, the resource files will only be downloaded to the
+   * Compute Node on which the primary Task is executed. There is a maximum size for
+   * the list of resource files.  When the max size is exceeded, the request will
+   * fail and the response error code will be RequestEntityTooLarge. If this occurs,
+   * the collection of ResourceFiles must be reduced in size. This can be achieved
+   * using .zip files, Application Packages, or Docker Containers.
+   */
+  resourceFiles?: ResourceFile[];
+  /**
+   * For multi-instance Tasks, the files will only be uploaded from the Compute Node
+   * on which the primary Task is executed.
+   */
+  outputFiles?: OutputFile[];
+  /** A list of environment variable settings for the Task. */
+  environmentSettings?: EnvironmentSetting[];
+  /**
+   * A locality hint that can be used by the Batch service to select a Compute Node
+   * on which to start a Task.
+   */
+  affinityInfo?: AffinityInformation;
+  /** Execution constraints to apply to a Task. */
+  constraints?: TaskConstraints;
+  /**
+   * The default is 1. A Task can only be scheduled to run on a compute node if the
+   * node has enough free scheduling slots available. For multi-instance Tasks, this
+   * must be 1.
+   */
+  requiredSlots?: number;
+  /** If omitted, the Task runs as a non-administrative user unique to the Task. */
+  userIdentity?: UserIdentity;
+  /** Information about the execution of a Task. */
+  executionInfo?: TaskExecutionInformation;
+  /** Information about the Compute Node on which a Task ran. */
+  nodeInfo?: ComputeNodeInformation;
+  /**
+   * Multi-instance Tasks are commonly used to support MPI Tasks. In the MPI case,
+   * if any of the subtasks fail (for example due to exiting with a non-zero exit
+   * code) the entire multi-instance Task fails. The multi-instance Task is then
+   * terminated and retried, up to its retry limit.
+   */
+  multiInstanceSettings?: MultiInstanceSettings;
+  /** Resource usage statistics for a Task. */
+  stats?: TaskStatistics;
+  /**
+   * This Task will not be scheduled until all Tasks that it depends on have
+   * completed successfully. If any of those Tasks fail and exhaust their retry
+   * counts, this Task will never be scheduled.
+   */
+  dependsOn?: TaskDependencies;
+  /**
+   * Application packages are downloaded and deployed to a shared directory, not the
+   * Task working directory. Therefore, if a referenced package is already on the
+   * Node, and is up to date, then it is not re-downloaded; the existing copy on the
+   * Compute Node is used. If a referenced Package cannot be installed, for example
+   * because the package has been deleted or because download failed, the Task
+   * fails.
+   */
+  applicationPackageReferences?: ApplicationPackageReference[];
+  /**
+   * If this property is set, the Batch service provides the Task with an
+   * authentication token which can be used to authenticate Batch service operations
+   * without requiring an Account access key. The token is provided via the
+   * AZ_BATCH_AUTHENTICATION_TOKEN environment variable. The operations that the
+   * Task can carry out using the token depend on the settings. For example, a Task
+   * can request Job permissions in order to add other Tasks to the Job, or check
+   * the status of the Job or of other Tasks under the Job.
+   */
+  authenticationTokenSettings?: AuthenticationTokenSettings;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * The maximum lifetime of a Task from addition to completion is 180 days. If a
+ * Task has not completed within 180 days of being added it will be terminated by
+ * the Batch service and left in whatever state it was in at that time.
+ */
+export async function addTask(
+  context: Client,
+  jobId: string,
+  options: Taskaddtaskoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context.path("/jobs/{jobId}/tasks", jobId).post({
+    headers: {
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.content_type && { "Content-Type": options.content_type }),
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    body: {
+      ...(options.id && { id: options.id }),
+      ...(options.displayName && { displayName: options.displayName }),
+      ...(options.exitConditions && { exitConditions: options.exitConditions }),
+      ...(options.commandLine && { commandLine: options.commandLine }),
+      ...(options.containerSettings && {
+        containerSettings: options.containerSettings,
+      }),
+      ...(options.resourceFiles && { resourceFiles: options.resourceFiles }),
+      ...(options.outputFiles && { outputFiles: options.outputFiles }),
+      ...(options.environmentSettings && {
+        environmentSettings: options.environmentSettings,
+      }),
+      ...(options.affinityInfo && { affinityInfo: options.affinityInfo }),
+      ...(options.constraints && { constraints: options.constraints }),
+      ...(options.requiredSlots && { requiredSlots: options.requiredSlots }),
+      ...(options.userIdentity && { userIdentity: options.userIdentity }),
+      ...(options.multiInstanceSettings && {
+        multiInstanceSettings: options.multiInstanceSettings,
+      }),
+      ...(options.dependsOn && { dependsOn: options.dependsOn }),
+      ...(options.applicationPackageReferences && {
+        applicationPackageReferences: options.applicationPackageReferences,
+      }),
+      ...(options.authenticationTokenSettings && {
+        authenticationTokenSettings: options.authenticationTokenSettings,
+      }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Tasklisttasksoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  maxresults?: number;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * An OData $filter clause. For more information on constructing this filter, see
+   * https://docs.microsoft.com/en-us/rest/api/batchservice/odata-filters-in-batch#list-tasks.
+   */
+  $filter?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/**
+ * For multi-instance Tasks, information such as affinityId, executionInfo and
+ * nodeInfo refer to the primary Task. Use the list subtasks API to retrieve
+ * information about subtasks.
+ */
+export async function listTasks(
+  context: Client,
+  jobId: string,
+  options: Tasklisttasksoptions = { requestOptions: {} }
+): Promise<BatchTaskListResult> {
+  const result = await context.path("/jobs/{jobId}/tasks", jobId).get({
+    headers: {
+      ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+      ...(options.clientRequestId && {
+        "client-request-id": options.clientRequestId,
+      }),
+      ...(options.returnClientRequestId && {
+        "return-client-request-id": options.returnClientRequestId,
+      }),
+      Accept: "application/json",
+      ...options.requestOptions?.headers,
+    },
+    queryParameters: {
+      ...(options.maxresults && { maxresults: options.maxresults }),
+      ...(options.timeOut && { timeOut: options.timeOut }),
+      ...(options.$filter && { $filter: options.$filter }),
+      ...(options.$select && { $select: options.$select }),
+      ...(options.$expand && { $expand: options.$expand }),
+    },
+  });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      displayName: p["displayName"],
+      url: p["url"],
+      eTag: p["eTag"],
+      lastModified: new Date(p["lastModified"] ?? ""),
+      creationTime: new Date(p["creationTime"] ?? ""),
+      exitConditions: !p.exitConditions
+        ? undefined
+        : {
+            exitCodes: (p.exitConditions?.["exitCodes"] ?? []).map((p) => ({
+              code: p["code"],
+              exitOptions: {
+                jobAction: p.exitOptions["jobAction"],
+                dependencyAction: p.exitOptions["dependencyAction"],
+              },
+            })),
+            exitCodeRanges: (p.exitConditions?.["exitCodeRanges"] ?? []).map(
+              (p) => ({
+                start: p["start"],
+                end: p["end"],
+                exitOptions: {
+                  jobAction: p.exitOptions["jobAction"],
+                  dependencyAction: p.exitOptions["dependencyAction"],
+                },
+              })
+            ),
+            preProcessingError: !p.exitConditions?.preProcessingError
+              ? undefined
+              : {
+                  jobAction:
+                    p.exitConditions?.preProcessingError?.["jobAction"],
+                  dependencyAction:
+                    p.exitConditions?.preProcessingError?.["dependencyAction"],
+                },
+            fileUploadError: !p.exitConditions?.fileUploadError
+              ? undefined
+              : {
+                  jobAction: p.exitConditions?.fileUploadError?.["jobAction"],
+                  dependencyAction:
+                    p.exitConditions?.fileUploadError?.["dependencyAction"],
+                },
+            default: !p.exitConditions?.default
+              ? undefined
+              : {
+                  jobAction: p.exitConditions?.default?.["jobAction"],
+                  dependencyAction:
+                    p.exitConditions?.default?.["dependencyAction"],
+                },
+          },
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      previousState: p["previousState"],
+      previousStateTransitionTime: new Date(
+        p["previousStateTransitionTime"] ?? ""
+      ),
+      commandLine: p["commandLine"],
+      containerSettings: !p.containerSettings
+        ? undefined
+        : {
+            containerRunOptions: p.containerSettings?.["containerRunOptions"],
+            imageName: p.containerSettings?.["imageName"],
+            registry: !p.containerSettings?.registry
+              ? undefined
+              : {
+                  username: p.containerSettings?.registry?.["username"],
+                  password: p.containerSettings?.registry?.["password"],
+                  registryServer:
+                    p.containerSettings?.registry?.["registryServer"],
+                  identityReference: !p.containerSettings?.registry
+                    ?.identityReference
+                    ? undefined
+                    : {
+                        resourceId:
+                          p.containerSettings?.registry?.identityReference?.[
+                            "resourceId"
+                          ],
+                      },
+                },
+            workingDirectory: p.containerSettings?.["workingDirectory"],
+          },
+      resourceFiles: (p["resourceFiles"] ?? []).map((p) => ({
+        autoStorageContainerName: p["autoStorageContainerName"],
+        storageContainerUrl: p["storageContainerUrl"],
+        httpUrl: p["httpUrl"],
+        blobPrefix: p["blobPrefix"],
+        filePath: p["filePath"],
+        fileMode: p["fileMode"],
+        identityReference: !p.identityReference
+          ? undefined
+          : { resourceId: p.identityReference?.["resourceId"] },
+      })),
+      outputFiles: (p["outputFiles"] ?? []).map((p) => ({
+        filePattern: p["filePattern"],
+        destination: {
+          container: !p.destination.container
+            ? undefined
+            : {
+                path: p.destination.container?.["path"],
+                containerUrl: p.destination.container?.["containerUrl"],
+                identityReference: !p.destination.container?.identityReference
+                  ? undefined
+                  : {
+                      resourceId:
+                        p.destination.container?.identityReference?.[
+                          "resourceId"
+                        ],
+                    },
+                uploadHeaders: (
+                  p.destination.container?.["uploadHeaders"] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+              },
+        },
+        uploadOptions: { uploadCondition: p.uploadOptions["uploadCondition"] },
+      })),
+      environmentSettings: (p["environmentSettings"] ?? []).map((p) => ({
+        name: p["name"],
+        value: p["value"],
+      })),
+      affinityInfo: !p.affinityInfo
+        ? undefined
+        : { affinityId: p.affinityInfo?.["affinityId"] },
+      constraints: !p.constraints
+        ? undefined
+        : {
+            maxWallClockTime: p.constraints?.["maxWallClockTime"],
+            retentionTime: p.constraints?.["retentionTime"],
+            maxTaskRetryCount: p.constraints?.["maxTaskRetryCount"],
+          },
+      requiredSlots: p["requiredSlots"],
+      userIdentity: !p.userIdentity
+        ? undefined
+        : {
+            username: p.userIdentity?.["username"],
+            autoUser: !p.userIdentity?.autoUser
+              ? undefined
+              : {
+                  scope: p.userIdentity?.autoUser?.["scope"],
+                  elevationLevel: p.userIdentity?.autoUser?.["elevationLevel"],
+                },
+          },
+      executionInfo: !p.executionInfo
+        ? undefined
+        : {
+            startTime: new Date(p.executionInfo?.["startTime"] ?? ""),
+            endTime: new Date(p.executionInfo?.["endTime"] ?? ""),
+            exitCode: p.executionInfo?.["exitCode"],
+            containerInfo: !p.executionInfo?.containerInfo
+              ? undefined
+              : {
+                  containerId: p.executionInfo?.containerInfo?.["containerId"],
+                  state: p.executionInfo?.containerInfo?.["state"],
+                  error: p.executionInfo?.containerInfo?.["error"],
+                },
+            failureInfo: !p.executionInfo?.failureInfo
+              ? undefined
+              : {
+                  category: p.executionInfo?.failureInfo?.["category"],
+                  code: p.executionInfo?.failureInfo?.["code"],
+                  message: p.executionInfo?.failureInfo?.["message"],
+                  details: (
+                    p.executionInfo?.failureInfo?.["details"] ?? []
+                  ).map((p) => ({ name: p["name"], value: p["value"] })),
+                },
+            retryCount: p.executionInfo?.["retryCount"],
+            lastRetryTime: new Date(p.executionInfo?.["lastRetryTime"] ?? ""),
+            requeueCount: p.executionInfo?.["requeueCount"],
+            lastRequeueTime: new Date(
+              p.executionInfo?.["lastRequeueTime"] ?? ""
+            ),
+            result: p.executionInfo?.["result"],
+          },
+      nodeInfo: !p.nodeInfo
+        ? undefined
+        : {
+            affinityId: p.nodeInfo?.["affinityId"],
+            nodeUrl: p.nodeInfo?.["nodeUrl"],
+            poolId: p.nodeInfo?.["poolId"],
+            nodeId: p.nodeInfo?.["nodeId"],
+            taskRootDirectory: p.nodeInfo?.["taskRootDirectory"],
+            taskRootDirectoryUrl: p.nodeInfo?.["taskRootDirectoryUrl"],
+          },
+      multiInstanceSettings: !p.multiInstanceSettings
+        ? undefined
+        : {
+            numberOfInstances: p.multiInstanceSettings?.["numberOfInstances"],
+            coordinationCommandLine:
+              p.multiInstanceSettings?.["coordinationCommandLine"],
+            commonResourceFiles: (
+              p.multiInstanceSettings?.["commonResourceFiles"] ?? []
+            ).map((p) => ({
+              autoStorageContainerName: p["autoStorageContainerName"],
+              storageContainerUrl: p["storageContainerUrl"],
+              httpUrl: p["httpUrl"],
+              blobPrefix: p["blobPrefix"],
+              filePath: p["filePath"],
+              fileMode: p["fileMode"],
+              identityReference: !p.identityReference
+                ? undefined
+                : { resourceId: p.identityReference?.["resourceId"] },
+            })),
+          },
+      stats: !p.stats
+        ? undefined
+        : {
+            url: p.stats?.["url"],
+            startTime: new Date(p.stats?.["startTime"] ?? ""),
+            lastUpdateTime: new Date(p.stats?.["lastUpdateTime"] ?? ""),
+            userCPUTime: p.stats?.["userCPUTime"],
+            kernelCPUTime: p.stats?.["kernelCPUTime"],
+            wallClockTime: p.stats?.["wallClockTime"],
+            readIOps: p.stats?.["readIOps"],
+            writeIOps: p.stats?.["writeIOps"],
+            readIOGiB: p.stats?.["readIOGiB"],
+            writeIOGiB: p.stats?.["writeIOGiB"],
+            waitTime: p.stats?.["waitTime"],
+          },
+      dependsOn: !p.dependsOn
+        ? undefined
+        : {
+            taskIds: p.dependsOn?.["taskIds"],
+            taskIdRanges: (p.dependsOn?.["taskIdRanges"] ?? []).map((p) => ({
+              start: p["start"],
+              end: p["end"],
+            })),
+          },
+      applicationPackageReferences: (
+        p["applicationPackageReferences"] ?? []
+      ).map((p) => ({
+        applicationId: p["applicationId"],
+        version: p["version"],
+      })),
+      authenticationTokenSettings: !p.authenticationTokenSettings
+        ? undefined
+        : { access: p.authenticationTokenSettings?.["access"] },
+    })),
+    "odata.nextLink": result.body["odata.nextLink"],
+  };
+}
+
+export interface Taskaddtaskcollectionoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/**
+ * Note that each Task must have a unique ID. The Batch service may not return the
+ * results for each Task in the same order the Tasks were submitted in this
+ * request. If the server times out or the connection is closed during the
+ * request, the request may have been partially or fully processed, or not at all.
+ * In such cases, the user should re-issue the request. Note that it is up to the
+ * user to correctly handle failures when re-issuing a request. For example, you
+ * should use the same Task IDs during a retry so that if the prior operation
+ * succeeded, the retry will not create extra Tasks unexpectedly. If the response
+ * contains any Tasks which failed to add, a client can retry the request. In a
+ * retry, it is most efficient to resubmit only Tasks that failed to add, and to
+ * omit Tasks that were successfully added on the first attempt. The maximum
+ * lifetime of a Task from addition to completion is 180 days. If a Task has not
+ * completed within 180 days of being added it will be terminated by the Batch
+ * service and left in whatever state it was in at that time.
+ */
+export async function addTaskCollection(
+  context: Client,
+  value: BatchTask[],
+  jobId: string,
+  options: Taskaddtaskcollectionoptions = { requestOptions: {} }
+): Promise<TaskAddCollectionResult> {
+  const result = await context
+    .path("/jobs/{jobId}/addtaskcollection", jobId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: { value: value },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      status: p["status"],
+      taskId: p["taskId"],
+      eTag: p["eTag"],
+      lastModified: new Date(p["lastModified"] ?? ""),
+      location: p["location"],
+      error: !p.error
+        ? undefined
+        : {
+            code: p.error?.["code"],
+            message: !p.error?.message
+              ? undefined
+              : {
+                  lang: p.error?.message?.["lang"],
+                  value: p.error?.message?.["value"],
+                },
+            values: (p.error?.["values"] ?? []).map((p) => ({
+              key: p["key"],
+              value: p["value"],
+            })),
+          },
+    })),
+  };
+}
+
+export interface Taskdeletetaskcollectionoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * When a Task is deleted, all of the files in its directory on the Compute Node
+ * where it ran are also deleted (regardless of the retention time). For
+ * multi-instance Tasks, the delete Task operation applies synchronously to the
+ * primary task; subtasks and their files are then deleted asynchronously in the
+ * background.
+ */
+export async function deleteTaskCollection(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Taskdeletetaskcollectionoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}", jobId, taskId)
+    .delete({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Taskgettaskcollectionoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** An OData $select clause. */
+  $select?: string;
+  /** An OData $expand clause. */
+  $expand?: string;
+}
+
+/**
+ * For multi-instance Tasks, information such as affinityId, executionInfo and
+ * nodeInfo refer to the primary Task. Use the list subtasks API to retrieve
+ * information about subtasks.
+ */
+export async function getTaskCollection(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Taskgettaskcollectionoptions = { requestOptions: {} }
+): Promise<BatchTask> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}", jobId, taskId)
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+        ...(options.$expand && { $expand: options.$expand }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    displayName: result.body["displayName"],
+    url: result.body["url"],
+    eTag: result.body["eTag"],
+    lastModified: new Date(result.body["lastModified"] ?? ""),
+    creationTime: new Date(result.body["creationTime"] ?? ""),
+    exitConditions: !result.body.exitConditions
+      ? undefined
+      : {
+          exitCodes: (result.body.exitConditions?.["exitCodes"] ?? []).map(
+            (p) => ({
+              code: p["code"],
+              exitOptions: {
+                jobAction: p.exitOptions["jobAction"],
+                dependencyAction: p.exitOptions["dependencyAction"],
+              },
+            })
+          ),
+          exitCodeRanges: (
+            result.body.exitConditions?.["exitCodeRanges"] ?? []
+          ).map((p) => ({
+            start: p["start"],
+            end: p["end"],
+            exitOptions: {
+              jobAction: p.exitOptions["jobAction"],
+              dependencyAction: p.exitOptions["dependencyAction"],
+            },
+          })),
+          preProcessingError: !result.body.exitConditions?.preProcessingError
+            ? undefined
+            : {
+                jobAction:
+                  result.body.exitConditions?.preProcessingError?.["jobAction"],
+                dependencyAction:
+                  result.body.exitConditions?.preProcessingError?.[
+                    "dependencyAction"
+                  ],
+              },
+          fileUploadError: !result.body.exitConditions?.fileUploadError
+            ? undefined
+            : {
+                jobAction:
+                  result.body.exitConditions?.fileUploadError?.["jobAction"],
+                dependencyAction:
+                  result.body.exitConditions?.fileUploadError?.[
+                    "dependencyAction"
+                  ],
+              },
+          default: !result.body.exitConditions?.default
+            ? undefined
+            : {
+                jobAction: result.body.exitConditions?.default?.["jobAction"],
+                dependencyAction:
+                  result.body.exitConditions?.default?.["dependencyAction"],
+              },
+        },
+    state: result.body["state"],
+    stateTransitionTime: new Date(result.body["stateTransitionTime"] ?? ""),
+    previousState: result.body["previousState"],
+    previousStateTransitionTime: new Date(
+      result.body["previousStateTransitionTime"] ?? ""
+    ),
+    commandLine: result.body["commandLine"],
+    containerSettings: !result.body.containerSettings
+      ? undefined
+      : {
+          containerRunOptions:
+            result.body.containerSettings?.["containerRunOptions"],
+          imageName: result.body.containerSettings?.["imageName"],
+          registry: !result.body.containerSettings?.registry
+            ? undefined
+            : {
+                username: result.body.containerSettings?.registry?.["username"],
+                password: result.body.containerSettings?.registry?.["password"],
+                registryServer:
+                  result.body.containerSettings?.registry?.["registryServer"],
+                identityReference: !result.body.containerSettings?.registry
+                  ?.identityReference
+                  ? undefined
+                  : {
+                      resourceId:
+                        result.body.containerSettings?.registry
+                          ?.identityReference?.["resourceId"],
+                    },
+              },
+          workingDirectory: result.body.containerSettings?.["workingDirectory"],
+        },
+    resourceFiles: (result.body["resourceFiles"] ?? []).map((p) => ({
+      autoStorageContainerName: p["autoStorageContainerName"],
+      storageContainerUrl: p["storageContainerUrl"],
+      httpUrl: p["httpUrl"],
+      blobPrefix: p["blobPrefix"],
+      filePath: p["filePath"],
+      fileMode: p["fileMode"],
+      identityReference: !p.identityReference
+        ? undefined
+        : { resourceId: p.identityReference?.["resourceId"] },
+    })),
+    outputFiles: (result.body["outputFiles"] ?? []).map((p) => ({
+      filePattern: p["filePattern"],
+      destination: {
+        container: !p.destination.container
+          ? undefined
+          : {
+              path: p.destination.container?.["path"],
+              containerUrl: p.destination.container?.["containerUrl"],
+              identityReference: !p.destination.container?.identityReference
+                ? undefined
+                : {
+                    resourceId:
+                      p.destination.container?.identityReference?.[
+                        "resourceId"
+                      ],
+                  },
+              uploadHeaders: (
+                p.destination.container?.["uploadHeaders"] ?? []
+              ).map((p) => ({ name: p["name"], value: p["value"] })),
+            },
+      },
+      uploadOptions: { uploadCondition: p.uploadOptions["uploadCondition"] },
+    })),
+    environmentSettings: (result.body["environmentSettings"] ?? []).map(
+      (p) => ({ name: p["name"], value: p["value"] })
+    ),
+    affinityInfo: !result.body.affinityInfo
+      ? undefined
+      : { affinityId: result.body.affinityInfo?.["affinityId"] },
+    constraints: !result.body.constraints
+      ? undefined
+      : {
+          maxWallClockTime: result.body.constraints?.["maxWallClockTime"],
+          retentionTime: result.body.constraints?.["retentionTime"],
+          maxTaskRetryCount: result.body.constraints?.["maxTaskRetryCount"],
+        },
+    requiredSlots: result.body["requiredSlots"],
+    userIdentity: !result.body.userIdentity
+      ? undefined
+      : {
+          username: result.body.userIdentity?.["username"],
+          autoUser: !result.body.userIdentity?.autoUser
+            ? undefined
+            : {
+                scope: result.body.userIdentity?.autoUser?.["scope"],
+                elevationLevel:
+                  result.body.userIdentity?.autoUser?.["elevationLevel"],
+              },
+        },
+    executionInfo: !result.body.executionInfo
+      ? undefined
+      : {
+          startTime: new Date(result.body.executionInfo?.["startTime"] ?? ""),
+          endTime: new Date(result.body.executionInfo?.["endTime"] ?? ""),
+          exitCode: result.body.executionInfo?.["exitCode"],
+          containerInfo: !result.body.executionInfo?.containerInfo
+            ? undefined
+            : {
+                containerId:
+                  result.body.executionInfo?.containerInfo?.["containerId"],
+                state: result.body.executionInfo?.containerInfo?.["state"],
+                error: result.body.executionInfo?.containerInfo?.["error"],
+              },
+          failureInfo: !result.body.executionInfo?.failureInfo
+            ? undefined
+            : {
+                category: result.body.executionInfo?.failureInfo?.["category"],
+                code: result.body.executionInfo?.failureInfo?.["code"],
+                message: result.body.executionInfo?.failureInfo?.["message"],
+                details: (
+                  result.body.executionInfo?.failureInfo?.["details"] ?? []
+                ).map((p) => ({ name: p["name"], value: p["value"] })),
+              },
+          retryCount: result.body.executionInfo?.["retryCount"],
+          lastRetryTime: new Date(
+            result.body.executionInfo?.["lastRetryTime"] ?? ""
+          ),
+          requeueCount: result.body.executionInfo?.["requeueCount"],
+          lastRequeueTime: new Date(
+            result.body.executionInfo?.["lastRequeueTime"] ?? ""
+          ),
+          result: result.body.executionInfo?.["result"],
+        },
+    nodeInfo: !result.body.nodeInfo
+      ? undefined
+      : {
+          affinityId: result.body.nodeInfo?.["affinityId"],
+          nodeUrl: result.body.nodeInfo?.["nodeUrl"],
+          poolId: result.body.nodeInfo?.["poolId"],
+          nodeId: result.body.nodeInfo?.["nodeId"],
+          taskRootDirectory: result.body.nodeInfo?.["taskRootDirectory"],
+          taskRootDirectoryUrl: result.body.nodeInfo?.["taskRootDirectoryUrl"],
+        },
+    multiInstanceSettings: !result.body.multiInstanceSettings
+      ? undefined
+      : {
+          numberOfInstances:
+            result.body.multiInstanceSettings?.["numberOfInstances"],
+          coordinationCommandLine:
+            result.body.multiInstanceSettings?.["coordinationCommandLine"],
+          commonResourceFiles: (
+            result.body.multiInstanceSettings?.["commonResourceFiles"] ?? []
+          ).map((p) => ({
+            autoStorageContainerName: p["autoStorageContainerName"],
+            storageContainerUrl: p["storageContainerUrl"],
+            httpUrl: p["httpUrl"],
+            blobPrefix: p["blobPrefix"],
+            filePath: p["filePath"],
+            fileMode: p["fileMode"],
+            identityReference: !p.identityReference
+              ? undefined
+              : { resourceId: p.identityReference?.["resourceId"] },
+          })),
+        },
+    stats: !result.body.stats
+      ? undefined
+      : {
+          url: result.body.stats?.["url"],
+          startTime: new Date(result.body.stats?.["startTime"] ?? ""),
+          lastUpdateTime: new Date(result.body.stats?.["lastUpdateTime"] ?? ""),
+          userCPUTime: result.body.stats?.["userCPUTime"],
+          kernelCPUTime: result.body.stats?.["kernelCPUTime"],
+          wallClockTime: result.body.stats?.["wallClockTime"],
+          readIOps: result.body.stats?.["readIOps"],
+          writeIOps: result.body.stats?.["writeIOps"],
+          readIOGiB: result.body.stats?.["readIOGiB"],
+          writeIOGiB: result.body.stats?.["writeIOGiB"],
+          waitTime: result.body.stats?.["waitTime"],
+        },
+    dependsOn: !result.body.dependsOn
+      ? undefined
+      : {
+          taskIds: result.body.dependsOn?.["taskIds"],
+          taskIdRanges: (result.body.dependsOn?.["taskIdRanges"] ?? []).map(
+            (p) => ({ start: p["start"], end: p["end"] })
+          ),
+        },
+    applicationPackageReferences: (
+      result.body["applicationPackageReferences"] ?? []
+    ).map((p) => ({
+      applicationId: p["applicationId"],
+      version: p["version"],
+    })),
+    authenticationTokenSettings: !result.body.authenticationTokenSettings
+      ? undefined
+      : { access: result.body.authenticationTokenSettings?.["access"] },
+  };
+}
+
+export interface Taskupdatetaskcollectionoptions extends RequestOptions {
+  /**
+   * The ID can contain any combination of alphanumeric characters including hyphens
+   * and underscores, and cannot contain more than 64 characters.
+   */
+  id?: string;
+  /**
+   * The display name need not be unique and can contain any Unicode characters up
+   * to a maximum length of 1024.
+   */
+  displayName?: string;
+  /** The URL of the Task. */
+  url?: string;
+  /**
+   * This is an opaque string. You can use it to detect whether the Task has changed
+   * between requests. In particular, you can be pass the ETag when updating a Task
+   * to specify that your changes should take effect only if nobody else has
+   * modified the Task in the meantime.
+   */
+  eTag?: string;
+  /** The last modified time of the Task. */
+  lastModified?: Date;
+  /** The creation time of the Task. */
+  creationTime?: Date;
+  /** How the Batch service should respond when the Task completes. */
+  exitConditions?: ExitConditions;
+  /** The state of the Task. */
+  state?: TaskState;
+  /** The time at which the Task entered its current state. */
+  stateTransitionTime?: Date;
+  /** This property is not set if the Task is in its initial Active state. */
+  previousState?: TaskState;
+  /** This property is not set if the Task is in its initial Active state. */
+  previousStateTransitionTime?: Date;
+  /**
+   * For multi-instance Tasks, the command line is executed as the primary Task,
+   * after the primary Task and all subtasks have finished executing the
+   * coordination command line. The command line does not run under a shell, and
+   * therefore cannot take advantage of shell features such as environment variable
+   * expansion. If you want to take advantage of such features, you should invoke
+   * the shell in the command line, for example using "cmd /c MyCommand" in
+   * Windows or "/bin/sh -c MyCommand" in Linux. If the command line refers to
+   * file paths, it should use a relative path (relative to the Task working
+   * directory), or use the Batch provided environment variable
+   * (https://docs.microsoft.com/en-us/azure/batch/batch-compute-node-environment-variables).
+   */
+  commandLine?: string;
+  /**
+   * If the Pool that will run this Task has containerConfiguration set, this must
+   * be set as well. If the Pool that will run this Task doesn't have
+   * containerConfiguration set, this must not be set. When this is specified, all
+   * directories recursively below the AZ_BATCH_NODE_ROOT_DIR (the root of Azure
+   * Batch directories on the node) are mapped into the container, all Task
+   * environment variables are mapped into the container, and the Task command line
+   * is executed in the container. Files produced in the container outside of
+   * AZ_BATCH_NODE_ROOT_DIR might not be reflected to the host disk, meaning that
+   * Batch file APIs will not be able to access those files.
+   */
+  containerSettings?: TaskContainerSettings;
+  /**
+   * For multi-instance Tasks, the resource files will only be downloaded to the
+   * Compute Node on which the primary Task is executed. There is a maximum size for
+   * the list of resource files.  When the max size is exceeded, the request will
+   * fail and the response error code will be RequestEntityTooLarge. If this occurs,
+   * the collection of ResourceFiles must be reduced in size. This can be achieved
+   * using .zip files, Application Packages, or Docker Containers.
+   */
+  resourceFiles?: ResourceFile[];
+  /**
+   * For multi-instance Tasks, the files will only be uploaded from the Compute Node
+   * on which the primary Task is executed.
+   */
+  outputFiles?: OutputFile[];
+  /** A list of environment variable settings for the Task. */
+  environmentSettings?: EnvironmentSetting[];
+  /**
+   * A locality hint that can be used by the Batch service to select a Compute Node
+   * on which to start a Task.
+   */
+  affinityInfo?: AffinityInformation;
+  /** Execution constraints to apply to a Task. */
+  constraints?: TaskConstraints;
+  /**
+   * The default is 1. A Task can only be scheduled to run on a compute node if the
+   * node has enough free scheduling slots available. For multi-instance Tasks, this
+   * must be 1.
+   */
+  requiredSlots?: number;
+  /** If omitted, the Task runs as a non-administrative user unique to the Task. */
+  userIdentity?: UserIdentity;
+  /** Information about the execution of a Task. */
+  executionInfo?: TaskExecutionInformation;
+  /** Information about the Compute Node on which a Task ran. */
+  nodeInfo?: ComputeNodeInformation;
+  /**
+   * Multi-instance Tasks are commonly used to support MPI Tasks. In the MPI case,
+   * if any of the subtasks fail (for example due to exiting with a non-zero exit
+   * code) the entire multi-instance Task fails. The multi-instance Task is then
+   * terminated and retried, up to its retry limit.
+   */
+  multiInstanceSettings?: MultiInstanceSettings;
+  /** Resource usage statistics for a Task. */
+  stats?: TaskStatistics;
+  /**
+   * This Task will not be scheduled until all Tasks that it depends on have
+   * completed successfully. If any of those Tasks fail and exhaust their retry
+   * counts, this Task will never be scheduled.
+   */
+  dependsOn?: TaskDependencies;
+  /**
+   * Application packages are downloaded and deployed to a shared directory, not the
+   * Task working directory. Therefore, if a referenced package is already on the
+   * Node, and is up to date, then it is not re-downloaded; the existing copy on the
+   * Compute Node is used. If a referenced Package cannot be installed, for example
+   * because the package has been deleted or because download failed, the Task
+   * fails.
+   */
+  applicationPackageReferences?: ApplicationPackageReference[];
+  /**
+   * If this property is set, the Batch service provides the Task with an
+   * authentication token which can be used to authenticate Batch service operations
+   * without requiring an Account access key. The token is provided via the
+   * AZ_BATCH_AUTHENTICATION_TOKEN environment variable. The operations that the
+   * Task can carry out using the token depend on the settings. For example, a Task
+   * can request Job permissions in order to add other Tasks to the Job, or check
+   * the status of the Job or of other Tasks under the Job.
+   */
+  authenticationTokenSettings?: AuthenticationTokenSettings;
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+  /** Body parameter Content-Type. Known values are: application/json. */
+  content_type?: string;
+}
+
+/** Updates the properties of the specified Task. */
+export async function updateTaskCollection(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Taskupdatetaskcollectionoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}", jobId, taskId)
+    .put({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...(options.content_type && { "Content-Type": options.content_type }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+      body: {
+        ...(options.id && { id: options.id }),
+        ...(options.displayName && { displayName: options.displayName }),
+        ...(options.exitConditions && {
+          exitConditions: options.exitConditions,
+        }),
+        ...(options.commandLine && { commandLine: options.commandLine }),
+        ...(options.containerSettings && {
+          containerSettings: options.containerSettings,
+        }),
+        ...(options.resourceFiles && { resourceFiles: options.resourceFiles }),
+        ...(options.outputFiles && { outputFiles: options.outputFiles }),
+        ...(options.environmentSettings && {
+          environmentSettings: options.environmentSettings,
+        }),
+        ...(options.affinityInfo && { affinityInfo: options.affinityInfo }),
+        ...(options.constraints && { constraints: options.constraints }),
+        ...(options.requiredSlots && { requiredSlots: options.requiredSlots }),
+        ...(options.userIdentity && { userIdentity: options.userIdentity }),
+        ...(options.multiInstanceSettings && {
+          multiInstanceSettings: options.multiInstanceSettings,
+        }),
+        ...(options.dependsOn && { dependsOn: options.dependsOn }),
+        ...(options.applicationPackageReferences && {
+          applicationPackageReferences: options.applicationPackageReferences,
+        }),
+        ...(options.authenticationTokenSettings && {
+          authenticationTokenSettings: options.authenticationTokenSettings,
+        }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Tasklistsubtasksoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /** An OData $select clause. */
+  $select?: string;
+}
+
+/** If the Task is not a multi-instance Task then this returns an empty collection. */
+export async function listSubtasks(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Tasklistsubtasksoptions = { requestOptions: {} }
+): Promise<BatchTaskListSubtasksResult> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}/subtasksinfo", jobId, taskId)
+    .get({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        Accept: "application/json",
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: {
+        ...(options.timeOut && { timeOut: options.timeOut }),
+        ...(options.$select && { $select: options.$select }),
+      },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    value: (result.body["value"] ?? []).map((p) => ({
+      id: p["id"],
+      nodeInfo: !p.nodeInfo
+        ? undefined
+        : {
+            affinityId: p.nodeInfo?.["affinityId"],
+            nodeUrl: p.nodeInfo?.["nodeUrl"],
+            poolId: p.nodeInfo?.["poolId"],
+            nodeId: p.nodeInfo?.["nodeId"],
+            taskRootDirectory: p.nodeInfo?.["taskRootDirectory"],
+            taskRootDirectoryUrl: p.nodeInfo?.["taskRootDirectoryUrl"],
+          },
+      startTime: new Date(p["startTime"] ?? ""),
+      endTime: new Date(p["endTime"] ?? ""),
+      exitCode: p["exitCode"],
+      containerInfo: !p.containerInfo
+        ? undefined
+        : {
+            containerId: p.containerInfo?.["containerId"],
+            state: p.containerInfo?.["state"],
+            error: p.containerInfo?.["error"],
+          },
+      failureInfo: !p.failureInfo
+        ? undefined
+        : {
+            category: p.failureInfo?.["category"],
+            code: p.failureInfo?.["code"],
+            message: p.failureInfo?.["message"],
+            details: (p.failureInfo?.["details"] ?? []).map((p) => ({
+              name: p["name"],
+              value: p["value"],
+            })),
+          },
+      state: p["state"],
+      stateTransitionTime: new Date(p["stateTransitionTime"] ?? ""),
+      previousState: p["previousState"],
+      previousStateTransitionTime: new Date(
+        p["previousStateTransitionTime"] ?? ""
+      ),
+      result: p["result"],
+    })),
+  };
+}
+
+export interface Taskterminatetaskcollectionoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * When the Task has been terminated, it moves to the completed state. For
+ * multi-instance Tasks, the terminate Task operation applies synchronously to the
+ * primary task; subtasks are then terminated asynchronously in the background.
+ */
+export async function terminateTaskCollection(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Taskterminatetaskcollectionoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}/terminate", jobId, taskId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+export interface Taskreactivatetaskcollectionoptions extends RequestOptions {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  clientRequestId?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  returnClientRequestId?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  ocpDate?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service exactly matches the value specified by the client.
+   */
+  ifMatch?: string;
+  /**
+   * An ETag value associated with the version of the resource known to the client.
+   * The operation will be performed only if the resource's current ETag on the
+   * service does not match the value specified by the client.
+   */
+  ifNoneMatch?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * been modified since the specified time.
+   */
+  ifModifiedSince?: string;
+  /**
+   * A timestamp indicating the last modified time of the resource known to the
+   * client. The operation will be performed only if the resource on the service has
+   * not been modified since the specified time.
+   */
+  ifUnmodifiedSince?: string;
+}
+
+/**
+ * Reactivation makes a Task eligible to be retried again up to its maximum retry
+ * count. The Task's state is changed to active. As the Task is no longer in the
+ * completed state, any previous exit code or failure information is no longer
+ * available after reactivation. Each time a Task is reactivated, its retry count
+ * is reset to 0. Reactivation will fail for Tasks that are not completed or that
+ * previously completed successfully (with an exit code of 0). Additionally, it
+ * will fail if the Job has completed (or is terminating or deleting).
+ */
+export async function reactivateTaskCollection(
+  context: Client,
+  jobId: string,
+  taskId: string,
+  options: Taskreactivatetaskcollectionoptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await context
+    .path("/jobs/{jobId}/tasks/{taskId}/reactivate", jobId, taskId)
+    .post({
+      headers: {
+        ...(options.clientRequestId && {
+          "client-request-id": options.clientRequestId,
+        }),
+        ...(options.returnClientRequestId && {
+          "return-client-request-id": options.returnClientRequestId,
+        }),
+        ...(options.ocpDate && { "ocp-date": options.ocpDate }),
+        ...(options.ifMatch && { "if-match": options.ifMatch }),
+        ...(options.ifNoneMatch && { "if-none-match": options.ifNoneMatch }),
+        ...(options.ifModifiedSince && {
+          "if-modified-since": options.ifModifiedSince,
+        }),
+        ...(options.ifUnmodifiedSince && {
+          "if-unmodified-since": options.ifUnmodifiedSince,
+        }),
+        ...options.requestOptions?.headers,
+      },
+      queryParameters: { ...(options.timeOut && { timeOut: options.timeOut }) },
+    });
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Task.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/api/Task.ts
@@ -26,7 +26,7 @@ import {
   BatchTaskListSubtasksResult,
 } from "./models.js";
 
-export interface Taskaddtaskoptions extends RequestOptions {
+export interface TaskAddTaskOptions extends RequestOptions {
   /**
    * The ID can contain any combination of alphanumeric characters including hyphens
    * and underscores, and cannot contain more than 64 characters.
@@ -184,7 +184,7 @@ export interface Taskaddtaskoptions extends RequestOptions {
 export async function addTask(
   context: Client,
   jobId: string,
-  options: Taskaddtaskoptions = { requestOptions: {} }
+  options: TaskAddTaskOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context.path("/jobs/{jobId}/tasks", jobId).post({
     headers: {
@@ -235,7 +235,7 @@ export async function addTask(
   return;
 }
 
-export interface Tasklisttasksoptions extends RequestOptions {
+export interface TaskListTasksOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -278,7 +278,7 @@ export interface Tasklisttasksoptions extends RequestOptions {
 export async function listTasks(
   context: Client,
   jobId: string,
-  options: Tasklisttasksoptions = { requestOptions: {} }
+  options: TaskListTasksOptions = { requestOptions: {} }
 ): Promise<BatchTaskListResult> {
   const result = await context.path("/jobs/{jobId}/tasks", jobId).get({
     headers: {
@@ -545,7 +545,7 @@ export async function listTasks(
   };
 }
 
-export interface Taskaddtaskcollectionoptions extends RequestOptions {
+export interface TaskAddTaskCollectionOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -588,7 +588,7 @@ export async function addTaskCollection(
   context: Client,
   value: BatchTask[],
   jobId: string,
-  options: Taskaddtaskcollectionoptions = { requestOptions: {} }
+  options: TaskAddTaskCollectionOptions = { requestOptions: {} }
 ): Promise<TaskAddCollectionResult> {
   const result = await context
     .path("/jobs/{jobId}/addtaskcollection", jobId)
@@ -638,7 +638,7 @@ export async function addTaskCollection(
   };
 }
 
-export interface Taskdeletetaskcollectionoptions extends RequestOptions {
+export interface TaskDeleteTaskCollectionOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -694,7 +694,7 @@ export async function deleteTaskCollection(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Taskdeletetaskcollectionoptions = { requestOptions: {} }
+  options: TaskDeleteTaskCollectionOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}", jobId, taskId)
@@ -726,7 +726,7 @@ export async function deleteTaskCollection(
   return;
 }
 
-export interface Taskgettaskcollectionoptions extends RequestOptions {
+export interface TaskGetTaskCollectionOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -784,7 +784,7 @@ export async function getTaskCollection(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Taskgettaskcollectionoptions = { requestOptions: {} }
+  options: TaskGetTaskCollectionOptions = { requestOptions: {} }
 ): Promise<BatchTask> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}", jobId, taskId)
@@ -1066,7 +1066,7 @@ export async function getTaskCollection(
   };
 }
 
-export interface Taskupdatetaskcollectionoptions extends RequestOptions {
+export interface TaskUpdateTaskCollectionOptions extends RequestOptions {
   /**
    * The ID can contain any combination of alphanumeric characters including hyphens
    * and underscores, and cannot contain more than 64 characters.
@@ -1245,7 +1245,7 @@ export async function updateTaskCollection(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Taskupdatetaskcollectionoptions = { requestOptions: {} }
+  options: TaskUpdateTaskCollectionOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}", jobId, taskId)
@@ -1308,7 +1308,7 @@ export async function updateTaskCollection(
   return;
 }
 
-export interface Tasklistsubtasksoptions extends RequestOptions {
+export interface TaskListSubtasksOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1336,7 +1336,7 @@ export async function listSubtasks(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Tasklistsubtasksoptions = { requestOptions: {} }
+  options: TaskListSubtasksOptions = { requestOptions: {} }
 ): Promise<BatchTaskListSubtasksResult> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}/subtasksinfo", jobId, taskId)
@@ -1406,7 +1406,7 @@ export async function listSubtasks(
   };
 }
 
-export interface Taskterminatetaskcollectionoptions extends RequestOptions {
+export interface TaskTerminateTaskCollectionOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1460,7 +1460,7 @@ export async function terminateTaskCollection(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Taskterminatetaskcollectionoptions = { requestOptions: {} }
+  options: TaskTerminateTaskCollectionOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}/terminate", jobId, taskId)
@@ -1492,7 +1492,7 @@ export async function terminateTaskCollection(
   return;
 }
 
-export interface Taskreactivatetaskcollectionoptions extends RequestOptions {
+export interface TaskReactivateTaskCollectionOptions extends RequestOptions {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1550,7 +1550,7 @@ export async function reactivateTaskCollection(
   context: Client,
   jobId: string,
   taskId: string,
-  options: Taskreactivatetaskcollectionoptions = { requestOptions: {} }
+  options: TaskReactivateTaskCollectionOptions = { requestOptions: {} }
 ): Promise<void> {
   const result = await context
     .path("/jobs/{jobId}/tasks/{taskId}/reactivate", jobId, taskId)

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/clientDefinitions.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/clientDefinitions.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT license.
 
 import {
-  ApplicationsListParameters,
+  ApplicationsListApplicationsParameters,
   ApplicationsGetParameters,
   PoolListUsageMetricsParameters,
   PoolGetAllLifetimeStatisticsParameters,
-  PoolAddParameters,
-  PoolListParameters,
-  PoolDeleteParameters,
+  PoolAddPoolParameters,
+  PoolListPoolsParameters,
+  PoolDeletePoolParameters,
   PoolExistsParameters,
-  PoolGetParameters,
-  PoolPatchParameters,
+  PoolGetPoolParameters,
+  PoolPatchPoolParameters,
   PoolDisableAutoScaleParameters,
   PoolEnableAutoScaleParameters,
   PoolEvaluateAutoScaleParameters,
@@ -22,23 +22,23 @@ import {
   AccountListSupportedImagesParameters,
   AccountListPoolNodeCountsParameters,
   JobGetAllLifetimeStatisticsParameters,
-  JobDeleteParameters,
-  JobGetParameters,
-  JobPatchParameters,
-  JobUpdateParameters,
-  JobDisableParameters,
-  JobEnableParameters,
-  JobTerminateParameters,
-  JobAddParameters,
-  JobListParameters,
+  JobDeleteJobParameters,
+  JobGetJobParameters,
+  JobPatchJobParameters,
+  JobUpdateJobParameters,
+  JobDisableJobParameters,
+  JobEnableJobParameters,
+  JobTerminateJobParameters,
+  JobAddJobParameters,
+  JobListJobsParameters,
   JobListFromJobScheduleParameters,
   JobListPreparationAndReleaseTaskStatusParameters,
   JobGetTaskCountsParameters,
-  CertificatesAddParameters,
-  CertificatesListParameters,
-  CertificatesCancelDeletionParameters,
-  CertificatesDeleteParameters,
-  CertificatesGetParameters,
+  CertificatesAddCertificateParameters,
+  CertificatesListCertificatesParameters,
+  CertificatesCancelCertificateDeletionParameters,
+  CertificatesDeleteCertificateParameters,
+  CertificatesGetCertificateParameters,
   FileDeleteFromTaskParameters,
   FileGetFromTaskParameters,
   FileGetPropertiesFromTaskParameters,
@@ -47,62 +47,62 @@ import {
   FileGetPropertiesFromComputeNodeParameters,
   FileListFromTaskParameters,
   FileListFromComputeNodeParameters,
-  JobScheduleExistsParameters,
-  JobScheduleDeleteParameters,
-  JobScheduleGetParameters,
-  JobSchedulePatchParameters,
-  JobScheduleUpdateParameters,
-  JobScheduleDisableParameters,
-  JobScheduleEnableParameters,
-  JobScheduleTerminateParameters,
-  JobScheduleAddParameters,
-  JobScheduleListParameters,
-  TaskAddParameters,
-  TaskListParameters,
-  TaskAddCollectionParameters,
-  TaskDeleteParameters,
-  TaskGetParameters,
-  TaskUpdateParameters,
+  JobScheduleJobScheduleExistsParameters,
+  JobScheduleDeleteJobScheduleParameters,
+  JobScheduleGetJobScheduleParameters,
+  JobSchedulePatchJobScheduleParameters,
+  JobScheduleUpdateJobScheduleParameters,
+  JobScheduleDisableJobScheduleParameters,
+  JobScheduleEnableJobScheduleParameters,
+  JobScheduleTerminateJobScheduleParameters,
+  JobScheduleAddJobScheduleParameters,
+  JobScheduleListJobSchedulesParameters,
+  TaskAddTaskParameters,
+  TaskListTasksParameters,
+  TaskAddTaskCollectionParameters,
+  TaskDeleteTaskCollectionParameters,
+  TaskGetTaskCollectionParameters,
+  TaskUpdateTaskCollectionParameters,
   TaskListSubtasksParameters,
-  TaskTerminateParameters,
-  TaskReactivateParameters,
+  TaskTerminateTaskCollectionParameters,
+  TaskReactivateTaskCollectionParameters,
   ComputeNodesAddUserParameters,
   ComputeNodesDeleteUserParameters,
   ComputeNodesUpdateUserParameters,
-  ComputeNodesGetParameters,
-  ComputeNodesRebootParameters,
-  ComputeNodesReimageParameters,
+  ComputeNodesGetComputeNodeParameters,
+  ComputeNodesRebootComputeNodeParameters,
+  ComputeNodesReimageComputeNodeParameters,
   ComputeNodesDisableSchedulingParameters,
   ComputeNodesEnableSchedulingParameters,
   ComputeNodesGetRemoteLoginSettingsParameters,
   ComputeNodesGetRemoteDesktopParameters,
   ComputeNodesUploadBatchServiceLogsParameters,
   ComputeNodesListParameters,
-  ComputeNodeExtensionsGetParameters,
-  ComputeNodeExtensionsListParameters,
+  ComputeNodeExtensionsGetComputeNodeExtensionsParameters,
+  ComputeNodeExtensionsListComputeNodeExtensionsParameters,
 } from "./parameters.js";
 import {
-  ApplicationsList200Response,
-  ApplicationsListDefaultResponse,
+  ApplicationsListApplications200Response,
+  ApplicationsListApplicationsDefaultResponse,
   ApplicationsGet200Response,
   ApplicationsGetDefaultResponse,
   PoolListUsageMetrics200Response,
   PoolListUsageMetricsDefaultResponse,
   PoolGetAllLifetimeStatistics200Response,
   PoolGetAllLifetimeStatisticsDefaultResponse,
-  PoolAdd201Response,
-  PoolAddDefaultResponse,
-  PoolList200Response,
-  PoolListDefaultResponse,
-  PoolDelete202Response,
-  PoolDeleteDefaultResponse,
+  PoolAddPool201Response,
+  PoolAddPoolDefaultResponse,
+  PoolListPools200Response,
+  PoolListPoolsDefaultResponse,
+  PoolDeletePool202Response,
+  PoolDeletePoolDefaultResponse,
   PoolExists200Response,
   PoolExists404Response,
   PoolExistsDefaultResponse,
-  PoolGet200Response,
-  PoolGetDefaultResponse,
-  PoolPatch200Response,
-  PoolPatchDefaultResponse,
+  PoolGetPool200Response,
+  PoolGetPoolDefaultResponse,
+  PoolPatchPool200Response,
+  PoolPatchPoolDefaultResponse,
   PoolDisableAutoScale200Response,
   PoolDisableAutoScaleDefaultResponse,
   PoolEnableAutoScale200Response,
@@ -123,40 +123,40 @@ import {
   AccountListPoolNodeCountsDefaultResponse,
   JobGetAllLifetimeStatistics200Response,
   JobGetAllLifetimeStatisticsDefaultResponse,
-  JobDelete202Response,
-  JobDeleteDefaultResponse,
-  JobGet200Response,
-  JobGetDefaultResponse,
-  JobPatch200Response,
-  JobPatchDefaultResponse,
-  JobUpdate200Response,
-  JobUpdateDefaultResponse,
-  JobDisable202Response,
-  JobDisableDefaultResponse,
-  JobEnable202Response,
-  JobEnableDefaultResponse,
-  JobTerminate202Response,
-  JobTerminateDefaultResponse,
-  JobAdd201Response,
-  JobAddDefaultResponse,
-  JobList200Response,
-  JobListDefaultResponse,
+  JobDeleteJob202Response,
+  JobDeleteJobDefaultResponse,
+  JobGetJob200Response,
+  JobGetJobDefaultResponse,
+  JobPatchJob200Response,
+  JobPatchJobDefaultResponse,
+  JobUpdateJob200Response,
+  JobUpdateJobDefaultResponse,
+  JobDisableJob202Response,
+  JobDisableJobDefaultResponse,
+  JobEnableJob202Response,
+  JobEnableJobDefaultResponse,
+  JobTerminateJob202Response,
+  JobTerminateJobDefaultResponse,
+  JobAddJob201Response,
+  JobAddJobDefaultResponse,
+  JobListJobs200Response,
+  JobListJobsDefaultResponse,
   JobListFromJobSchedule200Response,
   JobListFromJobScheduleDefaultResponse,
   JobListPreparationAndReleaseTaskStatus200Response,
   JobListPreparationAndReleaseTaskStatusDefaultResponse,
   JobGetTaskCounts200Response,
   JobGetTaskCountsDefaultResponse,
-  CertificatesAdd201Response,
-  CertificatesAddDefaultResponse,
-  CertificatesList200Response,
-  CertificatesListDefaultResponse,
-  CertificatesCancelDeletion204Response,
-  CertificatesCancelDeletionDefaultResponse,
-  CertificatesDelete202Response,
-  CertificatesDeleteDefaultResponse,
-  CertificatesGet200Response,
-  CertificatesGetDefaultResponse,
+  CertificatesAddCertificate201Response,
+  CertificatesAddCertificateDefaultResponse,
+  CertificatesListCertificates200Response,
+  CertificatesListCertificatesDefaultResponse,
+  CertificatesCancelCertificateDeletion204Response,
+  CertificatesCancelCertificateDeletionDefaultResponse,
+  CertificatesDeleteCertificate202Response,
+  CertificatesDeleteCertificateDefaultResponse,
+  CertificatesGetCertificate200Response,
+  CertificatesGetCertificateDefaultResponse,
   FileDeleteFromTask200Response,
   FileDeleteFromTaskDefaultResponse,
   FileGetFromTask200Response,
@@ -173,57 +173,57 @@ import {
   FileListFromTaskDefaultResponse,
   FileListFromComputeNode200Response,
   FileListFromComputeNodeDefaultResponse,
-  JobScheduleExists200Response,
-  JobScheduleExists404Response,
-  JobScheduleExistsDefaultResponse,
-  JobScheduleDelete202Response,
-  JobScheduleDeleteDefaultResponse,
-  JobScheduleGet200Response,
-  JobScheduleGetDefaultResponse,
-  JobSchedulePatch200Response,
-  JobSchedulePatchDefaultResponse,
-  JobScheduleUpdate200Response,
-  JobScheduleUpdateDefaultResponse,
-  JobScheduleDisable204Response,
-  JobScheduleDisableDefaultResponse,
-  JobScheduleEnable204Response,
-  JobScheduleEnableDefaultResponse,
-  JobScheduleTerminate202Response,
-  JobScheduleTerminateDefaultResponse,
-  JobScheduleAdd201Response,
-  JobScheduleAddDefaultResponse,
-  JobScheduleList200Response,
-  JobScheduleListDefaultResponse,
-  TaskAdd201Response,
-  TaskAddDefaultResponse,
-  TaskList200Response,
-  TaskListDefaultResponse,
-  TaskAddCollection200Response,
-  TaskAddCollectionDefaultResponse,
-  TaskDelete200Response,
-  TaskDeleteDefaultResponse,
-  TaskGet200Response,
-  TaskGetDefaultResponse,
-  TaskUpdate200Response,
-  TaskUpdateDefaultResponse,
+  JobScheduleJobScheduleExists200Response,
+  JobScheduleJobScheduleExists404Response,
+  JobScheduleJobScheduleExistsDefaultResponse,
+  JobScheduleDeleteJobSchedule202Response,
+  JobScheduleDeleteJobScheduleDefaultResponse,
+  JobScheduleGetJobSchedule200Response,
+  JobScheduleGetJobScheduleDefaultResponse,
+  JobSchedulePatchJobSchedule200Response,
+  JobSchedulePatchJobScheduleDefaultResponse,
+  JobScheduleUpdateJobSchedule200Response,
+  JobScheduleUpdateJobScheduleDefaultResponse,
+  JobScheduleDisableJobSchedule204Response,
+  JobScheduleDisableJobScheduleDefaultResponse,
+  JobScheduleEnableJobSchedule204Response,
+  JobScheduleEnableJobScheduleDefaultResponse,
+  JobScheduleTerminateJobSchedule202Response,
+  JobScheduleTerminateJobScheduleDefaultResponse,
+  JobScheduleAddJobSchedule201Response,
+  JobScheduleAddJobScheduleDefaultResponse,
+  JobScheduleListJobSchedules200Response,
+  JobScheduleListJobSchedulesDefaultResponse,
+  TaskAddTask201Response,
+  TaskAddTaskDefaultResponse,
+  TaskListTasks200Response,
+  TaskListTasksDefaultResponse,
+  TaskAddTaskCollection200Response,
+  TaskAddTaskCollectionDefaultResponse,
+  TaskDeleteTaskCollection200Response,
+  TaskDeleteTaskCollectionDefaultResponse,
+  TaskGetTaskCollection200Response,
+  TaskGetTaskCollectionDefaultResponse,
+  TaskUpdateTaskCollection200Response,
+  TaskUpdateTaskCollectionDefaultResponse,
   TaskListSubtasks200Response,
   TaskListSubtasksDefaultResponse,
-  TaskTerminate204Response,
-  TaskTerminateDefaultResponse,
-  TaskReactivate204Response,
-  TaskReactivateDefaultResponse,
+  TaskTerminateTaskCollection204Response,
+  TaskTerminateTaskCollectionDefaultResponse,
+  TaskReactivateTaskCollection204Response,
+  TaskReactivateTaskCollectionDefaultResponse,
   ComputeNodesAddUser201Response,
   ComputeNodesAddUserDefaultResponse,
   ComputeNodesDeleteUser200Response,
   ComputeNodesDeleteUserDefaultResponse,
   ComputeNodesUpdateUser200Response,
   ComputeNodesUpdateUserDefaultResponse,
-  ComputeNodesGet200Response,
-  ComputeNodesGetDefaultResponse,
-  ComputeNodesReboot202Response,
-  ComputeNodesRebootDefaultResponse,
-  ComputeNodesReimage202Response,
-  ComputeNodesReimageDefaultResponse,
+  ComputeNodesGetComputeNode200Response,
+  ComputeNodesGetComputeNodeDefaultResponse,
+  ComputeNodesRebootComputeNode202Response,
+  ComputeNodesRebootComputeNodeDefaultResponse,
+  ComputeNodesReimageComputeNode202Response,
+  ComputeNodesReimageComputeNodeDefaultResponse,
   ComputeNodesDisableScheduling200Response,
   ComputeNodesDisableSchedulingDefaultResponse,
   ComputeNodesEnableScheduling200Response,
@@ -236,14 +236,14 @@ import {
   ComputeNodesUploadBatchServiceLogsDefaultResponse,
   ComputeNodesList200Response,
   ComputeNodesListDefaultResponse,
-  ComputeNodeExtensionsGet200Response,
-  ComputeNodeExtensionsGetDefaultResponse,
-  ComputeNodeExtensionsList200Response,
-  ComputeNodeExtensionsListDefaultResponse,
+  ComputeNodeExtensionsGetComputeNodeExtensions200Response,
+  ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse,
+  ComputeNodeExtensionsListComputeNodeExtensions200Response,
+  ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse,
 } from "./responses.js";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
-export interface ApplicationsList {
+export interface ApplicationsListApplications {
   /**
    * This operation returns only Applications and versions that are available for
    * use on Compute Nodes; that is, that can be used in an Package reference. For
@@ -252,9 +252,10 @@ export interface ApplicationsList {
    * API.
    */
   get(
-    options?: ApplicationsListParameters
+    options?: ApplicationsListApplicationsParameters
   ): StreamableMethod<
-    ApplicationsList200Response | ApplicationsListDefaultResponse
+    | ApplicationsListApplications200Response
+    | ApplicationsListApplicationsDefaultResponse
   >;
 }
 
@@ -304,22 +305,22 @@ export interface PoolGetAllLifetimeStatistics {
   >;
 }
 
-export interface PoolAdd {
+export interface PoolAddPool {
   /**
    * When naming Pools, avoid including sensitive information such as user names or
    * secret project names. This information may appear in telemetry logs accessible
    * to Microsoft Support engineers.
    */
   post(
-    options: PoolAddParameters
-  ): StreamableMethod<PoolAdd201Response | PoolAddDefaultResponse>;
+    options: PoolAddPoolParameters
+  ): StreamableMethod<PoolAddPool201Response | PoolAddPoolDefaultResponse>;
   /** Lists all of the Pools in the specified Account. */
   get(
-    options?: PoolListParameters
-  ): StreamableMethod<PoolList200Response | PoolListDefaultResponse>;
+    options?: PoolListPoolsParameters
+  ): StreamableMethod<PoolListPools200Response | PoolListPoolsDefaultResponse>;
 }
 
-export interface PoolDelete {
+export interface PoolDeletePool {
   /**
    * When you request that a Pool be deleted, the following actions occur: the Pool
    * state is set to deleting; any ongoing resize operation on the Pool are stopped;
@@ -335,8 +336,10 @@ export interface PoolDelete {
    * error code PoolBeingDeleted.
    */
   delete(
-    options?: PoolDeleteParameters
-  ): StreamableMethod<PoolDelete202Response | PoolDeleteDefaultResponse>;
+    options?: PoolDeletePoolParameters
+  ): StreamableMethod<
+    PoolDeletePool202Response | PoolDeletePoolDefaultResponse
+  >;
   /** Gets basic properties of a Pool. */
   head(
     options?: PoolExistsParameters
@@ -345,16 +348,16 @@ export interface PoolDelete {
   >;
   /** Gets information about the specified Pool. */
   get(
-    options?: PoolGetParameters
-  ): StreamableMethod<PoolGet200Response | PoolGetDefaultResponse>;
+    options?: PoolGetPoolParameters
+  ): StreamableMethod<PoolGetPool200Response | PoolGetPoolDefaultResponse>;
   /**
    * This only replaces the Pool properties specified in the request. For example,
    * if the Pool has a StartTask associated with it, and a request does not specify
    * a StartTask element, then the Pool keeps the existing StartTask.
    */
   patch(
-    options: PoolPatchParameters
-  ): StreamableMethod<PoolPatch200Response | PoolPatchDefaultResponse>;
+    options: PoolPatchPoolParameters
+  ): StreamableMethod<PoolPatchPool200Response | PoolPatchPoolDefaultResponse>;
 }
 
 export interface PoolDisableAutoScale {
@@ -492,7 +495,7 @@ export interface JobGetAllLifetimeStatistics {
   >;
 }
 
-export interface JobDelete {
+export interface JobDeleteJob {
   /**
    * Deleting a Job also deletes all Tasks that are part of that Job, and all Job
    * statistics. This also overrides the retention period for Task data; that is, if
@@ -504,31 +507,31 @@ export interface JobDelete {
    * that the Job is being deleted.
    */
   delete(
-    options?: JobDeleteParameters
-  ): StreamableMethod<JobDelete202Response | JobDeleteDefaultResponse>;
+    options?: JobDeleteJobParameters
+  ): StreamableMethod<JobDeleteJob202Response | JobDeleteJobDefaultResponse>;
   /** Gets information about the specified Job. */
   get(
-    options?: JobGetParameters
-  ): StreamableMethod<JobGet200Response | JobGetDefaultResponse>;
+    options?: JobGetJobParameters
+  ): StreamableMethod<JobGetJob200Response | JobGetJobDefaultResponse>;
   /**
    * This replaces only the Job properties specified in the request. For example, if
    * the Job has constraints, and a request does not specify the constraints
    * element, then the Job keeps the existing constraints.
    */
   patch(
-    options: JobPatchParameters
-  ): StreamableMethod<JobPatch200Response | JobPatchDefaultResponse>;
+    options: JobPatchJobParameters
+  ): StreamableMethod<JobPatchJob200Response | JobPatchJobDefaultResponse>;
   /**
    * This fully replaces all the updatable properties of the Job. For example, if
    * the Job has constraints associated with it and if constraints is not specified
    * with this request, then the Batch service will remove the existing constraints.
    */
   put(
-    options: JobUpdateParameters
-  ): StreamableMethod<JobUpdate200Response | JobUpdateDefaultResponse>;
+    options: JobUpdateJobParameters
+  ): StreamableMethod<JobUpdateJob200Response | JobUpdateJobDefaultResponse>;
 }
 
-export interface JobDisable {
+export interface JobDisableJob {
   /**
    * The Batch Service immediately moves the Job to the disabling state. Batch then
    * uses the disableTasks parameter to determine what to do with the currently
@@ -540,11 +543,11 @@ export interface JobDisable {
    * the request fails with status code 409.
    */
   post(
-    options: JobDisableParameters
-  ): StreamableMethod<JobDisable202Response | JobDisableDefaultResponse>;
+    options: JobDisableJobParameters
+  ): StreamableMethod<JobDisableJob202Response | JobDisableJobDefaultResponse>;
 }
 
-export interface JobEnable {
+export interface JobEnableJob {
   /**
    * When you call this API, the Batch service sets a disabled Job to the enabling
    * state. After the this operation is completed, the Job moves to the active
@@ -554,11 +557,11 @@ export interface JobEnable {
    * than 180 days ago, those Tasks will not run.
    */
   post(
-    options?: JobEnableParameters
-  ): StreamableMethod<JobEnable202Response | JobEnableDefaultResponse>;
+    options?: JobEnableJobParameters
+  ): StreamableMethod<JobEnableJob202Response | JobEnableJobDefaultResponse>;
 }
 
-export interface JobTerminate {
+export interface JobTerminateJob {
   /**
    * When a Terminate Job request is received, the Batch service sets the Job to the
    * terminating state. The Batch service then terminates any running Tasks
@@ -568,11 +571,13 @@ export interface JobTerminate {
    * Tasks cannot be added and any remaining active Tasks will not be scheduled.
    */
   post(
-    options?: JobTerminateParameters
-  ): StreamableMethod<JobTerminate202Response | JobTerminateDefaultResponse>;
+    options?: JobTerminateJobParameters
+  ): StreamableMethod<
+    JobTerminateJob202Response | JobTerminateJobDefaultResponse
+  >;
 }
 
-export interface JobAdd {
+export interface JobAddJob {
   /**
    * The Batch service supports two ways to control the work done as part of a Job.
    * In the first approach, the user specifies a Job Manager Task. The Batch service
@@ -585,12 +590,12 @@ export interface JobAdd {
    * engineers.
    */
   post(
-    options: JobAddParameters
-  ): StreamableMethod<JobAdd201Response | JobAddDefaultResponse>;
+    options: JobAddJobParameters
+  ): StreamableMethod<JobAddJob201Response | JobAddJobDefaultResponse>;
   /** Lists all of the Jobs in the specified Account. */
   get(
-    options?: JobListParameters
-  ): StreamableMethod<JobList200Response | JobListDefaultResponse>;
+    options?: JobListJobsParameters
+  ): StreamableMethod<JobListJobs200Response | JobListJobsDefaultResponse>;
 }
 
 export interface JobListFromJobSchedule {
@@ -633,22 +638,24 @@ export interface JobGetTaskCounts {
   >;
 }
 
-export interface CertificatesAdd {
+export interface CertificatesAddCertificate {
   /** Adds a Certificate to the specified Account. */
   post(
-    options: CertificatesAddParameters
+    options: CertificatesAddCertificateParameters
   ): StreamableMethod<
-    CertificatesAdd201Response | CertificatesAddDefaultResponse
+    | CertificatesAddCertificate201Response
+    | CertificatesAddCertificateDefaultResponse
   >;
   /** Lists all of the Certificates that have been added to the specified Account. */
   get(
-    options?: CertificatesListParameters
+    options?: CertificatesListCertificatesParameters
   ): StreamableMethod<
-    CertificatesList200Response | CertificatesListDefaultResponse
+    | CertificatesListCertificates200Response
+    | CertificatesListCertificatesDefaultResponse
   >;
 }
 
-export interface CertificatesCancelDeletion {
+export interface CertificatesCancelCertificateDeletion {
   /**
    * If you try to delete a Certificate that is being used by a Pool or Compute
    * Node, the status of the Certificate changes to deleteFailed. If you decide that
@@ -659,14 +666,14 @@ export interface CertificatesCancelDeletion {
    * then you can try again to delete the Certificate.
    */
   post(
-    options?: CertificatesCancelDeletionParameters
+    options?: CertificatesCancelCertificateDeletionParameters
   ): StreamableMethod<
-    | CertificatesCancelDeletion204Response
-    | CertificatesCancelDeletionDefaultResponse
+    | CertificatesCancelCertificateDeletion204Response
+    | CertificatesCancelCertificateDeletionDefaultResponse
   >;
 }
 
-export interface CertificatesDelete {
+export interface CertificatesDeleteCertificate {
   /**
    * You cannot delete a Certificate if a resource (Pool or Compute Node) is using
    * it. Before you can delete a Certificate, you must therefore make sure that the
@@ -679,15 +686,17 @@ export interface CertificatesDelete {
    * active if you decide that you want to continue using the Certificate.
    */
   delete(
-    options?: CertificatesDeleteParameters
+    options?: CertificatesDeleteCertificateParameters
   ): StreamableMethod<
-    CertificatesDelete202Response | CertificatesDeleteDefaultResponse
+    | CertificatesDeleteCertificate202Response
+    | CertificatesDeleteCertificateDefaultResponse
   >;
   /** Gets information about the specified Certificate. */
   get(
-    options?: CertificatesGetParameters
+    options?: CertificatesGetCertificateParameters
   ): StreamableMethod<
-    CertificatesGet200Response | CertificatesGetDefaultResponse
+    | CertificatesGetCertificate200Response
+    | CertificatesGetCertificateDefaultResponse
   >;
 }
 
@@ -754,14 +763,14 @@ export interface FileListFromComputeNode {
   >;
 }
 
-export interface JobScheduleExists {
+export interface JobScheduleJobScheduleExists {
   /** Checks the specified Job Schedule exists. */
   head(
-    options?: JobScheduleExistsParameters
+    options?: JobScheduleJobScheduleExistsParameters
   ): StreamableMethod<
-    | JobScheduleExists200Response
-    | JobScheduleExists404Response
-    | JobScheduleExistsDefaultResponse
+    | JobScheduleJobScheduleExists200Response
+    | JobScheduleJobScheduleExists404Response
+    | JobScheduleJobScheduleExistsDefaultResponse
   >;
   /**
    * When you delete a Job Schedule, this also deletes all Jobs and Tasks under that
@@ -771,15 +780,17 @@ export interface JobScheduleExists {
    * though they are still counted towards Account lifetime statistics.
    */
   delete(
-    options?: JobScheduleDeleteParameters
+    options?: JobScheduleDeleteJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleDelete202Response | JobScheduleDeleteDefaultResponse
+    | JobScheduleDeleteJobSchedule202Response
+    | JobScheduleDeleteJobScheduleDefaultResponse
   >;
   /** Gets information about the specified Job Schedule. */
   get(
-    options?: JobScheduleGetParameters
+    options?: JobScheduleGetJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleGet200Response | JobScheduleGetDefaultResponse
+    | JobScheduleGetJobSchedule200Response
+    | JobScheduleGetJobScheduleDefaultResponse
   >;
   /**
    * This replaces only the Job Schedule properties specified in the request. For
@@ -789,9 +800,10 @@ export interface JobScheduleExists {
    * running Jobs are unaffected.
    */
   patch(
-    options: JobSchedulePatchParameters
+    options: JobSchedulePatchJobScheduleParameters
   ): StreamableMethod<
-    JobSchedulePatch200Response | JobSchedulePatchDefaultResponse
+    | JobSchedulePatchJobSchedule200Response
+    | JobSchedulePatchJobScheduleDefaultResponse
   >;
   /**
    * This fully replaces all the updatable properties of the Job Schedule. For
@@ -801,74 +813,80 @@ export interface JobScheduleExists {
    * running Jobs are unaffected.
    */
   put(
-    options: JobScheduleUpdateParameters
+    options: JobScheduleUpdateJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleUpdate200Response | JobScheduleUpdateDefaultResponse
+    | JobScheduleUpdateJobSchedule200Response
+    | JobScheduleUpdateJobScheduleDefaultResponse
   >;
 }
 
-export interface JobScheduleDisable {
+export interface JobScheduleDisableJobSchedule {
   /** No new Jobs will be created until the Job Schedule is enabled again. */
   post(
-    options?: JobScheduleDisableParameters
+    options?: JobScheduleDisableJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleDisable204Response | JobScheduleDisableDefaultResponse
+    | JobScheduleDisableJobSchedule204Response
+    | JobScheduleDisableJobScheduleDefaultResponse
   >;
 }
 
-export interface JobScheduleEnable {
+export interface JobScheduleEnableJobSchedule {
   /** Enables a Job Schedule. */
   post(
-    options?: JobScheduleEnableParameters
+    options?: JobScheduleEnableJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleEnable204Response | JobScheduleEnableDefaultResponse
+    | JobScheduleEnableJobSchedule204Response
+    | JobScheduleEnableJobScheduleDefaultResponse
   >;
 }
 
-export interface JobScheduleTerminate {
+export interface JobScheduleTerminateJobSchedule {
   /** Terminates a Job Schedule. */
   post(
-    options?: JobScheduleTerminateParameters
+    options?: JobScheduleTerminateJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleTerminate202Response | JobScheduleTerminateDefaultResponse
+    | JobScheduleTerminateJobSchedule202Response
+    | JobScheduleTerminateJobScheduleDefaultResponse
   >;
 }
 
-export interface JobScheduleAdd {
+export interface JobScheduleAddJobSchedule {
   /** Adds a Job Schedule to the specified Account. */
   post(
-    options: JobScheduleAddParameters
+    options: JobScheduleAddJobScheduleParameters
   ): StreamableMethod<
-    JobScheduleAdd201Response | JobScheduleAddDefaultResponse
+    | JobScheduleAddJobSchedule201Response
+    | JobScheduleAddJobScheduleDefaultResponse
   >;
   /** Lists all of the Job Schedules in the specified Account. */
   get(
-    options?: JobScheduleListParameters
+    options?: JobScheduleListJobSchedulesParameters
   ): StreamableMethod<
-    JobScheduleList200Response | JobScheduleListDefaultResponse
+    | JobScheduleListJobSchedules200Response
+    | JobScheduleListJobSchedulesDefaultResponse
   >;
 }
 
-export interface TaskAdd {
+export interface TaskAddTask {
   /**
    * The maximum lifetime of a Task from addition to completion is 180 days. If a
    * Task has not completed within 180 days of being added it will be terminated by
    * the Batch service and left in whatever state it was in at that time.
    */
   post(
-    options: TaskAddParameters
-  ): StreamableMethod<TaskAdd201Response | TaskAddDefaultResponse>;
+    options: TaskAddTaskParameters
+  ): StreamableMethod<TaskAddTask201Response | TaskAddTaskDefaultResponse>;
   /**
    * For multi-instance Tasks, information such as affinityId, executionInfo and
    * nodeInfo refer to the primary Task. Use the list subtasks API to retrieve
    * information about subtasks.
    */
   get(
-    options?: TaskListParameters
-  ): StreamableMethod<TaskList200Response | TaskListDefaultResponse>;
+    options?: TaskListTasksParameters
+  ): StreamableMethod<TaskListTasks200Response | TaskListTasksDefaultResponse>;
 }
 
-export interface TaskAddCollection {
+export interface TaskAddTaskCollection {
   /**
    * Note that each Task must have a unique ID. The Batch service may not return the
    * results for each Task in the same order the Tasks were submitted in this
@@ -886,13 +904,13 @@ export interface TaskAddCollection {
    * service and left in whatever state it was in at that time.
    */
   post(
-    options: TaskAddCollectionParameters
+    options: TaskAddTaskCollectionParameters
   ): StreamableMethod<
-    TaskAddCollection200Response | TaskAddCollectionDefaultResponse
+    TaskAddTaskCollection200Response | TaskAddTaskCollectionDefaultResponse
   >;
 }
 
-export interface TaskDelete {
+export interface TaskDeleteTaskCollection {
   /**
    * When a Task is deleted, all of the files in its directory on the Compute Node
    * where it ran are also deleted (regardless of the retention time). For
@@ -901,20 +919,28 @@ export interface TaskDelete {
    * background.
    */
   delete(
-    options?: TaskDeleteParameters
-  ): StreamableMethod<TaskDelete200Response | TaskDeleteDefaultResponse>;
+    options?: TaskDeleteTaskCollectionParameters
+  ): StreamableMethod<
+    | TaskDeleteTaskCollection200Response
+    | TaskDeleteTaskCollectionDefaultResponse
+  >;
   /**
    * For multi-instance Tasks, information such as affinityId, executionInfo and
    * nodeInfo refer to the primary Task. Use the list subtasks API to retrieve
    * information about subtasks.
    */
   get(
-    options?: TaskGetParameters
-  ): StreamableMethod<TaskGet200Response | TaskGetDefaultResponse>;
+    options?: TaskGetTaskCollectionParameters
+  ): StreamableMethod<
+    TaskGetTaskCollection200Response | TaskGetTaskCollectionDefaultResponse
+  >;
   /** Updates the properties of the specified Task. */
   put(
-    options: TaskUpdateParameters
-  ): StreamableMethod<TaskUpdate200Response | TaskUpdateDefaultResponse>;
+    options: TaskUpdateTaskCollectionParameters
+  ): StreamableMethod<
+    | TaskUpdateTaskCollection200Response
+    | TaskUpdateTaskCollectionDefaultResponse
+  >;
 }
 
 export interface TaskListSubtasks {
@@ -926,18 +952,21 @@ export interface TaskListSubtasks {
   >;
 }
 
-export interface TaskTerminate {
+export interface TaskTerminateTaskCollection {
   /**
    * When the Task has been terminated, it moves to the completed state. For
    * multi-instance Tasks, the terminate Task operation applies synchronously to the
    * primary task; subtasks are then terminated asynchronously in the background.
    */
   post(
-    options?: TaskTerminateParameters
-  ): StreamableMethod<TaskTerminate204Response | TaskTerminateDefaultResponse>;
+    options?: TaskTerminateTaskCollectionParameters
+  ): StreamableMethod<
+    | TaskTerminateTaskCollection204Response
+    | TaskTerminateTaskCollectionDefaultResponse
+  >;
 }
 
-export interface TaskReactivate {
+export interface TaskReactivateTaskCollection {
   /**
    * Reactivation makes a Task eligible to be retried again up to its maximum retry
    * count. The Task's state is changed to active. As the Task is no longer in the
@@ -948,9 +977,10 @@ export interface TaskReactivate {
    * will fail if the Job has completed (or is terminating or deleting).
    */
   post(
-    options?: TaskReactivateParameters
+    options?: TaskReactivateTaskCollectionParameters
   ): StreamableMethod<
-    TaskReactivate204Response | TaskReactivateDefaultResponse
+    | TaskReactivateTaskCollection204Response
+    | TaskReactivateTaskCollectionDefaultResponse
   >;
 }
 
@@ -989,34 +1019,37 @@ export interface ComputeNodesDeleteUser {
   >;
 }
 
-export interface ComputeNodesGet {
+export interface ComputeNodesGetComputeNode {
   /** Gets information about the specified Compute Node. */
   get(
-    options?: ComputeNodesGetParameters
+    options?: ComputeNodesGetComputeNodeParameters
   ): StreamableMethod<
-    ComputeNodesGet200Response | ComputeNodesGetDefaultResponse
+    | ComputeNodesGetComputeNode200Response
+    | ComputeNodesGetComputeNodeDefaultResponse
   >;
 }
 
-export interface ComputeNodesReboot {
+export interface ComputeNodesRebootComputeNode {
   /** You can restart a Compute Node only if it is in an idle or running state. */
   post(
-    options?: ComputeNodesRebootParameters
+    options?: ComputeNodesRebootComputeNodeParameters
   ): StreamableMethod<
-    ComputeNodesReboot202Response | ComputeNodesRebootDefaultResponse
+    | ComputeNodesRebootComputeNode202Response
+    | ComputeNodesRebootComputeNodeDefaultResponse
   >;
 }
 
-export interface ComputeNodesReimage {
+export interface ComputeNodesReimageComputeNode {
   /**
    * You can reinstall the operating system on a Compute Node only if it is in an
    * idle or running state. This API can be invoked only on Pools created with the
    * cloud service configuration property.
    */
   post(
-    options?: ComputeNodesReimageParameters
+    options?: ComputeNodesReimageComputeNodeParameters
   ): StreamableMethod<
-    ComputeNodesReimage202Response | ComputeNodesReimageDefaultResponse
+    | ComputeNodesReimageComputeNode202Response
+    | ComputeNodesReimageComputeNodeDefaultResponse
   >;
 }
 
@@ -1101,29 +1134,29 @@ export interface ComputeNodesList {
   >;
 }
 
-export interface ComputeNodeExtensionsGet {
+export interface ComputeNodeExtensionsGetComputeNodeExtensions {
   /** Gets information about the specified Compute Node Extension. */
   get(
-    options?: ComputeNodeExtensionsGetParameters
+    options?: ComputeNodeExtensionsGetComputeNodeExtensionsParameters
   ): StreamableMethod<
-    | ComputeNodeExtensionsGet200Response
-    | ComputeNodeExtensionsGetDefaultResponse
+    | ComputeNodeExtensionsGetComputeNodeExtensions200Response
+    | ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse
   >;
 }
 
-export interface ComputeNodeExtensionsList {
+export interface ComputeNodeExtensionsListComputeNodeExtensions {
   /** Lists the Compute Nodes Extensions in the specified Pool. */
   get(
-    options?: ComputeNodeExtensionsListParameters
+    options?: ComputeNodeExtensionsListComputeNodeExtensionsParameters
   ): StreamableMethod<
-    | ComputeNodeExtensionsList200Response
-    | ComputeNodeExtensionsListDefaultResponse
+    | ComputeNodeExtensionsListComputeNodeExtensions200Response
+    | ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse
   >;
 }
 
 export interface Routes {
   /** Resource for '/applications' has methods for the following verbs: get */
-  (path: "/applications"): ApplicationsList;
+  (path: "/applications"): ApplicationsListApplications;
   /** Resource for '/applications/\{applicationId\}' has methods for the following verbs: get */
   (
     path: "/applications/{applicationId}",
@@ -1134,9 +1167,9 @@ export interface Routes {
   /** Resource for '/lifetimepoolstats' has methods for the following verbs: get */
   (path: "/lifetimepoolstats"): PoolGetAllLifetimeStatistics;
   /** Resource for '/pools' has methods for the following verbs: post, get */
-  (path: "/pools"): PoolAdd;
+  (path: "/pools"): PoolAddPool;
   /** Resource for '/pools/\{poolId\}' has methods for the following verbs: delete, head, get, patch */
-  (path: "/pools/{poolId}", poolId: string): PoolDelete;
+  (path: "/pools/{poolId}", poolId: string): PoolDeletePool;
   /** Resource for '/pools/\{poolId\}/disableautoscale' has methods for the following verbs: post */
   (
     path: "/pools/{poolId}/disableautoscale",
@@ -1170,15 +1203,15 @@ export interface Routes {
   /** Resource for '/lifetimejobstats' has methods for the following verbs: get */
   (path: "/lifetimejobstats"): JobGetAllLifetimeStatistics;
   /** Resource for '/jobs/\{jobId\}' has methods for the following verbs: delete, get, patch, put */
-  (path: "/jobs/{jobId}", jobId: string): JobDelete;
+  (path: "/jobs/{jobId}", jobId: string): JobDeleteJob;
   /** Resource for '/jobs/\{jobId\}/disable' has methods for the following verbs: post */
-  (path: "/jobs/{jobId}/disable", jobId: string): JobDisable;
+  (path: "/jobs/{jobId}/disable", jobId: string): JobDisableJob;
   /** Resource for '/jobs/\{jobId\}/enable' has methods for the following verbs: post */
-  (path: "/jobs/{jobId}/enable", jobId: string): JobEnable;
+  (path: "/jobs/{jobId}/enable", jobId: string): JobEnableJob;
   /** Resource for '/jobs/\{jobId\}/terminate' has methods for the following verbs: post */
-  (path: "/jobs/{jobId}/terminate", jobId: string): JobTerminate;
+  (path: "/jobs/{jobId}/terminate", jobId: string): JobTerminateJob;
   /** Resource for '/jobs' has methods for the following verbs: post, get */
-  (path: "/jobs"): JobAdd;
+  (path: "/jobs"): JobAddJob;
   /** Resource for '/jobschedules/\{jobScheduleId\}/jobs' has methods for the following verbs: get */
   (
     path: "/jobschedules/{jobScheduleId}/jobs",
@@ -1192,19 +1225,19 @@ export interface Routes {
   /** Resource for '/jobs/\{jobId\}/taskcounts' has methods for the following verbs: get */
   (path: "/jobs/{jobId}/taskcounts", jobId: string): JobGetTaskCounts;
   /** Resource for '/certificates' has methods for the following verbs: post, get */
-  (path: "/certificates"): CertificatesAdd;
+  (path: "/certificates"): CertificatesAddCertificate;
   /** Resource for '/certificates(thumbprintAlgorithm=\{thumbprintAlgorithm\},thumbprint=\{thumbprint\})/canceldelete' has methods for the following verbs: post */
   (
     path: "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})/canceldelete",
     thumbprintAlgorithm: string,
     thumbprint: string
-  ): CertificatesCancelDeletion;
+  ): CertificatesCancelCertificateDeletion;
   /** Resource for '/certificates(thumbprintAlgorithm=\{thumbprintAlgorithm\},thumbprint=\{thumbprint\})' has methods for the following verbs: delete, get */
   (
     path: "/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})",
     thumbprintAlgorithm: string,
     thumbprint: string
-  ): CertificatesDelete;
+  ): CertificatesDeleteCertificate;
   /** Resource for '/jobs/\{jobId\}/tasks/\{taskId\}/files/\{filePath\}' has methods for the following verbs: delete, get, head */
   (
     path: "/jobs/{jobId}/tasks/{taskId}/files/{filePath}",
@@ -1235,34 +1268,37 @@ export interface Routes {
   (
     path: "/jobschedules/{jobScheduleId}",
     jobScheduleId: string
-  ): JobScheduleExists;
+  ): JobScheduleJobScheduleExists;
   /** Resource for '/jobschedules/\{jobScheduleId\}/disable' has methods for the following verbs: post */
   (
     path: "/jobschedules/{jobScheduleId}/disable",
     jobScheduleId: string
-  ): JobScheduleDisable;
+  ): JobScheduleDisableJobSchedule;
   /** Resource for '/jobschedules/\{jobScheduleId\}/enable' has methods for the following verbs: post */
   (
     path: "/jobschedules/{jobScheduleId}/enable",
     jobScheduleId: string
-  ): JobScheduleEnable;
+  ): JobScheduleEnableJobSchedule;
   /** Resource for '/jobschedules/\{jobScheduleId\}/terminate' has methods for the following verbs: post */
   (
     path: "/jobschedules/{jobScheduleId}/terminate",
     jobScheduleId: string
-  ): JobScheduleTerminate;
+  ): JobScheduleTerminateJobSchedule;
   /** Resource for '/jobschedules' has methods for the following verbs: post, get */
-  (path: "/jobschedules"): JobScheduleAdd;
+  (path: "/jobschedules"): JobScheduleAddJobSchedule;
   /** Resource for '/jobs/\{jobId\}/tasks' has methods for the following verbs: post, get */
-  (path: "/jobs/{jobId}/tasks", jobId: string): TaskAdd;
+  (path: "/jobs/{jobId}/tasks", jobId: string): TaskAddTask;
   /** Resource for '/jobs/\{jobId\}/addtaskcollection' has methods for the following verbs: post */
-  (path: "/jobs/{jobId}/addtaskcollection", jobId: string): TaskAddCollection;
+  (
+    path: "/jobs/{jobId}/addtaskcollection",
+    jobId: string
+  ): TaskAddTaskCollection;
   /** Resource for '/jobs/\{jobId\}/tasks/\{taskId\}' has methods for the following verbs: delete, get, put */
   (
     path: "/jobs/{jobId}/tasks/{taskId}",
     jobId: string,
     taskId: string
-  ): TaskDelete;
+  ): TaskDeleteTaskCollection;
   /** Resource for '/jobs/\{jobId\}/tasks/\{taskId\}/subtasksinfo' has methods for the following verbs: get */
   (
     path: "/jobs/{jobId}/tasks/{taskId}/subtasksinfo",
@@ -1274,13 +1310,13 @@ export interface Routes {
     path: "/jobs/{jobId}/tasks/{taskId}/terminate",
     jobId: string,
     taskId: string
-  ): TaskTerminate;
+  ): TaskTerminateTaskCollection;
   /** Resource for '/jobs/\{jobId\}/tasks/\{taskId\}/reactivate' has methods for the following verbs: post */
   (
     path: "/jobs/{jobId}/tasks/{taskId}/reactivate",
     jobId: string,
     taskId: string
-  ): TaskReactivate;
+  ): TaskReactivateTaskCollection;
   /** Resource for '/pools/\{poolId\}/nodes/\{nodeId\}/users' has methods for the following verbs: post */
   (
     path: "/pools/{poolId}/nodes/{nodeId}/users",
@@ -1299,19 +1335,19 @@ export interface Routes {
     path: "/pools/{poolId}/nodes/{nodeId}",
     poolId: string,
     nodeId: string
-  ): ComputeNodesGet;
+  ): ComputeNodesGetComputeNode;
   /** Resource for '/pools/\{poolId\}/nodes/\{nodeId\}/reboot' has methods for the following verbs: post */
   (
     path: "/pools/{poolId}/nodes/{nodeId}/reboot",
     poolId: string,
     nodeId: string
-  ): ComputeNodesReboot;
+  ): ComputeNodesRebootComputeNode;
   /** Resource for '/pools/\{poolId\}/nodes/\{nodeId\}/reimage' has methods for the following verbs: post */
   (
     path: "/pools/{poolId}/nodes/{nodeId}/reimage",
     poolId: string,
     nodeId: string
-  ): ComputeNodesReimage;
+  ): ComputeNodesReimageComputeNode;
   /** Resource for '/pools/\{poolId\}/nodes/\{nodeId\}/disablescheduling' has methods for the following verbs: post */
   (
     path: "/pools/{poolId}/nodes/{nodeId}/disablescheduling",
@@ -1350,13 +1386,13 @@ export interface Routes {
     poolId: string,
     nodeId: string,
     extensionName: string
-  ): ComputeNodeExtensionsGet;
+  ): ComputeNodeExtensionsGetComputeNodeExtensions;
   /** Resource for '/pools/\{poolId\}/nodes/\{nodeId\}/extensions' has methods for the following verbs: get */
   (
     path: "/pools/{poolId}/nodes/{nodeId}/extensions",
     poolId: string,
     nodeId: string
-  ): ComputeNodeExtensionsList;
+  ): ComputeNodeExtensionsListComputeNodeExtensions;
 }
 
 export type BatchServiceContext = Client & {

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/isUnexpected.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/isUnexpected.ts
@@ -2,27 +2,27 @@
 // Licensed under the MIT license.
 
 import {
-  ApplicationsList200Response,
-  ApplicationsListDefaultResponse,
+  ApplicationsListApplications200Response,
+  ApplicationsListApplicationsDefaultResponse,
   ApplicationsGet200Response,
   ApplicationsGetDefaultResponse,
   PoolListUsageMetrics200Response,
   PoolListUsageMetricsDefaultResponse,
   PoolGetAllLifetimeStatistics200Response,
   PoolGetAllLifetimeStatisticsDefaultResponse,
-  PoolAdd201Response,
-  PoolAddDefaultResponse,
-  PoolList200Response,
-  PoolListDefaultResponse,
-  PoolDelete202Response,
-  PoolDeleteDefaultResponse,
+  PoolAddPool201Response,
+  PoolAddPoolDefaultResponse,
+  PoolListPools200Response,
+  PoolListPoolsDefaultResponse,
+  PoolDeletePool202Response,
+  PoolDeletePoolDefaultResponse,
   PoolExists200Response,
   PoolExists404Response,
   PoolExistsDefaultResponse,
-  PoolGet200Response,
-  PoolGetDefaultResponse,
-  PoolPatch200Response,
-  PoolPatchDefaultResponse,
+  PoolGetPool200Response,
+  PoolGetPoolDefaultResponse,
+  PoolPatchPool200Response,
+  PoolPatchPoolDefaultResponse,
   PoolDisableAutoScale200Response,
   PoolDisableAutoScaleDefaultResponse,
   PoolEnableAutoScale200Response,
@@ -43,40 +43,40 @@ import {
   AccountListPoolNodeCountsDefaultResponse,
   JobGetAllLifetimeStatistics200Response,
   JobGetAllLifetimeStatisticsDefaultResponse,
-  JobDelete202Response,
-  JobDeleteDefaultResponse,
-  JobGet200Response,
-  JobGetDefaultResponse,
-  JobPatch200Response,
-  JobPatchDefaultResponse,
-  JobUpdate200Response,
-  JobUpdateDefaultResponse,
-  JobDisable202Response,
-  JobDisableDefaultResponse,
-  JobEnable202Response,
-  JobEnableDefaultResponse,
-  JobTerminate202Response,
-  JobTerminateDefaultResponse,
-  JobAdd201Response,
-  JobAddDefaultResponse,
-  JobList200Response,
-  JobListDefaultResponse,
+  JobDeleteJob202Response,
+  JobDeleteJobDefaultResponse,
+  JobGetJob200Response,
+  JobGetJobDefaultResponse,
+  JobPatchJob200Response,
+  JobPatchJobDefaultResponse,
+  JobUpdateJob200Response,
+  JobUpdateJobDefaultResponse,
+  JobDisableJob202Response,
+  JobDisableJobDefaultResponse,
+  JobEnableJob202Response,
+  JobEnableJobDefaultResponse,
+  JobTerminateJob202Response,
+  JobTerminateJobDefaultResponse,
+  JobAddJob201Response,
+  JobAddJobDefaultResponse,
+  JobListJobs200Response,
+  JobListJobsDefaultResponse,
   JobListFromJobSchedule200Response,
   JobListFromJobScheduleDefaultResponse,
   JobListPreparationAndReleaseTaskStatus200Response,
   JobListPreparationAndReleaseTaskStatusDefaultResponse,
   JobGetTaskCounts200Response,
   JobGetTaskCountsDefaultResponse,
-  CertificatesAdd201Response,
-  CertificatesAddDefaultResponse,
-  CertificatesList200Response,
-  CertificatesListDefaultResponse,
-  CertificatesCancelDeletion204Response,
-  CertificatesCancelDeletionDefaultResponse,
-  CertificatesDelete202Response,
-  CertificatesDeleteDefaultResponse,
-  CertificatesGet200Response,
-  CertificatesGetDefaultResponse,
+  CertificatesAddCertificate201Response,
+  CertificatesAddCertificateDefaultResponse,
+  CertificatesListCertificates200Response,
+  CertificatesListCertificatesDefaultResponse,
+  CertificatesCancelCertificateDeletion204Response,
+  CertificatesCancelCertificateDeletionDefaultResponse,
+  CertificatesDeleteCertificate202Response,
+  CertificatesDeleteCertificateDefaultResponse,
+  CertificatesGetCertificate200Response,
+  CertificatesGetCertificateDefaultResponse,
   FileDeleteFromTask200Response,
   FileDeleteFromTaskDefaultResponse,
   FileGetFromTask200Response,
@@ -93,57 +93,57 @@ import {
   FileListFromTaskDefaultResponse,
   FileListFromComputeNode200Response,
   FileListFromComputeNodeDefaultResponse,
-  JobScheduleExists200Response,
-  JobScheduleExists404Response,
-  JobScheduleExistsDefaultResponse,
-  JobScheduleDelete202Response,
-  JobScheduleDeleteDefaultResponse,
-  JobScheduleGet200Response,
-  JobScheduleGetDefaultResponse,
-  JobSchedulePatch200Response,
-  JobSchedulePatchDefaultResponse,
-  JobScheduleUpdate200Response,
-  JobScheduleUpdateDefaultResponse,
-  JobScheduleDisable204Response,
-  JobScheduleDisableDefaultResponse,
-  JobScheduleEnable204Response,
-  JobScheduleEnableDefaultResponse,
-  JobScheduleTerminate202Response,
-  JobScheduleTerminateDefaultResponse,
-  JobScheduleAdd201Response,
-  JobScheduleAddDefaultResponse,
-  JobScheduleList200Response,
-  JobScheduleListDefaultResponse,
-  TaskAdd201Response,
-  TaskAddDefaultResponse,
-  TaskList200Response,
-  TaskListDefaultResponse,
-  TaskAddCollection200Response,
-  TaskAddCollectionDefaultResponse,
-  TaskDelete200Response,
-  TaskDeleteDefaultResponse,
-  TaskGet200Response,
-  TaskGetDefaultResponse,
-  TaskUpdate200Response,
-  TaskUpdateDefaultResponse,
+  JobScheduleJobScheduleExists200Response,
+  JobScheduleJobScheduleExists404Response,
+  JobScheduleJobScheduleExistsDefaultResponse,
+  JobScheduleDeleteJobSchedule202Response,
+  JobScheduleDeleteJobScheduleDefaultResponse,
+  JobScheduleGetJobSchedule200Response,
+  JobScheduleGetJobScheduleDefaultResponse,
+  JobSchedulePatchJobSchedule200Response,
+  JobSchedulePatchJobScheduleDefaultResponse,
+  JobScheduleUpdateJobSchedule200Response,
+  JobScheduleUpdateJobScheduleDefaultResponse,
+  JobScheduleDisableJobSchedule204Response,
+  JobScheduleDisableJobScheduleDefaultResponse,
+  JobScheduleEnableJobSchedule204Response,
+  JobScheduleEnableJobScheduleDefaultResponse,
+  JobScheduleTerminateJobSchedule202Response,
+  JobScheduleTerminateJobScheduleDefaultResponse,
+  JobScheduleAddJobSchedule201Response,
+  JobScheduleAddJobScheduleDefaultResponse,
+  JobScheduleListJobSchedules200Response,
+  JobScheduleListJobSchedulesDefaultResponse,
+  TaskAddTask201Response,
+  TaskAddTaskDefaultResponse,
+  TaskListTasks200Response,
+  TaskListTasksDefaultResponse,
+  TaskAddTaskCollection200Response,
+  TaskAddTaskCollectionDefaultResponse,
+  TaskDeleteTaskCollection200Response,
+  TaskDeleteTaskCollectionDefaultResponse,
+  TaskGetTaskCollection200Response,
+  TaskGetTaskCollectionDefaultResponse,
+  TaskUpdateTaskCollection200Response,
+  TaskUpdateTaskCollectionDefaultResponse,
   TaskListSubtasks200Response,
   TaskListSubtasksDefaultResponse,
-  TaskTerminate204Response,
-  TaskTerminateDefaultResponse,
-  TaskReactivate204Response,
-  TaskReactivateDefaultResponse,
+  TaskTerminateTaskCollection204Response,
+  TaskTerminateTaskCollectionDefaultResponse,
+  TaskReactivateTaskCollection204Response,
+  TaskReactivateTaskCollectionDefaultResponse,
   ComputeNodesAddUser201Response,
   ComputeNodesAddUserDefaultResponse,
   ComputeNodesDeleteUser200Response,
   ComputeNodesDeleteUserDefaultResponse,
   ComputeNodesUpdateUser200Response,
   ComputeNodesUpdateUserDefaultResponse,
-  ComputeNodesGet200Response,
-  ComputeNodesGetDefaultResponse,
-  ComputeNodesReboot202Response,
-  ComputeNodesRebootDefaultResponse,
-  ComputeNodesReimage202Response,
-  ComputeNodesReimageDefaultResponse,
+  ComputeNodesGetComputeNode200Response,
+  ComputeNodesGetComputeNodeDefaultResponse,
+  ComputeNodesRebootComputeNode202Response,
+  ComputeNodesRebootComputeNodeDefaultResponse,
+  ComputeNodesReimageComputeNode202Response,
+  ComputeNodesReimageComputeNodeDefaultResponse,
   ComputeNodesDisableScheduling200Response,
   ComputeNodesDisableSchedulingDefaultResponse,
   ComputeNodesEnableScheduling200Response,
@@ -156,10 +156,10 @@ import {
   ComputeNodesUploadBatchServiceLogsDefaultResponse,
   ComputeNodesList200Response,
   ComputeNodesListDefaultResponse,
-  ComputeNodeExtensionsGet200Response,
-  ComputeNodeExtensionsGetDefaultResponse,
-  ComputeNodeExtensionsList200Response,
-  ComputeNodeExtensionsListDefaultResponse,
+  ComputeNodeExtensionsGetComputeNodeExtensions200Response,
+  ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse,
+  ComputeNodeExtensionsListComputeNodeExtensions200Response,
+  ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse,
 } from "./responses.js";
 
 const responseMap: Record<string, string[]> = {
@@ -247,8 +247,10 @@ const responseMap: Record<string, string[]> = {
 };
 
 export function isUnexpected(
-  response: ApplicationsList200Response | ApplicationsListDefaultResponse
-): response is ApplicationsListDefaultResponse;
+  response:
+    | ApplicationsListApplications200Response
+    | ApplicationsListApplicationsDefaultResponse
+): response is ApplicationsListApplicationsDefaultResponse;
 export function isUnexpected(
   response: ApplicationsGet200Response | ApplicationsGetDefaultResponse
 ): response is ApplicationsGetDefaultResponse;
@@ -263,14 +265,14 @@ export function isUnexpected(
     | PoolGetAllLifetimeStatisticsDefaultResponse
 ): response is PoolGetAllLifetimeStatisticsDefaultResponse;
 export function isUnexpected(
-  response: PoolAdd201Response | PoolAddDefaultResponse
-): response is PoolAddDefaultResponse;
+  response: PoolAddPool201Response | PoolAddPoolDefaultResponse
+): response is PoolAddPoolDefaultResponse;
 export function isUnexpected(
-  response: PoolList200Response | PoolListDefaultResponse
-): response is PoolListDefaultResponse;
+  response: PoolListPools200Response | PoolListPoolsDefaultResponse
+): response is PoolListPoolsDefaultResponse;
 export function isUnexpected(
-  response: PoolDelete202Response | PoolDeleteDefaultResponse
-): response is PoolDeleteDefaultResponse;
+  response: PoolDeletePool202Response | PoolDeletePoolDefaultResponse
+): response is PoolDeletePoolDefaultResponse;
 export function isUnexpected(
   response:
     | PoolExists200Response
@@ -278,11 +280,11 @@ export function isUnexpected(
     | PoolExistsDefaultResponse
 ): response is PoolExistsDefaultResponse;
 export function isUnexpected(
-  response: PoolGet200Response | PoolGetDefaultResponse
-): response is PoolGetDefaultResponse;
+  response: PoolGetPool200Response | PoolGetPoolDefaultResponse
+): response is PoolGetPoolDefaultResponse;
 export function isUnexpected(
-  response: PoolPatch200Response | PoolPatchDefaultResponse
-): response is PoolPatchDefaultResponse;
+  response: PoolPatchPool200Response | PoolPatchPoolDefaultResponse
+): response is PoolPatchPoolDefaultResponse;
 export function isUnexpected(
   response:
     | PoolDisableAutoScale200Response
@@ -326,32 +328,32 @@ export function isUnexpected(
     | JobGetAllLifetimeStatisticsDefaultResponse
 ): response is JobGetAllLifetimeStatisticsDefaultResponse;
 export function isUnexpected(
-  response: JobDelete202Response | JobDeleteDefaultResponse
-): response is JobDeleteDefaultResponse;
+  response: JobDeleteJob202Response | JobDeleteJobDefaultResponse
+): response is JobDeleteJobDefaultResponse;
 export function isUnexpected(
-  response: JobGet200Response | JobGetDefaultResponse
-): response is JobGetDefaultResponse;
+  response: JobGetJob200Response | JobGetJobDefaultResponse
+): response is JobGetJobDefaultResponse;
 export function isUnexpected(
-  response: JobPatch200Response | JobPatchDefaultResponse
-): response is JobPatchDefaultResponse;
+  response: JobPatchJob200Response | JobPatchJobDefaultResponse
+): response is JobPatchJobDefaultResponse;
 export function isUnexpected(
-  response: JobUpdate200Response | JobUpdateDefaultResponse
-): response is JobUpdateDefaultResponse;
+  response: JobUpdateJob200Response | JobUpdateJobDefaultResponse
+): response is JobUpdateJobDefaultResponse;
 export function isUnexpected(
-  response: JobDisable202Response | JobDisableDefaultResponse
-): response is JobDisableDefaultResponse;
+  response: JobDisableJob202Response | JobDisableJobDefaultResponse
+): response is JobDisableJobDefaultResponse;
 export function isUnexpected(
-  response: JobEnable202Response | JobEnableDefaultResponse
-): response is JobEnableDefaultResponse;
+  response: JobEnableJob202Response | JobEnableJobDefaultResponse
+): response is JobEnableJobDefaultResponse;
 export function isUnexpected(
-  response: JobTerminate202Response | JobTerminateDefaultResponse
-): response is JobTerminateDefaultResponse;
+  response: JobTerminateJob202Response | JobTerminateJobDefaultResponse
+): response is JobTerminateJobDefaultResponse;
 export function isUnexpected(
-  response: JobAdd201Response | JobAddDefaultResponse
-): response is JobAddDefaultResponse;
+  response: JobAddJob201Response | JobAddJobDefaultResponse
+): response is JobAddJobDefaultResponse;
 export function isUnexpected(
-  response: JobList200Response | JobListDefaultResponse
-): response is JobListDefaultResponse;
+  response: JobListJobs200Response | JobListJobsDefaultResponse
+): response is JobListJobsDefaultResponse;
 export function isUnexpected(
   response:
     | JobListFromJobSchedule200Response
@@ -366,22 +368,30 @@ export function isUnexpected(
   response: JobGetTaskCounts200Response | JobGetTaskCountsDefaultResponse
 ): response is JobGetTaskCountsDefaultResponse;
 export function isUnexpected(
-  response: CertificatesAdd201Response | CertificatesAddDefaultResponse
-): response is CertificatesAddDefaultResponse;
-export function isUnexpected(
-  response: CertificatesList200Response | CertificatesListDefaultResponse
-): response is CertificatesListDefaultResponse;
+  response:
+    | CertificatesAddCertificate201Response
+    | CertificatesAddCertificateDefaultResponse
+): response is CertificatesAddCertificateDefaultResponse;
 export function isUnexpected(
   response:
-    | CertificatesCancelDeletion204Response
-    | CertificatesCancelDeletionDefaultResponse
-): response is CertificatesCancelDeletionDefaultResponse;
+    | CertificatesListCertificates200Response
+    | CertificatesListCertificatesDefaultResponse
+): response is CertificatesListCertificatesDefaultResponse;
 export function isUnexpected(
-  response: CertificatesDelete202Response | CertificatesDeleteDefaultResponse
-): response is CertificatesDeleteDefaultResponse;
+  response:
+    | CertificatesCancelCertificateDeletion204Response
+    | CertificatesCancelCertificateDeletionDefaultResponse
+): response is CertificatesCancelCertificateDeletionDefaultResponse;
 export function isUnexpected(
-  response: CertificatesGet200Response | CertificatesGetDefaultResponse
-): response is CertificatesGetDefaultResponse;
+  response:
+    | CertificatesDeleteCertificate202Response
+    | CertificatesDeleteCertificateDefaultResponse
+): response is CertificatesDeleteCertificateDefaultResponse;
+export function isUnexpected(
+  response:
+    | CertificatesGetCertificate200Response
+    | CertificatesGetCertificateDefaultResponse
+): response is CertificatesGetCertificateDefaultResponse;
 export function isUnexpected(
   response: FileDeleteFromTask200Response | FileDeleteFromTaskDefaultResponse
 ): response is FileDeleteFromTaskDefaultResponse;
@@ -418,66 +428,94 @@ export function isUnexpected(
 ): response is FileListFromComputeNodeDefaultResponse;
 export function isUnexpected(
   response:
-    | JobScheduleExists200Response
-    | JobScheduleExists404Response
-    | JobScheduleExistsDefaultResponse
-): response is JobScheduleExistsDefaultResponse;
-export function isUnexpected(
-  response: JobScheduleDelete202Response | JobScheduleDeleteDefaultResponse
-): response is JobScheduleDeleteDefaultResponse;
-export function isUnexpected(
-  response: JobScheduleGet200Response | JobScheduleGetDefaultResponse
-): response is JobScheduleGetDefaultResponse;
-export function isUnexpected(
-  response: JobSchedulePatch200Response | JobSchedulePatchDefaultResponse
-): response is JobSchedulePatchDefaultResponse;
-export function isUnexpected(
-  response: JobScheduleUpdate200Response | JobScheduleUpdateDefaultResponse
-): response is JobScheduleUpdateDefaultResponse;
-export function isUnexpected(
-  response: JobScheduleDisable204Response | JobScheduleDisableDefaultResponse
-): response is JobScheduleDisableDefaultResponse;
-export function isUnexpected(
-  response: JobScheduleEnable204Response | JobScheduleEnableDefaultResponse
-): response is JobScheduleEnableDefaultResponse;
+    | JobScheduleJobScheduleExists200Response
+    | JobScheduleJobScheduleExists404Response
+    | JobScheduleJobScheduleExistsDefaultResponse
+): response is JobScheduleJobScheduleExistsDefaultResponse;
 export function isUnexpected(
   response:
-    | JobScheduleTerminate202Response
-    | JobScheduleTerminateDefaultResponse
-): response is JobScheduleTerminateDefaultResponse;
+    | JobScheduleDeleteJobSchedule202Response
+    | JobScheduleDeleteJobScheduleDefaultResponse
+): response is JobScheduleDeleteJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: JobScheduleAdd201Response | JobScheduleAddDefaultResponse
-): response is JobScheduleAddDefaultResponse;
+  response:
+    | JobScheduleGetJobSchedule200Response
+    | JobScheduleGetJobScheduleDefaultResponse
+): response is JobScheduleGetJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: JobScheduleList200Response | JobScheduleListDefaultResponse
-): response is JobScheduleListDefaultResponse;
+  response:
+    | JobSchedulePatchJobSchedule200Response
+    | JobSchedulePatchJobScheduleDefaultResponse
+): response is JobSchedulePatchJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: TaskAdd201Response | TaskAddDefaultResponse
-): response is TaskAddDefaultResponse;
+  response:
+    | JobScheduleUpdateJobSchedule200Response
+    | JobScheduleUpdateJobScheduleDefaultResponse
+): response is JobScheduleUpdateJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: TaskList200Response | TaskListDefaultResponse
-): response is TaskListDefaultResponse;
+  response:
+    | JobScheduleDisableJobSchedule204Response
+    | JobScheduleDisableJobScheduleDefaultResponse
+): response is JobScheduleDisableJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: TaskAddCollection200Response | TaskAddCollectionDefaultResponse
-): response is TaskAddCollectionDefaultResponse;
+  response:
+    | JobScheduleEnableJobSchedule204Response
+    | JobScheduleEnableJobScheduleDefaultResponse
+): response is JobScheduleEnableJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: TaskDelete200Response | TaskDeleteDefaultResponse
-): response is TaskDeleteDefaultResponse;
+  response:
+    | JobScheduleTerminateJobSchedule202Response
+    | JobScheduleTerminateJobScheduleDefaultResponse
+): response is JobScheduleTerminateJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: TaskGet200Response | TaskGetDefaultResponse
-): response is TaskGetDefaultResponse;
+  response:
+    | JobScheduleAddJobSchedule201Response
+    | JobScheduleAddJobScheduleDefaultResponse
+): response is JobScheduleAddJobScheduleDefaultResponse;
 export function isUnexpected(
-  response: TaskUpdate200Response | TaskUpdateDefaultResponse
-): response is TaskUpdateDefaultResponse;
+  response:
+    | JobScheduleListJobSchedules200Response
+    | JobScheduleListJobSchedulesDefaultResponse
+): response is JobScheduleListJobSchedulesDefaultResponse;
+export function isUnexpected(
+  response: TaskAddTask201Response | TaskAddTaskDefaultResponse
+): response is TaskAddTaskDefaultResponse;
+export function isUnexpected(
+  response: TaskListTasks200Response | TaskListTasksDefaultResponse
+): response is TaskListTasksDefaultResponse;
+export function isUnexpected(
+  response:
+    | TaskAddTaskCollection200Response
+    | TaskAddTaskCollectionDefaultResponse
+): response is TaskAddTaskCollectionDefaultResponse;
+export function isUnexpected(
+  response:
+    | TaskDeleteTaskCollection200Response
+    | TaskDeleteTaskCollectionDefaultResponse
+): response is TaskDeleteTaskCollectionDefaultResponse;
+export function isUnexpected(
+  response:
+    | TaskGetTaskCollection200Response
+    | TaskGetTaskCollectionDefaultResponse
+): response is TaskGetTaskCollectionDefaultResponse;
+export function isUnexpected(
+  response:
+    | TaskUpdateTaskCollection200Response
+    | TaskUpdateTaskCollectionDefaultResponse
+): response is TaskUpdateTaskCollectionDefaultResponse;
 export function isUnexpected(
   response: TaskListSubtasks200Response | TaskListSubtasksDefaultResponse
 ): response is TaskListSubtasksDefaultResponse;
 export function isUnexpected(
-  response: TaskTerminate204Response | TaskTerminateDefaultResponse
-): response is TaskTerminateDefaultResponse;
+  response:
+    | TaskTerminateTaskCollection204Response
+    | TaskTerminateTaskCollectionDefaultResponse
+): response is TaskTerminateTaskCollectionDefaultResponse;
 export function isUnexpected(
-  response: TaskReactivate204Response | TaskReactivateDefaultResponse
-): response is TaskReactivateDefaultResponse;
+  response:
+    | TaskReactivateTaskCollection204Response
+    | TaskReactivateTaskCollectionDefaultResponse
+): response is TaskReactivateTaskCollectionDefaultResponse;
 export function isUnexpected(
   response: ComputeNodesAddUser201Response | ComputeNodesAddUserDefaultResponse
 ): response is ComputeNodesAddUserDefaultResponse;
@@ -492,14 +530,20 @@ export function isUnexpected(
     | ComputeNodesUpdateUserDefaultResponse
 ): response is ComputeNodesUpdateUserDefaultResponse;
 export function isUnexpected(
-  response: ComputeNodesGet200Response | ComputeNodesGetDefaultResponse
-): response is ComputeNodesGetDefaultResponse;
+  response:
+    | ComputeNodesGetComputeNode200Response
+    | ComputeNodesGetComputeNodeDefaultResponse
+): response is ComputeNodesGetComputeNodeDefaultResponse;
 export function isUnexpected(
-  response: ComputeNodesReboot202Response | ComputeNodesRebootDefaultResponse
-): response is ComputeNodesRebootDefaultResponse;
+  response:
+    | ComputeNodesRebootComputeNode202Response
+    | ComputeNodesRebootComputeNodeDefaultResponse
+): response is ComputeNodesRebootComputeNodeDefaultResponse;
 export function isUnexpected(
-  response: ComputeNodesReimage202Response | ComputeNodesReimageDefaultResponse
-): response is ComputeNodesReimageDefaultResponse;
+  response:
+    | ComputeNodesReimageComputeNode202Response
+    | ComputeNodesReimageComputeNodeDefaultResponse
+): response is ComputeNodesReimageComputeNodeDefaultResponse;
 export function isUnexpected(
   response:
     | ComputeNodesDisableScheduling200Response
@@ -530,37 +574,37 @@ export function isUnexpected(
 ): response is ComputeNodesListDefaultResponse;
 export function isUnexpected(
   response:
-    | ComputeNodeExtensionsGet200Response
-    | ComputeNodeExtensionsGetDefaultResponse
-): response is ComputeNodeExtensionsGetDefaultResponse;
+    | ComputeNodeExtensionsGetComputeNodeExtensions200Response
+    | ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse
+): response is ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse;
 export function isUnexpected(
   response:
-    | ComputeNodeExtensionsList200Response
-    | ComputeNodeExtensionsListDefaultResponse
-): response is ComputeNodeExtensionsListDefaultResponse;
+    | ComputeNodeExtensionsListComputeNodeExtensions200Response
+    | ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse
+): response is ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse;
 export function isUnexpected(
   response:
-    | ApplicationsList200Response
-    | ApplicationsListDefaultResponse
+    | ApplicationsListApplications200Response
+    | ApplicationsListApplicationsDefaultResponse
     | ApplicationsGet200Response
     | ApplicationsGetDefaultResponse
     | PoolListUsageMetrics200Response
     | PoolListUsageMetricsDefaultResponse
     | PoolGetAllLifetimeStatistics200Response
     | PoolGetAllLifetimeStatisticsDefaultResponse
-    | PoolAdd201Response
-    | PoolAddDefaultResponse
-    | PoolList200Response
-    | PoolListDefaultResponse
-    | PoolDelete202Response
-    | PoolDeleteDefaultResponse
+    | PoolAddPool201Response
+    | PoolAddPoolDefaultResponse
+    | PoolListPools200Response
+    | PoolListPoolsDefaultResponse
+    | PoolDeletePool202Response
+    | PoolDeletePoolDefaultResponse
     | PoolExists200Response
     | PoolExists404Response
     | PoolExistsDefaultResponse
-    | PoolGet200Response
-    | PoolGetDefaultResponse
-    | PoolPatch200Response
-    | PoolPatchDefaultResponse
+    | PoolGetPool200Response
+    | PoolGetPoolDefaultResponse
+    | PoolPatchPool200Response
+    | PoolPatchPoolDefaultResponse
     | PoolDisableAutoScale200Response
     | PoolDisableAutoScaleDefaultResponse
     | PoolEnableAutoScale200Response
@@ -581,40 +625,40 @@ export function isUnexpected(
     | AccountListPoolNodeCountsDefaultResponse
     | JobGetAllLifetimeStatistics200Response
     | JobGetAllLifetimeStatisticsDefaultResponse
-    | JobDelete202Response
-    | JobDeleteDefaultResponse
-    | JobGet200Response
-    | JobGetDefaultResponse
-    | JobPatch200Response
-    | JobPatchDefaultResponse
-    | JobUpdate200Response
-    | JobUpdateDefaultResponse
-    | JobDisable202Response
-    | JobDisableDefaultResponse
-    | JobEnable202Response
-    | JobEnableDefaultResponse
-    | JobTerminate202Response
-    | JobTerminateDefaultResponse
-    | JobAdd201Response
-    | JobAddDefaultResponse
-    | JobList200Response
-    | JobListDefaultResponse
+    | JobDeleteJob202Response
+    | JobDeleteJobDefaultResponse
+    | JobGetJob200Response
+    | JobGetJobDefaultResponse
+    | JobPatchJob200Response
+    | JobPatchJobDefaultResponse
+    | JobUpdateJob200Response
+    | JobUpdateJobDefaultResponse
+    | JobDisableJob202Response
+    | JobDisableJobDefaultResponse
+    | JobEnableJob202Response
+    | JobEnableJobDefaultResponse
+    | JobTerminateJob202Response
+    | JobTerminateJobDefaultResponse
+    | JobAddJob201Response
+    | JobAddJobDefaultResponse
+    | JobListJobs200Response
+    | JobListJobsDefaultResponse
     | JobListFromJobSchedule200Response
     | JobListFromJobScheduleDefaultResponse
     | JobListPreparationAndReleaseTaskStatus200Response
     | JobListPreparationAndReleaseTaskStatusDefaultResponse
     | JobGetTaskCounts200Response
     | JobGetTaskCountsDefaultResponse
-    | CertificatesAdd201Response
-    | CertificatesAddDefaultResponse
-    | CertificatesList200Response
-    | CertificatesListDefaultResponse
-    | CertificatesCancelDeletion204Response
-    | CertificatesCancelDeletionDefaultResponse
-    | CertificatesDelete202Response
-    | CertificatesDeleteDefaultResponse
-    | CertificatesGet200Response
-    | CertificatesGetDefaultResponse
+    | CertificatesAddCertificate201Response
+    | CertificatesAddCertificateDefaultResponse
+    | CertificatesListCertificates200Response
+    | CertificatesListCertificatesDefaultResponse
+    | CertificatesCancelCertificateDeletion204Response
+    | CertificatesCancelCertificateDeletionDefaultResponse
+    | CertificatesDeleteCertificate202Response
+    | CertificatesDeleteCertificateDefaultResponse
+    | CertificatesGetCertificate200Response
+    | CertificatesGetCertificateDefaultResponse
     | FileDeleteFromTask200Response
     | FileDeleteFromTaskDefaultResponse
     | FileGetFromTask200Response
@@ -631,57 +675,57 @@ export function isUnexpected(
     | FileListFromTaskDefaultResponse
     | FileListFromComputeNode200Response
     | FileListFromComputeNodeDefaultResponse
-    | JobScheduleExists200Response
-    | JobScheduleExists404Response
-    | JobScheduleExistsDefaultResponse
-    | JobScheduleDelete202Response
-    | JobScheduleDeleteDefaultResponse
-    | JobScheduleGet200Response
-    | JobScheduleGetDefaultResponse
-    | JobSchedulePatch200Response
-    | JobSchedulePatchDefaultResponse
-    | JobScheduleUpdate200Response
-    | JobScheduleUpdateDefaultResponse
-    | JobScheduleDisable204Response
-    | JobScheduleDisableDefaultResponse
-    | JobScheduleEnable204Response
-    | JobScheduleEnableDefaultResponse
-    | JobScheduleTerminate202Response
-    | JobScheduleTerminateDefaultResponse
-    | JobScheduleAdd201Response
-    | JobScheduleAddDefaultResponse
-    | JobScheduleList200Response
-    | JobScheduleListDefaultResponse
-    | TaskAdd201Response
-    | TaskAddDefaultResponse
-    | TaskList200Response
-    | TaskListDefaultResponse
-    | TaskAddCollection200Response
-    | TaskAddCollectionDefaultResponse
-    | TaskDelete200Response
-    | TaskDeleteDefaultResponse
-    | TaskGet200Response
-    | TaskGetDefaultResponse
-    | TaskUpdate200Response
-    | TaskUpdateDefaultResponse
+    | JobScheduleJobScheduleExists200Response
+    | JobScheduleJobScheduleExists404Response
+    | JobScheduleJobScheduleExistsDefaultResponse
+    | JobScheduleDeleteJobSchedule202Response
+    | JobScheduleDeleteJobScheduleDefaultResponse
+    | JobScheduleGetJobSchedule200Response
+    | JobScheduleGetJobScheduleDefaultResponse
+    | JobSchedulePatchJobSchedule200Response
+    | JobSchedulePatchJobScheduleDefaultResponse
+    | JobScheduleUpdateJobSchedule200Response
+    | JobScheduleUpdateJobScheduleDefaultResponse
+    | JobScheduleDisableJobSchedule204Response
+    | JobScheduleDisableJobScheduleDefaultResponse
+    | JobScheduleEnableJobSchedule204Response
+    | JobScheduleEnableJobScheduleDefaultResponse
+    | JobScheduleTerminateJobSchedule202Response
+    | JobScheduleTerminateJobScheduleDefaultResponse
+    | JobScheduleAddJobSchedule201Response
+    | JobScheduleAddJobScheduleDefaultResponse
+    | JobScheduleListJobSchedules200Response
+    | JobScheduleListJobSchedulesDefaultResponse
+    | TaskAddTask201Response
+    | TaskAddTaskDefaultResponse
+    | TaskListTasks200Response
+    | TaskListTasksDefaultResponse
+    | TaskAddTaskCollection200Response
+    | TaskAddTaskCollectionDefaultResponse
+    | TaskDeleteTaskCollection200Response
+    | TaskDeleteTaskCollectionDefaultResponse
+    | TaskGetTaskCollection200Response
+    | TaskGetTaskCollectionDefaultResponse
+    | TaskUpdateTaskCollection200Response
+    | TaskUpdateTaskCollectionDefaultResponse
     | TaskListSubtasks200Response
     | TaskListSubtasksDefaultResponse
-    | TaskTerminate204Response
-    | TaskTerminateDefaultResponse
-    | TaskReactivate204Response
-    | TaskReactivateDefaultResponse
+    | TaskTerminateTaskCollection204Response
+    | TaskTerminateTaskCollectionDefaultResponse
+    | TaskReactivateTaskCollection204Response
+    | TaskReactivateTaskCollectionDefaultResponse
     | ComputeNodesAddUser201Response
     | ComputeNodesAddUserDefaultResponse
     | ComputeNodesDeleteUser200Response
     | ComputeNodesDeleteUserDefaultResponse
     | ComputeNodesUpdateUser200Response
     | ComputeNodesUpdateUserDefaultResponse
-    | ComputeNodesGet200Response
-    | ComputeNodesGetDefaultResponse
-    | ComputeNodesReboot202Response
-    | ComputeNodesRebootDefaultResponse
-    | ComputeNodesReimage202Response
-    | ComputeNodesReimageDefaultResponse
+    | ComputeNodesGetComputeNode200Response
+    | ComputeNodesGetComputeNodeDefaultResponse
+    | ComputeNodesRebootComputeNode202Response
+    | ComputeNodesRebootComputeNodeDefaultResponse
+    | ComputeNodesReimageComputeNode202Response
+    | ComputeNodesReimageComputeNodeDefaultResponse
     | ComputeNodesDisableScheduling200Response
     | ComputeNodesDisableSchedulingDefaultResponse
     | ComputeNodesEnableScheduling200Response
@@ -694,21 +738,21 @@ export function isUnexpected(
     | ComputeNodesUploadBatchServiceLogsDefaultResponse
     | ComputeNodesList200Response
     | ComputeNodesListDefaultResponse
-    | ComputeNodeExtensionsGet200Response
-    | ComputeNodeExtensionsGetDefaultResponse
-    | ComputeNodeExtensionsList200Response
-    | ComputeNodeExtensionsListDefaultResponse
+    | ComputeNodeExtensionsGetComputeNodeExtensions200Response
+    | ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse
+    | ComputeNodeExtensionsListComputeNodeExtensions200Response
+    | ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse
 ): response is
-  | ApplicationsListDefaultResponse
+  | ApplicationsListApplicationsDefaultResponse
   | ApplicationsGetDefaultResponse
   | PoolListUsageMetricsDefaultResponse
   | PoolGetAllLifetimeStatisticsDefaultResponse
-  | PoolAddDefaultResponse
-  | PoolListDefaultResponse
-  | PoolDeleteDefaultResponse
+  | PoolAddPoolDefaultResponse
+  | PoolListPoolsDefaultResponse
+  | PoolDeletePoolDefaultResponse
   | PoolExistsDefaultResponse
-  | PoolGetDefaultResponse
-  | PoolPatchDefaultResponse
+  | PoolGetPoolDefaultResponse
+  | PoolPatchPoolDefaultResponse
   | PoolDisableAutoScaleDefaultResponse
   | PoolEnableAutoScaleDefaultResponse
   | PoolEvaluateAutoScaleDefaultResponse
@@ -719,23 +763,23 @@ export function isUnexpected(
   | AccountListSupportedImagesDefaultResponse
   | AccountListPoolNodeCountsDefaultResponse
   | JobGetAllLifetimeStatisticsDefaultResponse
-  | JobDeleteDefaultResponse
-  | JobGetDefaultResponse
-  | JobPatchDefaultResponse
-  | JobUpdateDefaultResponse
-  | JobDisableDefaultResponse
-  | JobEnableDefaultResponse
-  | JobTerminateDefaultResponse
-  | JobAddDefaultResponse
-  | JobListDefaultResponse
+  | JobDeleteJobDefaultResponse
+  | JobGetJobDefaultResponse
+  | JobPatchJobDefaultResponse
+  | JobUpdateJobDefaultResponse
+  | JobDisableJobDefaultResponse
+  | JobEnableJobDefaultResponse
+  | JobTerminateJobDefaultResponse
+  | JobAddJobDefaultResponse
+  | JobListJobsDefaultResponse
   | JobListFromJobScheduleDefaultResponse
   | JobListPreparationAndReleaseTaskStatusDefaultResponse
   | JobGetTaskCountsDefaultResponse
-  | CertificatesAddDefaultResponse
-  | CertificatesListDefaultResponse
-  | CertificatesCancelDeletionDefaultResponse
-  | CertificatesDeleteDefaultResponse
-  | CertificatesGetDefaultResponse
+  | CertificatesAddCertificateDefaultResponse
+  | CertificatesListCertificatesDefaultResponse
+  | CertificatesCancelCertificateDeletionDefaultResponse
+  | CertificatesDeleteCertificateDefaultResponse
+  | CertificatesGetCertificateDefaultResponse
   | FileDeleteFromTaskDefaultResponse
   | FileGetFromTaskDefaultResponse
   | FileGetPropertiesFromTaskDefaultResponse
@@ -744,39 +788,39 @@ export function isUnexpected(
   | FileGetPropertiesFromComputeNodeDefaultResponse
   | FileListFromTaskDefaultResponse
   | FileListFromComputeNodeDefaultResponse
-  | JobScheduleExistsDefaultResponse
-  | JobScheduleDeleteDefaultResponse
-  | JobScheduleGetDefaultResponse
-  | JobSchedulePatchDefaultResponse
-  | JobScheduleUpdateDefaultResponse
-  | JobScheduleDisableDefaultResponse
-  | JobScheduleEnableDefaultResponse
-  | JobScheduleTerminateDefaultResponse
-  | JobScheduleAddDefaultResponse
-  | JobScheduleListDefaultResponse
-  | TaskAddDefaultResponse
-  | TaskListDefaultResponse
-  | TaskAddCollectionDefaultResponse
-  | TaskDeleteDefaultResponse
-  | TaskGetDefaultResponse
-  | TaskUpdateDefaultResponse
+  | JobScheduleJobScheduleExistsDefaultResponse
+  | JobScheduleDeleteJobScheduleDefaultResponse
+  | JobScheduleGetJobScheduleDefaultResponse
+  | JobSchedulePatchJobScheduleDefaultResponse
+  | JobScheduleUpdateJobScheduleDefaultResponse
+  | JobScheduleDisableJobScheduleDefaultResponse
+  | JobScheduleEnableJobScheduleDefaultResponse
+  | JobScheduleTerminateJobScheduleDefaultResponse
+  | JobScheduleAddJobScheduleDefaultResponse
+  | JobScheduleListJobSchedulesDefaultResponse
+  | TaskAddTaskDefaultResponse
+  | TaskListTasksDefaultResponse
+  | TaskAddTaskCollectionDefaultResponse
+  | TaskDeleteTaskCollectionDefaultResponse
+  | TaskGetTaskCollectionDefaultResponse
+  | TaskUpdateTaskCollectionDefaultResponse
   | TaskListSubtasksDefaultResponse
-  | TaskTerminateDefaultResponse
-  | TaskReactivateDefaultResponse
+  | TaskTerminateTaskCollectionDefaultResponse
+  | TaskReactivateTaskCollectionDefaultResponse
   | ComputeNodesAddUserDefaultResponse
   | ComputeNodesDeleteUserDefaultResponse
   | ComputeNodesUpdateUserDefaultResponse
-  | ComputeNodesGetDefaultResponse
-  | ComputeNodesRebootDefaultResponse
-  | ComputeNodesReimageDefaultResponse
+  | ComputeNodesGetComputeNodeDefaultResponse
+  | ComputeNodesRebootComputeNodeDefaultResponse
+  | ComputeNodesReimageComputeNodeDefaultResponse
   | ComputeNodesDisableSchedulingDefaultResponse
   | ComputeNodesEnableSchedulingDefaultResponse
   | ComputeNodesGetRemoteLoginSettingsDefaultResponse
   | ComputeNodesGetRemoteDesktopDefaultResponse
   | ComputeNodesUploadBatchServiceLogsDefaultResponse
   | ComputeNodesListDefaultResponse
-  | ComputeNodeExtensionsGetDefaultResponse
-  | ComputeNodeExtensionsListDefaultResponse {
+  | ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse
+  | ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse {
   const lroOriginal = response.headers["x-ms-original-url"];
   const url = new URL(lroOriginal ?? response.request.url);
   const method = response.request.method;

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/parameters.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/parameters.ts
@@ -24,7 +24,7 @@ import {
   UploadBatchServiceLogsConfiguration,
 } from "./models.js";
 
-export interface ApplicationsListHeaders {
+export interface ApplicationsListApplicationsHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -40,7 +40,7 @@ export interface ApplicationsListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface ApplicationsListQueryParamProperties {
+export interface ApplicationsListApplicationsQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -53,17 +53,18 @@ export interface ApplicationsListQueryParamProperties {
   timeOut?: number;
 }
 
-export interface ApplicationsListQueryParam {
-  queryParameters?: ApplicationsListQueryParamProperties;
+export interface ApplicationsListApplicationsQueryParam {
+  queryParameters?: ApplicationsListApplicationsQueryParamProperties;
 }
 
-export interface ApplicationsListHeaderParam {
-  headers?: RawHttpHeadersInput & ApplicationsListHeaders;
+export interface ApplicationsListApplicationsHeaderParam {
+  headers?: RawHttpHeadersInput & ApplicationsListApplicationsHeaders;
 }
 
-export type ApplicationsListParameters = ApplicationsListQueryParam &
-  ApplicationsListHeaderParam &
-  RequestParameters;
+export type ApplicationsListApplicationsParameters =
+  ApplicationsListApplicationsQueryParam &
+    ApplicationsListApplicationsHeaderParam &
+    RequestParameters;
 export type ApplicationsGetParameters = RequestParameters;
 export type PoolListUsageMetricsParameters = RequestParameters;
 
@@ -104,7 +105,7 @@ export type PoolGetAllLifetimeStatisticsParameters =
     PoolGetAllLifetimeStatisticsHeaderParam &
     RequestParameters;
 
-export interface PoolAddHeaders {
+export interface PoolAddPoolHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -120,12 +121,12 @@ export interface PoolAddHeaders {
   "ocp-date"?: string;
 }
 
-export interface PoolAddBodyParam {
+export interface PoolAddPoolBodyParam {
   /** The Pool to be added. */
   body: BatchPool;
 }
 
-export interface PoolAddQueryParamProperties {
+export interface PoolAddPoolQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -133,20 +134,20 @@ export interface PoolAddQueryParamProperties {
   timeOut?: number;
 }
 
-export interface PoolAddQueryParam {
-  queryParameters?: PoolAddQueryParamProperties;
+export interface PoolAddPoolQueryParam {
+  queryParameters?: PoolAddPoolQueryParamProperties;
 }
 
-export interface PoolAddHeaderParam {
-  headers?: RawHttpHeadersInput & PoolAddHeaders;
+export interface PoolAddPoolHeaderParam {
+  headers?: RawHttpHeadersInput & PoolAddPoolHeaders;
 }
 
-export type PoolAddParameters = PoolAddQueryParam &
-  PoolAddHeaderParam &
-  PoolAddBodyParam &
+export type PoolAddPoolParameters = PoolAddPoolQueryParam &
+  PoolAddPoolHeaderParam &
+  PoolAddPoolBodyParam &
   RequestParameters;
 
-export interface PoolListHeaders {
+export interface PoolListPoolsHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -162,7 +163,7 @@ export interface PoolListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface PoolListQueryParamProperties {
+export interface PoolListPoolsQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -184,19 +185,19 @@ export interface PoolListQueryParamProperties {
   $expand?: string;
 }
 
-export interface PoolListQueryParam {
-  queryParameters?: PoolListQueryParamProperties;
+export interface PoolListPoolsQueryParam {
+  queryParameters?: PoolListPoolsQueryParamProperties;
 }
 
-export interface PoolListHeaderParam {
-  headers?: RawHttpHeadersInput & PoolListHeaders;
+export interface PoolListPoolsHeaderParam {
+  headers?: RawHttpHeadersInput & PoolListPoolsHeaders;
 }
 
-export type PoolListParameters = PoolListQueryParam &
-  PoolListHeaderParam &
+export type PoolListPoolsParameters = PoolListPoolsQueryParam &
+  PoolListPoolsHeaderParam &
   RequestParameters;
 
-export interface PoolDeleteHeaders {
+export interface PoolDeletePoolHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -236,7 +237,7 @@ export interface PoolDeleteHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface PoolDeleteQueryParamProperties {
+export interface PoolDeletePoolQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -244,16 +245,16 @@ export interface PoolDeleteQueryParamProperties {
   timeOut?: number;
 }
 
-export interface PoolDeleteQueryParam {
-  queryParameters?: PoolDeleteQueryParamProperties;
+export interface PoolDeletePoolQueryParam {
+  queryParameters?: PoolDeletePoolQueryParamProperties;
 }
 
-export interface PoolDeleteHeaderParam {
-  headers?: RawHttpHeadersInput & PoolDeleteHeaders;
+export interface PoolDeletePoolHeaderParam {
+  headers?: RawHttpHeadersInput & PoolDeletePoolHeaders;
 }
 
-export type PoolDeleteParameters = PoolDeleteQueryParam &
-  PoolDeleteHeaderParam &
+export type PoolDeletePoolParameters = PoolDeletePoolQueryParam &
+  PoolDeletePoolHeaderParam &
   RequestParameters;
 
 export interface PoolExistsHeaders {
@@ -316,7 +317,7 @@ export type PoolExistsParameters = PoolExistsQueryParam &
   PoolExistsHeaderParam &
   RequestParameters;
 
-export interface PoolGetHeaders {
+export interface PoolGetPoolHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -356,7 +357,7 @@ export interface PoolGetHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface PoolGetQueryParamProperties {
+export interface PoolGetPoolQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -368,19 +369,19 @@ export interface PoolGetQueryParamProperties {
   $expand?: string;
 }
 
-export interface PoolGetQueryParam {
-  queryParameters?: PoolGetQueryParamProperties;
+export interface PoolGetPoolQueryParam {
+  queryParameters?: PoolGetPoolQueryParamProperties;
 }
 
-export interface PoolGetHeaderParam {
-  headers?: RawHttpHeadersInput & PoolGetHeaders;
+export interface PoolGetPoolHeaderParam {
+  headers?: RawHttpHeadersInput & PoolGetPoolHeaders;
 }
 
-export type PoolGetParameters = PoolGetQueryParam &
-  PoolGetHeaderParam &
+export type PoolGetPoolParameters = PoolGetPoolQueryParam &
+  PoolGetPoolHeaderParam &
   RequestParameters;
 
-export interface PoolPatchHeaders {
+export interface PoolPatchPoolHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -420,12 +421,12 @@ export interface PoolPatchHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface PoolPatchBodyParam {
+export interface PoolPatchPoolBodyParam {
   /** The parameters for the request. */
   body: BatchPool;
 }
 
-export interface PoolPatchQueryParamProperties {
+export interface PoolPatchPoolQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -433,17 +434,17 @@ export interface PoolPatchQueryParamProperties {
   timeOut?: number;
 }
 
-export interface PoolPatchQueryParam {
-  queryParameters?: PoolPatchQueryParamProperties;
+export interface PoolPatchPoolQueryParam {
+  queryParameters?: PoolPatchPoolQueryParamProperties;
 }
 
-export interface PoolPatchHeaderParam {
-  headers?: RawHttpHeadersInput & PoolPatchHeaders;
+export interface PoolPatchPoolHeaderParam {
+  headers?: RawHttpHeadersInput & PoolPatchPoolHeaders;
 }
 
-export type PoolPatchParameters = PoolPatchQueryParam &
-  PoolPatchHeaderParam &
-  PoolPatchBodyParam &
+export type PoolPatchPoolParameters = PoolPatchPoolQueryParam &
+  PoolPatchPoolHeaderParam &
+  PoolPatchPoolBodyParam &
   RequestParameters;
 
 export interface PoolDisableAutoScaleHeaders {
@@ -955,7 +956,7 @@ export type JobGetAllLifetimeStatisticsParameters =
     JobGetAllLifetimeStatisticsHeaderParam &
     RequestParameters;
 
-export interface JobDeleteHeaders {
+export interface JobDeleteJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -995,7 +996,7 @@ export interface JobDeleteHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobDeleteQueryParamProperties {
+export interface JobDeleteJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1003,19 +1004,19 @@ export interface JobDeleteQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobDeleteQueryParam {
-  queryParameters?: JobDeleteQueryParamProperties;
+export interface JobDeleteJobQueryParam {
+  queryParameters?: JobDeleteJobQueryParamProperties;
 }
 
-export interface JobDeleteHeaderParam {
-  headers?: RawHttpHeadersInput & JobDeleteHeaders;
+export interface JobDeleteJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobDeleteJobHeaders;
 }
 
-export type JobDeleteParameters = JobDeleteQueryParam &
-  JobDeleteHeaderParam &
+export type JobDeleteJobParameters = JobDeleteJobQueryParam &
+  JobDeleteJobHeaderParam &
   RequestParameters;
 
-export interface JobGetHeaders {
+export interface JobGetJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1055,7 +1056,7 @@ export interface JobGetHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobGetQueryParamProperties {
+export interface JobGetJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1067,19 +1068,19 @@ export interface JobGetQueryParamProperties {
   $expand?: string;
 }
 
-export interface JobGetQueryParam {
-  queryParameters?: JobGetQueryParamProperties;
+export interface JobGetJobQueryParam {
+  queryParameters?: JobGetJobQueryParamProperties;
 }
 
-export interface JobGetHeaderParam {
-  headers?: RawHttpHeadersInput & JobGetHeaders;
+export interface JobGetJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobGetJobHeaders;
 }
 
-export type JobGetParameters = JobGetQueryParam &
-  JobGetHeaderParam &
+export type JobGetJobParameters = JobGetJobQueryParam &
+  JobGetJobHeaderParam &
   RequestParameters;
 
-export interface JobPatchHeaders {
+export interface JobPatchJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1119,12 +1120,12 @@ export interface JobPatchHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobPatchBodyParam {
+export interface JobPatchJobBodyParam {
   /** The parameters for the request. */
   body: BatchJob;
 }
 
-export interface JobPatchQueryParamProperties {
+export interface JobPatchJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1132,20 +1133,20 @@ export interface JobPatchQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobPatchQueryParam {
-  queryParameters?: JobPatchQueryParamProperties;
+export interface JobPatchJobQueryParam {
+  queryParameters?: JobPatchJobQueryParamProperties;
 }
 
-export interface JobPatchHeaderParam {
-  headers?: RawHttpHeadersInput & JobPatchHeaders;
+export interface JobPatchJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobPatchJobHeaders;
 }
 
-export type JobPatchParameters = JobPatchQueryParam &
-  JobPatchHeaderParam &
-  JobPatchBodyParam &
+export type JobPatchJobParameters = JobPatchJobQueryParam &
+  JobPatchJobHeaderParam &
+  JobPatchJobBodyParam &
   RequestParameters;
 
-export interface JobUpdateHeaders {
+export interface JobUpdateJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1185,12 +1186,12 @@ export interface JobUpdateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobUpdateBodyParam {
+export interface JobUpdateJobBodyParam {
   /** The parameters for the request. */
   body: BatchJob;
 }
 
-export interface JobUpdateQueryParamProperties {
+export interface JobUpdateJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1198,20 +1199,20 @@ export interface JobUpdateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobUpdateQueryParam {
-  queryParameters?: JobUpdateQueryParamProperties;
+export interface JobUpdateJobQueryParam {
+  queryParameters?: JobUpdateJobQueryParamProperties;
 }
 
-export interface JobUpdateHeaderParam {
-  headers?: RawHttpHeadersInput & JobUpdateHeaders;
+export interface JobUpdateJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobUpdateJobHeaders;
 }
 
-export type JobUpdateParameters = JobUpdateQueryParam &
-  JobUpdateHeaderParam &
-  JobUpdateBodyParam &
+export type JobUpdateJobParameters = JobUpdateJobQueryParam &
+  JobUpdateJobHeaderParam &
+  JobUpdateJobBodyParam &
   RequestParameters;
 
-export interface JobDisableHeaders {
+export interface JobDisableJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1251,12 +1252,12 @@ export interface JobDisableHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobDisableBodyParam {
+export interface JobDisableJobBodyParam {
   /** The parameters for the request. */
   body: BatchJobDisableParameters;
 }
 
-export interface JobDisableQueryParamProperties {
+export interface JobDisableJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1264,20 +1265,20 @@ export interface JobDisableQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobDisableQueryParam {
-  queryParameters?: JobDisableQueryParamProperties;
+export interface JobDisableJobQueryParam {
+  queryParameters?: JobDisableJobQueryParamProperties;
 }
 
-export interface JobDisableHeaderParam {
-  headers?: RawHttpHeadersInput & JobDisableHeaders;
+export interface JobDisableJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobDisableJobHeaders;
 }
 
-export type JobDisableParameters = JobDisableQueryParam &
-  JobDisableHeaderParam &
-  JobDisableBodyParam &
+export type JobDisableJobParameters = JobDisableJobQueryParam &
+  JobDisableJobHeaderParam &
+  JobDisableJobBodyParam &
   RequestParameters;
 
-export interface JobEnableHeaders {
+export interface JobEnableJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1317,7 +1318,7 @@ export interface JobEnableHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobEnableQueryParamProperties {
+export interface JobEnableJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1325,19 +1326,19 @@ export interface JobEnableQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobEnableQueryParam {
-  queryParameters?: JobEnableQueryParamProperties;
+export interface JobEnableJobQueryParam {
+  queryParameters?: JobEnableJobQueryParamProperties;
 }
 
-export interface JobEnableHeaderParam {
-  headers?: RawHttpHeadersInput & JobEnableHeaders;
+export interface JobEnableJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobEnableJobHeaders;
 }
 
-export type JobEnableParameters = JobEnableQueryParam &
-  JobEnableHeaderParam &
+export type JobEnableJobParameters = JobEnableJobQueryParam &
+  JobEnableJobHeaderParam &
   RequestParameters;
 
-export interface JobTerminateHeaders {
+export interface JobTerminateJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1377,12 +1378,12 @@ export interface JobTerminateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobTerminateBodyParam {
+export interface JobTerminateJobBodyParam {
   /** The parameters for the request. */
   body?: BatchJobTerminateParameters;
 }
 
-export interface JobTerminateQueryParamProperties {
+export interface JobTerminateJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1390,20 +1391,20 @@ export interface JobTerminateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobTerminateQueryParam {
-  queryParameters?: JobTerminateQueryParamProperties;
+export interface JobTerminateJobQueryParam {
+  queryParameters?: JobTerminateJobQueryParamProperties;
 }
 
-export interface JobTerminateHeaderParam {
-  headers?: RawHttpHeadersInput & JobTerminateHeaders;
+export interface JobTerminateJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobTerminateJobHeaders;
 }
 
-export type JobTerminateParameters = JobTerminateQueryParam &
-  JobTerminateHeaderParam &
-  JobTerminateBodyParam &
+export type JobTerminateJobParameters = JobTerminateJobQueryParam &
+  JobTerminateJobHeaderParam &
+  JobTerminateJobBodyParam &
   RequestParameters;
 
-export interface JobAddHeaders {
+export interface JobAddJobHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1419,12 +1420,12 @@ export interface JobAddHeaders {
   "ocp-date"?: string;
 }
 
-export interface JobAddBodyParam {
+export interface JobAddJobBodyParam {
   /** The Job to be added. */
   body: BatchJob;
 }
 
-export interface JobAddQueryParamProperties {
+export interface JobAddJobQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1432,20 +1433,20 @@ export interface JobAddQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobAddQueryParam {
-  queryParameters?: JobAddQueryParamProperties;
+export interface JobAddJobQueryParam {
+  queryParameters?: JobAddJobQueryParamProperties;
 }
 
-export interface JobAddHeaderParam {
-  headers?: RawHttpHeadersInput & JobAddHeaders;
+export interface JobAddJobHeaderParam {
+  headers?: RawHttpHeadersInput & JobAddJobHeaders;
 }
 
-export type JobAddParameters = JobAddQueryParam &
-  JobAddHeaderParam &
-  JobAddBodyParam &
+export type JobAddJobParameters = JobAddJobQueryParam &
+  JobAddJobHeaderParam &
+  JobAddJobBodyParam &
   RequestParameters;
 
-export interface JobListHeaders {
+export interface JobListJobsHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -1461,7 +1462,7 @@ export interface JobListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface JobListQueryParamProperties {
+export interface JobListJobsQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1483,16 +1484,16 @@ export interface JobListQueryParamProperties {
   $expand?: string;
 }
 
-export interface JobListQueryParam {
-  queryParameters?: JobListQueryParamProperties;
+export interface JobListJobsQueryParam {
+  queryParameters?: JobListJobsQueryParamProperties;
 }
 
-export interface JobListHeaderParam {
-  headers?: RawHttpHeadersInput & JobListHeaders;
+export interface JobListJobsHeaderParam {
+  headers?: RawHttpHeadersInput & JobListJobsHeaders;
 }
 
-export type JobListParameters = JobListQueryParam &
-  JobListHeaderParam &
+export type JobListJobsParameters = JobListJobsQueryParam &
+  JobListJobsHeaderParam &
   RequestParameters;
 
 export interface JobListFromJobScheduleHeaders {
@@ -1631,7 +1632,7 @@ export type JobGetTaskCountsParameters = JobGetTaskCountsQueryParam &
   JobGetTaskCountsHeaderParam &
   RequestParameters;
 
-export interface CertificatesAddHeaders {
+export interface CertificatesAddCertificateHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1647,12 +1648,12 @@ export interface CertificatesAddHeaders {
   "ocp-date"?: string;
 }
 
-export interface CertificatesAddBodyParam {
+export interface CertificatesAddCertificateBodyParam {
   /** The Certificate to be added. */
   body: Certificate;
 }
 
-export interface CertificatesAddQueryParamProperties {
+export interface CertificatesAddCertificateQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1660,20 +1661,21 @@ export interface CertificatesAddQueryParamProperties {
   timeOut?: number;
 }
 
-export interface CertificatesAddQueryParam {
-  queryParameters?: CertificatesAddQueryParamProperties;
+export interface CertificatesAddCertificateQueryParam {
+  queryParameters?: CertificatesAddCertificateQueryParamProperties;
 }
 
-export interface CertificatesAddHeaderParam {
-  headers?: RawHttpHeadersInput & CertificatesAddHeaders;
+export interface CertificatesAddCertificateHeaderParam {
+  headers?: RawHttpHeadersInput & CertificatesAddCertificateHeaders;
 }
 
-export type CertificatesAddParameters = CertificatesAddQueryParam &
-  CertificatesAddHeaderParam &
-  CertificatesAddBodyParam &
-  RequestParameters;
+export type CertificatesAddCertificateParameters =
+  CertificatesAddCertificateQueryParam &
+    CertificatesAddCertificateHeaderParam &
+    CertificatesAddCertificateBodyParam &
+    RequestParameters;
 
-export interface CertificatesListHeaders {
+export interface CertificatesListCertificatesHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -1689,7 +1691,7 @@ export interface CertificatesListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface CertificatesListQueryParamProperties {
+export interface CertificatesListCertificatesQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1709,56 +1711,20 @@ export interface CertificatesListQueryParamProperties {
   $select?: string;
 }
 
-export interface CertificatesListQueryParam {
-  queryParameters?: CertificatesListQueryParamProperties;
+export interface CertificatesListCertificatesQueryParam {
+  queryParameters?: CertificatesListCertificatesQueryParamProperties;
 }
 
-export interface CertificatesListHeaderParam {
-  headers?: RawHttpHeadersInput & CertificatesListHeaders;
+export interface CertificatesListCertificatesHeaderParam {
+  headers?: RawHttpHeadersInput & CertificatesListCertificatesHeaders;
 }
 
-export type CertificatesListParameters = CertificatesListQueryParam &
-  CertificatesListHeaderParam &
-  RequestParameters;
-
-export interface CertificatesCancelDeletionHeaders {
-  /**
-   * The caller-generated request identity, in the form of a GUID with no decoration
-   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
-   */
-  "client-request-id"?: string;
-  /** Whether the server should return the client-request-id in the response. */
-  "return-client-request-id"?: boolean;
-  /**
-   * The time the request was issued. Client libraries typically set this to the
-   * current system clock time; set it explicitly if you are calling the REST API
-   * directly.
-   */
-  "ocp-date"?: string;
-}
-
-export interface CertificatesCancelDeletionQueryParamProperties {
-  /**
-   * The maximum number of items to return in the response. A maximum of 1000
-   * applications can be returned.
-   */
-  timeOut?: number;
-}
-
-export interface CertificatesCancelDeletionQueryParam {
-  queryParameters?: CertificatesCancelDeletionQueryParamProperties;
-}
-
-export interface CertificatesCancelDeletionHeaderParam {
-  headers?: RawHttpHeadersInput & CertificatesCancelDeletionHeaders;
-}
-
-export type CertificatesCancelDeletionParameters =
-  CertificatesCancelDeletionQueryParam &
-    CertificatesCancelDeletionHeaderParam &
+export type CertificatesListCertificatesParameters =
+  CertificatesListCertificatesQueryParam &
+    CertificatesListCertificatesHeaderParam &
     RequestParameters;
 
-export interface CertificatesDeleteHeaders {
+export interface CertificatesCancelCertificateDeletionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1774,7 +1740,7 @@ export interface CertificatesDeleteHeaders {
   "ocp-date"?: string;
 }
 
-export interface CertificatesDeleteQueryParamProperties {
+export interface CertificatesCancelCertificateDeletionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1782,19 +1748,20 @@ export interface CertificatesDeleteQueryParamProperties {
   timeOut?: number;
 }
 
-export interface CertificatesDeleteQueryParam {
-  queryParameters?: CertificatesDeleteQueryParamProperties;
+export interface CertificatesCancelCertificateDeletionQueryParam {
+  queryParameters?: CertificatesCancelCertificateDeletionQueryParamProperties;
 }
 
-export interface CertificatesDeleteHeaderParam {
-  headers?: RawHttpHeadersInput & CertificatesDeleteHeaders;
+export interface CertificatesCancelCertificateDeletionHeaderParam {
+  headers?: RawHttpHeadersInput & CertificatesCancelCertificateDeletionHeaders;
 }
 
-export type CertificatesDeleteParameters = CertificatesDeleteQueryParam &
-  CertificatesDeleteHeaderParam &
-  RequestParameters;
+export type CertificatesCancelCertificateDeletionParameters =
+  CertificatesCancelCertificateDeletionQueryParam &
+    CertificatesCancelCertificateDeletionHeaderParam &
+    RequestParameters;
 
-export interface CertificatesGetHeaders {
+export interface CertificatesDeleteCertificateHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -1810,7 +1777,44 @@ export interface CertificatesGetHeaders {
   "ocp-date"?: string;
 }
 
-export interface CertificatesGetQueryParamProperties {
+export interface CertificatesDeleteCertificateQueryParamProperties {
+  /**
+   * The maximum number of items to return in the response. A maximum of 1000
+   * applications can be returned.
+   */
+  timeOut?: number;
+}
+
+export interface CertificatesDeleteCertificateQueryParam {
+  queryParameters?: CertificatesDeleteCertificateQueryParamProperties;
+}
+
+export interface CertificatesDeleteCertificateHeaderParam {
+  headers?: RawHttpHeadersInput & CertificatesDeleteCertificateHeaders;
+}
+
+export type CertificatesDeleteCertificateParameters =
+  CertificatesDeleteCertificateQueryParam &
+    CertificatesDeleteCertificateHeaderParam &
+    RequestParameters;
+
+export interface CertificatesGetCertificateHeaders {
+  /**
+   * The caller-generated request identity, in the form of a GUID with no decoration
+   * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
+   */
+  "client-request-id"?: string;
+  /** Whether the server should return the client-request-id in the response. */
+  "return-client-request-id"?: boolean;
+  /**
+   * The time the request was issued. Client libraries typically set this to the
+   * current system clock time; set it explicitly if you are calling the REST API
+   * directly.
+   */
+  "ocp-date"?: string;
+}
+
+export interface CertificatesGetCertificateQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -1820,17 +1824,18 @@ export interface CertificatesGetQueryParamProperties {
   $select?: string;
 }
 
-export interface CertificatesGetQueryParam {
-  queryParameters?: CertificatesGetQueryParamProperties;
+export interface CertificatesGetCertificateQueryParam {
+  queryParameters?: CertificatesGetCertificateQueryParamProperties;
 }
 
-export interface CertificatesGetHeaderParam {
-  headers?: RawHttpHeadersInput & CertificatesGetHeaders;
+export interface CertificatesGetCertificateHeaderParam {
+  headers?: RawHttpHeadersInput & CertificatesGetCertificateHeaders;
 }
 
-export type CertificatesGetParameters = CertificatesGetQueryParam &
-  CertificatesGetHeaderParam &
-  RequestParameters;
+export type CertificatesGetCertificateParameters =
+  CertificatesGetCertificateQueryParam &
+    CertificatesGetCertificateHeaderParam &
+    RequestParameters;
 
 export interface FileDeleteFromTaskHeaders {
   /**
@@ -2224,7 +2229,7 @@ export type FileListFromComputeNodeParameters =
     FileListFromComputeNodeHeaderParam &
     RequestParameters;
 
-export interface JobScheduleExistsHeaders {
+export interface JobScheduleJobScheduleExistsHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2264,7 +2269,7 @@ export interface JobScheduleExistsHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleExistsQueryParamProperties {
+export interface JobScheduleJobScheduleExistsQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2272,19 +2277,20 @@ export interface JobScheduleExistsQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleExistsQueryParam {
-  queryParameters?: JobScheduleExistsQueryParamProperties;
+export interface JobScheduleJobScheduleExistsQueryParam {
+  queryParameters?: JobScheduleJobScheduleExistsQueryParamProperties;
 }
 
-export interface JobScheduleExistsHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleExistsHeaders;
+export interface JobScheduleJobScheduleExistsHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleJobScheduleExistsHeaders;
 }
 
-export type JobScheduleExistsParameters = JobScheduleExistsQueryParam &
-  JobScheduleExistsHeaderParam &
-  RequestParameters;
+export type JobScheduleJobScheduleExistsParameters =
+  JobScheduleJobScheduleExistsQueryParam &
+    JobScheduleJobScheduleExistsHeaderParam &
+    RequestParameters;
 
-export interface JobScheduleDeleteHeaders {
+export interface JobScheduleDeleteJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2324,7 +2330,7 @@ export interface JobScheduleDeleteHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleDeleteQueryParamProperties {
+export interface JobScheduleDeleteJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2332,19 +2338,20 @@ export interface JobScheduleDeleteQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleDeleteQueryParam {
-  queryParameters?: JobScheduleDeleteQueryParamProperties;
+export interface JobScheduleDeleteJobScheduleQueryParam {
+  queryParameters?: JobScheduleDeleteJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleDeleteHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleDeleteHeaders;
+export interface JobScheduleDeleteJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleDeleteJobScheduleHeaders;
 }
 
-export type JobScheduleDeleteParameters = JobScheduleDeleteQueryParam &
-  JobScheduleDeleteHeaderParam &
-  RequestParameters;
+export type JobScheduleDeleteJobScheduleParameters =
+  JobScheduleDeleteJobScheduleQueryParam &
+    JobScheduleDeleteJobScheduleHeaderParam &
+    RequestParameters;
 
-export interface JobScheduleGetHeaders {
+export interface JobScheduleGetJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2384,7 +2391,7 @@ export interface JobScheduleGetHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleGetQueryParamProperties {
+export interface JobScheduleGetJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2396,19 +2403,20 @@ export interface JobScheduleGetQueryParamProperties {
   $expand?: string;
 }
 
-export interface JobScheduleGetQueryParam {
-  queryParameters?: JobScheduleGetQueryParamProperties;
+export interface JobScheduleGetJobScheduleQueryParam {
+  queryParameters?: JobScheduleGetJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleGetHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleGetHeaders;
+export interface JobScheduleGetJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleGetJobScheduleHeaders;
 }
 
-export type JobScheduleGetParameters = JobScheduleGetQueryParam &
-  JobScheduleGetHeaderParam &
-  RequestParameters;
+export type JobScheduleGetJobScheduleParameters =
+  JobScheduleGetJobScheduleQueryParam &
+    JobScheduleGetJobScheduleHeaderParam &
+    RequestParameters;
 
-export interface JobSchedulePatchHeaders {
+export interface JobSchedulePatchJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2448,12 +2456,12 @@ export interface JobSchedulePatchHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobSchedulePatchBodyParam {
+export interface JobSchedulePatchJobScheduleBodyParam {
   /** The parameters for the request. */
   body: BatchJobSchedule;
 }
 
-export interface JobSchedulePatchQueryParamProperties {
+export interface JobSchedulePatchJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2461,20 +2469,21 @@ export interface JobSchedulePatchQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobSchedulePatchQueryParam {
-  queryParameters?: JobSchedulePatchQueryParamProperties;
+export interface JobSchedulePatchJobScheduleQueryParam {
+  queryParameters?: JobSchedulePatchJobScheduleQueryParamProperties;
 }
 
-export interface JobSchedulePatchHeaderParam {
-  headers?: RawHttpHeadersInput & JobSchedulePatchHeaders;
+export interface JobSchedulePatchJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobSchedulePatchJobScheduleHeaders;
 }
 
-export type JobSchedulePatchParameters = JobSchedulePatchQueryParam &
-  JobSchedulePatchHeaderParam &
-  JobSchedulePatchBodyParam &
-  RequestParameters;
+export type JobSchedulePatchJobScheduleParameters =
+  JobSchedulePatchJobScheduleQueryParam &
+    JobSchedulePatchJobScheduleHeaderParam &
+    JobSchedulePatchJobScheduleBodyParam &
+    RequestParameters;
 
-export interface JobScheduleUpdateHeaders {
+export interface JobScheduleUpdateJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2514,12 +2523,12 @@ export interface JobScheduleUpdateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleUpdateBodyParam {
+export interface JobScheduleUpdateJobScheduleBodyParam {
   /** The parameters for the request. */
   body: BatchJobSchedule;
 }
 
-export interface JobScheduleUpdateQueryParamProperties {
+export interface JobScheduleUpdateJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2527,20 +2536,21 @@ export interface JobScheduleUpdateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleUpdateQueryParam {
-  queryParameters?: JobScheduleUpdateQueryParamProperties;
+export interface JobScheduleUpdateJobScheduleQueryParam {
+  queryParameters?: JobScheduleUpdateJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleUpdateHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleUpdateHeaders;
+export interface JobScheduleUpdateJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleUpdateJobScheduleHeaders;
 }
 
-export type JobScheduleUpdateParameters = JobScheduleUpdateQueryParam &
-  JobScheduleUpdateHeaderParam &
-  JobScheduleUpdateBodyParam &
-  RequestParameters;
+export type JobScheduleUpdateJobScheduleParameters =
+  JobScheduleUpdateJobScheduleQueryParam &
+    JobScheduleUpdateJobScheduleHeaderParam &
+    JobScheduleUpdateJobScheduleBodyParam &
+    RequestParameters;
 
-export interface JobScheduleDisableHeaders {
+export interface JobScheduleDisableJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2580,7 +2590,7 @@ export interface JobScheduleDisableHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleDisableQueryParamProperties {
+export interface JobScheduleDisableJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2588,19 +2598,20 @@ export interface JobScheduleDisableQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleDisableQueryParam {
-  queryParameters?: JobScheduleDisableQueryParamProperties;
+export interface JobScheduleDisableJobScheduleQueryParam {
+  queryParameters?: JobScheduleDisableJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleDisableHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleDisableHeaders;
+export interface JobScheduleDisableJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleDisableJobScheduleHeaders;
 }
 
-export type JobScheduleDisableParameters = JobScheduleDisableQueryParam &
-  JobScheduleDisableHeaderParam &
-  RequestParameters;
+export type JobScheduleDisableJobScheduleParameters =
+  JobScheduleDisableJobScheduleQueryParam &
+    JobScheduleDisableJobScheduleHeaderParam &
+    RequestParameters;
 
-export interface JobScheduleEnableHeaders {
+export interface JobScheduleEnableJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2640,7 +2651,7 @@ export interface JobScheduleEnableHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleEnableQueryParamProperties {
+export interface JobScheduleEnableJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2648,19 +2659,20 @@ export interface JobScheduleEnableQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleEnableQueryParam {
-  queryParameters?: JobScheduleEnableQueryParamProperties;
+export interface JobScheduleEnableJobScheduleQueryParam {
+  queryParameters?: JobScheduleEnableJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleEnableHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleEnableHeaders;
+export interface JobScheduleEnableJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleEnableJobScheduleHeaders;
 }
 
-export type JobScheduleEnableParameters = JobScheduleEnableQueryParam &
-  JobScheduleEnableHeaderParam &
-  RequestParameters;
+export type JobScheduleEnableJobScheduleParameters =
+  JobScheduleEnableJobScheduleQueryParam &
+    JobScheduleEnableJobScheduleHeaderParam &
+    RequestParameters;
 
-export interface JobScheduleTerminateHeaders {
+export interface JobScheduleTerminateJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2700,7 +2712,7 @@ export interface JobScheduleTerminateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface JobScheduleTerminateQueryParamProperties {
+export interface JobScheduleTerminateJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2708,19 +2720,20 @@ export interface JobScheduleTerminateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleTerminateQueryParam {
-  queryParameters?: JobScheduleTerminateQueryParamProperties;
+export interface JobScheduleTerminateJobScheduleQueryParam {
+  queryParameters?: JobScheduleTerminateJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleTerminateHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleTerminateHeaders;
+export interface JobScheduleTerminateJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleTerminateJobScheduleHeaders;
 }
 
-export type JobScheduleTerminateParameters = JobScheduleTerminateQueryParam &
-  JobScheduleTerminateHeaderParam &
-  RequestParameters;
+export type JobScheduleTerminateJobScheduleParameters =
+  JobScheduleTerminateJobScheduleQueryParam &
+    JobScheduleTerminateJobScheduleHeaderParam &
+    RequestParameters;
 
-export interface JobScheduleAddHeaders {
+export interface JobScheduleAddJobScheduleHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2736,12 +2749,12 @@ export interface JobScheduleAddHeaders {
   "ocp-date"?: string;
 }
 
-export interface JobScheduleAddBodyParam {
+export interface JobScheduleAddJobScheduleBodyParam {
   /** The Job Schedule to be added. */
   body: BatchJobSchedule;
 }
 
-export interface JobScheduleAddQueryParamProperties {
+export interface JobScheduleAddJobScheduleQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2749,20 +2762,21 @@ export interface JobScheduleAddQueryParamProperties {
   timeOut?: number;
 }
 
-export interface JobScheduleAddQueryParam {
-  queryParameters?: JobScheduleAddQueryParamProperties;
+export interface JobScheduleAddJobScheduleQueryParam {
+  queryParameters?: JobScheduleAddJobScheduleQueryParamProperties;
 }
 
-export interface JobScheduleAddHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleAddHeaders;
+export interface JobScheduleAddJobScheduleHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleAddJobScheduleHeaders;
 }
 
-export type JobScheduleAddParameters = JobScheduleAddQueryParam &
-  JobScheduleAddHeaderParam &
-  JobScheduleAddBodyParam &
-  RequestParameters;
+export type JobScheduleAddJobScheduleParameters =
+  JobScheduleAddJobScheduleQueryParam &
+    JobScheduleAddJobScheduleHeaderParam &
+    JobScheduleAddJobScheduleBodyParam &
+    RequestParameters;
 
-export interface JobScheduleListHeaders {
+export interface JobScheduleListJobSchedulesHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -2778,7 +2792,7 @@ export interface JobScheduleListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface JobScheduleListQueryParamProperties {
+export interface JobScheduleListJobSchedulesQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2800,19 +2814,20 @@ export interface JobScheduleListQueryParamProperties {
   $expand?: string;
 }
 
-export interface JobScheduleListQueryParam {
-  queryParameters?: JobScheduleListQueryParamProperties;
+export interface JobScheduleListJobSchedulesQueryParam {
+  queryParameters?: JobScheduleListJobSchedulesQueryParamProperties;
 }
 
-export interface JobScheduleListHeaderParam {
-  headers?: RawHttpHeadersInput & JobScheduleListHeaders;
+export interface JobScheduleListJobSchedulesHeaderParam {
+  headers?: RawHttpHeadersInput & JobScheduleListJobSchedulesHeaders;
 }
 
-export type JobScheduleListParameters = JobScheduleListQueryParam &
-  JobScheduleListHeaderParam &
-  RequestParameters;
+export type JobScheduleListJobSchedulesParameters =
+  JobScheduleListJobSchedulesQueryParam &
+    JobScheduleListJobSchedulesHeaderParam &
+    RequestParameters;
 
-export interface TaskAddHeaders {
+export interface TaskAddTaskHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2828,12 +2843,12 @@ export interface TaskAddHeaders {
   "ocp-date"?: string;
 }
 
-export interface TaskAddBodyParam {
+export interface TaskAddTaskBodyParam {
   /** The Task to be added. */
   body: BatchTask;
 }
 
-export interface TaskAddQueryParamProperties {
+export interface TaskAddTaskQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2841,20 +2856,20 @@ export interface TaskAddQueryParamProperties {
   timeOut?: number;
 }
 
-export interface TaskAddQueryParam {
-  queryParameters?: TaskAddQueryParamProperties;
+export interface TaskAddTaskQueryParam {
+  queryParameters?: TaskAddTaskQueryParamProperties;
 }
 
-export interface TaskAddHeaderParam {
-  headers?: RawHttpHeadersInput & TaskAddHeaders;
+export interface TaskAddTaskHeaderParam {
+  headers?: RawHttpHeadersInput & TaskAddTaskHeaders;
 }
 
-export type TaskAddParameters = TaskAddQueryParam &
-  TaskAddHeaderParam &
-  TaskAddBodyParam &
+export type TaskAddTaskParameters = TaskAddTaskQueryParam &
+  TaskAddTaskHeaderParam &
+  TaskAddTaskBodyParam &
   RequestParameters;
 
-export interface TaskListHeaders {
+export interface TaskListTasksHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -2870,7 +2885,7 @@ export interface TaskListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface TaskListQueryParamProperties {
+export interface TaskListTasksQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2892,19 +2907,19 @@ export interface TaskListQueryParamProperties {
   $expand?: string;
 }
 
-export interface TaskListQueryParam {
-  queryParameters?: TaskListQueryParamProperties;
+export interface TaskListTasksQueryParam {
+  queryParameters?: TaskListTasksQueryParamProperties;
 }
 
-export interface TaskListHeaderParam {
-  headers?: RawHttpHeadersInput & TaskListHeaders;
+export interface TaskListTasksHeaderParam {
+  headers?: RawHttpHeadersInput & TaskListTasksHeaders;
 }
 
-export type TaskListParameters = TaskListQueryParam &
-  TaskListHeaderParam &
+export type TaskListTasksParameters = TaskListTasksQueryParam &
+  TaskListTasksHeaderParam &
   RequestParameters;
 
-export interface TaskAddCollectionHeaders {
+export interface TaskAddTaskCollectionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2920,12 +2935,12 @@ export interface TaskAddCollectionHeaders {
   "ocp-date"?: string;
 }
 
-export interface TaskAddCollectionBodyParam {
+export interface TaskAddTaskCollectionBodyParam {
   /** The Tasks to be added. */
   body: BatchTaskCollection;
 }
 
-export interface TaskAddCollectionQueryParamProperties {
+export interface TaskAddTaskCollectionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2933,20 +2948,20 @@ export interface TaskAddCollectionQueryParamProperties {
   timeOut?: number;
 }
 
-export interface TaskAddCollectionQueryParam {
-  queryParameters?: TaskAddCollectionQueryParamProperties;
+export interface TaskAddTaskCollectionQueryParam {
+  queryParameters?: TaskAddTaskCollectionQueryParamProperties;
 }
 
-export interface TaskAddCollectionHeaderParam {
-  headers?: RawHttpHeadersInput & TaskAddCollectionHeaders;
+export interface TaskAddTaskCollectionHeaderParam {
+  headers?: RawHttpHeadersInput & TaskAddTaskCollectionHeaders;
 }
 
-export type TaskAddCollectionParameters = TaskAddCollectionQueryParam &
-  TaskAddCollectionHeaderParam &
-  TaskAddCollectionBodyParam &
+export type TaskAddTaskCollectionParameters = TaskAddTaskCollectionQueryParam &
+  TaskAddTaskCollectionHeaderParam &
+  TaskAddTaskCollectionBodyParam &
   RequestParameters;
 
-export interface TaskDeleteHeaders {
+export interface TaskDeleteTaskCollectionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -2986,7 +3001,7 @@ export interface TaskDeleteHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface TaskDeleteQueryParamProperties {
+export interface TaskDeleteTaskCollectionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -2994,19 +3009,20 @@ export interface TaskDeleteQueryParamProperties {
   timeOut?: number;
 }
 
-export interface TaskDeleteQueryParam {
-  queryParameters?: TaskDeleteQueryParamProperties;
+export interface TaskDeleteTaskCollectionQueryParam {
+  queryParameters?: TaskDeleteTaskCollectionQueryParamProperties;
 }
 
-export interface TaskDeleteHeaderParam {
-  headers?: RawHttpHeadersInput & TaskDeleteHeaders;
+export interface TaskDeleteTaskCollectionHeaderParam {
+  headers?: RawHttpHeadersInput & TaskDeleteTaskCollectionHeaders;
 }
 
-export type TaskDeleteParameters = TaskDeleteQueryParam &
-  TaskDeleteHeaderParam &
-  RequestParameters;
+export type TaskDeleteTaskCollectionParameters =
+  TaskDeleteTaskCollectionQueryParam &
+    TaskDeleteTaskCollectionHeaderParam &
+    RequestParameters;
 
-export interface TaskGetHeaders {
+export interface TaskGetTaskCollectionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3046,7 +3062,7 @@ export interface TaskGetHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface TaskGetQueryParamProperties {
+export interface TaskGetTaskCollectionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3058,19 +3074,19 @@ export interface TaskGetQueryParamProperties {
   $expand?: string;
 }
 
-export interface TaskGetQueryParam {
-  queryParameters?: TaskGetQueryParamProperties;
+export interface TaskGetTaskCollectionQueryParam {
+  queryParameters?: TaskGetTaskCollectionQueryParamProperties;
 }
 
-export interface TaskGetHeaderParam {
-  headers?: RawHttpHeadersInput & TaskGetHeaders;
+export interface TaskGetTaskCollectionHeaderParam {
+  headers?: RawHttpHeadersInput & TaskGetTaskCollectionHeaders;
 }
 
-export type TaskGetParameters = TaskGetQueryParam &
-  TaskGetHeaderParam &
+export type TaskGetTaskCollectionParameters = TaskGetTaskCollectionQueryParam &
+  TaskGetTaskCollectionHeaderParam &
   RequestParameters;
 
-export interface TaskUpdateHeaders {
+export interface TaskUpdateTaskCollectionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3110,12 +3126,12 @@ export interface TaskUpdateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface TaskUpdateBodyParam {
+export interface TaskUpdateTaskCollectionBodyParam {
   /** The parameters for the request. */
   body: BatchTask;
 }
 
-export interface TaskUpdateQueryParamProperties {
+export interface TaskUpdateTaskCollectionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3123,18 +3139,19 @@ export interface TaskUpdateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface TaskUpdateQueryParam {
-  queryParameters?: TaskUpdateQueryParamProperties;
+export interface TaskUpdateTaskCollectionQueryParam {
+  queryParameters?: TaskUpdateTaskCollectionQueryParamProperties;
 }
 
-export interface TaskUpdateHeaderParam {
-  headers?: RawHttpHeadersInput & TaskUpdateHeaders;
+export interface TaskUpdateTaskCollectionHeaderParam {
+  headers?: RawHttpHeadersInput & TaskUpdateTaskCollectionHeaders;
 }
 
-export type TaskUpdateParameters = TaskUpdateQueryParam &
-  TaskUpdateHeaderParam &
-  TaskUpdateBodyParam &
-  RequestParameters;
+export type TaskUpdateTaskCollectionParameters =
+  TaskUpdateTaskCollectionQueryParam &
+    TaskUpdateTaskCollectionHeaderParam &
+    TaskUpdateTaskCollectionBodyParam &
+    RequestParameters;
 
 export interface TaskListSubtasksHeaders {
   /**
@@ -3174,7 +3191,7 @@ export type TaskListSubtasksParameters = TaskListSubtasksQueryParam &
   TaskListSubtasksHeaderParam &
   RequestParameters;
 
-export interface TaskTerminateHeaders {
+export interface TaskTerminateTaskCollectionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3214,7 +3231,7 @@ export interface TaskTerminateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface TaskTerminateQueryParamProperties {
+export interface TaskTerminateTaskCollectionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3222,19 +3239,20 @@ export interface TaskTerminateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface TaskTerminateQueryParam {
-  queryParameters?: TaskTerminateQueryParamProperties;
+export interface TaskTerminateTaskCollectionQueryParam {
+  queryParameters?: TaskTerminateTaskCollectionQueryParamProperties;
 }
 
-export interface TaskTerminateHeaderParam {
-  headers?: RawHttpHeadersInput & TaskTerminateHeaders;
+export interface TaskTerminateTaskCollectionHeaderParam {
+  headers?: RawHttpHeadersInput & TaskTerminateTaskCollectionHeaders;
 }
 
-export type TaskTerminateParameters = TaskTerminateQueryParam &
-  TaskTerminateHeaderParam &
-  RequestParameters;
+export type TaskTerminateTaskCollectionParameters =
+  TaskTerminateTaskCollectionQueryParam &
+    TaskTerminateTaskCollectionHeaderParam &
+    RequestParameters;
 
-export interface TaskReactivateHeaders {
+export interface TaskReactivateTaskCollectionHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3274,7 +3292,7 @@ export interface TaskReactivateHeaders {
   "if-unmodified-since"?: string;
 }
 
-export interface TaskReactivateQueryParamProperties {
+export interface TaskReactivateTaskCollectionQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3282,17 +3300,18 @@ export interface TaskReactivateQueryParamProperties {
   timeOut?: number;
 }
 
-export interface TaskReactivateQueryParam {
-  queryParameters?: TaskReactivateQueryParamProperties;
+export interface TaskReactivateTaskCollectionQueryParam {
+  queryParameters?: TaskReactivateTaskCollectionQueryParamProperties;
 }
 
-export interface TaskReactivateHeaderParam {
-  headers?: RawHttpHeadersInput & TaskReactivateHeaders;
+export interface TaskReactivateTaskCollectionHeaderParam {
+  headers?: RawHttpHeadersInput & TaskReactivateTaskCollectionHeaders;
 }
 
-export type TaskReactivateParameters = TaskReactivateQueryParam &
-  TaskReactivateHeaderParam &
-  RequestParameters;
+export type TaskReactivateTaskCollectionParameters =
+  TaskReactivateTaskCollectionQueryParam &
+    TaskReactivateTaskCollectionHeaderParam &
+    RequestParameters;
 
 export interface ComputeNodesAddUserHeaders {
   /**
@@ -3416,7 +3435,7 @@ export type ComputeNodesUpdateUserParameters =
     ComputeNodesUpdateUserBodyParam &
     RequestParameters;
 
-export interface ComputeNodesGetHeaders {
+export interface ComputeNodesGetComputeNodeHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3432,7 +3451,7 @@ export interface ComputeNodesGetHeaders {
   "ocp-date"?: string;
 }
 
-export interface ComputeNodesGetQueryParamProperties {
+export interface ComputeNodesGetComputeNodeQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3442,19 +3461,20 @@ export interface ComputeNodesGetQueryParamProperties {
   $select?: string;
 }
 
-export interface ComputeNodesGetQueryParam {
-  queryParameters?: ComputeNodesGetQueryParamProperties;
+export interface ComputeNodesGetComputeNodeQueryParam {
+  queryParameters?: ComputeNodesGetComputeNodeQueryParamProperties;
 }
 
-export interface ComputeNodesGetHeaderParam {
-  headers?: RawHttpHeadersInput & ComputeNodesGetHeaders;
+export interface ComputeNodesGetComputeNodeHeaderParam {
+  headers?: RawHttpHeadersInput & ComputeNodesGetComputeNodeHeaders;
 }
 
-export type ComputeNodesGetParameters = ComputeNodesGetQueryParam &
-  ComputeNodesGetHeaderParam &
-  RequestParameters;
+export type ComputeNodesGetComputeNodeParameters =
+  ComputeNodesGetComputeNodeQueryParam &
+    ComputeNodesGetComputeNodeHeaderParam &
+    RequestParameters;
 
-export interface ComputeNodesRebootHeaders {
+export interface ComputeNodesRebootComputeNodeHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3470,12 +3490,12 @@ export interface ComputeNodesRebootHeaders {
   "ocp-date"?: string;
 }
 
-export interface ComputeNodesRebootBodyParam {
+export interface ComputeNodesRebootComputeNodeBodyParam {
   /** The parameters for the request. */
   body?: NodeRebootParameters;
 }
 
-export interface ComputeNodesRebootQueryParamProperties {
+export interface ComputeNodesRebootComputeNodeQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3483,20 +3503,21 @@ export interface ComputeNodesRebootQueryParamProperties {
   timeOut?: number;
 }
 
-export interface ComputeNodesRebootQueryParam {
-  queryParameters?: ComputeNodesRebootQueryParamProperties;
+export interface ComputeNodesRebootComputeNodeQueryParam {
+  queryParameters?: ComputeNodesRebootComputeNodeQueryParamProperties;
 }
 
-export interface ComputeNodesRebootHeaderParam {
-  headers?: RawHttpHeadersInput & ComputeNodesRebootHeaders;
+export interface ComputeNodesRebootComputeNodeHeaderParam {
+  headers?: RawHttpHeadersInput & ComputeNodesRebootComputeNodeHeaders;
 }
 
-export type ComputeNodesRebootParameters = ComputeNodesRebootQueryParam &
-  ComputeNodesRebootHeaderParam &
-  ComputeNodesRebootBodyParam &
-  RequestParameters;
+export type ComputeNodesRebootComputeNodeParameters =
+  ComputeNodesRebootComputeNodeQueryParam &
+    ComputeNodesRebootComputeNodeHeaderParam &
+    ComputeNodesRebootComputeNodeBodyParam &
+    RequestParameters;
 
-export interface ComputeNodesReimageHeaders {
+export interface ComputeNodesReimageComputeNodeHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3512,12 +3533,12 @@ export interface ComputeNodesReimageHeaders {
   "ocp-date"?: string;
 }
 
-export interface ComputeNodesReimageBodyParam {
+export interface ComputeNodesReimageComputeNodeBodyParam {
   /** The parameters for the request. */
   body?: NodeReimageParameters;
 }
 
-export interface ComputeNodesReimageQueryParamProperties {
+export interface ComputeNodesReimageComputeNodeQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3525,18 +3546,19 @@ export interface ComputeNodesReimageQueryParamProperties {
   timeOut?: number;
 }
 
-export interface ComputeNodesReimageQueryParam {
-  queryParameters?: ComputeNodesReimageQueryParamProperties;
+export interface ComputeNodesReimageComputeNodeQueryParam {
+  queryParameters?: ComputeNodesReimageComputeNodeQueryParamProperties;
 }
 
-export interface ComputeNodesReimageHeaderParam {
-  headers?: RawHttpHeadersInput & ComputeNodesReimageHeaders;
+export interface ComputeNodesReimageComputeNodeHeaderParam {
+  headers?: RawHttpHeadersInput & ComputeNodesReimageComputeNodeHeaders;
 }
 
-export type ComputeNodesReimageParameters = ComputeNodesReimageQueryParam &
-  ComputeNodesReimageHeaderParam &
-  ComputeNodesReimageBodyParam &
-  RequestParameters;
+export type ComputeNodesReimageComputeNodeParameters =
+  ComputeNodesReimageComputeNodeQueryParam &
+    ComputeNodesReimageComputeNodeHeaderParam &
+    ComputeNodesReimageComputeNodeBodyParam &
+    RequestParameters;
 
 export interface ComputeNodesDisableSchedulingHeaders {
   /**
@@ -3783,7 +3805,7 @@ export type ComputeNodesListParameters = ComputeNodesListQueryParam &
   ComputeNodesListHeaderParam &
   RequestParameters;
 
-export interface ComputeNodeExtensionsGetHeaders {
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsHeaders {
   /**
    * The caller-generated request identity, in the form of a GUID with no decoration
    * such as curly braces, e.g. 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
@@ -3799,7 +3821,7 @@ export interface ComputeNodeExtensionsGetHeaders {
   "ocp-date"?: string;
 }
 
-export interface ComputeNodeExtensionsGetQueryParamProperties {
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3809,20 +3831,21 @@ export interface ComputeNodeExtensionsGetQueryParamProperties {
   $select?: string;
 }
 
-export interface ComputeNodeExtensionsGetQueryParam {
-  queryParameters?: ComputeNodeExtensionsGetQueryParamProperties;
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsQueryParam {
+  queryParameters?: ComputeNodeExtensionsGetComputeNodeExtensionsQueryParamProperties;
 }
 
-export interface ComputeNodeExtensionsGetHeaderParam {
-  headers?: RawHttpHeadersInput & ComputeNodeExtensionsGetHeaders;
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsHeaderParam {
+  headers?: RawHttpHeadersInput &
+    ComputeNodeExtensionsGetComputeNodeExtensionsHeaders;
 }
 
-export type ComputeNodeExtensionsGetParameters =
-  ComputeNodeExtensionsGetQueryParam &
-    ComputeNodeExtensionsGetHeaderParam &
+export type ComputeNodeExtensionsGetComputeNodeExtensionsParameters =
+  ComputeNodeExtensionsGetComputeNodeExtensionsQueryParam &
+    ComputeNodeExtensionsGetComputeNodeExtensionsHeaderParam &
     RequestParameters;
 
-export interface ComputeNodeExtensionsListHeaders {
+export interface ComputeNodeExtensionsListComputeNodeExtensionsHeaders {
   /**
    * The time the request was issued. Client libraries typically set this to the
    * current system clock time; set it explicitly if you are calling the REST API
@@ -3838,7 +3861,7 @@ export interface ComputeNodeExtensionsListHeaders {
   "return-client-request-id"?: boolean;
 }
 
-export interface ComputeNodeExtensionsListQueryParamProperties {
+export interface ComputeNodeExtensionsListComputeNodeExtensionsQueryParamProperties {
   /**
    * The maximum number of items to return in the response. A maximum of 1000
    * applications can be returned.
@@ -3853,15 +3876,16 @@ export interface ComputeNodeExtensionsListQueryParamProperties {
   $select?: string;
 }
 
-export interface ComputeNodeExtensionsListQueryParam {
-  queryParameters?: ComputeNodeExtensionsListQueryParamProperties;
+export interface ComputeNodeExtensionsListComputeNodeExtensionsQueryParam {
+  queryParameters?: ComputeNodeExtensionsListComputeNodeExtensionsQueryParamProperties;
 }
 
-export interface ComputeNodeExtensionsListHeaderParam {
-  headers?: RawHttpHeadersInput & ComputeNodeExtensionsListHeaders;
+export interface ComputeNodeExtensionsListComputeNodeExtensionsHeaderParam {
+  headers?: RawHttpHeadersInput &
+    ComputeNodeExtensionsListComputeNodeExtensionsHeaders;
 }
 
-export type ComputeNodeExtensionsListParameters =
-  ComputeNodeExtensionsListQueryParam &
-    ComputeNodeExtensionsListHeaderParam &
+export type ComputeNodeExtensionsListComputeNodeExtensionsParameters =
+  ComputeNodeExtensionsListComputeNodeExtensionsQueryParam &
+    ComputeNodeExtensionsListComputeNodeExtensionsHeaderParam &
     RequestParameters;

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/responses.ts
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/src/rest/responses.ts
@@ -35,7 +35,7 @@ import {
   NodeVMExtensionListOutput,
 } from "./outputModels.js";
 
-export interface ApplicationsList200Headers {
+export interface ApplicationsListApplications200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -47,21 +47,22 @@ export interface ApplicationsList200Headers {
 }
 
 /** The request has succeeded. */
-export interface ApplicationsList200Response extends HttpResponse {
+export interface ApplicationsListApplications200Response extends HttpResponse {
   status: "200";
   body: ApplicationListResultOutput;
-  headers: RawHttpHeaders & ApplicationsList200Headers;
+  headers: RawHttpHeaders & ApplicationsListApplications200Headers;
 }
 
-export interface ApplicationsListDefaultHeaders {
+export interface ApplicationsListApplicationsDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface ApplicationsListDefaultResponse extends HttpResponse {
+export interface ApplicationsListApplicationsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & ApplicationsListDefaultHeaders;
+  headers: RawHttpHeaders & ApplicationsListApplicationsDefaultHeaders;
 }
 
 /** The request has succeeded. */
@@ -128,7 +129,7 @@ export interface PoolGetAllLifetimeStatisticsDefaultResponse
   headers: RawHttpHeaders & PoolGetAllLifetimeStatisticsDefaultHeaders;
 }
 
-export interface PoolAdd201Headers {
+export interface PoolAddPool201Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -142,23 +143,23 @@ export interface PoolAdd201Headers {
 }
 
 /** The request has succeeded and a new resource has been created as a result. */
-export interface PoolAdd201Response extends HttpResponse {
+export interface PoolAddPool201Response extends HttpResponse {
   status: "201";
-  headers: RawHttpHeaders & PoolAdd201Headers;
+  headers: RawHttpHeaders & PoolAddPool201Headers;
 }
 
-export interface PoolAddDefaultHeaders {
+export interface PoolAddPoolDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface PoolAddDefaultResponse extends HttpResponse {
+export interface PoolAddPoolDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & PoolAddDefaultHeaders;
+  headers: RawHttpHeaders & PoolAddPoolDefaultHeaders;
 }
 
-export interface PoolList200Headers {
+export interface PoolListPools200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -170,24 +171,24 @@ export interface PoolList200Headers {
 }
 
 /** The request has succeeded. */
-export interface PoolList200Response extends HttpResponse {
+export interface PoolListPools200Response extends HttpResponse {
   status: "200";
   body: BatchPoolListResultOutput;
-  headers: RawHttpHeaders & PoolList200Headers;
+  headers: RawHttpHeaders & PoolListPools200Headers;
 }
 
-export interface PoolListDefaultHeaders {
+export interface PoolListPoolsDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface PoolListDefaultResponse extends HttpResponse {
+export interface PoolListPoolsDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & PoolListDefaultHeaders;
+  headers: RawHttpHeaders & PoolListPoolsDefaultHeaders;
 }
 
-export interface PoolDelete202Headers {
+export interface PoolDeletePool202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -195,20 +196,20 @@ export interface PoolDelete202Headers {
 }
 
 /** The parameters for a widget status request */
-export interface PoolDelete202Response extends HttpResponse {
+export interface PoolDeletePool202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & PoolDelete202Headers;
+  headers: RawHttpHeaders & PoolDeletePool202Headers;
 }
 
-export interface PoolDeleteDefaultHeaders {
+export interface PoolDeletePoolDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface PoolDeleteDefaultResponse extends HttpResponse {
+export interface PoolDeletePoolDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & PoolDeleteDefaultHeaders;
+  headers: RawHttpHeaders & PoolDeletePoolDefaultHeaders;
 }
 
 export interface PoolExists200Headers {
@@ -244,7 +245,7 @@ export interface PoolExistsDefaultResponse extends HttpResponse {
   headers: RawHttpHeaders & PoolExistsDefaultHeaders;
 }
 
-export interface PoolGet200Headers {
+export interface PoolGetPool200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -256,24 +257,24 @@ export interface PoolGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface PoolGet200Response extends HttpResponse {
+export interface PoolGetPool200Response extends HttpResponse {
   status: "200";
   body: BatchPoolOutput;
-  headers: RawHttpHeaders & PoolGet200Headers;
+  headers: RawHttpHeaders & PoolGetPool200Headers;
 }
 
-export interface PoolGetDefaultHeaders {
+export interface PoolGetPoolDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface PoolGetDefaultResponse extends HttpResponse {
+export interface PoolGetPoolDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & PoolGetDefaultHeaders;
+  headers: RawHttpHeaders & PoolGetPoolDefaultHeaders;
 }
 
-export interface PoolPatch200Headers {
+export interface PoolPatchPool200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -287,20 +288,20 @@ export interface PoolPatch200Headers {
 }
 
 /** The request has succeeded. */
-export interface PoolPatch200Response extends HttpResponse {
+export interface PoolPatchPool200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & PoolPatch200Headers;
+  headers: RawHttpHeaders & PoolPatchPool200Headers;
 }
 
-export interface PoolPatchDefaultHeaders {
+export interface PoolPatchPoolDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface PoolPatchDefaultResponse extends HttpResponse {
+export interface PoolPatchPoolDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & PoolPatchDefaultHeaders;
+  headers: RawHttpHeaders & PoolPatchPoolDefaultHeaders;
 }
 
 export interface PoolDisableAutoScale200Headers {
@@ -599,7 +600,7 @@ export interface JobGetAllLifetimeStatisticsDefaultResponse
   headers: RawHttpHeaders & JobGetAllLifetimeStatisticsDefaultHeaders;
 }
 
-export interface JobDelete202Headers {
+export interface JobDeleteJob202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -607,23 +608,23 @@ export interface JobDelete202Headers {
 }
 
 /** The parameters for a widget status request */
-export interface JobDelete202Response extends HttpResponse {
+export interface JobDeleteJob202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & JobDelete202Headers;
+  headers: RawHttpHeaders & JobDeleteJob202Headers;
 }
 
-export interface JobDeleteDefaultHeaders {
+export interface JobDeleteJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobDeleteDefaultResponse extends HttpResponse {
+export interface JobDeleteJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobDeleteDefaultHeaders;
+  headers: RawHttpHeaders & JobDeleteJobDefaultHeaders;
 }
 
-export interface JobGet200Headers {
+export interface JobGetJob200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -635,24 +636,24 @@ export interface JobGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobGet200Response extends HttpResponse {
+export interface JobGetJob200Response extends HttpResponse {
   status: "200";
   body: BatchJobOutput;
-  headers: RawHttpHeaders & JobGet200Headers;
+  headers: RawHttpHeaders & JobGetJob200Headers;
 }
 
-export interface JobGetDefaultHeaders {
+export interface JobGetJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobGetDefaultResponse extends HttpResponse {
+export interface JobGetJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobGetDefaultHeaders;
+  headers: RawHttpHeaders & JobGetJobDefaultHeaders;
 }
 
-export interface JobPatch200Headers {
+export interface JobPatchJob200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -666,23 +667,23 @@ export interface JobPatch200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobPatch200Response extends HttpResponse {
+export interface JobPatchJob200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & JobPatch200Headers;
+  headers: RawHttpHeaders & JobPatchJob200Headers;
 }
 
-export interface JobPatchDefaultHeaders {
+export interface JobPatchJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobPatchDefaultResponse extends HttpResponse {
+export interface JobPatchJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobPatchDefaultHeaders;
+  headers: RawHttpHeaders & JobPatchJobDefaultHeaders;
 }
 
-export interface JobUpdate200Headers {
+export interface JobUpdateJob200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -696,23 +697,23 @@ export interface JobUpdate200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobUpdate200Response extends HttpResponse {
+export interface JobUpdateJob200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & JobUpdate200Headers;
+  headers: RawHttpHeaders & JobUpdateJob200Headers;
 }
 
-export interface JobUpdateDefaultHeaders {
+export interface JobUpdateJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobUpdateDefaultResponse extends HttpResponse {
+export interface JobUpdateJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobUpdateDefaultHeaders;
+  headers: RawHttpHeaders & JobUpdateJobDefaultHeaders;
 }
 
-export interface JobDisable202Headers {
+export interface JobDisableJob202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -726,23 +727,23 @@ export interface JobDisable202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface JobDisable202Response extends HttpResponse {
+export interface JobDisableJob202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & JobDisable202Headers;
+  headers: RawHttpHeaders & JobDisableJob202Headers;
 }
 
-export interface JobDisableDefaultHeaders {
+export interface JobDisableJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobDisableDefaultResponse extends HttpResponse {
+export interface JobDisableJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobDisableDefaultHeaders;
+  headers: RawHttpHeaders & JobDisableJobDefaultHeaders;
 }
 
-export interface JobEnable202Headers {
+export interface JobEnableJob202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -756,23 +757,23 @@ export interface JobEnable202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface JobEnable202Response extends HttpResponse {
+export interface JobEnableJob202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & JobEnable202Headers;
+  headers: RawHttpHeaders & JobEnableJob202Headers;
 }
 
-export interface JobEnableDefaultHeaders {
+export interface JobEnableJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobEnableDefaultResponse extends HttpResponse {
+export interface JobEnableJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobEnableDefaultHeaders;
+  headers: RawHttpHeaders & JobEnableJobDefaultHeaders;
 }
 
-export interface JobTerminate202Headers {
+export interface JobTerminateJob202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -786,23 +787,23 @@ export interface JobTerminate202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface JobTerminate202Response extends HttpResponse {
+export interface JobTerminateJob202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & JobTerminate202Headers;
+  headers: RawHttpHeaders & JobTerminateJob202Headers;
 }
 
-export interface JobTerminateDefaultHeaders {
+export interface JobTerminateJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobTerminateDefaultResponse extends HttpResponse {
+export interface JobTerminateJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobTerminateDefaultHeaders;
+  headers: RawHttpHeaders & JobTerminateJobDefaultHeaders;
 }
 
-export interface JobAdd201Headers {
+export interface JobAddJob201Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -816,23 +817,23 @@ export interface JobAdd201Headers {
 }
 
 /** The request has succeeded and a new resource has been created as a result. */
-export interface JobAdd201Response extends HttpResponse {
+export interface JobAddJob201Response extends HttpResponse {
   status: "201";
-  headers: RawHttpHeaders & JobAdd201Headers;
+  headers: RawHttpHeaders & JobAddJob201Headers;
 }
 
-export interface JobAddDefaultHeaders {
+export interface JobAddJobDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobAddDefaultResponse extends HttpResponse {
+export interface JobAddJobDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobAddDefaultHeaders;
+  headers: RawHttpHeaders & JobAddJobDefaultHeaders;
 }
 
-export interface JobList200Headers {
+export interface JobListJobs200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -844,21 +845,21 @@ export interface JobList200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobList200Response extends HttpResponse {
+export interface JobListJobs200Response extends HttpResponse {
   status: "200";
   body: BatchJobListResultOutput;
-  headers: RawHttpHeaders & JobList200Headers;
+  headers: RawHttpHeaders & JobListJobs200Headers;
 }
 
-export interface JobListDefaultHeaders {
+export interface JobListJobsDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobListDefaultResponse extends HttpResponse {
+export interface JobListJobsDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobListDefaultHeaders;
+  headers: RawHttpHeaders & JobListJobsDefaultHeaders;
 }
 
 export interface JobListFromJobSchedule200Headers {
@@ -947,7 +948,7 @@ export interface JobGetTaskCountsDefaultResponse extends HttpResponse {
   headers: RawHttpHeaders & JobGetTaskCountsDefaultHeaders;
 }
 
-export interface CertificatesAdd201Headers {
+export interface CertificatesAddCertificate201Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -959,23 +960,24 @@ export interface CertificatesAdd201Headers {
 }
 
 /** The request has succeeded and a new resource has been created as a result. */
-export interface CertificatesAdd201Response extends HttpResponse {
+export interface CertificatesAddCertificate201Response extends HttpResponse {
   status: "201";
-  headers: RawHttpHeaders & CertificatesAdd201Headers;
+  headers: RawHttpHeaders & CertificatesAddCertificate201Headers;
 }
 
-export interface CertificatesAddDefaultHeaders {
+export interface CertificatesAddCertificateDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface CertificatesAddDefaultResponse extends HttpResponse {
+export interface CertificatesAddCertificateDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & CertificatesAddDefaultHeaders;
+  headers: RawHttpHeaders & CertificatesAddCertificateDefaultHeaders;
 }
 
-export interface CertificatesList200Headers {
+export interface CertificatesListCertificates200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -987,24 +989,25 @@ export interface CertificatesList200Headers {
 }
 
 /** The request has succeeded. */
-export interface CertificatesList200Response extends HttpResponse {
+export interface CertificatesListCertificates200Response extends HttpResponse {
   status: "200";
   body: CertificateListResultOutput;
-  headers: RawHttpHeaders & CertificatesList200Headers;
+  headers: RawHttpHeaders & CertificatesListCertificates200Headers;
 }
 
-export interface CertificatesListDefaultHeaders {
+export interface CertificatesListCertificatesDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface CertificatesListDefaultResponse extends HttpResponse {
+export interface CertificatesListCertificatesDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & CertificatesListDefaultHeaders;
+  headers: RawHttpHeaders & CertificatesListCertificatesDefaultHeaders;
 }
 
-export interface CertificatesCancelDeletion204Headers {
+export interface CertificatesCancelCertificateDeletion204Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1018,24 +1021,25 @@ export interface CertificatesCancelDeletion204Headers {
 }
 
 /** There is no content to send for this request, but the headers may be useful. */
-export interface CertificatesCancelDeletion204Response extends HttpResponse {
+export interface CertificatesCancelCertificateDeletion204Response
+  extends HttpResponse {
   status: "204";
-  headers: RawHttpHeaders & CertificatesCancelDeletion204Headers;
+  headers: RawHttpHeaders & CertificatesCancelCertificateDeletion204Headers;
 }
 
-export interface CertificatesCancelDeletionDefaultHeaders {
+export interface CertificatesCancelCertificateDeletionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface CertificatesCancelDeletionDefaultResponse
+export interface CertificatesCancelCertificateDeletionDefaultResponse
   extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & CertificatesCancelDeletionDefaultHeaders;
+  headers: RawHttpHeaders & CertificatesCancelCertificateDeletionDefaultHeaders;
 }
 
-export interface CertificatesDelete202Headers {
+export interface CertificatesDeleteCertificate202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1047,23 +1051,24 @@ export interface CertificatesDelete202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface CertificatesDelete202Response extends HttpResponse {
+export interface CertificatesDeleteCertificate202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & CertificatesDelete202Headers;
+  headers: RawHttpHeaders & CertificatesDeleteCertificate202Headers;
 }
 
-export interface CertificatesDeleteDefaultHeaders {
+export interface CertificatesDeleteCertificateDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface CertificatesDeleteDefaultResponse extends HttpResponse {
+export interface CertificatesDeleteCertificateDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & CertificatesDeleteDefaultHeaders;
+  headers: RawHttpHeaders & CertificatesDeleteCertificateDefaultHeaders;
 }
 
-export interface CertificatesGet200Headers {
+export interface CertificatesGetCertificate200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1075,21 +1080,22 @@ export interface CertificatesGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface CertificatesGet200Response extends HttpResponse {
+export interface CertificatesGetCertificate200Response extends HttpResponse {
   status: "200";
   body: CertificateOutput;
-  headers: RawHttpHeaders & CertificatesGet200Headers;
+  headers: RawHttpHeaders & CertificatesGetCertificate200Headers;
 }
 
-export interface CertificatesGetDefaultHeaders {
+export interface CertificatesGetCertificateDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface CertificatesGetDefaultResponse extends HttpResponse {
+export interface CertificatesGetCertificateDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & CertificatesGetDefaultHeaders;
+  headers: RawHttpHeaders & CertificatesGetCertificateDefaultHeaders;
 }
 
 export interface FileDeleteFromTask200Headers {
@@ -1356,7 +1362,7 @@ export interface FileListFromComputeNodeDefaultResponse extends HttpResponse {
   headers: RawHttpHeaders & FileListFromComputeNodeDefaultHeaders;
 }
 
-export interface JobScheduleExists200Headers {
+export interface JobScheduleJobScheduleExists200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1368,28 +1374,29 @@ export interface JobScheduleExists200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobScheduleExists200Response extends HttpResponse {
+export interface JobScheduleJobScheduleExists200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & JobScheduleExists200Headers;
+  headers: RawHttpHeaders & JobScheduleJobScheduleExists200Headers;
 }
 
 /** The server cannot find the requested resource. */
-export interface JobScheduleExists404Response extends HttpResponse {
+export interface JobScheduleJobScheduleExists404Response extends HttpResponse {
   status: "404";
 }
 
-export interface JobScheduleExistsDefaultHeaders {
+export interface JobScheduleJobScheduleExistsDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleExistsDefaultResponse extends HttpResponse {
+export interface JobScheduleJobScheduleExistsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleExistsDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleJobScheduleExistsDefaultHeaders;
 }
 
-export interface JobScheduleDelete202Headers {
+export interface JobScheduleDeleteJobSchedule202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1397,23 +1404,24 @@ export interface JobScheduleDelete202Headers {
 }
 
 /** The parameters for a widget status request */
-export interface JobScheduleDelete202Response extends HttpResponse {
+export interface JobScheduleDeleteJobSchedule202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & JobScheduleDelete202Headers;
+  headers: RawHttpHeaders & JobScheduleDeleteJobSchedule202Headers;
 }
 
-export interface JobScheduleDeleteDefaultHeaders {
+export interface JobScheduleDeleteJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleDeleteDefaultResponse extends HttpResponse {
+export interface JobScheduleDeleteJobScheduleDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleDeleteDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleDeleteJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleGet200Headers {
+export interface JobScheduleGetJobSchedule200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1425,24 +1433,24 @@ export interface JobScheduleGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobScheduleGet200Response extends HttpResponse {
+export interface JobScheduleGetJobSchedule200Response extends HttpResponse {
   status: "200";
   body: BatchJobScheduleOutput;
-  headers: RawHttpHeaders & JobScheduleGet200Headers;
+  headers: RawHttpHeaders & JobScheduleGetJobSchedule200Headers;
 }
 
-export interface JobScheduleGetDefaultHeaders {
+export interface JobScheduleGetJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleGetDefaultResponse extends HttpResponse {
+export interface JobScheduleGetJobScheduleDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleGetDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleGetJobScheduleDefaultHeaders;
 }
 
-export interface JobSchedulePatch200Headers {
+export interface JobSchedulePatchJobSchedule200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1456,23 +1464,24 @@ export interface JobSchedulePatch200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobSchedulePatch200Response extends HttpResponse {
+export interface JobSchedulePatchJobSchedule200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & JobSchedulePatch200Headers;
+  headers: RawHttpHeaders & JobSchedulePatchJobSchedule200Headers;
 }
 
-export interface JobSchedulePatchDefaultHeaders {
+export interface JobSchedulePatchJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobSchedulePatchDefaultResponse extends HttpResponse {
+export interface JobSchedulePatchJobScheduleDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobSchedulePatchDefaultHeaders;
+  headers: RawHttpHeaders & JobSchedulePatchJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleUpdate200Headers {
+export interface JobScheduleUpdateJobSchedule200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1486,23 +1495,24 @@ export interface JobScheduleUpdate200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobScheduleUpdate200Response extends HttpResponse {
+export interface JobScheduleUpdateJobSchedule200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & JobScheduleUpdate200Headers;
+  headers: RawHttpHeaders & JobScheduleUpdateJobSchedule200Headers;
 }
 
-export interface JobScheduleUpdateDefaultHeaders {
+export interface JobScheduleUpdateJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleUpdateDefaultResponse extends HttpResponse {
+export interface JobScheduleUpdateJobScheduleDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleUpdateDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleUpdateJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleDisable204Headers {
+export interface JobScheduleDisableJobSchedule204Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1516,23 +1526,24 @@ export interface JobScheduleDisable204Headers {
 }
 
 /** There is no content to send for this request, but the headers may be useful. */
-export interface JobScheduleDisable204Response extends HttpResponse {
+export interface JobScheduleDisableJobSchedule204Response extends HttpResponse {
   status: "204";
-  headers: RawHttpHeaders & JobScheduleDisable204Headers;
+  headers: RawHttpHeaders & JobScheduleDisableJobSchedule204Headers;
 }
 
-export interface JobScheduleDisableDefaultHeaders {
+export interface JobScheduleDisableJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleDisableDefaultResponse extends HttpResponse {
+export interface JobScheduleDisableJobScheduleDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleDisableDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleDisableJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleEnable204Headers {
+export interface JobScheduleEnableJobSchedule204Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1546,23 +1557,24 @@ export interface JobScheduleEnable204Headers {
 }
 
 /** There is no content to send for this request, but the headers may be useful. */
-export interface JobScheduleEnable204Response extends HttpResponse {
+export interface JobScheduleEnableJobSchedule204Response extends HttpResponse {
   status: "204";
-  headers: RawHttpHeaders & JobScheduleEnable204Headers;
+  headers: RawHttpHeaders & JobScheduleEnableJobSchedule204Headers;
 }
 
-export interface JobScheduleEnableDefaultHeaders {
+export interface JobScheduleEnableJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleEnableDefaultResponse extends HttpResponse {
+export interface JobScheduleEnableJobScheduleDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleEnableDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleEnableJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleTerminate202Headers {
+export interface JobScheduleTerminateJobSchedule202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1576,23 +1588,25 @@ export interface JobScheduleTerminate202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface JobScheduleTerminate202Response extends HttpResponse {
+export interface JobScheduleTerminateJobSchedule202Response
+  extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & JobScheduleTerminate202Headers;
+  headers: RawHttpHeaders & JobScheduleTerminateJobSchedule202Headers;
 }
 
-export interface JobScheduleTerminateDefaultHeaders {
+export interface JobScheduleTerminateJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleTerminateDefaultResponse extends HttpResponse {
+export interface JobScheduleTerminateJobScheduleDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleTerminateDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleTerminateJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleAdd201Headers {
+export interface JobScheduleAddJobSchedule201Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1606,23 +1620,23 @@ export interface JobScheduleAdd201Headers {
 }
 
 /** The request has succeeded and a new resource has been created as a result. */
-export interface JobScheduleAdd201Response extends HttpResponse {
+export interface JobScheduleAddJobSchedule201Response extends HttpResponse {
   status: "201";
-  headers: RawHttpHeaders & JobScheduleAdd201Headers;
+  headers: RawHttpHeaders & JobScheduleAddJobSchedule201Headers;
 }
 
-export interface JobScheduleAddDefaultHeaders {
+export interface JobScheduleAddJobScheduleDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleAddDefaultResponse extends HttpResponse {
+export interface JobScheduleAddJobScheduleDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleAddDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleAddJobScheduleDefaultHeaders;
 }
 
-export interface JobScheduleList200Headers {
+export interface JobScheduleListJobSchedules200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1634,24 +1648,25 @@ export interface JobScheduleList200Headers {
 }
 
 /** The request has succeeded. */
-export interface JobScheduleList200Response extends HttpResponse {
+export interface JobScheduleListJobSchedules200Response extends HttpResponse {
   status: "200";
   body: BatchJobScheduleListResultOutput;
-  headers: RawHttpHeaders & JobScheduleList200Headers;
+  headers: RawHttpHeaders & JobScheduleListJobSchedules200Headers;
 }
 
-export interface JobScheduleListDefaultHeaders {
+export interface JobScheduleListJobSchedulesDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface JobScheduleListDefaultResponse extends HttpResponse {
+export interface JobScheduleListJobSchedulesDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & JobScheduleListDefaultHeaders;
+  headers: RawHttpHeaders & JobScheduleListJobSchedulesDefaultHeaders;
 }
 
-export interface TaskAdd201Headers {
+export interface TaskAddTask201Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1665,23 +1680,23 @@ export interface TaskAdd201Headers {
 }
 
 /** The request has succeeded and a new resource has been created as a result. */
-export interface TaskAdd201Response extends HttpResponse {
+export interface TaskAddTask201Response extends HttpResponse {
   status: "201";
-  headers: RawHttpHeaders & TaskAdd201Headers;
+  headers: RawHttpHeaders & TaskAddTask201Headers;
 }
 
-export interface TaskAddDefaultHeaders {
+export interface TaskAddTaskDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskAddDefaultResponse extends HttpResponse {
+export interface TaskAddTaskDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskAddDefaultHeaders;
+  headers: RawHttpHeaders & TaskAddTaskDefaultHeaders;
 }
 
-export interface TaskList200Headers {
+export interface TaskListTasks200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1693,24 +1708,24 @@ export interface TaskList200Headers {
 }
 
 /** The request has succeeded. */
-export interface TaskList200Response extends HttpResponse {
+export interface TaskListTasks200Response extends HttpResponse {
   status: "200";
   body: BatchTaskListResultOutput;
-  headers: RawHttpHeaders & TaskList200Headers;
+  headers: RawHttpHeaders & TaskListTasks200Headers;
 }
 
-export interface TaskListDefaultHeaders {
+export interface TaskListTasksDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskListDefaultResponse extends HttpResponse {
+export interface TaskListTasksDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskListDefaultHeaders;
+  headers: RawHttpHeaders & TaskListTasksDefaultHeaders;
 }
 
-export interface TaskAddCollection200Headers {
+export interface TaskAddTaskCollection200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1718,24 +1733,24 @@ export interface TaskAddCollection200Headers {
 }
 
 /** The request has succeeded. */
-export interface TaskAddCollection200Response extends HttpResponse {
+export interface TaskAddTaskCollection200Response extends HttpResponse {
   status: "200";
   body: TaskAddCollectionResultOutput;
-  headers: RawHttpHeaders & TaskAddCollection200Headers;
+  headers: RawHttpHeaders & TaskAddTaskCollection200Headers;
 }
 
-export interface TaskAddCollectionDefaultHeaders {
+export interface TaskAddTaskCollectionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskAddCollectionDefaultResponse extends HttpResponse {
+export interface TaskAddTaskCollectionDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskAddCollectionDefaultHeaders;
+  headers: RawHttpHeaders & TaskAddTaskCollectionDefaultHeaders;
 }
 
-export interface TaskDelete200Headers {
+export interface TaskDeleteTaskCollection200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1743,23 +1758,23 @@ export interface TaskDelete200Headers {
 }
 
 /** The request has succeeded. */
-export interface TaskDelete200Response extends HttpResponse {
+export interface TaskDeleteTaskCollection200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & TaskDelete200Headers;
+  headers: RawHttpHeaders & TaskDeleteTaskCollection200Headers;
 }
 
-export interface TaskDeleteDefaultHeaders {
+export interface TaskDeleteTaskCollectionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskDeleteDefaultResponse extends HttpResponse {
+export interface TaskDeleteTaskCollectionDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskDeleteDefaultHeaders;
+  headers: RawHttpHeaders & TaskDeleteTaskCollectionDefaultHeaders;
 }
 
-export interface TaskGet200Headers {
+export interface TaskGetTaskCollection200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1773,24 +1788,24 @@ export interface TaskGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface TaskGet200Response extends HttpResponse {
+export interface TaskGetTaskCollection200Response extends HttpResponse {
   status: "200";
   body: BatchTaskOutput;
-  headers: RawHttpHeaders & TaskGet200Headers;
+  headers: RawHttpHeaders & TaskGetTaskCollection200Headers;
 }
 
-export interface TaskGetDefaultHeaders {
+export interface TaskGetTaskCollectionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskGetDefaultResponse extends HttpResponse {
+export interface TaskGetTaskCollectionDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskGetDefaultHeaders;
+  headers: RawHttpHeaders & TaskGetTaskCollectionDefaultHeaders;
 }
 
-export interface TaskUpdate200Headers {
+export interface TaskUpdateTaskCollection200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1804,20 +1819,20 @@ export interface TaskUpdate200Headers {
 }
 
 /** The request has succeeded. */
-export interface TaskUpdate200Response extends HttpResponse {
+export interface TaskUpdateTaskCollection200Response extends HttpResponse {
   status: "200";
-  headers: RawHttpHeaders & TaskUpdate200Headers;
+  headers: RawHttpHeaders & TaskUpdateTaskCollection200Headers;
 }
 
-export interface TaskUpdateDefaultHeaders {
+export interface TaskUpdateTaskCollectionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskUpdateDefaultResponse extends HttpResponse {
+export interface TaskUpdateTaskCollectionDefaultResponse extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskUpdateDefaultHeaders;
+  headers: RawHttpHeaders & TaskUpdateTaskCollectionDefaultHeaders;
 }
 
 export interface TaskListSubtasks200Headers {
@@ -1849,7 +1864,7 @@ export interface TaskListSubtasksDefaultResponse extends HttpResponse {
   headers: RawHttpHeaders & TaskListSubtasksDefaultHeaders;
 }
 
-export interface TaskTerminate204Headers {
+export interface TaskTerminateTaskCollection204Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1863,23 +1878,24 @@ export interface TaskTerminate204Headers {
 }
 
 /** There is no content to send for this request, but the headers may be useful. */
-export interface TaskTerminate204Response extends HttpResponse {
+export interface TaskTerminateTaskCollection204Response extends HttpResponse {
   status: "204";
-  headers: RawHttpHeaders & TaskTerminate204Headers;
+  headers: RawHttpHeaders & TaskTerminateTaskCollection204Headers;
 }
 
-export interface TaskTerminateDefaultHeaders {
+export interface TaskTerminateTaskCollectionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskTerminateDefaultResponse extends HttpResponse {
+export interface TaskTerminateTaskCollectionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskTerminateDefaultHeaders;
+  headers: RawHttpHeaders & TaskTerminateTaskCollectionDefaultHeaders;
 }
 
-export interface TaskReactivate204Headers {
+export interface TaskReactivateTaskCollection204Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -1893,20 +1909,21 @@ export interface TaskReactivate204Headers {
 }
 
 /** There is no content to send for this request, but the headers may be useful. */
-export interface TaskReactivate204Response extends HttpResponse {
+export interface TaskReactivateTaskCollection204Response extends HttpResponse {
   status: "204";
-  headers: RawHttpHeaders & TaskReactivate204Headers;
+  headers: RawHttpHeaders & TaskReactivateTaskCollection204Headers;
 }
 
-export interface TaskReactivateDefaultHeaders {
+export interface TaskReactivateTaskCollectionDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface TaskReactivateDefaultResponse extends HttpResponse {
+export interface TaskReactivateTaskCollectionDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & TaskReactivateDefaultHeaders;
+  headers: RawHttpHeaders & TaskReactivateTaskCollectionDefaultHeaders;
 }
 
 export interface ComputeNodesAddUser201Headers {
@@ -1993,7 +2010,7 @@ export interface ComputeNodesUpdateUserDefaultResponse extends HttpResponse {
   headers: RawHttpHeaders & ComputeNodesUpdateUserDefaultHeaders;
 }
 
-export interface ComputeNodesGet200Headers {
+export interface ComputeNodesGetComputeNode200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -2005,24 +2022,25 @@ export interface ComputeNodesGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface ComputeNodesGet200Response extends HttpResponse {
+export interface ComputeNodesGetComputeNode200Response extends HttpResponse {
   status: "200";
   body: ComputeNodeOutput;
-  headers: RawHttpHeaders & ComputeNodesGet200Headers;
+  headers: RawHttpHeaders & ComputeNodesGetComputeNode200Headers;
 }
 
-export interface ComputeNodesGetDefaultHeaders {
+export interface ComputeNodesGetComputeNodeDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface ComputeNodesGetDefaultResponse extends HttpResponse {
+export interface ComputeNodesGetComputeNodeDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & ComputeNodesGetDefaultHeaders;
+  headers: RawHttpHeaders & ComputeNodesGetComputeNodeDefaultHeaders;
 }
 
-export interface ComputeNodesReboot202Headers {
+export interface ComputeNodesRebootComputeNode202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -2036,23 +2054,24 @@ export interface ComputeNodesReboot202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface ComputeNodesReboot202Response extends HttpResponse {
+export interface ComputeNodesRebootComputeNode202Response extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & ComputeNodesReboot202Headers;
+  headers: RawHttpHeaders & ComputeNodesRebootComputeNode202Headers;
 }
 
-export interface ComputeNodesRebootDefaultHeaders {
+export interface ComputeNodesRebootComputeNodeDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface ComputeNodesRebootDefaultResponse extends HttpResponse {
+export interface ComputeNodesRebootComputeNodeDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & ComputeNodesRebootDefaultHeaders;
+  headers: RawHttpHeaders & ComputeNodesRebootComputeNodeDefaultHeaders;
 }
 
-export interface ComputeNodesReimage202Headers {
+export interface ComputeNodesReimageComputeNode202Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -2066,20 +2085,22 @@ export interface ComputeNodesReimage202Headers {
 }
 
 /** The request has been accepted for processing, but processing has not yet completed. */
-export interface ComputeNodesReimage202Response extends HttpResponse {
+export interface ComputeNodesReimageComputeNode202Response
+  extends HttpResponse {
   status: "202";
-  headers: RawHttpHeaders & ComputeNodesReimage202Headers;
+  headers: RawHttpHeaders & ComputeNodesReimageComputeNode202Headers;
 }
 
-export interface ComputeNodesReimageDefaultHeaders {
+export interface ComputeNodesReimageComputeNodeDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface ComputeNodesReimageDefaultResponse extends HttpResponse {
+export interface ComputeNodesReimageComputeNodeDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & ComputeNodesReimageDefaultHeaders;
+  headers: RawHttpHeaders & ComputeNodesReimageComputeNodeDefaultHeaders;
 }
 
 export interface ComputeNodesDisableScheduling200Headers {
@@ -2262,7 +2283,7 @@ export interface ComputeNodesListDefaultResponse extends HttpResponse {
   headers: RawHttpHeaders & ComputeNodesListDefaultHeaders;
 }
 
-export interface ComputeNodeExtensionsGet200Headers {
+export interface ComputeNodeExtensionsGetComputeNodeExtensions200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -2274,24 +2295,28 @@ export interface ComputeNodeExtensionsGet200Headers {
 }
 
 /** The request has succeeded. */
-export interface ComputeNodeExtensionsGet200Response extends HttpResponse {
+export interface ComputeNodeExtensionsGetComputeNodeExtensions200Response
+  extends HttpResponse {
   status: "200";
   body: NodeVMExtensionOutput;
-  headers: RawHttpHeaders & ComputeNodeExtensionsGet200Headers;
+  headers: RawHttpHeaders &
+    ComputeNodeExtensionsGetComputeNodeExtensions200Headers;
 }
 
-export interface ComputeNodeExtensionsGetDefaultHeaders {
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface ComputeNodeExtensionsGetDefaultResponse extends HttpResponse {
+export interface ComputeNodeExtensionsGetComputeNodeExtensionsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & ComputeNodeExtensionsGetDefaultHeaders;
+  headers: RawHttpHeaders &
+    ComputeNodeExtensionsGetComputeNodeExtensionsDefaultHeaders;
 }
 
-export interface ComputeNodeExtensionsList200Headers {
+export interface ComputeNodeExtensionsListComputeNodeExtensions200Headers {
   /** The client-request-id provided by the client during the request. This will be returned only if the return-client-request-id parameter was set to true. */
   "client-request-id"?: string;
   /** A unique identifier for the request that was made to the Batch service. If a request is consistently failing and you have verified that the request is properly formulated, you may use this value to report the error to Microsoft. In your report, include the value of this request ID, the approximate time that the request was made, the Batch Account against which the request was made, and the region that Account resides in. */
@@ -2303,19 +2328,23 @@ export interface ComputeNodeExtensionsList200Headers {
 }
 
 /** The request has succeeded. */
-export interface ComputeNodeExtensionsList200Response extends HttpResponse {
+export interface ComputeNodeExtensionsListComputeNodeExtensions200Response
+  extends HttpResponse {
   status: "200";
   body: NodeVMExtensionListOutput;
-  headers: RawHttpHeaders & ComputeNodeExtensionsList200Headers;
+  headers: RawHttpHeaders &
+    ComputeNodeExtensionsListComputeNodeExtensions200Headers;
 }
 
-export interface ComputeNodeExtensionsListDefaultHeaders {
+export interface ComputeNodeExtensionsListComputeNodeExtensionsDefaultHeaders {
   /** String error code indicating what went wrong. */
   "x-ms-error-code"?: string;
 }
 
-export interface ComputeNodeExtensionsListDefaultResponse extends HttpResponse {
+export interface ComputeNodeExtensionsListComputeNodeExtensionsDefaultResponse
+  extends HttpResponse {
   status: string;
   body: ErrorResponse;
-  headers: RawHttpHeaders & ComputeNodeExtensionsListDefaultHeaders;
+  headers: RawHttpHeaders &
+    ComputeNodeExtensionsListComputeNodeExtensionsDefaultHeaders;
 }

--- a/packages/typespec-test/test/batch_modular/spec/routes.tsp
+++ b/packages/typespec-test/test/batch_modular/spec/routes.tsp
@@ -34,7 +34,7 @@ API.
   @route("/applications")
   @operationId("Application_List")
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListApplications is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders,
     BatchResponseHeaders & ApplicationListResult
   > ; 
@@ -128,7 +128,7 @@ to Microsoft Support engineers.
     "Add a pool with mount drive specified"
   )
   @post
-  Add is Azure.Core.Foundations.Operation<
+  AddPool is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @body
       @doc("The Pool to be added.")
@@ -153,7 +153,7 @@ to Microsoft Support engineers.
     "Pool list"
   )
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListPools is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders &{
       @doc("""
 An OData $filter clause. For more information on constructing this filter, see
@@ -196,7 +196,7 @@ error code PoolBeingDeleted.
   )
   @route("/pools/{poolId}")
   @delete
-  Delete is Azure.Core.Foundations.Operation<
+  DeletePool is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchPoolHeaders,
     DeleteResponseHeaders
   >;
@@ -227,7 +227,7 @@ error code PoolBeingDeleted.
   )
   @route("/pools/{poolId}")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetPool is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchPoolHeaders & {
 
       @doc("An OData $select clause.")
@@ -254,7 +254,7 @@ a StartTask element, then the Pool keeps the existing StartTask.
   )
   @route("/pools/{poolId}")
   @patch
-  Patch is Azure.Core.Foundations.Operation<
+  PatchPool is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchPoolHeaders &{
       @doc("The parameters for the request.")
       @body
@@ -543,7 +543,7 @@ that the Job is being deleted.
   @example("./examples/JobDelete.json", "Delete Job")
   @route("/jobs/{jobId}")
   @delete
-  Delete is Azure.Core.Foundations.Operation<
+  DeleteJob is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job to delete.")
       @path
@@ -558,7 +558,7 @@ that the Job is being deleted.
   @example("./examples/JobGet.json", "Job get")
   @route("/jobs/{jobId}")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetJob is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job.")
       @path
@@ -587,7 +587,7 @@ element, then the Job keeps the existing constraints.
   @example("./examples/JobPatch.json", "Job patch")
   @route("/jobs/{jobId}")
   @patch
-  Patch is Azure.Core.Foundations.Operation<
+  PatchJob is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job whose properties you want to update.")
       @path
@@ -617,7 +617,7 @@ with this request, then the Batch service will remove the existing constraints.
   @example("./examples/JobUpdate.json", "Job update")
   @route("/jobs/{jobId}")
   @put
-  Update is Azure.Core.Foundations.Operation<
+  UpdateJob is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job whose properties you want to update.")
       @path
@@ -652,7 +652,7 @@ the request fails with status code 409.
   @example("./examples/JobDisable.json", "Job disable")
   @route("/jobs/{jobId}/disable")
   @post
-  Disable is Azure.Core.Foundations.Operation<
+  DisableJob is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & BatchMatchHeaders &{
       @doc("The ID of the Job to disable.")
       @path
@@ -684,7 +684,7 @@ than 180 days ago, those Tasks will not run.
   @example("./examples/JobEnable.json", "Job enable")
   @route("/jobs/{jobId}/enable")
   @post
-  Enable is Azure.Core.Foundations.Operation<
+  EnableJob is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job to enable.")
       @path
@@ -713,7 +713,7 @@ Tasks cannot be added and any remaining active Tasks will not be scheduled.
   @example("./examples/JobTerminate.json", "Job terminate")
   @route("/jobs/{jobId}/terminate")
   @post
-  Terminate is Azure.Core.Foundations.Operation<
+  TerminateJob is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job to terminate.")
       @path
@@ -749,7 +749,7 @@ engineers.
   @example("./examples/JobAdd_Complex.json", "Add a complex job")
   @route("/jobs")
   @post
-  Add is Azure.Core.Foundations.Operation<
+  AddJob is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The Job to be added.")
       @body
@@ -770,7 +770,7 @@ engineers.
   @example("./examples/JobList.json", "Job list")
   @route("/jobs")
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListJobs is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders & {
       @doc("""
 An OData $filter clause. For more information on constructing this filter, see
@@ -883,7 +883,7 @@ interface Certificates {
   @example("./examples/CertificateAdd.json", "Certificate add")
   @route("/certificates")
   @post
-  Add is Azure.Core.Foundations.Operation<
+  AddCertificate is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
     
       @doc("The Certificate to be added.")
@@ -901,7 +901,7 @@ interface Certificates {
   @example("./examples/CertificateList.json", "Certificate list")
   @route("/certificates")
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListCertificates is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders & {
       @doc("""
 An OData $filter clause. For more information on constructing this filter, see
@@ -930,7 +930,7 @@ then you can try again to delete the Certificate.
   @example("./examples/CertificateCancelDelete.json", "Certificate cancel delete")
   @route("/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})/canceldelete")
   @post
-  CancelDeletion is Azure.Core.Foundations.Operation<
+  CancelCertificateDeletion is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The algorithm used to derive the thumbprint parameter. This must be sha1.")
       @path
@@ -967,7 +967,7 @@ active if you decide that you want to continue using the Certificate.
   @example("./examples/CertificateDelete.json", "Certificate delete")
   @route("/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})")
   @delete
-  Delete is Azure.Core.Foundations.Operation<
+  DeleteCertificate is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The algorithm used to derive the thumbprint parameter. This must be sha1.")
       @path
@@ -987,7 +987,7 @@ active if you decide that you want to continue using the Certificate.
   @example("./examples/CertificateGet.json", "Certificate get")
   @route("/certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetCertificate is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The algorithm used to derive the thumbprint parameter. This must be sha1.")
       @path
@@ -1188,7 +1188,7 @@ interface JobSchedule {
   @example("./examples/JobScheduleExists.json", "Check Job Schedule Exists")
   @route("/jobschedules/{jobScheduleId}")
   @head
-  Exists is Azure.Core.Foundations.Operation<
+  JobScheduleExists is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule which you want to check.")
       @path
@@ -1215,7 +1215,7 @@ though they are still counted towards Account lifetime statistics.
   @example("./examples/JobScheduleDelete.json", "JobSchedule delete")
   @route("/jobschedules/{jobScheduleId}")
   @delete
-  Delete is Azure.Core.Foundations.Operation<
+  DeleteJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to delete.")
       @path
@@ -1228,7 +1228,7 @@ though they are still counted towards Account lifetime statistics.
   @example("./examples/JobScheduleGet.json", "JobSchedule get")
   @route("/jobschedules/{jobScheduleId}")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to get.")
       @path
@@ -1256,7 +1256,7 @@ running Jobs are unaffected.
   @example("./examples/JobSchedulePatch.json", "JobSchedule patch")
   @route("/jobschedules/{jobScheduleId}")
   @patch
-  Patch is Azure.Core.Foundations.Operation<
+  PatchJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to update.")
       @path
@@ -1287,7 +1287,7 @@ running Jobs are unaffected.
   @example("./examples/JobScheduleUpdate.json", "JobSchedule update")
   @route("/jobschedules/{jobScheduleId}")
   @put
-  Update is Azure.Core.Foundations.Operation<
+  UpdateJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to update.")
       @path
@@ -1312,7 +1312,7 @@ running Jobs are unaffected.
   @example("./examples/JobScheduleDisable.json", "JobSchedule disable")
   @route("/jobschedules/{jobScheduleId}/disable")
   @post
-  Disable is Azure.Core.Foundations.Operation<
+  DisableJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to disable.")
       @path
@@ -1333,7 +1333,7 @@ running Jobs are unaffected.
   @example("./examples/JobScheduleEnable.json", "JobSchedule enable")
   @route("/jobschedules/{jobScheduleId}/enable")
   @post
-  Enable is Azure.Core.Foundations.Operation<
+  EnableJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to enable.")
       @path
@@ -1354,7 +1354,7 @@ running Jobs are unaffected.
   @example("./examples/JobScheduleTerminate.json", "JobSchedule terminate")
   @route("/jobschedules/{jobScheduleId}/terminate")
   @post
-  Terminate is Azure.Core.Foundations.Operation<
+  TerminateJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job Schedule to terminates.")
       @path
@@ -1376,7 +1376,7 @@ running Jobs are unaffected.
   @example("./examples/JobScheduleAdd_Complex.json", "Add a complex JobScheduleAdd")
   @route("/jobschedules")
   @post
-  Add is Azure.Core.Foundations.Operation<
+  AddJobSchedule is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The Job Schedule to be added.")
       @body
@@ -1397,7 +1397,7 @@ running Jobs are unaffected.
   @example("./examples/JobScheduleList.json", "JobSchedule list")
   @route("/jobschedules")
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListJobSchedules is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders & {
       @doc("""
 An OData $filter clause. For more information on constructing this filter, see
@@ -1433,7 +1433,7 @@ the Batch service and left in whatever state it was in at that time.
   @example("./examples/TaskAdd_RequiredSlots.json", "Add a task with extra slot requirement")
   @route("/jobs/{jobId}/tasks")
   @post
-  Add is Azure.Core.Foundations.Operation<
+  AddTask is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The ID of the Job to which the Task is to be added.")
       @path
@@ -1462,7 +1462,7 @@ information about subtasks.
   @example("./examples/TaskList.json", "Task list")
   @route("/jobs/{jobId}/tasks")
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListTasks is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders & {
       @doc("The ID of the Job.")
       @path
@@ -1507,7 +1507,7 @@ service and left in whatever state it was in at that time.
   @example("./examples/TaskAddCollection_Complex.json", "Add a complex collection of tasks")
   @route("/jobs/{jobId}/addtaskcollection")
   @post
-  AddCollection is Azure.Core.Foundations.Operation<
+  AddTaskCollection is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The ID of the Job to which the Task collection is to be added.")
       @path
@@ -1531,7 +1531,7 @@ background.
   @example("./examples/TaskDelete.json", "Task delete")
   @route("/jobs/{jobId}/tasks/{taskId}")
   @delete
-  Delete is Azure.Core.Foundations.Operation<
+  DeleteTaskCollection is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job from which to delete the Task.")
       @path
@@ -1556,7 +1556,7 @@ information about subtasks.
   @example("./examples/TaskGet.json", "Task get")
   @route("/jobs/{jobId}/tasks/{taskId}")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetTaskCollection is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job that contains the Task.")
       @path
@@ -1586,7 +1586,7 @@ information about subtasks.
   @example("./examples/TaskUpdate.json", "Task update")
   @route("/jobs/{jobId}/tasks/{taskId}")
   @put
-  Update is Azure.Core.Foundations.Operation<
+  UpdateTaskCollection is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job containing the Task.")
       @path
@@ -1644,7 +1644,7 @@ primary task; subtasks are then terminated asynchronously in the background.
   @example("./examples/TaskTerminate.json", "Task terminate")
   @route("/jobs/{jobId}/tasks/{taskId}/terminate")
   @post
-  Terminate is Azure.Core.Foundations.Operation<
+  TerminateTaskCollection is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job containing the Task.")
       @path
@@ -1677,7 +1677,7 @@ will fail if the Job has completed (or is terminating or deleting).
   @example("./examples/TaskReactivate.json", "Task reactivate")
   @route("/jobs/{jobId}/tasks/{taskId}/reactivate")
   @post
-  Reactivate is Azure.Core.Foundations.Operation<
+  ReactivateTaskCollection is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & BatchMatchHeaders & {
       @doc("The ID of the Job containing the Task.")
       @path
@@ -1804,7 +1804,7 @@ Account on a Compute Node only when it is in the idle or running state.
   @example("./examples/NodeGet_Basic.json", "Node get")
   @route("/pools/{poolId}/nodes/{nodeId}")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetComputeNode is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & {
       @doc("The ID of the Pool that contains the Compute Node.")
       @path
@@ -1826,7 +1826,7 @@ Account on a Compute Node only when it is in the idle or running state.
   @example("./examples/NodeReboot.json", "Node reboot")
   @route("/pools/{poolId}/nodes/{nodeId}/reboot")
   @post
-  Reboot is Azure.Core.Foundations.Operation<
+  RebootComputeNode is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & {
       @doc("The ID of the Pool that contains the Compute Node.")
       @path
@@ -1859,7 +1859,7 @@ cloud service configuration property.
   @example("./examples/NodeReimage.json", "Node reimage")
   @route("/pools/{poolId}/nodes/{nodeId}/reimage")
   @post
-  Reimage is Azure.Core.Foundations.Operation<
+  ReimageComputeNode is Azure.Core.Foundations.Operation<
      BatchClientRequestHeaders & {
       @doc("The ID of the Pool that contains the Compute Node.")
       @path
@@ -2066,7 +2066,7 @@ interface ComputeNodeExtensions {
   @example("./examples/ComputeNodeExtensionGet.json", "Get compute node extension")
   @route("/pools/{poolId}/nodes/{nodeId}/extensions/{extensionName}")
   @get
-  Get is Azure.Core.Foundations.Operation<
+  GetComputeNodeExtensions is Azure.Core.Foundations.Operation<
     BatchClientRequestHeaders & {
       @doc("The ID of the Pool that contains the Compute Node.")
       @path
@@ -2095,7 +2095,7 @@ about.
   @example("./examples/ComputeNodeExtensionList.json", "List compute node extensions")
   @route("/pools/{poolId}/nodes/{nodeId}/extensions")
   @get
-  List is Azure.Core.Foundations.Operation<
+  ListComputeNodeExtensions is Azure.Core.Foundations.Operation<
     BatchApplicationListHeaders &  {
       @doc("The ID of the Pool that contains Compute Node.")
       @path

--- a/packages/typespec-ts/src/casingUtils.ts
+++ b/packages/typespec-ts/src/casingUtils.ts
@@ -28,14 +28,21 @@ export function camelToSnakeCase(name: string): string {
   return camelToSnakeCaseRe(name[0]!.toLowerCase() + name.slice(1));
 }
 
-export function toPascalCase(name: string) {
-  return `${name}`
-    .toLowerCase()
-    .replace(new RegExp(/[-_]+/, "g"), " ")
-    .replace(new RegExp(/[^a-zA-Z0-9\s]/, "g"), "")
-    .replace(
-      new RegExp(/\s+(.)(\w*)/, "g"),
-      (_$1, $2, $3) => `${$2.toUpperCase() + $3.toLowerCase()}`
-    )
-    .replace(new RegExp(/\w/), (s) => s.toUpperCase());
+export function toPascalCase(name: string): string {
+  let str = name;
+  // Handle snake case or dash-separated words
+  str = str.replace(/[-_]+/g, " ");
+
+  // Handle pascal case or camel case
+  str = str.replace(/([a-z])([A-Z])/g, (_match, p1, p2) => {
+    return p1 + " " + p2.toLowerCase();
+  });
+
+  // Convert to camel case
+  str = str.replace(/\s(.)/g, (_match, p1) => {
+    return p1.toUpperCase();
+  });
+
+  // Lowercase the first character
+  return str.charAt(0).toUpperCase() + str.slice(1);
 }

--- a/packages/typespec-ts/src/casingUtils.ts
+++ b/packages/typespec-ts/src/casingUtils.ts
@@ -27,3 +27,15 @@ export function camelToSnakeCase(name: string): string {
 
   return camelToSnakeCaseRe(name[0]!.toLowerCase() + name.slice(1));
 }
+
+export function toPascalCase(name: string) {
+  return `${name}`
+    .toLowerCase()
+    .replace(new RegExp(/[-_]+/, "g"), " ")
+    .replace(new RegExp(/[^a-zA-Z0-9\s]/, "g"), "")
+    .replace(
+      new RegExp(/\s+(.)(\w*)/, "g"),
+      (_$1, $2, $3) => `${$2.toUpperCase() + $3.toLowerCase()}`
+    )
+    .replace(new RegExp(/\w/), (s) => s.toUpperCase());
+}

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -41,6 +41,7 @@ import { buildClientContext } from "./modular/buildClientContext.js";
 import { emitCodeModel } from "./modular/buildCodeModel.js";
 import { buildRootIndex } from "./modular/buildRootIndex.js";
 import { buildModels } from "./modular/emitModels.js";
+import { buildOperationFiles } from "./modular/buildOperations.js";
 // import { emitPackage, emitTsConfig } from "./modular/buildProjectFiles.js";
 
 export async function $onEmit(context: EmitContext) {
@@ -112,6 +113,7 @@ export async function $onEmit(context: EmitContext) {
       buildClientContext(client, project, srcPath);
       buildRootIndex(project, srcPath);
       buildModels(modularCodeModel, project, srcPath);
+      buildOperationFiles(client, project, srcPath);
       // emitPackage(project, srcPath, modularCodeModel);
       // emitTsConfig(project, srcPath, modularCodeModel);
     }

--- a/packages/typespec-ts/src/modular/buildOperations.ts
+++ b/packages/typespec-ts/src/modular/buildOperations.ts
@@ -1,0 +1,395 @@
+import {
+  FunctionDeclarationStructure,
+  OptionalKind,
+  ParameterDeclarationStructure,
+  Project,
+  SourceFile
+} from "ts-morph";
+import { toPascalCase } from "../casingUtils.js";
+import { getType } from "./helpers/getType.js";
+import {
+  Client,
+  Operation,
+  Parameter,
+  Property,
+  Type
+} from "./modularCodeModel.js";
+
+/**
+ * This function creates a file under /api for each operation group.
+ * If there is no operation group in the TypeSpec program, we create a single
+ * file called operations.ts where all operations are generated.
+ */
+export function buildOperationFiles(
+  client: Client,
+  project: Project,
+  srcPath: string = "src"
+) {
+  for (const operationGroup of client.operationGroups) {
+    const fileName = operationGroup.className
+      ? `${operationGroup.className}`
+      : // When the program has no operation groups defined all operations are put
+        // into a nameless operation group. We'll call this operations.
+        "operations";
+
+    const operationGroupFile = project.createSourceFile(
+      `${srcPath}/src/api/${fileName}.ts`
+    );
+
+    operationGroup.operations.forEach((o) => {
+      const optionsName = buildOperationOptions(o, operationGroupFile);
+      const operationDeclaration = getOperationFunction(o, optionsName);
+      operationGroupFile.addFunction(operationDeclaration);
+    });
+
+    operationGroupFile.addImportDeclarations([
+      {
+        moduleSpecifier: "../rest/index.js",
+        namedImports: [`${client.name}Context as Client`, "isUnexpected"]
+      }
+    ]);
+
+    // Import models used from ./models.ts
+    importModels(operationGroupFile, project);
+    operationGroupFile.fixMissingImports();
+  }
+}
+
+function importModels(sourceFile: SourceFile, project: Project) {
+  const modelsFile = project.getSourceFile("models.ts");
+  const models: string[] = [];
+
+  for (const entry of modelsFile?.getExportedDeclarations().entries() ?? []) {
+    models.push(entry[0]);
+  }
+
+  sourceFile.addImportDeclaration({
+    moduleSpecifier: "./models.js",
+    namedImports: models
+  });
+
+  // Import all models and then let ts-morph clean up the unused ones
+  sourceFile.fixUnusedIdentifiers();
+}
+
+/**
+ * This operation builds and returns the function declaration for an operation.
+ */
+export function getOperationFunction(
+  operation: Operation,
+  optionsType: string
+): OptionalKind<FunctionDeclarationStructure> {
+  // Extract required parameters
+  let parameters: OptionalKind<ParameterDeclarationStructure>[] = (
+    operation.bodyParameter?.type.properties ?? []
+  )
+    .filter((p) => !p.optional)
+    .map((p) => buildParameterType(p.clientName, p.type));
+
+  parameters = parameters.concat(
+    operation.parameters
+      .filter(
+        (p) =>
+          p.implementation === "Method" &&
+          p.type.type !== "constant" &&
+          !p.optional
+      )
+      .map((p) => buildParameterType(p.clientName, p.type))
+  );
+
+  // Add context as the first parameter
+  parameters.unshift({ name: "context", type: "Client" });
+
+  // Add the options parameter
+  parameters.push({
+    name: "options",
+    type: optionsType,
+    initializer: "{ requestOptions: {} }"
+  });
+
+  // TODO: Support operation overloads
+  const response = operation.responses[0]!;
+  const returnType =
+    response?.type?.type === "model"
+      ? buildParameterType(response.type.name, response.type)
+      : { name: "", type: "void" };
+
+  const functionStatement: OptionalKind<FunctionDeclarationStructure> = {
+    docs: [operation.description],
+    isAsync: true,
+    isExported: true,
+    name: operation.name,
+    parameters,
+    returnType: `Promise<${returnType.type}>`
+  };
+
+  const operationPath = operation.url;
+  const operationMethod = operation.method.toLowerCase();
+
+  const statements: string[] = [];
+  statements.push(
+    `const result = await context.path("${operationPath}", ${getPathParameters(
+      operation
+    )}).${operationMethod}({${getRequestParameters(operation)}});`
+  );
+
+  statements.push(`if(isUnexpected(result)){`, "throw result.body", "}");
+
+  if (!response?.type?.properties) {
+    statements.push(`return;`);
+  } else {
+    statements.push(
+      `return {`,
+      getResponseMapping(response.type.properties ?? []).join(","),
+      `}`
+    );
+  }
+  return {
+    ...functionStatement,
+    statements
+  };
+}
+
+/**
+ * This function build the request parameters that we will provide to the
+ * RLC internally. This will translate High Level parameters into the RLC ones.
+ * Figuring out what goes in headers, body, path and qsp.
+ */
+function getRequestParameters(operation: Operation): string {
+  if (!operation.parameters) {
+    return "";
+  }
+
+  const operationParameters = operation.parameters.filter(
+    (p) => p.implementation !== "Client"
+  );
+
+  const parametersImplementation: Record<
+    "header" | "query" | "body",
+    string[]
+  > = {
+    header: [],
+    query: [],
+    body: []
+  };
+
+  for (const param of operationParameters) {
+    if (param.location === "header" || param.location === "query") {
+      parametersImplementation[param.location].push(getParameterMap(param));
+    }
+  }
+
+  for (const param of operation.bodyParameter?.type.properties?.filter(
+    (p) => !p.readonly
+  ) ?? []) {
+    parametersImplementation.body.push(getParameterMap(param));
+  }
+
+  let paramStr = "";
+
+  if (parametersImplementation.header.length) {
+    paramStr = `${paramStr}\nheaders: {${parametersImplementation.header.join(
+      "\n"
+    )}...options.requestOptions?.headers},`;
+  }
+
+  if (parametersImplementation.query.length) {
+    paramStr = `${paramStr}\nqueryParameters: {${parametersImplementation.query.join(
+      "\n"
+    )}},`;
+  }
+
+  if (operation.bodyParameter && operation.bodyParameter.type.properties) {
+    paramStr = `${paramStr}\nbody: {${parametersImplementation.body.join(
+      "\n"
+    )}},`;
+  }
+
+  return paramStr;
+}
+
+/**
+ * This function helps with renames, translating client names to rest api names
+ */
+function getParameterMap(param: Parameter | Property) {
+  const defaultValue = getDefaultValue(param);
+
+  if (param.optional || (param.type.type === "constant" && !defaultValue)) {
+    return `...(options.${param.clientName} && {"${
+      param.restApiName
+    }": ${`options.${param.clientName}})`},`;
+  }
+
+  return `"${param.restApiName}": ${
+    param.optional
+      ? `options.${param.clientName} ${defaultValue}`
+      : param.type.type === "constant"
+      ? `${defaultValue}`
+      : param.clientName
+  },`;
+}
+
+/**
+ * This function generates the interfaces for each operation options
+ */
+export function buildOperationOptions(
+  operation: Operation,
+  sourceFile: SourceFile
+) {
+  const optionalParameters = operation.parameters.filter((p) => p.optional);
+  const optionalBodyParams = (
+    operation.bodyParameter?.type.properties ?? []
+  ).filter((p) => p.optional);
+  const options = [...optionalBodyParams, ...optionalParameters];
+
+  const name = toPascalCase(`${operation.groupName}${operation.name}Options`);
+
+  sourceFile.addInterface({
+    name,
+    isExported: true,
+    extends: ["RequestOptions"],
+    properties: options.map((p) => {
+      return {
+        docs: [p.description],
+        hasQuestionToken: true,
+        ...buildParameterType(p.clientName, p.type)
+      };
+    })
+  });
+
+  return name;
+}
+
+function buildParameterType(
+  clientName: string | undefined,
+  type: Type | undefined
+) {
+  if (!type) {
+    throw new Error("Type should be defined");
+  }
+
+  let typeMetadata = getType(type);
+  let typeName = typeMetadata.name;
+  if (typeMetadata.modifier === "Array") {
+    typeName = `${typeName}[]`;
+  }
+  return { name: clientName ?? "", type: typeName };
+}
+
+/**
+ * Builds the assignment for when a property or parameter has a default value
+ */
+function getDefaultValue(param: Parameter | Property) {
+  return (param.clientDefaultValue ?? param.type.clientDefaultValue) !==
+    undefined
+    ? `${param.optional ? "??" : ""} "${
+        param.clientDefaultValue ?? param.type.clientDefaultValue
+      }"`
+    : "";
+}
+
+/**
+ * Extracts the path parameters
+ */
+function getPathParameters(operation: Operation) {
+  if (!operation.parameters) {
+    return "";
+  }
+
+  let pathParams = "";
+  for (const param of operation.parameters) {
+    if (param.location === "path") {
+      if (!param.optional) {
+        pathParams = `${pathParams} ${param.clientName},`;
+        continue;
+      }
+
+      const defaultValue = getDefaultValue(param);
+
+      pathParams = `${pathParams}, options.${param.clientName}`;
+
+      if (defaultValue) {
+        pathParams = ` ?? "${defaultValue}"`;
+      }
+      pathParams = `${pathParams},`;
+    }
+  }
+
+  return pathParams;
+}
+
+/**
+ * This function helps translating an RLC response to an HLC response,
+ * extracting properties from body and headers and building the HLC response object
+ */
+function getResponseMapping(
+  properties: Property[],
+  propertyPath: string = "result.body"
+) {
+  const props: string[] = [];
+  for (const property of properties) {
+    // TODO: Do we need to also add headers in the result type?
+    if (property.type.type === "model") {
+      props.push(
+        `"${property.restApiName}": ${
+          !property.optional
+            ? ""
+            : `!${propertyPath}.${property.clientName} ? undefined :`
+        } {${getResponseMapping(
+          property.type.properties ?? [],
+          `${propertyPath}.${property.restApiName}${
+            property.optional ? "?" : ""
+          }`
+        )}}`
+      );
+    } else {
+      const dot = propertyPath.endsWith("?") ? "." : "";
+      const restValue = `${
+        propertyPath ? `${propertyPath}${dot}` : `${dot}`
+      }["${property.restApiName}"]`;
+      props.push(
+        `"${property.clientName}": ${deserializeResponseValue(
+          property.type,
+          restValue
+        )}`
+      );
+    }
+  }
+
+  return props;
+}
+
+/**
+ * This function helps converting strings into JS complex types recursively.
+ * We need to drill down into Array elements to make sure that the element type is
+ * deserialized correctly
+ */
+function deserializeResponseValue(type: Type, restValue: string): string {
+  switch (type.type) {
+    case "datetime":
+      return `new Date(${restValue} ?? "")`;
+    case "list":
+      if (type.elementType?.type === "model") {
+        return `(${restValue} ?? []).map(p => ({${getResponseMapping(
+          type.elementType?.properties ?? [],
+          "p"
+        )}}))`;
+      } else if (
+        type.elementType?.properties?.some((p) => needsDeserialize(p.type))
+      ) {
+        return `(${restValue} ?? []).map(p => ${deserializeResponseValue(
+          type.elementType!,
+          "p"
+        )})`;
+      } else {
+        return restValue;
+      }
+
+    default:
+      return restValue;
+  }
+}
+
+function needsDeserialize(type?: Type) {
+  return type?.type === "datetime" || type?.type === "model";
+}

--- a/packages/typespec-ts/src/modular/buildOperations.ts
+++ b/packages/typespec-ts/src/modular/buildOperations.ts
@@ -242,7 +242,9 @@ export function buildOperationOptions(
   ).filter((p) => p.optional);
   const options = [...optionalBodyParams, ...optionalParameters];
 
-  const name = toPascalCase(`${operation.groupName}${operation.name}Options`);
+  const name = `${toPascalCase(operation.groupName)}${toPascalCase(
+    operation.name
+  )}Options`;
 
   sourceFile.addInterface({
     name,
@@ -268,7 +270,7 @@ function buildParameterType(
     throw new Error("Type should be defined");
   }
 
-  let typeMetadata = getType(type);
+  const typeMetadata = getType(type);
   let typeName = typeMetadata.name;
   if (typeMetadata.modifier === "Array") {
     typeName = `${typeName}[]`;


### PR DESCRIPTION
This PR adds support for generating operations. This will generate a file per operation spec. In case there is no operation specs defined in TypeSpec we will generate a single "operations.ts" file in which all operation will be generated.