### PR TITLE
upgrade-m4-to-4.26.2 to support final state-schema

### DIFF
--- a/packages/autorest.typescript/README.md
+++ b/packages/autorest.typescript/README.md
@@ -55,7 +55,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ```yaml
 version: 3.6.6
 use-extension:
-  "@autorest/modelerfour": "4.25.0"
+  "@autorest/modelerfour": "4.26.2"
 
 modelerfour:
   # this runs a pre-namer step to clean up names


### PR DESCRIPTION
upgrade m4 version to 4.26.2 to support final-state-schema