### PR TITLE
Add `ts-node` to dev dependencies when generating tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If your contribution is significantly big it is better to first check with the p
 
 Want to get started hacking on the code? Great! Keep reading. This contributing guide helps you to start working with and contributing to the Azure Typescript/Javascript SDK Generator.
 
-## Prerequisites  
+## Prerequisites
 
 In order contribute to this project, You will need to install some prerequisite dependencies to get start.
 
@@ -43,7 +43,7 @@ In order contribute to this project, You will need to install some prerequisite 
   - Install / update Rush globally via `npm install -g @microsoft/rush`.
   - Rush will automatically manage the specific version needed by this repo as long as you have any v5 version installed.
   - If you're unable to install a global tool, you can instead call the wrapper script `node <repo root>/common/scripts/install-run-rush.js` any time the guide instructs you to run `rush`. The wrapper script will install a managed copy of Rush in a temporary directory for you.
-- [Autorest](https://www.npmjs.com/package/autorest), if you're planning contribute to the generator code from swagger either for high level client or for rest level client.  
+- [Autorest](https://www.npmjs.com/package/autorest), if you're planning contribute to the generator code from swagger either for high level client or for rest level client.
 - [Cadl Compiler](https://www.npmjs.com/package/@cadl-lang/compiler), if you're planning contribute to the generator code from cadl.
 
 ### Things to keep in mind when contributing
@@ -61,6 +61,6 @@ If your test case is working fine as expected, now you are ready to create the P
 Our generated SDKs take dependency on various packages which you can see in the generated package.json files. These will need to be upgraded from time to time to stay on the latest major version so that we get bug fixes automatically due to semver.
 
 - Update the version of the dependency you are looking for in the methods `restLevelPackage` and/or `regularAutorestPackage` in the [`packageFileGenerator.ts`](https://github.com/Azure/autorest.typescript/blob/main/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts) file.
-- Run `rush rebuild && npm run generate-swaggers && npm run smoke-tests` to update the generated files in the repo and run smoke tests before creating the PR.
+- Run `rush rebuild && npm run generate-swaggers && npm run smoke-test` to update the generated files in the repo and run smoke tests before creating the PR.
 
 For example, see the [PR 1271](https://github.com/Azure/autorest.typescript/pull/1271) that updates the version of `prettier` that the generated SDKs depend on.

--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -199,6 +199,8 @@ function regularAutorestPackage(
     packageInfo.devDependencies["chai"] = "^4.2.0";
     packageInfo.devDependencies["cross-env"] = "^7.0.2";
     packageInfo.devDependencies["@types/node"] = "^14.0.0";
+    packageInfo.devDependencies["ts-node"] = "^10.0.0";
+
     packageInfo.scripts["test"] = "npm run integration-test";
     packageInfo.scripts["unit-test"] =
       "npm run unit-test:node && npm run unit-test:browser";

--- a/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
@@ -35,7 +35,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/integration/generated/datasearch/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datasearch/package.json
@@ -36,7 +36,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/integration/generated/patterntest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/patterntest/package.json
@@ -36,7 +36,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -94,7 +94,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -97,7 +97,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -97,7 +97,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
@@ -37,7 +37,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
@@ -39,7 +39,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
@@ -39,7 +39,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
@@ -37,7 +37,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
@@ -39,7 +39,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
@@ -39,7 +39,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
@@ -39,7 +39,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
@@ -39,7 +39,8 @@
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",
-    "@types/node": "^14.0.0"
+    "@types/node": "^14.0.0",
+    "ts-node": "^10.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/rlc-common/src/metadata/buildPackageFile.ts
+++ b/packages/rlc-common/src/metadata/buildPackageFile.ts
@@ -251,6 +251,7 @@ function restLevelPackage(model: RLCModel, hasSamplesGenerated: boolean) {
     packageInfo.devDependencies["karma"] = "^6.2.0";
     packageInfo.devDependencies["nyc"] = "^15.0.0";
     packageInfo.devDependencies["source-map-support"] = "^0.5.9";
+    packageInfo.devDependencies["ts-node"] = "^10.0.0";
     packageInfo.scripts["test"] =
       "npm run clean && npm run build:test && npm run unit-test";
     packageInfo.scripts["test:node"] =

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/package.json
@@ -95,7 +95,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/authoring/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/authoring/generated/typespec-ts/package.json
@@ -97,7 +97,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/collectionFormat/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/collectionFormat/generated/typespec-ts/package.json
@@ -94,7 +94,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/confidentialLedger/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/confidentialLedger/generated/typespec-ts/package.json
@@ -95,7 +95,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/contoso/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/contoso/generated/typespec-ts/package.json
@@ -97,7 +97,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/customWrapper/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/customWrapper/generated/typespec-ts/package.json
@@ -94,7 +94,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/healthinsight/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/healthinsight/generated/typespec-ts/package.json
@@ -96,7 +96,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/loadTest/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/loadTest/generated/typespec-ts/package.json
@@ -97,7 +97,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/package.json
@@ -97,7 +97,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/openai/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai/generated/typespec-ts/package.json
@@ -94,7 +94,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-test/test/translator/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/translator/generated/typespec-ts/package.json
@@ -94,7 +94,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "browser": {
     "./dist-esm/test/public/utils/env.js": "./dist-esm/test/public/utils/env.browser.js"

--- a/packages/typespec-ts/test/integration/generated/authentication/apiKey/package.json
+++ b/packages/typespec-ts/test/integration/generated/authentication/apiKey/package.json
@@ -75,7 +75,6 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
-    "ts-node": "^10.0.0",
     "@azure-tools/test-credential": "^1.0.0",
     "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^3.0.0",
@@ -95,7 +94,8 @@
     "karma-source-map-support": "~1.4.0",
     "karma-sourcemap-loader": "^0.3.8",
     "karma": "^6.2.0",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "ts-node": "^10.0.0"
   },
   "type": "module",
   "browser": {

--- a/packages/typespec-ts/test/integration/generated/authentication/apiKey/package.json
+++ b/packages/typespec-ts/test/integration/generated/authentication/apiKey/package.json
@@ -75,6 +75,7 @@
     "rollup": "^2.66.1",
     "rollup-plugin-sourcemaps": "^0.6.3",
     "uglify-js": "^3.4.9",
+    "ts-node": "^10.0.0",
     "@azure-tools/test-credential": "^1.0.0",
     "@azure/identity": "^2.0.1",
     "@azure-tools/test-recorder": "^3.0.0",


### PR DESCRIPTION
as tests relies on it to run .ts test files.