### PR TITLE
nightly test ci - override version way

### DIFF
--- a/common/config/rush/pnpm-config.json
+++ b/common/config/rush/pnpm-config.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/pnpm-config.schema.json",
+  "strictPeerDependencies": false,
+  "pnpmStore": "local",
+  "preventManualShrinkwrapChanges": true,
+  "globalOverrides": {
+    "@typespec/compiler": "0.44.0-dev.21",
+    "@typespec/rest": "0.44.0-dev.6",
+    "@typespec/http": "0.44.0-dev.6",
+    "@typespec/versioning": "0.44.0-dev.7",
+    "@azure-tools/typespec-azure-core": "0.30.0-dev.27"
+  }
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,5 +1,12 @@
 lockfileVersion: 5.3
 
+overrides:
+  '@typespec/compiler': 0.44.0-dev.21
+  '@typespec/rest': 0.44.0-dev.6
+  '@typespec/http': 0.44.0-dev.6
+  '@typespec/versioning': 0.44.0-dev.7
+  '@azure-tools/typespec-azure-core': 0.30.0-dev.27
+
 specifiers:
   '@rush-temp/rlc-common': file:./projects/rlc-common.tgz
   '@rush-temp/typescript': file:./projects/typescript.tgz
@@ -35,13 +42,13 @@ packages:
     resolution: {integrity: sha512-MCWfTUr7HA9wNi+Odv7/bKp/nydIL1ZjbVEZPNrqvpqzRa/NLoMtAWle0nIqG+iie6XofKGC0ji2zeEJMEVtKQ==}
     dev: false
 
