### PR TITLE
Only having one cadl-ranch cases

### DIFF
--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -294,7 +294,7 @@ stages:
           - publish: $(CADL_TESTSERVER_COVERAGE_REPORT)
             artifact: CoverageReport
             displayName: "Publish coverage report"
-            condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq( variables['Agent.OS'], 'Linux' ))
+            condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq( variables['Agent.OS'], 'Linux'))
           - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
               - task: AzureCLI@2
                 displayName: "Upload to Cadl Ranch Coverage Report"

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -255,10 +255,10 @@ stages:
           - template: globals.yml
         strategy:
           matrix:
-            # macOS_Node16:
-            #   Pool:
-            #   OSVmImage: "macOS-latest"
-            #   NodeTestVersion: "16.x"
+            macOS_Node16:
+              Pool:
+              OSVmImage: "macOS-latest"
+              NodeTestVersion: "16.x"
             Linux_Node16:
               Pool: ${{ parameters.LinuxPool }}
               OSVmImage: "ubuntu-20.04"
@@ -294,7 +294,7 @@ stages:
           - publish: $(CADL_TESTSERVER_COVERAGE_REPORT)
             artifact: CoverageReport
             displayName: "Publish coverage report"
-            condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
+            condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'), eq( variables['Agent.OS'], 'Linux' ))
           - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
               - task: AzureCLI@2
                 displayName: "Upload to Cadl Ranch Coverage Report"

--- a/.scripts/ci.yml
+++ b/.scripts/ci.yml
@@ -255,10 +255,10 @@ stages:
           - template: globals.yml
         strategy:
           matrix:
-            macOS_Node16:
-              Pool:
-              OSVmImage: "macOS-latest"
-              NodeTestVersion: "16.x"
+            # macOS_Node16:
+            #   Pool:
+            #   OSVmImage: "macOS-latest"
+            #   NodeTestVersion: "16.x"
             Linux_Node16:
               Pool: ${{ parameters.LinuxPool }}
               OSVmImage: "ubuntu-20.04"


### PR DESCRIPTION
fixes ci failure: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2777974&view=logs&j=167756e8-11e6-5b09-f247-464e3cdd37fc&t=6e80cffa-694f-5c66-c385-ea5dadb8d133&l=31

```
ApplicationInsightsTelemetrySender correlated 2 events with X-TFS-Session ca244b04-7122-40aa-89b9-88e5162c7eeb
##[error]Artifact CoverageReport already exists for build 2777974.
Finishing: Publish coverage report

```