### PR TITLE
Fix the query datetime support issue

### DIFF
--- a/packages/typespec-ts/src/transform/transformParameters.ts
+++ b/packages/typespec-ts/src/transform/transformParameters.ts
@@ -126,17 +126,18 @@ function getParameterMetadata(
   paramType: "query" | "path" | "header",
   parameter: HttpOperationParameter
 ): ParameterMetadata {
+  const schemaContext = [SchemaContext.Exception, SchemaContext.Input];
   const schema = getSchemaForType(
     program,
     dpgContext,
     parameter.param.type,
-    [SchemaContext.Exception, SchemaContext.Input],
+    schemaContext,
     false,
     parameter.param
   ) as Schema;
   let type =
     paramType === "query"
-      ? getTypeName(schema, [SchemaContext.Exception, SchemaContext.Input])
+      ? getTypeName(schema, schemaContext)
       : getTypeName(schema);
   const name = getParameterName(parameter.name);
   let description =

--- a/packages/typespec-ts/src/transform/transformParameters.ts
+++ b/packages/typespec-ts/src/transform/transformParameters.ts
@@ -134,7 +134,10 @@ function getParameterMetadata(
     false,
     parameter.param
   ) as Schema;
-  let type = getTypeName(schema);
+  let type =
+    paramType === "query"
+      ? getTypeName(schema, [SchemaContext.Exception, SchemaContext.Input])
+      : getTypeName(schema);
   const name = getParameterName(parameter.name);
   let description =
     getFormattedPropertyDoc(program, parameter.param, schema) ?? "";


### PR DESCRIPTION
Generate the datetime as `Date | string` when the parameter is in query & model property, as `string` in header.