-  /@azure-rest/core-client/1.1.2:
-    resolution: {integrity: sha512-bXOel3/GXdDuNnuIVQ6tO8vPexmg734pz+hrwkxS1GeUP/RbOGbHs7pLTB8uklfNbQabcuE8H2H3+T5wHP877A==}
+  /@azure-rest/core-client/1.1.3:
+    resolution: {integrity: sha512-qsnjofSRe0vif0SVmguRkuaQKa9KTvtUcfoxkrjeriQCVF23nD93fKSv0nMARAyhSZTr7iycuWAwz6dZuZwFvQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/core-auth': 1.4.0
       '@azure/core-rest-pipeline': 1.10.3
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       tslib: 2.5.0
     transitivePeerDependencies:
       - supports-color
@@ -55,92 +62,108 @@ packages:
       proper-lockfile: 2.0.1
     dev: false
 
-  /@azure-tools/cadl-ranch-api/0.2.4:
-    resolution: {integrity: sha512-YKGqwO7aZv4wl/gefbCjcUCCgXAfYr8RYC3YWBs6ToYuI/Soj8adV/wavarHd+dPHU7/Z3KGQIX5N6FfPYnX0w==}
+  /@azure-tools/cadl-ranch-api/0.2.5:
+    resolution: {integrity: sha512-CsKyegg2/aM7KR5b+AZ0UN065T3YnneZUtZbQSI6AxQCIjqyMc3DEHw2oWC1fFBAQ243GDS91vaFzmh+f6BbcQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
       body-parser: 1.20.2
-      deep-equal: 2.2.0
+      deep-equal: 2.2.1
       express: 4.18.2
       express-promise-router: 4.1.1_express@4.18.2
-      glob: 8.1.0
+      glob: 10.2.2
       morgan: 1.10.0
       picocolors: 1.0.0
       winston: 3.8.2
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/express'
     dev: false
 
-  /@azure-tools/cadl-ranch-coverage-sdk/0.2.2:
-    resolution: {integrity: sha512-sZCte7G49qJhd5wYvmonj1zuCGP+JX/8BsROtF1V34Iq8A6rP24RRWVAeykB8KHTfp/IC+SmJthe/Ig2w2ypmg==}
+  /@azure-tools/cadl-ranch-coverage-sdk/0.2.3:
+    resolution: {integrity: sha512-vc/Eqqkh9tQ5yVSB4aayUfyc5y3tNZs3ZXx6MzgnZf/joF7/t1tV804RK+2ZQYj2eK/2GWf2JUHkvLE/h8pwPg==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@azure/identity': 3.1.4
       '@azure/storage-blob': 12.14.0
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     transitivePeerDependencies:
       - encoding
       - supports-color
     dev: false
 
-  /@azure-tools/cadl-ranch-expect/0.2.3_402126a56c0aec99e52d5c3ab81bd82d:
-    resolution: {integrity: sha512-0DF+GXiIJ5SSUs5+UYgoxERZNzyo0Sn3UI1BIwCIVxBNpBf9Nv1MnsoEiHdkopgZFvaRKaCkS35gEpkptobaSw==}
+  /@azure-tools/cadl-ranch-expect/0.2.5_89e44fee31152018c55c857855680979:
+    resolution: {integrity: sha512-BKTXkYAZGqgwsnx/5zUyTWAS+agkDJUiibvzXs017bTAPj1Qk/tv0/AcC3PgRKY5V+Uzsc2sycSs2qr4vlmnoA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@typespec/compiler': ~0.43.0
       '@typespec/http': ~0.43.1
       '@typespec/rest': ~0.43.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
     dev: false
 
-  /@azure-tools/cadl-ranch-specs/0.14.2_bd61dc72c94e80567c8cb3296aa23ca2:
-    resolution: {integrity: sha512-J8oF0qWw96sO9Cga/zwVItXkH1eMkrF9Z+f76FSOplxQjvVuKv8hgmyQdheDS9uVaw2sKjmFbo58UNDEnJKNBw==}
+  /@azure-tools/cadl-ranch-expect/0.3.0_eb72834da16efb9c128c55fd63afd799:
+    resolution: {integrity: sha512-+kqMvlAHChvz4+h9FYsZfPp5KigFYdwH+FzdUWlB5NN3WjK+X8A5CuXh2MLCVd53tiQr3qv2Ji5NlGMlhyH4Qw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@azure-tools/cadl-ranch-expect': ~0.2.3
+      '@typespec/compiler': ~0.43.0
+      '@typespec/http': ~0.43.1
+      '@typespec/rest': ~0.43.0
+      '@typespec/versioning': ~0.43.0
+    dependencies:
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/versioning': 0.44.0-dev.7
+    dev: false
+
+  /@azure-tools/cadl-ranch-specs/0.14.8_d47b450dae1ba437bd5fb0d162a989ac:
+    resolution: {integrity: sha512-u09ZQ7G30d++Ted4FsRI6WqhzyzeQVXGTQZZvvlXXv981hD77eMY1pGRxseE7tvFLCDFnZycEbXGIkhM0VlT1g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@azure-tools/cadl-ranch-expect': ~0.3.0
       '@azure-tools/typespec-azure-core': ~0.29.0
       '@typespec/compiler': ~0.43.0
       '@typespec/http': ~0.43.1
       '@typespec/rest': ~0.43.0
       '@typespec/versioning': ~0.43.0
     dependencies:
-      '@azure-tools/cadl-ranch': 0.4.6
-      '@azure-tools/cadl-ranch-api': 0.2.4
-      '@azure-tools/cadl-ranch-expect': 0.2.3_402126a56c0aec99e52d5c3ab81bd82d
-      '@azure-tools/typespec-azure-core': 0.29.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
-      '@typespec/versioning': 0.43.0
+      '@azure-tools/cadl-ranch': 0.4.11_f887650a9b7d9e8e67eb12700d7b199b
+      '@azure-tools/cadl-ranch-api': 0.2.5
+      '@azure-tools/cadl-ranch-expect': 0.2.5_89e44fee31152018c55c857855680979
+      '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/versioning': 0.44.0-dev.7
     transitivePeerDependencies:
       - '@types/express'
       - encoding
       - supports-color
     dev: false
 
-  /@azure-tools/cadl-ranch/0.4.6:
-    resolution: {integrity: sha512-9c4XWErpBuYkQsIg7v2pOsbczSgKMUW2gqDt1cx93OBcf65vP8FIxVZHVyvveUqi4D4CWophr7mWG6/MOOZZfA==}
+  /@azure-tools/cadl-ranch/0.4.11_f887650a9b7d9e8e67eb12700d7b199b:
+    resolution: {integrity: sha512-Wbw9MsfeqZLifB8eeADkDvW9lD5SxvcPQXiC6c6N8HH4POTi93bmTPiyx995EVB0Q3Py0tNDMq0KBmRdsOHjyQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
-      '@azure-tools/cadl-ranch-api': 0.2.4
-      '@azure-tools/cadl-ranch-coverage-sdk': 0.2.2
-      '@azure-tools/cadl-ranch-expect': 0.2.3_402126a56c0aec99e52d5c3ab81bd82d
+      '@azure-tools/cadl-ranch-api': 0.2.5
+      '@azure-tools/cadl-ranch-coverage-sdk': 0.2.3
+      '@azure-tools/cadl-ranch-expect': 0.3.0_eb72834da16efb9c128c55fd63afd799
       '@azure/identity': 3.1.4
       '@types/js-yaml': 4.0.5
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
-      ajv: 8.11.0
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      ajv: 8.12.0
       body-parser: 1.20.2
-      deep-equal: 2.2.0
+      deep-equal: 2.2.1
       express: 4.18.2
       express-promise-router: 4.1.1_express@4.18.2
-      glob: 8.1.0
+      glob: 10.2.2
+      jackspeak: 2.1.1
       js-yaml: 4.1.0
       morgan: 1.10.0
       node-fetch: 3.3.1
@@ -148,10 +171,11 @@ packages:
       prettier: 2.8.8
       source-map-support: 0.5.21
       winston: 3.8.2
-      xml2js: 0.4.23
-      yargs: 17.7.1
+      xml2js: 0.5.0
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/express'
+      - '@typespec/versioning'
       - encoding
       - supports-color
     dev: false
@@ -176,13 +200,13 @@ packages:
     dependencies:
       '@azure/core-auth': 1.4.0
       '@azure/core-rest-pipeline': 1.10.3
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@azure-tools/typespec-autorest/0.29.0_dc07eaa457c0d0f9d1f8446f800dd756:
+  /@azure-tools/typespec-autorest/0.29.0_d7143a750bcdddc7e6374819f72e5be6:
     resolution: {integrity: sha512-am5qSHlW8/X0o9FaLGNDydgVnGpXlTI88fgN1JU08xP1PPO5jnLIhYPCoqyPsp3bxC7j9YILRgppfvTkTQtdUQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -193,29 +217,29 @@ packages:
       '@typespec/rest': ~0.43.0
       '@typespec/versioning': ~0.43.0
     dependencies:
-      '@azure-tools/typespec-azure-core': 0.29.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/openapi': 0.43.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
-      '@typespec/versioning': 0.43.0
+      '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/openapi': 0.43.0_89e44fee31152018c55c857855680979
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/versioning': 0.44.0-dev.7
     dev: false
 
-  /@azure-tools/typespec-azure-core/0.29.0_402126a56c0aec99e52d5c3ab81bd82d:
-    resolution: {integrity: sha512-JJ8o/aCDdt1clrPeKwQloXqPPMO146ifdhQd69GAenR/OfmzUnuc23ubkzYcgs5fmH+5i37fKsxGhFGFDJiL1g==}
+  /@azure-tools/typespec-azure-core/0.30.0-dev.27_89e44fee31152018c55c857855680979:
+    resolution: {integrity: sha512-ui4vgcXomu2iUKDEuLs1fB0v+2RwOXWXRiuaICbephOYE7NpGYICOIFq82e6xFv+cJfgefPq4MMs3r2WlaJsig==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.43.0
-      '@typespec/http': ~0.43.0
-      '@typespec/rest': ~0.43.0
+      '@typespec/compiler': '>=0.43.0'
+      '@typespec/http': '>=0.43.1'
+      '@typespec/rest': '>=0.43.0'
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/lint': 0.43.0_@typespec+compiler@0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/lint': 0.43.0_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
     dev: false
 
-  /@azure-tools/typespec-client-generator-core/0.29.0_402126a56c0aec99e52d5c3ab81bd82d:
+  /@azure-tools/typespec-client-generator-core/0.29.0_89e44fee31152018c55c857855680979:
     resolution: {integrity: sha512-dfUNeQWnhrrNErIjC1S6JhxXZW/0tPTK4jPB7eN6QiFlvbD2SMvE7uSRktjzET/bhhJUSfKdLY2kGkWYuRKQsw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -223,9 +247,9 @@ packages:
       '@typespec/http': ~0.43.0
       '@typespec/rest': ~0.43.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
     dev: false
 
   /@azure/abort-controller/1.1.0:
@@ -256,7 +280,7 @@ packages:
       '@azure/core-auth': 1.4.0
       '@azure/core-rest-pipeline': 1.10.3
       '@azure/core-tracing': 1.0.1
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
       tslib: 2.5.0
     transitivePeerDependencies:
@@ -304,7 +328,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.4.0
       '@azure/core-tracing': 1.0.0-preview.13
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
       '@types/node-fetch': 2.6.3
       '@types/tunnel': 0.0.3
@@ -319,12 +343,12 @@ packages:
       - encoding
     dev: false
 
-  /@azure/core-lro/2.5.2:
-    resolution: {integrity: sha512-tucUutPhBwCPu6v16KEFYML81npEL6gnT+iwewXvK5ZD55sr0/Vw2jfQETMiKVeARRrXHB2QQ3SpxxGi1zAUWg==}
+  /@azure/core-lro/2.5.3:
+    resolution: {integrity: sha512-ubkOf2YCnVtq7KqEJQqAI8dDD5rH1M6OP5kW0KO/JQyTaxLA0N0pjFWvvaysCj9eHMNBcuuoZXhhl0ypjod2DA==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
       tslib: 2.5.0
     dev: false
@@ -343,7 +367,7 @@ packages:
       '@azure/abort-controller': 1.1.0
       '@azure/core-auth': 1.4.0
       '@azure/core-tracing': 1.0.1
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
       form-data: 4.0.0
       http-proxy-agent: 5.0.0
@@ -377,8 +401,8 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@azure/core-util/1.3.1:
-    resolution: {integrity: sha512-pjfOUAb+MPLODhGuXot/Hy8wUgPD0UTqYkY3BiYcwEETrLcUCVM1t0roIvlQMgvn1lc48TGy5bsonsFpF862Jw==}
+  /@azure/core-util/1.3.2:
+    resolution: {integrity: sha512-2bECOUh88RvL1pMZTcc6OzfobBeWDBf5oBbhjIhT1MV9otMVWCzpOJkkiKtrnO88y5GGBelgY8At73KGAdbkeQ==}
     engines: {node: '>=14.0.0'}
     dependencies:
       '@azure/abort-controller': 1.1.0
@@ -402,11 +426,11 @@ packages:
       '@azure/core-client': 1.7.2
       '@azure/core-rest-pipeline': 1.10.3
       '@azure/core-tracing': 1.0.1
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/logger': 1.0.4
-      '@azure/msal-browser': 2.36.0
+      '@azure/msal-browser': 2.37.0
       '@azure/msal-common': 9.1.1
-      '@azure/msal-node': 1.17.1
+      '@azure/msal-node': 1.17.2
       events: 3.3.0
       jws: 4.0.0
       open: 8.4.2
@@ -424,15 +448,15 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@azure/msal-browser/2.36.0:
-    resolution: {integrity: sha512-OrVDZ9ftO7ExqZVHripAt+doKg6G14YbP2LoSygiWQoSqoO4CejoXLRLqANc/HGg18N0p/oaRETw4IHZvwsxZw==}
+  /@azure/msal-browser/2.37.0:
+    resolution: {integrity: sha512-YNGD/W/tw/5wDWlXOfmrVILaxVsorVLxYU2ovmL1PDvxkdudbQRyGk/76l4emqgDAl/kPQeqyivxjOU6w1YfvQ==}
     engines: {node: '>=0.8.0'}
     dependencies:
-      '@azure/msal-common': 12.1.0
+      '@azure/msal-common': 13.0.0
     dev: false
 
-  /@azure/msal-common/12.1.0:
-    resolution: {integrity: sha512-9RUiv0evSHvYtvF7r9ksShw9FgCeT6Rf6JB/SOMbMzI0VySZDUBSE+0b9e7DgL2Ph8wSARIh3m8c5pCK9TRY3w==}
+  /@azure/msal-common/13.0.0:
+    resolution: {integrity: sha512-GqCOg5H5bouvLij9NFXFkh+asRRxsPBRwnTDsfK7o0KcxYHJbuidKw8/VXpycahGXNxgtuhqtK/n5he+5NhyEA==}
     engines: {node: '>=0.8.0'}
     dev: false
 
@@ -441,11 +465,11 @@ packages:
     engines: {node: '>=0.8.0'}
     dev: false
 
-  /@azure/msal-node/1.17.1:
-    resolution: {integrity: sha512-1lC80yV+Y/gHqkYJ21Qy1Ej/cI/Kt1JcdY0xiM7/+mcEuBAkArR9B1YMY538PMZ5GfyVlYkCHYh/N0CBD5FJlQ==}
+  /@azure/msal-node/1.17.2:
+    resolution: {integrity: sha512-l8edYnA2LQj4ue3pjxVz1Qy4HuU5xbcoebfe2bGTRvBL9Q6n2Df47aGftkLIyimD1HxHuA4ZZOe23a/HshoYXw==}
     engines: {node: 10 || 12 || 14 || 16 || 18}
     dependencies:
-      '@azure/msal-common': 12.1.0
+      '@azure/msal-common': 13.0.0
       jsonwebtoken: 9.0.0
       uuid: 8.3.2
     dev: false
@@ -456,7 +480,7 @@ packages:
     dependencies:
       '@azure/abort-controller': 1.1.0
       '@azure/core-http': 3.0.1
-      '@azure/core-lro': 2.5.2
+      '@azure/core-lro': 2.5.3
       '@azure/core-paging': 1.5.0
       '@azure/core-tracing': 1.0.0-preview.13
       '@azure/logger': 1.0.4
@@ -466,8 +490,8 @@ packages:
       - encoding
     dev: false
 
-  /@babel/code-frame/7.18.6:
-    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
+  /@babel/code-frame/7.21.4:
+    resolution: {integrity: sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/highlight': 7.18.6
@@ -512,28 +536,28 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /@eslint-community/eslint-utils/4.4.0_eslint@8.39.0:
+  /@eslint-community/eslint-utils/4.4.0_eslint@8.40.0:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.39.0
-      eslint-visitor-keys: 3.4.0
+      eslint: 8.40.0
+      eslint-visitor-keys: 3.4.1
     dev: false
 
-  /@eslint-community/regexpp/4.5.0:
-    resolution: {integrity: sha512-vITaYzIcNmjn5tF5uxcZ/ft7/RXGrMUIS9HalWckEOF6ESiwXKoMzAQf2UW0aVd6rnOeExTJVd5hmWXucBKGXQ==}
+  /@eslint-community/regexpp/4.5.1:
+    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: false
 
-  /@eslint/eslintrc/2.0.2:
-    resolution: {integrity: sha512-3W4f5tDUra+pA+FzgugqL2pRimUTDJWKr7BINqOpkZrC0uYI0NIc0/JFgBROCU07HR6GieA5m3/rsPIhDmCXTQ==}
+  /@eslint/eslintrc/2.0.3:
+    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4
-      espree: 9.5.1
+      espree: 9.5.2
       globals: 13.20.0
       ignore: 5.2.4
       import-fresh: 3.3.0
@@ -544,8 +568,8 @@ packages:
       - supports-color
     dev: false
 
-  /@eslint/js/8.39.0:
-    resolution: {integrity: sha512-kf9RB0Fg7NZfap83B3QOqOGg9QmD9yBudqQXzzOtn3i4y7ZUXe5ONeW34Gwi+TxhH4mvj72R1Zc300KUMa9Bng==}
+  /@eslint/js/8.40.0:
+    resolution: {integrity: sha512-ElyB54bJIhXQYVKjDSvCkPO1iU1tSAeVQJbllWJq1XQSmmA4dgFk8CbiBGpiOPxleE48vDogxCtmMYku4HSVLA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -632,7 +656,7 @@ packages:
       body-parser: 1.20.2
       busboy: 1.6.0
       commonmark: 0.30.0
-      deep-equal: 2.2.0
+      deep-equal: 2.2.1
       express: 4.18.2
       express-promise-router: 4.1.1_express@4.18.2
       glob: 8.1.0
@@ -645,7 +669,7 @@ packages:
       underscore: 1.13.6
       winston: 3.8.2
       xml2js: 0.4.23
-      yargs: 17.7.1
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@types/express'
       - debug
@@ -687,6 +711,13 @@ packages:
     resolution: {integrity: sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==}
     engines: {node: '>=8.0.0'}
     dev: false
+
+  /@pkgjs/parseargs/0.11.0:
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /@sinonjs/commons/1.8.6:
     resolution: {integrity: sha512-Ky+XkAkqPZSm3NLBeUng77EBQl3cmeJhITaGHdYH8kjVB+aun3S4XBRti2zt17mtt0mIUDiNxYeoJm6drVvBJQ==}
@@ -749,11 +780,11 @@ packages:
   /@types/chai-as-promised/7.1.5:
     resolution: {integrity: sha512-jStwss93SITGBwt/niYrkf2C+/1KTeZCZl1LaeezTlqppAKeoQC7jxyqYuP72sxBGKCIbw7oHgbYssIRzT5FCQ==}
     dependencies:
-      '@types/chai': 4.3.4
+      '@types/chai': 4.3.5
     dev: false
 
-  /@types/chai/4.3.4:
-    resolution: {integrity: sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==}
+  /@types/chai/4.3.5:
+    resolution: {integrity: sha512-mEo1sAde+UCE6b2hxn332f1g1E8WfYRu6p5SvTKr2ZKC1f7gFJXk4h5PyGP9Dt6gCaG8y8XhwnXWC6Iy2cmBng==}
     dev: false
 
   /@types/cookie/0.4.1:
@@ -763,7 +794,7 @@ packages:
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     dev: false
 
   /@types/eslint-scope/3.7.4:
@@ -787,13 +818,13 @@ packages:
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     dev: false
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     dev: false
 
   /@types/js-yaml/3.12.1:
@@ -823,12 +854,12 @@ packages:
   /@types/node-fetch/2.6.3:
     resolution: {integrity: sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
       form-data: 3.0.1
     dev: false
 
-  /@types/node/18.16.0:
-    resolution: {integrity: sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ==}
+  /@types/node/18.16.5:
+    resolution: {integrity: sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA==}
     dev: false
 
   /@types/prettier/1.19.1:
@@ -860,13 +891,13 @@ packages:
   /@types/tunnel/0.0.1:
     resolution: {integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     dev: false
 
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     dev: false
 
   /@types/xmlbuilder/0.0.34:
@@ -887,12 +918,12 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.59.0_11cfb5a4cf513b8198497b14ca70f9ec:
-    resolution: {integrity: sha512-p0QgrEyrxAWBecR56gyn3wkG15TJdI//eetInP3zYRewDh0XS+DhB3VUAd3QqvziFsfaQIoIuZMxZRB7vXYaYw==}
+  /@typescript-eslint/eslint-plugin/5.59.2_bd146c8f07b05803d57de58a9f6edcff:
+    resolution: {integrity: sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -902,13 +933,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.59.0_eslint@8.39.0+typescript@5.0.4
-      '@typescript-eslint/scope-manager': 5.59.0
-      '@typescript-eslint/type-utils': 5.59.0_eslint@8.39.0+typescript@5.0.4
-      '@typescript-eslint/utils': 5.59.0_eslint@8.39.0+typescript@5.0.4
+      '@eslint-community/regexpp': 4.5.1
+      '@typescript-eslint/parser': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/type-utils': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/utils': 5.59.2_eslint@8.40.0+typescript@5.0.4
       debug: 4.3.4
-      eslint: 8.39.0
+      eslint: 8.40.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -919,8 +950,8 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.59.0_eslint@8.39.0+typescript@5.0.4:
-    resolution: {integrity: sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==}
+  /@typescript-eslint/parser/5.59.2_eslint@8.40.0+typescript@5.0.4:
+    resolution: {integrity: sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -929,26 +960,26 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.59.0
-      '@typescript-eslint/types': 5.59.0
-      '@typescript-eslint/typescript-estree': 5.59.0_typescript@5.0.4
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/typescript-estree': 5.59.2_typescript@5.0.4
       debug: 4.3.4
-      eslint: 8.39.0
+      eslint: 8.40.0
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/scope-manager/5.59.0:
-    resolution: {integrity: sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==}
+  /@typescript-eslint/scope-manager/5.59.2:
+    resolution: {integrity: sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.0
-      '@typescript-eslint/visitor-keys': 5.59.0
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/visitor-keys': 5.59.2
     dev: false
 
-  /@typescript-eslint/type-utils/5.59.0_eslint@8.39.0+typescript@5.0.4:
-    resolution: {integrity: sha512-d/B6VSWnZwu70kcKQSCqjcXpVH+7ABKH8P1KNn4K7j5PXXuycZTPXF44Nui0TEm6rbWGi8kc78xRgOC4n7xFgA==}
+  /@typescript-eslint/type-utils/5.59.2_eslint@8.40.0+typescript@5.0.4:
+    resolution: {integrity: sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -957,23 +988,23 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.0_typescript@5.0.4
-      '@typescript-eslint/utils': 5.59.0_eslint@8.39.0+typescript@5.0.4
+      '@typescript-eslint/typescript-estree': 5.59.2_typescript@5.0.4
+      '@typescript-eslint/utils': 5.59.2_eslint@8.40.0+typescript@5.0.4
       debug: 4.3.4
-      eslint: 8.39.0
+      eslint: 8.40.0
       tsutils: 3.21.0_typescript@5.0.4
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/types/5.59.0:
-    resolution: {integrity: sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==}
+  /@typescript-eslint/types/5.59.2:
+    resolution: {integrity: sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.59.0_typescript@5.0.4:
-    resolution: {integrity: sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==}
+  /@typescript-eslint/typescript-estree/5.59.2_typescript@5.0.4:
+    resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -981,8 +1012,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.59.0
-      '@typescript-eslint/visitor-keys': 5.59.0
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/visitor-keys': 5.59.2
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -993,19 +1024,19 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.59.0_eslint@8.39.0+typescript@5.0.4:
-    resolution: {integrity: sha512-GGLFd+86drlHSvPgN/el6dRQNYYGOvRSDVydsUaQluwIW3HvbXuxyuD5JETvBt/9qGYe+lOrDk6gRrWOHb/FvA==}
+  /@typescript-eslint/utils/5.59.2_eslint@8.40.0+typescript@5.0.4:
+    resolution: {integrity: sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.39.0
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.40.0
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.59.0
-      '@typescript-eslint/types': 5.59.0
-      '@typescript-eslint/typescript-estree': 5.59.0_typescript@5.0.4
-      eslint: 8.39.0
+      '@typescript-eslint/scope-manager': 5.59.2
+      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/typescript-estree': 5.59.2_typescript@5.0.4
+      eslint: 8.40.0
       eslint-scope: 5.1.1
       semver: 7.5.0
     transitivePeerDependencies:
@@ -1013,55 +1044,55 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/visitor-keys/5.59.0:
-    resolution: {integrity: sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==}
+  /@typescript-eslint/visitor-keys/5.59.2:
+    resolution: {integrity: sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.0
-      eslint-visitor-keys: 3.4.0
+      '@typescript-eslint/types': 5.59.2
+      eslint-visitor-keys: 3.4.1
     dev: false
 
-  /@typespec/compiler/0.43.0:
-    resolution: {integrity: sha512-VSOEuD8UMgySm8YhZ/9rvoZjyp8dp9y8arKjUjt3+uBnNQr8ZgbRbOBcxbauJuRYEO9i6dRvunf9rvLIvXyEEQ==}
+  /@typespec/compiler/0.44.0-dev.21:
+    resolution: {integrity: sha512-j5eadBDuebOmb9Q5j6214Vr7i1DQrsahN7xl+wZ9LDKH6THr5g8h9RPVPibRThHLAe+hFwKnvObB8EtHwY+CjQ==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.18.6
-      ajv: 8.11.2
+      '@babel/code-frame': 7.21.4
+      ajv: 8.12.0
       change-case: 4.1.2
       globby: 13.1.4
       js-yaml: 4.1.0
-      mkdirp: 1.0.4
+      mkdirp: 2.1.6
       mustache: 4.2.0
       node-fetch: 3.2.8
       node-watch: 0.7.3
       picocolors: 1.0.0
       prettier: 2.8.8
       prompts: 2.4.2
-      vscode-languageserver: 8.0.2
+      vscode-languageserver: 8.1.0
       vscode-languageserver-textdocument: 1.0.8
-      yargs: 17.6.2
+      yargs: 17.7.2
     dev: false
 
-  /@typespec/http/0.43.1_@typespec+compiler@0.43.0:
-    resolution: {integrity: sha512-tgXrEYmhW6xPMfi57sgfEIA+6N4QIVBqBmvU2s0xouAuqdmYWsulcJjewMHkzOdj0agRyEjNEfQLWkCTIQVl4A==}
+  /@typespec/http/0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21:
+    resolution: {integrity: sha512-beAC6UCdZJIBLL2HkzfGB8aaV7V122/TFvLV+6rb1XNksiCEfjtIHNNxr815yTZFarNxf56rJFsgaUkjZ195vg==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.43.0
+      '@typespec/compiler': '>=0.43.0'
     dependencies:
-      '@typespec/compiler': 0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
     dev: false
 
-  /@typespec/lint/0.43.0_@typespec+compiler@0.43.0:
+  /@typespec/lint/0.43.0_@typespec+compiler@0.44.0-dev.21:
     resolution: {integrity: sha512-Hs4zEws8+ZOu3wuN32dmAKOkvlmQzdpkd96Wyx8tT4j3aovf1APqlGjozgp9DZcKxpT+jAxpS+GLpjBTZEeUnQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@typespec/compiler': ~0.43.0
     dependencies:
-      '@typespec/compiler': 0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
     dev: false
 
-  /@typespec/openapi/0.43.0_402126a56c0aec99e52d5c3ab81bd82d:
+  /@typespec/openapi/0.43.0_89e44fee31152018c55c857855680979:
     resolution: {integrity: sha512-WDQopOJBGsUoztpNUtoYJ5gEJac0W5g8JGKqMaAmAjJ47Cq/BJh2NCrxJKZeFEhKI98zz13IQmRbcf1zmSLPJw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -1069,12 +1100,12 @@ packages:
       '@typespec/http': ~0.43.0
       '@typespec/rest': ~0.43.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
     dev: false
 
-  /@typespec/openapi3/0.43.0_5a2c39ff95ddcf9cf828ada1ad35ba9c:
+  /@typespec/openapi3/0.43.0_9631a837fbe64cdd0bafbe821aa3c073:
     resolution: {integrity: sha512-fzYg/voRLhN932xrZkCXlg8wGyvS0kLFmUVlxE3ROLkRVvKXLkC6o3QAkdevzm0V1O17tB9ekkvHJYaeFpXziQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -1084,11 +1115,11 @@ packages:
       '@typespec/rest': ~0.43.0
       '@typespec/versioning': ~0.43.0
     dependencies:
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/openapi': 0.43.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
-      '@typespec/versioning': 0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/openapi': 0.43.0_89e44fee31152018c55c857855680979
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/versioning': 0.44.0-dev.7
       js-yaml: 4.1.0
     dev: false
 
@@ -1098,20 +1129,20 @@ packages:
       prettier: 2.8.8
     dev: false
 
-  /@typespec/rest/0.43.0_@typespec+compiler@0.43.0:
-    resolution: {integrity: sha512-de+muAnsANmUtcLsBagrRxdylS4dLsEoPGpz7TQe52pBkog+bbtPTQqRM5TqwxwK//94yS3dEMNynFXE1Yey8Q==}
+  /@typespec/rest/0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21:
+    resolution: {integrity: sha512-Ti5NIHGJAzHFbZPDTBpeQ/luO9rq9h8hETxc66F0hUTBVymblUoA8f3n2BZCpIh+QEGqSCvmTWMZHPaUXhtwoQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
-      '@typespec/compiler': ~0.43.0
+      '@typespec/compiler': '>=0.43.0'
     dependencies:
-      '@typespec/compiler': 0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
     dev: false
 
-  /@typespec/versioning/0.43.0:
-    resolution: {integrity: sha512-YxU9QPH05wF/8k0BjyR1pFTxA5qWxjeq8RyQtwFf+smz1pFbFLf7RmqEUZgXChC4H+7cwsIC8eLefx4ukObF9Q==}
+  /@typespec/versioning/0.44.0-dev.7:
+    resolution: {integrity: sha512-SvIXLiesoIH3BllS3+zWCMp4cwlbwqZw2B/rCqu+I+zQmMY9fTi3EDS8cInBNZf1mjARvjvoe/EFdZYt8ucGSA==}
     engines: {node: '>=16.0.0'}
     dependencies:
-      '@typespec/compiler': 0.43.0
+      '@typespec/compiler': 0.44.0-dev.21
     dev: false
 
   /@ungap/promise-all-settled/1.1.2:
@@ -1224,14 +1255,14 @@ packages:
       '@xtuc/long': 4.2.2
     dev: false
 
-  /@webpack-cli/configtest/1.2.0_4928b0a7794957798db49b2ad8123ccd:
+  /@webpack-cli/configtest/1.2.0_ab3e3f9699f147a056afc453e760bcda:
     resolution: {integrity: sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==}
     peerDependencies:
       webpack: 4.x.x || 5.x.x
       webpack-cli: 4.x.x
     dependencies:
-      webpack: 5.80.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_webpack@5.80.0
+      webpack: 5.82.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@5.82.0
     dev: false
 
   /@webpack-cli/info/1.5.0_webpack-cli@4.10.0:
@@ -1240,7 +1271,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.10.0_webpack@5.80.0
+      webpack-cli: 4.10.0_webpack@5.82.0
     dev: false
 
   /@webpack-cli/serve/1.7.0_webpack-cli@4.10.0:
@@ -1252,7 +1283,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.10.0_webpack@5.80.0
+      webpack-cli: 4.10.0_webpack@5.82.0
     dev: false
 
   /@xtuc/ieee754/1.2.0:
@@ -1333,17 +1364,8 @@ packages:
       uri-js: 4.4.1
     dev: false
 
-  /ajv/8.11.0:
-    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==}
-    dependencies:
-      fast-deep-equal: 3.1.3
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-      uri-js: 4.4.1
-    dev: false
-
-  /ajv/8.11.2:
-    resolution: {integrity: sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==}
+  /ajv/8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
@@ -1566,8 +1588,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001481
-      electron-to-chromium: 1.4.369
+      caniuse-lite: 1.0.30001486
+      electron-to-chromium: 1.4.385
       node-releases: 2.0.10
       update-browserslist-db: 1.0.11_browserslist@4.21.5
     dev: false
@@ -1634,8 +1656,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /caniuse-lite/1.0.30001481:
-    resolution: {integrity: sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==}
+  /caniuse-lite/1.0.30001486:
+    resolution: {integrity: sha512-uv7/gXuHi10Whlj0pp5q/tsK/32J2QSqVRKQhs2j8VsDCjgyruAh/eEXHF822VqO9yT6iZKw3nRwZRSPBE9OQg==}
     dev: false
 
   /capital-case/1.0.4:
@@ -1996,9 +2018,10 @@ packages:
       type-detect: 4.0.8
     dev: false
 
-  /deep-equal/2.2.0:
-    resolution: {integrity: sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==}
+  /deep-equal/2.2.1:
+    resolution: {integrity: sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==}
     dependencies:
+      array-buffer-byte-length: 1.0.0
       call-bind: 1.0.2
       es-get-iterator: 1.1.3
       get-intrinsic: 1.2.0
@@ -2121,8 +2144,8 @@ packages:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
-  /electron-to-chromium/1.4.369:
-    resolution: {integrity: sha512-LfxbHXdA/S+qyoTEA4EbhxGjrxx7WK2h6yb5K2v0UCOufUKX+VZaHbl3svlzZfv9sGseym/g3Ne4DpsgRULmqg==}
+  /electron-to-chromium/1.4.385:
+    resolution: {integrity: sha512-L9zlje9bIw0h+CwPQumiuVlfMcV4boxRjFIWDcLfFqTZNbkwOExBzfmswytHawObQX4OUhtNv8gIiB21kOurIg==}
     dev: false
 
   /emoji-regex/8.0.0:
@@ -2154,13 +2177,13 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /engine.io/6.4.1:
-    resolution: {integrity: sha512-JFYQurD/nbsA5BSPmbaOSLa3tSVj8L6o4srSwXXY3NqE+gGUNmmPTbhn8tjzcCtSqhFgIeqef81ngny8JM25hw==}
+  /engine.io/6.4.2:
+    resolution: {integrity: sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==}
     engines: {node: '>=10.0.0'}
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -2313,20 +2336,20 @@ packages:
       estraverse: 5.3.0
     dev: false
 
-  /eslint-visitor-keys/3.4.0:
-    resolution: {integrity: sha512-HPpKPUBQcAsZOsHAFwTtIKcYlCje62XB7SEAcxjtmW6TD1WVpkS6i6/hOVtTZIl4zGj/mBqpFVGvaDneik+VoQ==}
+  /eslint-visitor-keys/3.4.1:
+    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /eslint/8.39.0:
-    resolution: {integrity: sha512-mwiok6cy7KTW7rBpo05k6+p4YVZByLNjAZ/ACB9DRCu4YDRwjXI01tWHp6KAUWelsBetTxKK/2sHB0vdS8Z2Og==}
+  /eslint/8.40.0:
+    resolution: {integrity: sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0_eslint@8.39.0
-      '@eslint-community/regexpp': 4.5.0
-      '@eslint/eslintrc': 2.0.2
-      '@eslint/js': 8.39.0
+      '@eslint-community/eslint-utils': 4.4.0_eslint@8.40.0
+      '@eslint-community/regexpp': 4.5.1
+      '@eslint/eslintrc': 2.0.3
+      '@eslint/js': 8.40.0
       '@humanwhocodes/config-array': 0.11.8
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
@@ -2337,8 +2360,8 @@ packages:
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.0
-      espree: 9.5.1
+      eslint-visitor-keys: 3.4.1
+      espree: 9.5.2
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
@@ -2367,13 +2390,13 @@ packages:
       - supports-color
     dev: false
 
-  /espree/9.5.1:
-    resolution: {integrity: sha512-5yxtHSZXRSW5pvv3hAlXM5+/Oswi1AUFqBmbibKb5s6bp3rGIDkyXU6xCoyuuLhijr4SFwPrXRoZjz0AZDN9tg==}
+  /espree/9.5.2:
+    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       acorn: 8.8.2
       acorn-jsx: 5.3.2_acorn@8.8.2
-      eslint-visitor-keys: 3.4.0
+      eslint-visitor-keys: 3.4.1
     dev: false
 
   /esquery/1.5.0:
@@ -2647,6 +2670,14 @@ packages:
       is-callable: 1.2.7
     dev: false
 
+  /foreground-child/3.1.1:
+    resolution: {integrity: sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==}
+    engines: {node: '>=14'}
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.0.1
+    dev: false
+
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: false
@@ -2810,6 +2841,18 @@ packages:
 
   /glob-to-regexp/0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+    dev: false
+
+  /glob/10.2.2:
+    resolution: {integrity: sha512-Xsa0BcxIC6th9UwNjZkhrMtNo/MnyRL8jGCP+uEwhA5oFOCY1f2s1/oNKY47xQ0Bg5nkjsfAEIej1VeH62bDDQ==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+    dependencies:
+      foreground-child: 3.1.1
+      jackspeak: 2.1.1
+      minimatch: 9.0.0
+      minipass: 5.0.0
+      path-scurry: 1.7.0
     dev: false
 
   /glob/7.2.0:
@@ -3360,11 +3403,20 @@ packages:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: false
 
+  /jackspeak/2.1.1:
+    resolution: {integrity: sha512-juf9stUEwUaILepraGOWIJTLwg48bUnBmRqd2ln2Os1sW987zeoj/hzhbvRB95oMuS2ZTpjULmdwHNX4rzZIZw==}
+    engines: {node: '>=14'}
+    dependencies:
+      cliui: 8.0.1
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+    dev: false
+
   /jest-worker/27.5.1:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -3678,6 +3730,11 @@ packages:
       yallist: 4.0.0
     dev: false
 
+  /lru-cache/9.1.1:
+    resolution: {integrity: sha512-65/Jky17UwSb0BuB9V+MyDpsOtXKmYwzhyl+cOa9XUiI4uV2Ouy/2voFP3+al0BjZbJgMBD8FojMpAf+Z+qn4A==}
+    engines: {node: 14 || >=16.14}
+    dev: false
+
   /make-error/1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
     dev: false
@@ -3766,8 +3823,20 @@ packages:
       brace-expansion: 2.0.1
     dev: false
 
+  /minimatch/9.0.0:
+    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist/1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+    dev: false
+
+  /minipass/5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
     dev: false
 
   /mkdirp-classic/0.5.3:
@@ -4170,6 +4239,14 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: false
+
+  /path-scurry/1.7.0:
+    resolution: {integrity: sha512-UkZUeDjczjYRE495+9thsgcVgsaCPkaw80slmfVFgllxY+IO8ubTsOpFVjDPROBqJdHfVPUFRHPBV/WciOVfWg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      lru-cache: 9.1.1
+      minipass: 5.0.0
     dev: false
 
   /path-to-regexp/0.1.7:
@@ -4692,6 +4769,11 @@ packages:
       object-inspect: 1.12.3
     dev: false
 
+  /signal-exit/4.0.1:
+    resolution: {integrity: sha512-uUWsN4aOxJAS8KOuf3QMyFtgm1pkb6I+KRZbRF/ghdf5T7sM+B1lLLzPDxswUjkmHyxQAVzEgG35E3NzDM9GVw==}
+    engines: {node: '>=14'}
+    dev: false
+
   /simple-swizzle/0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
     dependencies:
@@ -4756,7 +4838,7 @@ packages:
       accepts: 1.3.8
       base64id: 2.0.0
       debug: 4.3.4
-      engine.io: 6.4.1
+      engine.io: 6.4.2
       socket.io-adapter: 2.5.2
       socket.io-parser: 4.2.2
     transitivePeerDependencies:
@@ -4765,7 +4847,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /source-map-loader/1.1.3_webpack@5.80.0:
+  /source-map-loader/1.1.3_webpack@5.82.0:
     resolution: {integrity: sha512-6YHeF+XzDOrT/ycFJNI53cgEsp/tHTMl37hi7uVyqFAlTXW109JazaQCkbc+jjoL2637qkH1amLi+JzrIpt5lA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -4776,7 +4858,7 @@ packages:
       loader-utils: 2.0.4
       schema-utils: 3.1.2
       source-map: 0.6.1
-      webpack: 5.80.0_webpack-cli@4.10.0
+      webpack: 5.82.0_webpack-cli@4.10.0
       whatwg-mimetype: 2.3.0
     dev: false
 
@@ -5002,8 +5084,8 @@ packages:
       readable-stream: 3.6.2
     dev: false
 
-  /terser-webpack-plugin/5.3.7_webpack@5.80.0:
-    resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
+  /terser-webpack-plugin/5.3.8_webpack@5.82.0:
+    resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -5023,7 +5105,7 @@ packages:
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.1
-      webpack: 5.80.0_webpack-cli@4.10.0
+      webpack: 5.82.0_webpack-cli@4.10.0
     dev: false
 
   /terser/5.17.1:
@@ -5101,7 +5183,7 @@ packages:
       code-block-writer: 11.0.3
     dev: false
 
-  /ts-node/10.9.1_315f8af43b3e9c6a6037dae9fcf08bf8:
+  /ts-node/10.9.1_bf7bb2a4ab07bfc9387594c5b721df1e:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -5120,7 +5202,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -5362,31 +5444,31 @@ packages:
     engines: {node: '>=4.0.0 || >=6.0.0'}
     dev: false
 
-  /vscode-jsonrpc/8.0.2:
-    resolution: {integrity: sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==}
+  /vscode-jsonrpc/8.1.0:
+    resolution: {integrity: sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==}
     engines: {node: '>=14.0.0'}
     dev: false
 
-  /vscode-languageserver-protocol/3.17.2:
-    resolution: {integrity: sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==}
+  /vscode-languageserver-protocol/3.17.3:
+    resolution: {integrity: sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==}
     dependencies:
-      vscode-jsonrpc: 8.0.2
-      vscode-languageserver-types: 3.17.2
+      vscode-jsonrpc: 8.1.0
+      vscode-languageserver-types: 3.17.3
     dev: false
 
   /vscode-languageserver-textdocument/1.0.8:
     resolution: {integrity: sha512-1bonkGqQs5/fxGT5UchTgjGVnfysL0O8v1AYMBjqTbWQTFn721zaPGDYFkOKtfDgFiSgXM3KwaG3FMGfW4Ed9Q==}
     dev: false
 
-  /vscode-languageserver-types/3.17.2:
-    resolution: {integrity: sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==}
+  /vscode-languageserver-types/3.17.3:
+    resolution: {integrity: sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==}
     dev: false
 
-  /vscode-languageserver/8.0.2:
-    resolution: {integrity: sha512-bpEt2ggPxKzsAOZlXmCJ50bV7VrxwCS5BI4+egUmure/oI/t4OlFzi/YNtVvY24A2UDOZAgwFGgnZPwqSJubkA==}
+  /vscode-languageserver/8.1.0:
+    resolution: {integrity: sha512-eUt8f1z2N2IEUDBsKaNapkz7jl5QpskN2Y0G01T/ItMxBxw1fJwvtySGB9QMecatne8jFIWJGWI61dWjyTLQsw==}
     hasBin: true
     dependencies:
-      vscode-languageserver-protocol: 3.17.2
+      vscode-languageserver-protocol: 3.17.3
     dev: false
 
   /wait-port/0.2.14:
@@ -5418,7 +5500,7 @@ packages:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: false
 
-  /webpack-cli/4.10.0_webpack@5.80.0:
+  /webpack-cli/4.10.0_webpack@5.82.0:
     resolution: {integrity: sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -5439,7 +5521,7 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0_4928b0a7794957798db49b2ad8123ccd
+      '@webpack-cli/configtest': 1.2.0_ab3e3f9699f147a056afc453e760bcda
       '@webpack-cli/info': 1.5.0_webpack-cli@4.10.0
       '@webpack-cli/serve': 1.7.0_webpack-cli@4.10.0
       colorette: 2.0.20
@@ -5449,7 +5531,7 @@ packages:
       import-local: 3.1.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.80.0_webpack-cli@4.10.0
+      webpack: 5.82.0_webpack-cli@4.10.0
       webpack-merge: 5.8.0
     dev: false
 
@@ -5458,7 +5540,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       clone-deep: 4.0.1
-      wildcard: 2.0.0
+      wildcard: 2.0.1
     dev: false
 
   /webpack-sources/3.2.3:
@@ -5466,8 +5548,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: false
 
-  /webpack/5.80.0_webpack-cli@4.10.0:
-    resolution: {integrity: sha512-OIMiq37XK1rWO8mH9ssfFKZsXg4n6klTEDL7S8/HqbAOBBaiy8ABvXvz0dDCXeEF9gqwxSvVk611zFPjS8hJxA==}
+  /webpack/5.82.0_webpack-cli@4.10.0:
+    resolution: {integrity: sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -5497,9 +5579,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.7_webpack@5.80.0
+      terser-webpack-plugin: 5.3.8_webpack@5.82.0
       watchpack: 2.4.0
-      webpack-cli: 4.10.0_webpack@5.80.0
+      webpack-cli: 4.10.0_webpack@5.82.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
       - '@swc/core'
@@ -5564,8 +5646,8 @@ packages:
       isexe: 2.0.0
     dev: false
 
-  /wildcard/2.0.0:
-    resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+  /wildcard/2.0.1:
+    resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
     dev: false
 
   /winston-transport/4.5.0:
@@ -5709,21 +5791,8 @@ packages:
       yargs-parser: 20.2.4
     dev: false
 
-  /yargs/17.6.2:
-    resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-    dev: false
-
-  /yargs/17.7.1:
-    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
+  /yargs/17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
@@ -5759,15 +5828,15 @@ packages:
     dependencies:
       '@types/fs-extra': 8.1.2
       '@types/lodash': 4.14.194
-      '@types/node': 18.16.0
-      eslint: 8.39.0
+      '@types/node': 18.16.5
+      eslint: 8.40.0
       fs-extra: 10.1.0
       handlebars: 4.7.7
       lodash: 4.17.21
       prettier: 2.7.1
       rimraf: 3.0.2
       ts-morph: 15.1.0
-      ts-node: 10.9.1_315f8af43b3e9c6a6037dae9fcf08bf8
+      ts-node: 10.9.1_bf7bb2a4ab07bfc9387594c5b721df1e
       typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -5783,7 +5852,7 @@ packages:
       '@autorest/codemodel': 4.19.3
       '@autorest/extension-base': 3.5.1
       '@autorest/testmodeler': 2.5.1
-      '@azure-rest/core-client': 1.1.2
+      '@azure-rest/core-client': 1.1.3
       '@azure-tools/codegen': 2.9.2
       '@azure-tools/test-recorder': 3.0.0
       '@azure/abort-controller': 1.1.0
@@ -5791,27 +5860,27 @@ packages:
       '@azure/core-client': 1.7.2
       '@azure/core-http': 1.2.6
       '@azure/core-http-compat': 1.3.0
-      '@azure/core-lro': 2.5.2
+      '@azure/core-lro': 2.5.3
       '@azure/core-paging': 1.5.0
       '@azure/core-rest-pipeline': 1.10.3
       '@azure/core-tracing': 1.0.1
-      '@azure/core-util': 1.3.1
+      '@azure/core-util': 1.3.2
       '@azure/core-xml': 1.3.3
       '@azure/logger': 1.0.4
       '@microsoft.azure/autorest.testserver': 3.3.46
-      '@types/chai': 4.3.4
+      '@types/chai': 4.3.5
       '@types/chai-as-promised': 7.1.5
       '@types/fs-extra': 9.0.13
       '@types/js-yaml': 3.12.1
       '@types/lodash': 4.14.194
       '@types/mocha': 5.2.7
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
       '@types/prettier': 1.19.1
       '@types/sinon': 10.0.14
       '@types/xmlbuilder': 0.0.34
       '@types/yargs': 17.0.24
-      '@typescript-eslint/eslint-plugin': 5.59.0_11cfb5a4cf513b8198497b14ca70f9ec
-      '@typescript-eslint/parser': 5.59.0_eslint@8.39.0+typescript@5.0.4
+      '@typescript-eslint/eslint-plugin': 5.59.2_bd146c8f07b05803d57de58a9f6edcff
+      '@typescript-eslint/parser': 5.59.2_eslint@8.40.0+typescript@5.0.4
       autorest: 3.6.3
       buffer: 6.0.3
       chai: 4.3.7
@@ -5819,7 +5888,7 @@ packages:
       chalk: 4.1.2
       directory-tree: 2.3.1
       dotenv: 16.0.3
-      eslint: 8.39.0
+      eslint: 8.40.0
       fs-extra: 11.1.1
       handlebars: 4.7.7
       karma: 6.4.2
@@ -5837,16 +5906,16 @@ packages:
       puppeteer: 3.3.0
       rimraf: 3.0.2
       sinon: 10.0.0
-      source-map-loader: 1.1.3_webpack@5.80.0
+      source-map-loader: 1.1.3_webpack@5.82.0
       source-map-support: 0.5.21
       ts-morph: 15.1.0
       ts-node: 8.10.2_typescript@5.0.4
       tslib: 2.5.0
       typescript: 5.0.4
       wait-port: 0.2.14
-      webpack: 5.80.0_webpack-cli@4.10.0
-      webpack-cli: 4.10.0_webpack@5.80.0
-      yargs: 17.7.1
+      webpack: 5.82.0_webpack-cli@4.10.0
+      webpack-cli: 4.10.0_webpack@5.82.0
+      yargs: 17.7.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@types/express'
@@ -5868,18 +5937,18 @@ packages:
     name: '@rush-temp/typespec-test'
     version: 0.0.0
     dependencies:
-      '@azure-tools/typespec-autorest': 0.29.0_dc07eaa457c0d0f9d1f8446f800dd756
-      '@azure-tools/typespec-azure-core': 0.29.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@azure-tools/typespec-client-generator-core': 0.29.0_402126a56c0aec99e52d5c3ab81bd82d
+      '@azure-tools/typespec-autorest': 0.29.0_d7143a750bcdddc7e6374819f72e5be6
+      '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
+      '@azure-tools/typespec-client-generator-core': 0.29.0_89e44fee31152018c55c857855680979
       '@types/mocha': 5.2.7
-      '@types/node': 18.16.0
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/openapi': 0.43.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@typespec/openapi3': 0.43.0_5a2c39ff95ddcf9cf828ada1ad35ba9c
+      '@types/node': 18.16.5
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/openapi': 0.43.0_89e44fee31152018c55c857855680979
+      '@typespec/openapi3': 0.43.0_9631a837fbe64cdd0bafbe821aa3c073
       '@typespec/prettier-plugin-typespec': 0.43.0
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
-      '@typespec/versioning': 0.43.0
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/versioning': 0.44.0-dev.7
       prettier: 2.7.1
       ts-node: 8.10.2_typescript@5.0.4
       typescript: 5.0.4
@@ -5890,41 +5959,41 @@ packages:
     name: '@rush-temp/typespec-ts'
     version: 0.0.0
     dependencies:
-      '@azure-rest/core-client': 1.1.2
-      '@azure-tools/cadl-ranch': 0.4.6
-      '@azure-tools/cadl-ranch-expect': 0.2.3_402126a56c0aec99e52d5c3ab81bd82d
-      '@azure-tools/cadl-ranch-specs': 0.14.2_bd61dc72c94e80567c8cb3296aa23ca2
-      '@azure-tools/typespec-autorest': 0.29.0_dc07eaa457c0d0f9d1f8446f800dd756
-      '@azure-tools/typespec-azure-core': 0.29.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@azure-tools/typespec-client-generator-core': 0.29.0_402126a56c0aec99e52d5c3ab81bd82d
+      '@azure-rest/core-client': 1.1.3
+      '@azure-tools/cadl-ranch': 0.4.11_f887650a9b7d9e8e67eb12700d7b199b
+      '@azure-tools/cadl-ranch-expect': 0.2.5_89e44fee31152018c55c857855680979
+      '@azure-tools/cadl-ranch-specs': 0.14.8_d47b450dae1ba437bd5fb0d162a989ac
+      '@azure-tools/typespec-autorest': 0.29.0_d7143a750bcdddc7e6374819f72e5be6
+      '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
+      '@azure-tools/typespec-client-generator-core': 0.29.0_89e44fee31152018c55c857855680979
       '@azure/core-auth': 1.4.0
-      '@azure/core-lro': 2.5.2
+      '@azure/core-lro': 2.5.3
       '@azure/core-paging': 1.5.0
       '@azure/core-rest-pipeline': 1.10.3
-      '@types/chai': 4.3.4
+      '@types/chai': 4.3.5
       '@types/fs-extra': 9.0.13
       '@types/mocha': 9.1.1
-      '@types/node': 18.16.0
+      '@types/node': 18.16.5
       '@types/prettier': 2.7.2
-      '@typescript-eslint/eslint-plugin': 5.59.0_11cfb5a4cf513b8198497b14ca70f9ec
-      '@typescript-eslint/parser': 5.59.0_eslint@8.39.0+typescript@5.0.4
-      '@typespec/compiler': 0.43.0
-      '@typespec/http': 0.43.1_@typespec+compiler@0.43.0
-      '@typespec/openapi': 0.43.0_402126a56c0aec99e52d5c3ab81bd82d
-      '@typespec/openapi3': 0.43.0_5a2c39ff95ddcf9cf828ada1ad35ba9c
-      '@typespec/rest': 0.43.0_@typespec+compiler@0.43.0
-      '@typespec/versioning': 0.43.0
+      '@typescript-eslint/eslint-plugin': 5.59.2_bd146c8f07b05803d57de58a9f6edcff
+      '@typescript-eslint/parser': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typespec/compiler': 0.44.0-dev.21
+      '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/openapi': 0.43.0_89e44fee31152018c55c857855680979
+      '@typespec/openapi3': 0.43.0_9631a837fbe64cdd0bafbe821aa3c073
+      '@typespec/rest': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
+      '@typespec/versioning': 0.44.0-dev.7
       chai: 4.3.7
       chalk: 4.1.2
       cross-env: 7.0.3
-      eslint: 8.39.0
+      eslint: 8.40.0
       fs-extra: 11.1.1
       mkdirp: 2.1.6
       mocha: 9.2.2
       prettier: 2.7.1
       rimraf: 3.0.2
       ts-morph: 15.1.0
-      ts-node: 10.9.1_315f8af43b3e9c6a6037dae9fcf08bf8
+      ts-node: 10.9.1_bf7bb2a4ab07bfc9387594c5b721df1e
       tslib: 2.5.0
       typescript: 5.0.4
     transitivePeerDependencies:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -85,7 +85,7 @@ packages:
     dependencies:
       '@azure/identity': 3.1.4
       '@azure/storage-blob': 12.14.0
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -119,8 +119,8 @@ packages:
       '@typespec/versioning': 0.44.0-dev.7
     dev: false
 
-  /@azure-tools/cadl-ranch-specs/0.14.8_d47b450dae1ba437bd5fb0d162a989ac:
-    resolution: {integrity: sha512-u09ZQ7G30d++Ted4FsRI6WqhzyzeQVXGTQZZvvlXXv981hD77eMY1pGRxseE7tvFLCDFnZycEbXGIkhM0VlT1g==}
+  /@azure-tools/cadl-ranch-specs/0.14.10_d47b450dae1ba437bd5fb0d162a989ac:
+    resolution: {integrity: sha512-BkBRnh6pI/vWoycYPxOaKNlgob1pdZPZdv5LoUovsInShS4X6YHJ58GWYSxSaAGDWMwjd2YJ9EwBY9mc9cwzfQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@azure-tools/cadl-ranch-expect': ~0.3.0
@@ -130,7 +130,7 @@ packages:
       '@typespec/rest': ~0.43.0
       '@typespec/versioning': ~0.43.0
     dependencies:
-      '@azure-tools/cadl-ranch': 0.4.11_f887650a9b7d9e8e67eb12700d7b199b
+      '@azure-tools/cadl-ranch': 0.4.13_f887650a9b7d9e8e67eb12700d7b199b
       '@azure-tools/cadl-ranch-api': 0.2.5
       '@azure-tools/cadl-ranch-expect': 0.2.5_89e44fee31152018c55c857855680979
       '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
@@ -144,8 +144,8 @@ packages:
       - supports-color
     dev: false
 
-  /@azure-tools/cadl-ranch/0.4.11_f887650a9b7d9e8e67eb12700d7b199b:
-    resolution: {integrity: sha512-Wbw9MsfeqZLifB8eeADkDvW9lD5SxvcPQXiC6c6N8HH4POTi93bmTPiyx995EVB0Q3Py0tNDMq0KBmRdsOHjyQ==}
+  /@azure-tools/cadl-ranch/0.4.13_f887650a9b7d9e8e67eb12700d7b199b:
+    resolution: {integrity: sha512-3YAUs0ErlcGLna9RO71S8rZ1lRAJ4yYWhEhpGhOXsNfz43qrn7pa/ur/u9qJxRz8kOMCXC6aAUR8C49SylOyeg==}
     engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
@@ -310,7 +310,7 @@ packages:
       '@types/node-fetch': 2.6.3
       '@types/tunnel': 0.0.1
       form-data: 3.0.1
-      node-fetch: 2.6.9
+      node-fetch: 2.6.10
       process: 0.11.10
       tough-cookie: 4.1.2
       tslib: 2.5.0
@@ -333,7 +333,7 @@ packages:
       '@types/node-fetch': 2.6.3
       '@types/tunnel': 0.0.3
       form-data: 4.0.0
-      node-fetch: 2.6.9
+      node-fetch: 2.6.10
       process: 0.11.10
       tslib: 2.5.0
       tunnel: 0.0.6
@@ -794,7 +794,7 @@ packages:
   /@types/cors/2.8.13:
     resolution: {integrity: sha512-RG8AStHlUiV5ysZQKq97copd2UmVYw3/pRMLefISZ3S1hK104Cwm7iLQ3fTKx+lsUH2CE8FlLaYeEA2LSeqYUA==}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     dev: false
 
   /@types/eslint-scope/3.7.4:
@@ -818,13 +818,13 @@ packages:
   /@types/fs-extra/8.1.2:
     resolution: {integrity: sha512-SvSrYXfWSc7R4eqnOzbQF4TZmfpNSM9FrSWLU3EUnWBuyZqNBOrv1B1JA3byUDPUl9z4Ab3jeZG2eDdySlgNMg==}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     dev: false
 
   /@types/fs-extra/9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     dev: false
 
   /@types/js-yaml/3.12.1:
@@ -854,12 +854,12 @@ packages:
   /@types/node-fetch/2.6.3:
     resolution: {integrity: sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       form-data: 3.0.1
     dev: false
 
-  /@types/node/18.16.5:
-    resolution: {integrity: sha512-seOA34WMo9KB+UA78qaJoCO20RJzZGVXQ5Sh6FWu0g/hfT44nKXnej3/tCQl7FL97idFpBhisLYCTB50S0EirA==}
+  /@types/node/18.16.6:
+    resolution: {integrity: sha512-N7KINmeB8IN3vRR8dhgHEp+YpWvGFcpDoh5XZ8jB5a00AdFKCKEyyGTOPTddUf4JqU1ZKTVxkOxakDvchNVI2Q==}
     dev: false
 
   /@types/prettier/1.19.1:
@@ -870,8 +870,8 @@ packages:
     resolution: {integrity: sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==}
     dev: false
 
-  /@types/semver/7.3.13:
-    resolution: {integrity: sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==}
+  /@types/semver/7.5.0:
+    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: false
 
   /@types/sinon/10.0.14:
@@ -891,13 +891,13 @@ packages:
   /@types/tunnel/0.0.1:
     resolution: {integrity: sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     dev: false
 
   /@types/tunnel/0.0.3:
     resolution: {integrity: sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     dev: false
 
   /@types/xmlbuilder/0.0.34:
@@ -918,12 +918,12 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
     dev: false
     optional: true
 
-  /@typescript-eslint/eslint-plugin/5.59.2_bd146c8f07b05803d57de58a9f6edcff:
-    resolution: {integrity: sha512-yVrXupeHjRxLDcPKL10sGQ/QlVrA8J5IYOEWVqk0lJaSZP7X5DfnP7Ns3cc74/blmbipQ1htFNVGsHX6wsYm0A==}
+  /@typescript-eslint/eslint-plugin/5.59.5_c813e1c8fb591eb523722dcc1beadac8:
+    resolution: {integrity: sha512-feA9xbVRWJZor+AnLNAr7A8JRWeZqHUf4T9tlP+TN04b05pFVhO5eN7/O93Y/1OUlLMHKbnJisgDURs/qvtqdg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       '@typescript-eslint/parser': ^5.0.0
@@ -934,10 +934,10 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.2_eslint@8.40.0+typescript@5.0.4
-      '@typescript-eslint/scope-manager': 5.59.2
-      '@typescript-eslint/type-utils': 5.59.2_eslint@8.40.0+typescript@5.0.4
-      '@typescript-eslint/utils': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/parser': 5.59.5_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/scope-manager': 5.59.5
+      '@typescript-eslint/type-utils': 5.59.5_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/utils': 5.59.5_eslint@8.40.0+typescript@5.0.4
       debug: 4.3.4
       eslint: 8.40.0
       grapheme-splitter: 1.0.4
@@ -950,8 +950,8 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.59.2_eslint@8.40.0+typescript@5.0.4:
-    resolution: {integrity: sha512-uq0sKyw6ao1iFOZZGk9F8Nro/8+gfB5ezl1cA06SrqbgJAt0SRoFhb9pXaHvkrxUpZaoLxt8KlovHNk8Gp6/HQ==}
+  /@typescript-eslint/parser/5.59.5_eslint@8.40.0+typescript@5.0.4:
+    resolution: {integrity: sha512-NJXQC4MRnF9N9yWqQE2/KLRSOLvrrlZb48NGVfBa+RuPMN6B7ZcK5jZOvhuygv4D64fRKnZI4L4p8+M+rfeQuw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -960,9 +960,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.59.2
-      '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2_typescript@5.0.4
+      '@typescript-eslint/scope-manager': 5.59.5
+      '@typescript-eslint/types': 5.59.5
+      '@typescript-eslint/typescript-estree': 5.59.5_typescript@5.0.4
       debug: 4.3.4
       eslint: 8.40.0
       typescript: 5.0.4
@@ -970,16 +970,16 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/scope-manager/5.59.2:
-    resolution: {integrity: sha512-dB1v7ROySwQWKqQ8rEWcdbTsFjh2G0vn8KUyvTXdPoyzSL6lLGkiXEV5CvpJsEe9xIdKV+8Zqb7wif2issoOFA==}
+  /@typescript-eslint/scope-manager/5.59.5:
+    resolution: {integrity: sha512-jVecWwnkX6ZgutF+DovbBJirZcAxgxC0EOHYt/niMROf8p4PwxxG32Qdhj/iIQQIuOflLjNkxoXyArkcIP7C3A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/visitor-keys': 5.59.2
+      '@typescript-eslint/types': 5.59.5
+      '@typescript-eslint/visitor-keys': 5.59.5
     dev: false
 
-  /@typescript-eslint/type-utils/5.59.2_eslint@8.40.0+typescript@5.0.4:
-    resolution: {integrity: sha512-b1LS2phBOsEy/T381bxkkywfQXkV1dWda/z0PhnIy3bC5+rQWQDS7fk9CSpcXBccPY27Z6vBEuaPBCKCgYezyQ==}
+  /@typescript-eslint/type-utils/5.59.5_eslint@8.40.0+typescript@5.0.4:
+    resolution: {integrity: sha512-4eyhS7oGym67/pSxA2mmNq7X164oqDYNnZCUayBwJZIRVvKpBCMBzFnFxjeoDeShjtO6RQBHBuwybuX3POnDqg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '*'
@@ -988,8 +988,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.2_typescript@5.0.4
-      '@typescript-eslint/utils': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/typescript-estree': 5.59.5_typescript@5.0.4
+      '@typescript-eslint/utils': 5.59.5_eslint@8.40.0+typescript@5.0.4
       debug: 4.3.4
       eslint: 8.40.0
       tsutils: 3.21.0_typescript@5.0.4
@@ -998,13 +998,13 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/types/5.59.2:
-    resolution: {integrity: sha512-LbJ/HqoVs2XTGq5shkiKaNTuVv5tTejdHgfdjqRUGdYhjW1crm/M7og2jhVskMt8/4wS3T1+PfFvL1K3wqYj4w==}
+  /@typescript-eslint/types/5.59.5:
+    resolution: {integrity: sha512-xkfRPHbqSH4Ggx4eHRIO/eGL8XL4Ysb4woL8c87YuAo8Md7AUjyWKa9YMwTL519SyDPrfEgKdewjkxNCVeJW7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.59.2_typescript@5.0.4:
-    resolution: {integrity: sha512-+j4SmbwVmZsQ9jEyBMgpuBD0rKwi9RxRpjX71Brr73RsYnEr3Lt5QZ624Bxphp8HUkSKfqGnPJp1kA5nl0Sh7Q==}
+  /@typescript-eslint/typescript-estree/5.59.5_typescript@5.0.4:
+    resolution: {integrity: sha512-+XXdLN2CZLZcD/mO7mQtJMvCkzRfmODbeSKuMY/yXbGkzvA9rJyDY5qDYNoiz2kP/dmyAxXquL2BvLQLJFPQIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -1012,8 +1012,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/visitor-keys': 5.59.2
+      '@typescript-eslint/types': 5.59.5
+      '@typescript-eslint/visitor-keys': 5.59.5
       debug: 4.3.4
       globby: 11.1.0
       is-glob: 4.0.3
@@ -1024,18 +1024,18 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.59.2_eslint@8.40.0+typescript@5.0.4:
-    resolution: {integrity: sha512-kSuF6/77TZzyGPhGO4uVp+f0SBoYxCDf+lW3GKhtKru/L8k/Hd7NFQxyWUeY7Z/KGB2C6Fe3yf2vVi4V9TsCSQ==}
+  /@typescript-eslint/utils/5.59.5_eslint@8.40.0+typescript@5.0.4:
+    resolution: {integrity: sha512-sCEHOiw+RbyTii9c3/qN74hYDPNORb8yWCoPLmB7BIflhplJ65u2PBpdRla12e3SSTJ2erRkPjz7ngLHhUegxA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0_eslint@8.40.0
       '@types/json-schema': 7.0.11
-      '@types/semver': 7.3.13
-      '@typescript-eslint/scope-manager': 5.59.2
-      '@typescript-eslint/types': 5.59.2
-      '@typescript-eslint/typescript-estree': 5.59.2_typescript@5.0.4
+      '@types/semver': 7.5.0
+      '@typescript-eslint/scope-manager': 5.59.5
+      '@typescript-eslint/types': 5.59.5
+      '@typescript-eslint/typescript-estree': 5.59.5_typescript@5.0.4
       eslint: 8.40.0
       eslint-scope: 5.1.1
       semver: 7.5.0
@@ -1044,11 +1044,11 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/visitor-keys/5.59.2:
-    resolution: {integrity: sha512-EEpsO8m3RASrKAHI9jpavNv9NlEUebV4qmF1OWxSTtKSFBpC1NCmWazDQHFivRf0O1DV11BA645yrLEVQ0/Lig==}
+  /@typescript-eslint/visitor-keys/5.59.5:
+    resolution: {integrity: sha512-qL+Oz+dbeBRTeyJTIy0eniD3uvqU7x+y1QceBismZ41hd4aBSRh8UAw4pZP0+XzLuPZmx4raNMq/I+59W2lXKA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.2
+      '@typescript-eslint/types': 5.59.5
       eslint-visitor-keys: 3.4.1
     dev: false
 
@@ -1421,7 +1421,7 @@ packages:
     dev: false
 
   /array-flatten/1.1.1:
-    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+    resolution: {integrity: sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=}
     dev: false
 
   /array-union/2.1.0:
@@ -1589,7 +1589,7 @@ packages:
     hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001486
-      electron-to-chromium: 1.4.385
+      electron-to-chromium: 1.4.387
       node-releases: 2.0.10
       update-browserslist-db: 1.0.11_browserslist@4.21.5
     dev: false
@@ -1599,7 +1599,7 @@ packages:
     dev: false
 
   /buffer-equal-constant-time/1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+    resolution: {integrity: sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=}
     dev: false
 
   /buffer-from/1.1.2:
@@ -1863,7 +1863,7 @@ packages:
     dev: false
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: false
 
   /connect/3.7.0:
@@ -1897,7 +1897,7 @@ packages:
     dev: false
 
   /cookie-signature/1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+    resolution: {integrity: sha1-4wOogrNCzD7oylE6eZmXNNqzriw=}
     dev: false
 
   /cookie/0.4.2:
@@ -2141,11 +2141,11 @@ packages:
     dev: false
 
   /ee-first/1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+    resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
     dev: false
 
-  /electron-to-chromium/1.4.385:
-    resolution: {integrity: sha512-L9zlje9bIw0h+CwPQumiuVlfMcV4boxRjFIWDcLfFqTZNbkwOExBzfmswytHawObQX4OUhtNv8gIiB21kOurIg==}
+  /electron-to-chromium/1.4.387:
+    resolution: {integrity: sha512-tutLf+alr1/0YqJwKPdstVvDLmxmLb5xNyDLNS0RZmenHcEYk9qKfpKDCVZEKJ00JVbnayJm1MZAbYhYDFpcOw==}
     dev: false
 
   /emoji-regex/8.0.0:
@@ -2183,7 +2183,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.13
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -2722,7 +2722,7 @@ packages:
     dev: false
 
   /fresh/0.5.2:
-    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    resolution: {integrity: sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -3416,7 +3416,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -3744,7 +3744,7 @@ packages:
     dev: false
 
   /media-typer/0.3.0:
-    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
     engines: {node: '>= 0.6'}
     dev: false
 
@@ -3754,7 +3754,7 @@ packages:
     dev: false
 
   /merge-descriptors/1.0.1:
-    resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
+    resolution: {integrity: sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=}
     dev: false
 
   /merge-stream/2.0.0:
@@ -3978,8 +3978,8 @@ packages:
     engines: {node: '>=10.5.0'}
     dev: false
 
-  /node-fetch/2.6.9:
-    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+  /node-fetch/2.6.10:
+    resolution: {integrity: sha512-5YytjUVbwzjE/BX4N62vnPPkGNxlJPwdA9/ArUc4pcM6cYS4Hinuv4VazzwjMGgnWuiQqcemOanib/5PpcsGug==}
     engines: {node: 4.x || >=6.0.0}
     peerDependencies:
       encoding: ^0.1.0
@@ -5104,12 +5104,12 @@ packages:
       jest-worker: 27.5.1
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
-      terser: 5.17.1
+      terser: 5.17.2
       webpack: 5.82.0_webpack-cli@4.10.0
     dev: false
 
-  /terser/5.17.1:
-    resolution: {integrity: sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==}
+  /terser/5.17.2:
+    resolution: {integrity: sha512-1D1aGbOF1Mnayq5PvfMc0amAR1y5Z1nrZaGCvI5xsdEfZEVte8okonk02OiaK5fw5hG1GWuuVsakOnpZW8y25A==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
@@ -5183,7 +5183,7 @@ packages:
       code-block-writer: 11.0.3
     dev: false
 
-  /ts-node/10.9.1_bf7bb2a4ab07bfc9387594c5b721df1e:
+  /ts-node/10.9.1_db3a79a79fc8d5579e2c26a002d7d47a:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
     hasBin: true
     peerDependencies:
@@ -5202,7 +5202,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.3
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3
@@ -5394,7 +5394,7 @@ packages:
     dev: false
 
   /utils-merge/1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    resolution: {integrity: sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=}
     engines: {node: '>= 0.4.0'}
     dev: false
 
@@ -5828,7 +5828,7 @@ packages:
     dependencies:
       '@types/fs-extra': 8.1.2
       '@types/lodash': 4.14.194
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       eslint: 8.40.0
       fs-extra: 10.1.0
       handlebars: 4.7.7
@@ -5836,7 +5836,7 @@ packages:
       prettier: 2.7.1
       rimraf: 3.0.2
       ts-morph: 15.1.0
-      ts-node: 10.9.1_bf7bb2a4ab07bfc9387594c5b721df1e
+      ts-node: 10.9.1_db3a79a79fc8d5579e2c26a002d7d47a
       typescript: 5.0.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -5874,13 +5874,13 @@ packages:
       '@types/js-yaml': 3.12.1
       '@types/lodash': 4.14.194
       '@types/mocha': 5.2.7
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       '@types/prettier': 1.19.1
       '@types/sinon': 10.0.14
       '@types/xmlbuilder': 0.0.34
       '@types/yargs': 17.0.24
-      '@typescript-eslint/eslint-plugin': 5.59.2_bd146c8f07b05803d57de58a9f6edcff
-      '@typescript-eslint/parser': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/eslint-plugin': 5.59.5_c813e1c8fb591eb523722dcc1beadac8
+      '@typescript-eslint/parser': 5.59.5_eslint@8.40.0+typescript@5.0.4
       autorest: 3.6.3
       buffer: 6.0.3
       chai: 4.3.7
@@ -5941,7 +5941,7 @@ packages:
       '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
       '@azure-tools/typespec-client-generator-core': 0.29.0_89e44fee31152018c55c857855680979
       '@types/mocha': 5.2.7
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       '@typespec/compiler': 0.44.0-dev.21
       '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
       '@typespec/openapi': 0.43.0_89e44fee31152018c55c857855680979
@@ -5960,9 +5960,9 @@ packages:
     version: 0.0.0
     dependencies:
       '@azure-rest/core-client': 1.1.3
-      '@azure-tools/cadl-ranch': 0.4.11_f887650a9b7d9e8e67eb12700d7b199b
+      '@azure-tools/cadl-ranch': 0.4.13_f887650a9b7d9e8e67eb12700d7b199b
       '@azure-tools/cadl-ranch-expect': 0.2.5_89e44fee31152018c55c857855680979
-      '@azure-tools/cadl-ranch-specs': 0.14.8_d47b450dae1ba437bd5fb0d162a989ac
+      '@azure-tools/cadl-ranch-specs': 0.14.10_d47b450dae1ba437bd5fb0d162a989ac
       '@azure-tools/typespec-autorest': 0.29.0_d7143a750bcdddc7e6374819f72e5be6
       '@azure-tools/typespec-azure-core': 0.30.0-dev.27_89e44fee31152018c55c857855680979
       '@azure-tools/typespec-client-generator-core': 0.29.0_89e44fee31152018c55c857855680979
@@ -5970,13 +5970,14 @@ packages:
       '@azure/core-lro': 2.5.3
       '@azure/core-paging': 1.5.0
       '@azure/core-rest-pipeline': 1.10.3
+      '@azure/logger': 1.0.4
       '@types/chai': 4.3.5
       '@types/fs-extra': 9.0.13
       '@types/mocha': 9.1.1
-      '@types/node': 18.16.5
+      '@types/node': 18.16.6
       '@types/prettier': 2.7.2
-      '@typescript-eslint/eslint-plugin': 5.59.2_bd146c8f07b05803d57de58a9f6edcff
-      '@typescript-eslint/parser': 5.59.2_eslint@8.40.0+typescript@5.0.4
+      '@typescript-eslint/eslint-plugin': 5.59.5_c813e1c8fb591eb523722dcc1beadac8
+      '@typescript-eslint/parser': 5.59.5_eslint@8.40.0+typescript@5.0.4
       '@typespec/compiler': 0.44.0-dev.21
       '@typespec/http': 0.44.0-dev.6_@typespec+compiler@0.44.0-dev.21
       '@typespec/openapi': 0.43.0_89e44fee31152018c55c857855680979
@@ -5993,7 +5994,7 @@ packages:
       prettier: 2.7.1
       rimraf: 3.0.2
       ts-morph: 15.1.0
-      ts-node: 10.9.1_bf7bb2a4ab07bfc9387594c5b721df1e
+      ts-node: 10.9.1_db3a79a79fc8d5579e2c26a002d7d47a
       tslib: 2.5.0
       typescript: 5.0.4
     transitivePeerDependencies:

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,0 +1,4 @@
+// DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
+{
+  "pnpmShrinkwrapHash": "042b1a413b567e4a3622a04d35b225e791ad18b1"
+}

--- a/common/config/rush/repo-state.json
+++ b/common/config/rush/repo-state.json
@@ -1,4 +1,4 @@
 // DO NOT MODIFY THIS FILE MANUALLY BUT DO COMMIT IT. It is generated and used by Rush.
 {
-  "pnpmShrinkwrapHash": "042b1a413b567e4a3622a04d35b225e791ad18b1"
+  "pnpmShrinkwrapHash": "1025a8178e57f6d2c2224eab8f2ffbdf43ed1e19"
 }

--- a/common/scripts/install-run.js
+++ b/common/scripts/install-run.js
@@ -3,7 +3,11 @@
 // See the @microsoft/rush package's LICENSE file for license information.
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -79,9 +83,9 @@ function _parsePackageSpecifier(rawPackageSpecifier) {
  *
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities.copyAndTrimNpmrcFile()
  */
-function _copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath) {
-    console.log(`Transforming ${sourceNpmrcPath}`); // Verbose
-    console.log(`  --> "${targetNpmrcPath}"`);
+function _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath) {
+    logger.info(`Transforming ${sourceNpmrcPath}`); // Verbose
+    logger.info(`  --> "${targetNpmrcPath}"`);
     let npmrcFileLines = fs.readFileSync(sourceNpmrcPath).toString().split('\n');
     npmrcFileLines = npmrcFileLines.map((line) => (line || '').trim());
     const resultLines = [];
@@ -125,16 +129,16 @@ function _copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath) {
  *
  * IMPORTANT: THIS CODE SHOULD BE KEPT UP TO DATE WITH Utilities._syncNpmrc()
  */
-function _syncNpmrc(sourceNpmrcFolder, targetNpmrcFolder, useNpmrcPublish) {
+function _syncNpmrc(logger, sourceNpmrcFolder, targetNpmrcFolder, useNpmrcPublish) {
     const sourceNpmrcPath = path.join(sourceNpmrcFolder, !useNpmrcPublish ? '.npmrc' : '.npmrc-publish');
     const targetNpmrcPath = path.join(targetNpmrcFolder, '.npmrc');
     try {
         if (fs.existsSync(sourceNpmrcPath)) {
-            _copyAndTrimNpmrcFile(sourceNpmrcPath, targetNpmrcPath);
+            _copyAndTrimNpmrcFile(logger, sourceNpmrcPath, targetNpmrcPath);
         }
         else if (fs.existsSync(targetNpmrcPath)) {
             // If the source .npmrc doesn't exist and there is one in the target, delete the one in the target
-            console.log(`Deleting ${targetNpmrcPath}`); // Verbose
+            logger.info(`Deleting ${targetNpmrcPath}`); // Verbose
             fs.unlinkSync(targetNpmrcPath);
         }
     }
@@ -215,7 +219,7 @@ function _getRushTempFolder(rushCommonFolder) {
 /**
  * Resolve a package specifier to a static version
  */
-function _resolvePackageVersion(rushCommonFolder, { name, version }) {
+function _resolvePackageVersion(logger, rushCommonFolder, { name, version }) {
     if (!version) {
         version = '*'; // If no version is specified, use the latest version
     }
@@ -229,7 +233,7 @@ function _resolvePackageVersion(rushCommonFolder, { name, version }) {
         try {
             const rushTempFolder = _getRushTempFolder(rushCommonFolder);
             const sourceNpmrcFolder = path.join(rushCommonFolder, 'config', 'rush');
-            _syncNpmrc(sourceNpmrcFolder, rushTempFolder);
+            _syncNpmrc(logger, sourceNpmrcFolder, rushTempFolder);
             const npmPath = getNpmPath();
             // This returns something that looks like:
             //  @microsoft/rush@3.0.0 '3.0.0'
@@ -350,9 +354,9 @@ function _createPackageJson(packageInstallFolder, name, version) {
 /**
  * Run "npm install" in the package install folder.
  */
-function _installPackage(packageInstallFolder, name, version) {
+function _installPackage(logger, packageInstallFolder, name, version) {
     try {
-        console.log(`Installing ${name}...`);
+        logger.info(`Installing ${name}...`);
         const npmPath = getNpmPath();
         const result = childProcess.spawnSync(npmPath, ['install'], {
             stdio: 'inherit',
@@ -362,7 +366,7 @@ function _installPackage(packageInstallFolder, name, version) {
         if (result.status !== 0) {
             throw new Error('"npm install" encountered an error');
         }
-        console.log(`Successfully installed ${name}@${version}`);
+        logger.info(`Successfully installed ${name}@${version}`);
     }
     catch (e) {
         throw new Error(`Unable to install package: ${e}`);
@@ -388,7 +392,7 @@ function _writeFlagFile(packageInstallFolder) {
         throw new Error(`Unable to create installed.flag file in ${packageInstallFolder}`);
     }
 }
-function installAndRun(packageName, packageVersion, packageBinName, packageBinArgs) {
+function installAndRun(logger, packageName, packageVersion, packageBinName, packageBinArgs) {
     const rushJsonFolder = findRushJsonFolder();
     const rushCommonFolder = path.join(rushJsonFolder, 'common');
     const rushTempFolder = _getRushTempFolder(rushCommonFolder);
@@ -397,14 +401,14 @@ function installAndRun(packageName, packageVersion, packageBinName, packageBinAr
         // The package isn't already installed
         _cleanInstallFolder(rushTempFolder, packageInstallFolder);
         const sourceNpmrcFolder = path.join(rushCommonFolder, 'config', 'rush');
-        _syncNpmrc(sourceNpmrcFolder, packageInstallFolder);
+        _syncNpmrc(logger, sourceNpmrcFolder, packageInstallFolder);
         _createPackageJson(packageInstallFolder, packageName, packageVersion);
-        _installPackage(packageInstallFolder, packageName, packageVersion);
+        _installPackage(logger, packageInstallFolder, packageName, packageVersion);
         _writeFlagFile(packageInstallFolder);
     }
     const statusMessage = `Invoking "${packageBinName} ${packageBinArgs.join(' ')}"`;
     const statusMessageLine = new Array(statusMessage.length + 1).join('-');
-    console.log(os.EOL + statusMessage + os.EOL + statusMessageLine + os.EOL);
+    logger.info(os.EOL + statusMessage + os.EOL + statusMessageLine + os.EOL);
     const binPath = _getBinPath(packageInstallFolder, packageBinName);
     const binFolderPath = path.resolve(packageInstallFolder, NODE_MODULES_FOLDER_NAME, '.bin');
     // Windows environment variables are case-insensitive.  Instead of using SpawnSyncOptions.env, we need to
@@ -436,14 +440,14 @@ function installAndRun(packageName, packageVersion, packageBinName, packageBinAr
     }
 }
 exports.installAndRun = installAndRun;
-function runWithErrorAndStatusCode(fn) {
+function runWithErrorAndStatusCode(logger, fn) {
     process.exitCode = 1;
     try {
         const exitCode = fn();
         process.exitCode = exitCode;
     }
     catch (e) {
-        console.error(os.EOL + os.EOL + e.toString() + os.EOL + os.EOL);
+        logger.error(os.EOL + os.EOL + e.toString() + os.EOL + os.EOL);
     }
 }
 exports.runWithErrorAndStatusCode = runWithErrorAndStatusCode;
@@ -462,16 +466,17 @@ function _run() {
         console.log('Example: install-run.js qrcode@1.2.2 qrcode https://rushjs.io');
         process.exit(1);
     }
-    runWithErrorAndStatusCode(() => {
+    const logger = { info: console.log, error: console.error };
+    runWithErrorAndStatusCode(logger, () => {
         const rushJsonFolder = findRushJsonFolder();
         const rushCommonFolder = _ensureAndJoinPath(rushJsonFolder, 'common');
         const packageSpecifier = _parsePackageSpecifier(rawPackageSpecifier);
         const name = packageSpecifier.name;
-        const version = _resolvePackageVersion(rushCommonFolder, packageSpecifier);
+        const version = _resolvePackageVersion(logger, rushCommonFolder, packageSpecifier);
         if (packageSpecifier.version !== version) {
             console.log(`Resolved to ${name}@${version}`);
         }
-        return installAndRun(name, version, packageBinName, packageBinArgs);
+        return installAndRun(logger, name, version, packageBinName, packageBinArgs);
     });
 }
 _run();

--- a/rush.json
+++ b/rush.json
@@ -14,7 +14,7 @@
    * path segment in the "$schema" field for all your Rush config files.  This will ensure
    * correct error-underlining and tab-completion for editors such as VS Code.
    */
-  "rushVersion": "5.63.0",
+  "rushVersion": "5.79.0",
   /**
    * The next field selects which package manager should be installed and determines its version.
    * Rush installs its own local copy of the package manager to ensure that your build process
@@ -26,32 +26,7 @@
   "pnpmVersion": "6.32.3",
   // "npmVersion": "8.12.1",
   // "yarnVersion": "1.9.4",
-  /**
-   * Options that are only used when the PNPM package manager is selected
-   */
-  "pnpmOptions": {
-    /**
-     * If true, then Rush will add the "--strict-peer-dependencies" option when invoking PNPM.
-     * This causes "rush install" to fail if there are unsatisfied peer dependencies, which is
-     * an invalid state that can cause build failures or incompatible dependency versions.
-     * (For historical reasons, JavaScript package managers generally do not treat this invalid
-     * state as an error.)
-     *
-     * The default value is false to avoid legacy compatibility issues.
-     * It is strongly recommended to set strictPeerDependencies=true.
-     */
-    "strictPeerDependencies": false,
-    /**
-     * Configures the strategy used to select versions during installation.
-     *
-     * This feature requires PNPM version 3.1 or newer.  It corresponds to the "--resolution-strategy" command-line
-     * option for PNPM.  Possible values are "fast" and "fewer-dependencies".  PNPM's default is "fast", but this may
-     * be incompatible with certain packages, for example the "@types" packages from DefinitelyTyped.  Rush's default
-     * is "fewer-dependencies", which causes PNPM to avoid installing a newer version if an already installed version
-     * can be reused; this is more similar to NPM's algorithm.
-     */
-    "resolutionStrategy": "fewer-dependencies"
-  },
+
   /**
    * Older releases of the NodeJS engine may be missing features required by your system.
    * Other releases may have bugs.  In particular, the "latest" version will not be a


### PR DESCRIPTION
Step in nightly ci:

-  npm install -g @typespec/compiler@next
-  run scripts to update the pnpm-config.json
```json
"globalOverrides": {
    "@typespec/compiler": "0.44.0-dev.21",
    "@typespec/rest": "0.44.0-dev.6",
    "@typespec/http": "0.44.0-dev.6",
    "@typespec/versioning": "0.44.0-dev.7",
    "@azure-tools/typespec-azure-core": "0.30.0-dev.27"
  }
```
- rush update && rush build
- npm list
- npm run test
