### PR TITLE
Fix collectionFormat issue in header

### DIFF
--- a/packages/autorest.typescript/src/restLevelClient/transforms/transformParameterTypes.ts
+++ b/packages/autorest.typescript/src/restLevelClient/transforms/transformParameterTypes.ts
@@ -171,12 +171,7 @@ function transformBodyParameters(
     );
   } else {
     rlcBodyParam.body = [
-      getParameterSchema(
-        bodyParameters[0],
-        importedModels,
-        false,
-        contentTypeParam
-      )
+      getParameterSchema(bodyParameters[0], importedModels, false, contentTypeParam)
     ];
   }
 
@@ -249,22 +244,9 @@ function getParameterSchema(
   }
   if (type === "Array<string>") {
     const serializeInfo = getSpecialSerializeInfo(parameter);
-    if (
-      serializeInfo.hasMultiCollection ||
-      serializeInfo.hasPipeCollection ||
-      serializeInfo.hasSsvCollection ||
-      serializeInfo.hasTsvCollection
-    ) {
+    if (serializeInfo.hasMultiCollection || serializeInfo.hasPipeCollection || serializeInfo.hasSsvCollection || serializeInfo.hasTsvCollection) {
       type = "string";
-      description += ` This parameter needs to be formatted as ${serializeInfo.collectionInfo.join(
-        ", "
-      )} collection, we provide ${serializeInfo.descriptions.join(
-        ", "
-      )} from serializeHelper.ts to help${
-        serializeInfo.hasMultiCollection
-          ? ", you will probably need to set skipUrlEncoding as true when sending the request"
-          : ""
-      }`;
+      description += ` This parameter needs to be formatted as ${serializeInfo.collectionInfo.join(", ")} collection, we provide ${serializeInfo.descriptions.join(", ")} from serializeHelper.ts to help${serializeInfo.hasMultiCollection? ", you will probably need to set skipUrlEncoding as true when sending the request": ""}`;
     }
   }
   return {
@@ -282,10 +264,7 @@ export function getSpecialSerializeInfo(parameter: Parameter) {
   let hasTsvCollection = false;
   const descriptions = [];
   const collectionInfo = [];
-  if (
-    parameter.protocol.http?.explode === true &&
-    parameter.protocol.http?.style === "form"
-  ) {
+  if (parameter.protocol.http?.explode === true && parameter.protocol.http?.style === 'form') {
     hasMultiCollection = true;
     descriptions.push("buildMultiCollection");
     collectionInfo.push("multi");
@@ -312,7 +291,7 @@ export function getSpecialSerializeInfo(parameter: Parameter) {
     hasTsvCollection,
     descriptions,
     collectionInfo
-  };
+  }
 }
 
 /**

--- a/packages/autorest.typescript/src/restLevelClient/transforms/transformParameterTypes.ts
+++ b/packages/autorest.typescript/src/restLevelClient/transforms/transformParameterTypes.ts
@@ -9,8 +9,7 @@ import {
   Property,
   SchemaContext,
   ObjectSchema as M4ObjectSchema,
-  Request as M4OperationRequest,
-  VirtualParameter
+  Request as M4OperationRequest
 } from "@autorest/codemodel";
 import {
   ImportKind,
@@ -254,8 +253,7 @@ function getParameterSchema(
       serializeInfo.hasMultiCollection ||
       serializeInfo.hasPipeCollection ||
       serializeInfo.hasSsvCollection ||
-      serializeInfo.hasTsvCollection ||
-      serializeInfo.hasCsvCollection
+      serializeInfo.hasTsvCollection
     ) {
       type = "string";
       description += ` This parameter needs to be formatted as ${serializeInfo.collectionInfo.join(
@@ -282,12 +280,8 @@ export function getSpecialSerializeInfo(parameter: Parameter) {
   let hasPipeCollection = false;
   let hasSsvCollection = false;
   let hasTsvCollection = false;
-  let hasCsvCollection = false;
   const descriptions = [];
   const collectionInfo = [];
-  const httpInfo =
-    parameter.protocol.http ||
-    (parameter as VirtualParameter).originalParameter.protocol.http;
   if (
     parameter.protocol.http?.explode === true &&
     parameter.protocol.http?.style === "form"
@@ -295,15 +289,6 @@ export function getSpecialSerializeInfo(parameter: Parameter) {
     hasMultiCollection = true;
     descriptions.push("buildMultiCollection");
     collectionInfo.push("multi");
-  }
-  if (
-    httpInfo &&
-    httpInfo.in === ParameterLocation.Header &&
-    parameter.protocol.http?.style === "simple"
-  ) {
-    hasCsvCollection = true;
-    descriptions.push("buildCsvCollection");
-    collectionInfo.push("csv");
   }
   if (parameter.protocol.http?.style === "spaceDelimited") {
     hasSsvCollection = true;
@@ -325,7 +310,6 @@ export function getSpecialSerializeInfo(parameter: Parameter) {
     hasPipeCollection,
     hasSsvCollection,
     hasTsvCollection,
-    hasCsvCollection,
     descriptions,
     collectionInfo
   };

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/src/serializeHelper.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/src/serializeHelper.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildMultiCollection(
-  queryParameters: string[],
-  parameterName: string
-) {
-  return queryParameters
+export function buildMultiCollection(items: string[], parameterName: string) {
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;

--- a/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/src/serializeHelper.ts
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/urlRest/src/serializeHelper.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildPipeCollection(queryParameters: string[]): string {
-  return queryParameters.join("|");
+export function buildPipeCollection(items: string[]): string {
+  return items.join("|");
 }
 
-export function buildSsvCollection(queryParameters: string[]): string {
-  return queryParameters.join(" ");
+export function buildSsvCollection(items: string[]): string {
+  return items.join(" ");
 }
 
-export function buildTsvCollection(queryParameters: string[]) {
-  return queryParameters.join("\t");
+export function buildTsvCollection(items: string[]) {
+  return items.join("\t");
 }

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/review/agrifood-data-plane.api.md
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/review/agrifood-data-plane.api.md
@@ -854,7 +854,7 @@ export interface BoundaryOverlapResponseOutput {
 export type BoundaryResourceMergeAndPatch = Partial<Boundary>;
 
 // @public (undocumented)
-export function buildMultiCollection(queryParameters: string[], parameterName: string): string;
+export function buildMultiCollection(items: string[], parameterName: string): string;
 
 // @public
 export interface CascadeDeleteJobOutput {

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/src/serializeHelper.ts
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/src/serializeHelper.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildMultiCollection(
-  queryParameters: string[],
-  parameterName: string
-) {
-  return queryParameters
+export function buildMultiCollection(items: string[], parameterName: string) {
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;

--- a/packages/rlc-common/src/buildIndexFile.ts
+++ b/packages/rlc-common/src/buildIndexFile.ts
@@ -4,6 +4,7 @@
 import { Project, SourceFile } from "ts-morph";
 import { NameType, normalizeName } from "./helpers/nameUtils.js";
 import {
+  hasCsvCollection,
   hasInputModels,
   hasMultiCollection,
   hasOutputModels,
@@ -134,7 +135,8 @@ function generateRLCIndexForMultiClient(file: SourceFile, model: RLCModel) {
     hasMultiCollection(model) ||
     hasSsvCollection(model) ||
     hasPipeCollection(model) ||
-    hasTsvCollection(model)
+    hasTsvCollection(model) ||
+    hasCsvCollection(model)
   ) {
     file.addImportDeclaration({
       namespaceImport: "SerializeHelper",

--- a/packages/rlc-common/src/buildSerializeHelper.ts
+++ b/packages/rlc-common/src/buildSerializeHelper.ts
@@ -3,12 +3,14 @@ import * as path from "path";
 // @ts-ignore: to fix the handlebars issue
 import hbs from "handlebars";
 import {
+  hasCsvCollection,
   hasMultiCollection,
   hasPipeCollection,
   hasSsvCollection,
   hasTsvCollection
 } from "./helpers/operationHelpers.js";
 import {
+  buildCsvCollectionContent,
   buildMultiCollectionContent,
   buildPipeCollectionContent,
   buildSsvCollectionContent,
@@ -28,6 +30,9 @@ export function buildSerializeHelper(model: RLCModel) {
   }
   if (hasTsvCollection(model)) {
     serializeHelperContent += "\n" + buildTsvCollectionContent;
+  }
+  if (hasCsvCollection(model)) {
+    serializeHelperContent += "\n" + buildCsvCollectionContent;
   }
   if (serializeHelperContent !== "") {
     const readmeFileContents = hbs.compile(serializeHelperContent, {

--- a/packages/rlc-common/src/helpers/operationHelpers.ts
+++ b/packages/rlc-common/src/helpers/operationHelpers.ts
@@ -84,6 +84,10 @@ export function hasTsvCollection(model: RLCModel) {
   return Boolean(model.helperDetails?.hasTsvCollection);
 }
 
+export function hasCsvCollection(model: RLCModel) {
+  return Boolean(model.helperDetails?.hasCsvCollection);
+}
+
 export function hasUnexpectedHelper(model: RLCModel) {
   const pathDictionary = model.paths;
   for (const details of Object.values(pathDictionary)) {

--- a/packages/rlc-common/src/interfaces.ts
+++ b/packages/rlc-common/src/interfaces.ts
@@ -40,6 +40,7 @@ export interface HelperFunctionDetails {
   hasPipeCollection?: boolean;
   hasSsvCollection?: boolean;
   hasTsvCollection?: boolean;
+  hasCsvCollection?: boolean;
 }
 
 export interface PagingDetails {

--- a/packages/rlc-common/src/static/serializeHelper.ts
+++ b/packages/rlc-common/src/static/serializeHelper.ts
@@ -1,9 +1,9 @@
 export const buildMultiCollectionContent = `
 export function buildMultiCollection(
-  queryParameters: string[],
+  items: string[],
   parameterName: string
 ) {
-  return queryParameters
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;
@@ -14,16 +14,21 @@ export function buildMultiCollection(
 }`;
 
 export const buildPipeCollectionContent = `
-export function buildPipeCollection(queryParameters: string[]): string {
-  return queryParameters.join("|");
+export function buildPipeCollection(items: string[]): string {
+  return items.join("|");
 }`;
 
 export const buildSsvCollectionContent = `
-export function buildSsvCollection(queryParameters: string[]): string {
-  return queryParameters.join(" ");
+export function buildSsvCollection(items: string[]): string {
+  return items.join(" ");
 }`;
 
 export const buildTsvCollectionContent = `
-export function buildTsvCollection(queryParameters: string[]) {
-  return queryParameters.join("\\t");
+export function buildTsvCollection(items: string[]) {
+  return items.join("\\t");
+}`;
+
+export const buildCsvCollectionContent = `
+export function buildCsvCollection(items: string[]) {
+  return items.join(",");
 }`;

--- a/packages/typespec-test/test/collectionFormat/generated/typespec-ts/review/collection-format.api.md
+++ b/packages/typespec-test/test/collectionFormat/generated/typespec-ts/review/collection-format.api.md
@@ -11,7 +11,7 @@ import { RequestParameters } from '@azure-rest/core-client';
 import { StreamableMethod } from '@azure-rest/core-client';
 
 // @public (undocumented)
-export function buildMultiCollection(queryParameters: string[], parameterName: string): string;
+export function buildMultiCollection(items: string[], parameterName: string): string;
 
 // @public (undocumented)
 export type CollectionFormatTestServiceClient = Client & {

--- a/packages/typespec-test/test/collectionFormat/generated/typespec-ts/src/serializeHelper.ts
+++ b/packages/typespec-test/test/collectionFormat/generated/typespec-ts/src/serializeHelper.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildMultiCollection(
-  queryParameters: string[],
-  parameterName: string
-) {
-  return queryParameters
+export function buildMultiCollection(items: string[], parameterName: string) {
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;

--- a/packages/typespec-test/test/translator/generated/typespec-ts/review/cognitiveservices-translator.api.md
+++ b/packages/typespec-test/test/translator/generated/typespec-ts/review/cognitiveservices-translator.api.md
@@ -98,7 +98,7 @@ export interface BreakSentenceQueryParamProperties {
 }
 
 // @public (undocumented)
-export function buildMultiCollection(queryParameters: string[], parameterName: string): string;
+export function buildMultiCollection(items: string[], parameterName: string): string;
 
 // @public
 export interface CommonScriptModelOutput {

--- a/packages/typespec-test/test/translator/generated/typespec-ts/src/serializeHelper.ts
+++ b/packages/typespec-test/test/translator/generated/typespec-ts/src/serializeHelper.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildMultiCollection(
-  queryParameters: string[],
-  parameterName: string
-) {
-  return queryParameters
+export function buildMultiCollection(items: string[], parameterName: string) {
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;

--- a/packages/typespec-ts/src/transform/transformHelperFunctionDetails.ts
+++ b/packages/typespec-ts/src/transform/transformHelperFunctionDetails.ts
@@ -194,6 +194,7 @@ function extractSpecialSerializeInfo(
   let hasPipeCollection = false;
   let hasTsvCollection = false;
   let hasSsvCollection = false;
+  let hasCsvCollection = false;
   const operationGroups = listOperationGroups(dpgContext, client);
   for (const operationGroup of operationGroups) {
     const operations = listOperationsInOperationGroup(
@@ -216,6 +217,9 @@ function extractSpecialSerializeInfo(
         hasSsvCollection = hasSsvCollection
           ? hasSsvCollection
           : serializeInfo.hasSsvCollection;
+        hasCsvCollection = hasCsvCollection
+          ? hasCsvCollection
+          : serializeInfo.hasCsvCollection;
       });
     }
   }
@@ -236,12 +240,16 @@ function extractSpecialSerializeInfo(
       hasSsvCollection = hasSsvCollection
         ? hasSsvCollection
         : serializeInfo.hasSsvCollection;
+      hasCsvCollection = hasCsvCollection
+        ? hasCsvCollection
+        : serializeInfo.hasCsvCollection;
     });
   }
   return {
     hasMultiCollection,
     hasPipeCollection,
     hasTsvCollection,
-    hasSsvCollection
+    hasSsvCollection,
+    hasCsvCollection
   };
 }

--- a/packages/typespec-ts/src/transform/transformParameters.ts
+++ b/packages/typespec-ts/src/transform/transformParameters.ts
@@ -144,7 +144,8 @@ function getParameterMetadata(
       serializeInfo.hasMultiCollection ||
       serializeInfo.hasPipeCollection ||
       serializeInfo.hasSsvCollection ||
-      serializeInfo.hasTsvCollection
+      serializeInfo.hasTsvCollection ||
+      serializeInfo.hasCsvCollection
     ) {
       type = "string";
       description += ` This parameter needs to be formatted as ${serializeInfo.collectionInfo.join(
@@ -495,6 +496,7 @@ export function getSpecialSerializeInfo(parameter: HttpOperationParameter) {
   let hasPipeCollection = false;
   let hasSsvCollection = false;
   let hasTsvCollection = false;
+  let hasCsvCollection = false;
   const descriptions = [];
   const collectionInfo = [];
   if (
@@ -522,11 +524,18 @@ export function getSpecialSerializeInfo(parameter: HttpOperationParameter) {
     descriptions.push("buildPipeCollection");
     collectionInfo.push("pipe");
   }
+
+  if (parameter.type === "header" && (parameter as any).format === "csv") {
+    hasCsvCollection = true;
+    descriptions.push("buildCsvCollection");
+    collectionInfo.push("csv");
+  }
   return {
     hasMultiCollection,
     hasPipeCollection,
     hasSsvCollection,
     hasTsvCollection,
+    hasCsvCollection,
     descriptions,
     collectionInfo
   };

--- a/packages/typespec-ts/test/integration/collectionFormat.spec.ts
+++ b/packages/typespec-ts/test/integration/collectionFormat.spec.ts
@@ -6,6 +6,7 @@ import CollectionFormatClientFactory, {
   buildTsvCollection,
   CollectionFormatClient
 } from "./generated/parameters/collection-format/src/index.js";
+import { buildCsvCollection } from "./generated/encode/src/serializeHelper.js";
 describe("Collection Format Rest Client", () => {
   let client: CollectionFormatClient;
   const colors = ["blue", "red", "green"];
@@ -21,12 +22,14 @@ describe("Collection Format Rest Client", () => {
 
   it("should serialize multi format query array parameter", async () => {
     try {
-      const result = await client.path("/parameters/collection-format/query/multi").get({
-        queryParameters: {
-          colors: buildMultiCollection(colors, "colors")
-        },
-        skipUrlEncoding: true
-      });
+      const result = await client
+        .path("/parameters/collection-format/query/multi")
+        .get({
+          queryParameters: {
+            colors: buildMultiCollection(colors, "colors")
+          },
+          skipUrlEncoding: true
+        });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);
@@ -35,12 +38,14 @@ describe("Collection Format Rest Client", () => {
 
   it("should serialize csv format query array parameter", async () => {
     try {
-      const result = await client.path("/parameters/collection-format/query/csv").get({
-        queryParameters: {
-          colors: colors
-        },
-        skipUrlEncoding: true
-      });
+      const result = await client
+        .path("/parameters/collection-format/query/csv")
+        .get({
+          queryParameters: {
+            colors: colors
+          },
+          skipUrlEncoding: true
+        });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);
@@ -49,11 +54,13 @@ describe("Collection Format Rest Client", () => {
 
   it("should serialize ssv format query array parameter", async () => {
     try {
-      const result = await client.path("/parameters/collection-format/query/ssv").get({
-        queryParameters: {
-          colors: buildSsvCollection(colors)
-        }
-      });
+      const result = await client
+        .path("/parameters/collection-format/query/ssv")
+        .get({
+          queryParameters: {
+            colors: buildSsvCollection(colors)
+          }
+        });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);
@@ -62,26 +69,29 @@ describe("Collection Format Rest Client", () => {
 
   it("should serialize tsv format query array parameter", async () => {
     try {
-      const result = await client.path("/parameters/collection-format/query/tsv").get({
-        queryParameters: {
-          colors: buildTsvCollection(colors)
-        }
-      });
+      const result = await client
+        .path("/parameters/collection-format/query/tsv")
+        .get({
+          queryParameters: {
+            colors: buildTsvCollection(colors)
+          }
+        });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);
     }
   });
 
-
   it("should serialize pipes format query array parameter", async () => {
     try {
-      const result = await client.path("/parameters/collection-format/query/pipes").get({
-        queryParameters: {
-          colors: buildPipeCollection(colors)
-        },
-        skipUrlEncoding: true
-      });
+      const result = await client
+        .path("/parameters/collection-format/query/pipes")
+        .get({
+          queryParameters: {
+            colors: buildPipeCollection(colors)
+          },
+          skipUrlEncoding: true
+        });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);
@@ -90,12 +100,14 @@ describe("Collection Format Rest Client", () => {
 
   it("should serialize csv format header array parameter", async () => {
     try {
-      const result = await client.path("/parameters/collection-format/header/csv").get({
-        headers: {
-          colors: colors as any
-        },
-        skipUrlEncoding: true
-      });
+      const result = await client
+        .path("/parameters/collection-format/header/csv")
+        .get({
+          headers: {
+            colors: buildCsvCollection(colors)
+          },
+          skipUrlEncoding: true
+        });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);

--- a/packages/typespec-ts/test/integration/encode.spec.ts
+++ b/packages/typespec-ts/test/integration/encode.spec.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import EncodeDurationClientFactory, {
   DurationClient
 } from "./generated/encode/src/index.js";
+import { buildCsvCollection } from "./generated/encode/src/serializeHelper.js";
 describe("EncodeDurationClient Rest Client", () => {
   let client: DurationClient;
 
@@ -207,7 +208,7 @@ describe("EncodeDurationClient Rest Client", () => {
           .path(`/encode/duration/header/iso8601-array`)
           .get({
             headers: {
-              duration: ["P40D", "P50D"] as any
+              duration: buildCsvCollection(["P40D", "P50D"])
             }
           });
         assert.strictEqual(result.status, "204");

--- a/packages/typespec-ts/test/integration/generated/azure/core/src/serializeHelper.ts
+++ b/packages/typespec-ts/test/integration/generated/azure/core/src/serializeHelper.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildMultiCollection(
-  queryParameters: string[],
-  parameterName: string
-) {
-  return queryParameters
+export function buildMultiCollection(items: string[], parameterName: string) {
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;

--- a/packages/typespec-ts/test/integration/generated/encode/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/encode/src/parameters.ts
@@ -122,7 +122,8 @@ export type HeaderIso8601Parameters = HeaderIso8601HeaderParam &
   RequestParameters;
 
 export interface HeaderIso8601ArrayHeaders {
-  duration: string[];
+  /**  This parameter needs to be formatted as csv collection, we provide buildCsvCollection from serializeHelper.ts to help */
+  duration: string;
 }
 
 export interface HeaderIso8601ArrayHeaderParam {

--- a/packages/typespec-ts/test/integration/generated/encode/src/serializeHelper.ts
+++ b/packages/typespec-ts/test/integration/generated/encode/src/serializeHelper.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export function buildCsvCollection(items: string[]) {
+  return items.join(",");
+}

--- a/packages/typespec-ts/test/integration/generated/parameters/collection-format/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/parameters/collection-format/src/parameters.ts
@@ -60,8 +60,8 @@ export interface QueryCsvQueryParam {
 export type QueryCsvParameters = QueryCsvQueryParam & RequestParameters;
 
 export interface HeaderCsvHeaders {
-  /** Possible values for colors are [blue,red,green] */
-  colors: string[];
+  /** Possible values for colors are [blue,red,green] This parameter needs to be formatted as csv collection, we provide buildCsvCollection from serializeHelper.ts to help */
+  colors: string;
 }
 
 export interface HeaderCsvHeaderParam {

--- a/packages/typespec-ts/test/integration/generated/parameters/collection-format/src/serializeHelper.ts
+++ b/packages/typespec-ts/test/integration/generated/parameters/collection-format/src/serializeHelper.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-export function buildMultiCollection(
-  queryParameters: string[],
-  parameterName: string
-) {
-  return queryParameters
+export function buildMultiCollection(items: string[], parameterName: string) {
+  return items
     .map((item, index) => {
       if (index === 0) {
         return item;
@@ -15,14 +12,18 @@ export function buildMultiCollection(
     .join("&");
 }
 
-export function buildPipeCollection(queryParameters: string[]): string {
-  return queryParameters.join("|");
+export function buildPipeCollection(items: string[]): string {
+  return items.join("|");
 }
 
-export function buildSsvCollection(queryParameters: string[]): string {
-  return queryParameters.join(" ");
+export function buildSsvCollection(items: string[]): string {
+  return items.join(" ");
 }
 
-export function buildTsvCollection(queryParameters: string[]) {
-  return queryParameters.join("\t");
+export function buildTsvCollection(items: string[]) {
+  return items.join("\t");
+}
+
+export function buildCsvCollection(items: string[]) {
+  return items.join(",");
 }


### PR DESCRIPTION
When touching the collectionFormat integration cases we generate string[] for header with format defined, but I notice that `RawHttpHeadersInput` only allows for `string|number|boolean` which means there would exist type inference conflict for this property.

https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-rest-pipeline/src/interfaces.ts#L12-L15

To fix that we need to build a helper function for the default csv format for header.