### PR TITLE
Support customization process part 1

### DIFF
--- a/packages/typespec-test/eng/smoke-test.js
+++ b/packages/typespec-test/eng/smoke-test.js
@@ -35,7 +35,7 @@ function copyFile(path) {
     const result = execSync(cp, {
       maxBuffer: MAX_BUFFER,
     });
-    console.log("Generated output:", result.toString("utf8"));
+    console.log("Copy file output:", result.toString("utf8"));
   }
 }
 

--- a/packages/typespec-test/eng/smoke-test.js
+++ b/packages/typespec-test/eng/smoke-test.js
@@ -8,7 +8,7 @@ const MAX_BUFFER = 10 * 1024 * 1024;
 function generate(path) {
   let command = `cd ${path} && npx tsp compile ./spec`;
   try {
-    if(existsSync(join(path, "spec", "client.tsp"))) {
+    if (existsSync(join(path, "spec", "client.tsp"))) {
       command += "/client.tsp";
     }
   } catch (e) {
@@ -23,6 +23,19 @@ function generate(path) {
   } catch (e) {
     console.error(Error(e.stdout.toString("utf8")));
     process.exitCode = 1;
+  }
+}
+
+function copyFile(path) {
+  const customizationPath = join(path, "generated/typespec-ts/sources/generated/src");
+  const srcPath = join(path, "generated/typespec-ts");
+  if (existsSync(customizationPath)) {
+    const cp = `cp -rf ${customizationPath} ${srcPath}`;
+    console.log(cp);
+    const result = execSync(cp, {
+      maxBuffer: MAX_BUFFER,
+    });
+    console.log("Generated output:", result.toString("utf8"));
   }
 }
 
@@ -62,6 +75,7 @@ async function main() {
       console.log(`          ##### Skipped #####          `);
     } else {
       generate(path);
+      copyFile(path);
       build(path);
     }
     console.log(`================End ${folder}===============`);

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/WidgetServiceClient.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/WidgetServiceClient.ts
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Widget, ColorType, AnalyzeResult } from "./models/models.js";
+import {
+  ListWidgetsOptions,
+  GetWidgetOptions,
+  CreateWidgetOptions,
+  UpdateWidgetOptions,
+  DeleteWidgetOptions,
+  AnalyzeWidgetOptions,
+} from "./models/options.js";
+import {
+  listWidgets,
+  getWidget,
+  createWidget,
+  updateWidget,
+  deleteWidget,
+  analyzeWidget,
+  createWidgetService,
+  WidgetServiceClientOptions,
+  WidgetServiceContext,
+} from "./api/index.js";
+
+export { WidgetServiceClientOptions } from "./api/WidgetServiceContext.js";
+
+export class WidgetServiceClient {
+  private _client: WidgetServiceContext;
+
+  constructor(endpoint: string, options: WidgetServiceClientOptions = {}) {
+    this._client = createWidgetService(endpoint, options);
+  }
+
+  /**
+   * List all widgets in the system. This operation is not paginated, and returns a simple array of widgets.
+   *
+   * It does not accept any options or parameters.
+   */
+  listWidgets(
+    options: ListWidgetsOptions = { requestOptions: {} }
+  ): Promise<Widget[]> {
+    return listWidgets(this._client, options);
+  }
+
+  /** Get a widget by ID. */
+  getWidget(
+    id: string,
+    options: GetWidgetOptions = { requestOptions: {} }
+  ): Promise<Widget> {
+    return getWidget(this._client, id, options);
+  }
+
+  /**
+   * Create a new widget.
+   *
+   * The widget ID is not required during creation, as it is automatically set by the server. Providing an ID will
+   * result in an error.
+   */
+  createWidget(
+    weight: number,
+    color: ColorType,
+    options: CreateWidgetOptions = { requestOptions: {} }
+  ): Promise<Widget> {
+    return createWidget(this._client, weight, color, options);
+  }
+
+  /**
+   * Update the contents of the widget. The widget ID is required in the input, but cannot be changed. All other fields
+   * are optional and will be updated within the widget if provided.
+   */
+  updateWidget(
+    id: string,
+    options: UpdateWidgetOptions = { requestOptions: {} }
+  ): Promise<Widget> {
+    return updateWidget(this._client, id, options);
+  }
+
+  /** Delete a widget by ID. */
+  deleteWidget(
+    id: string,
+    options: DeleteWidgetOptions = { requestOptions: {} }
+  ): Promise<void> {
+    return deleteWidget(this._client, id, options);
+  }
+
+  /** Analyze a widget. The only guarantee is that this method will return a string containing the results of the analysis. */
+  analyzeWidget(
+    id: string,
+    options: AnalyzeWidgetOptions = { requestOptions: {} }
+  ): Promise<AnalyzeResult> {
+    return analyzeWidget(this._client, id, options);
+  }
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/api/WidgetServiceContext.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/api/WidgetServiceContext.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientOptions } from "@azure-rest/core-client";
+import { WidgetServiceContext } from "../rest/index.js";
+import getClient from "../rest/index.js";
+
+export interface WidgetServiceClientOptions extends ClientOptions {}
+
+export { WidgetServiceContext } from "../rest/index.js";
+
+export function createWidgetService(
+  endpoint: string,
+  options: WidgetServiceClientOptions = {}
+): WidgetServiceContext {
+  const baseUrl = endpoint;
+  const clientContext = getClient(baseUrl, options);
+  return clientContext;
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/api/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/api/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export {
+  listWidgets,
+  getWidget,
+  createWidget,
+  updateWidget,
+  deleteWidget,
+  analyzeWidget,
+} from "./operations.js";
+export {
+  createWidgetService,
+  WidgetServiceClientOptions,
+  WidgetServiceContext,
+} from "./WidgetServiceContext.js";

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/api/operations.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/api/operations.ts
@@ -1,0 +1,248 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Widget, ColorType, AnalyzeResult } from "../models/models.js";
+import {
+  AnalyzeWidget200Response,
+  AnalyzeWidgetDefaultResponse,
+  CreateWidget201Response,
+  CreateWidgetDefaultResponse,
+  DeleteWidget204Response,
+  DeleteWidgetDefaultResponse,
+  GetWidget200Response,
+  GetWidgetDefaultResponse,
+  isUnexpected,
+  ListWidgets200Response,
+  ListWidgetsDefaultResponse,
+  UpdateWidget200Response,
+  UpdateWidgetDefaultResponse,
+  WidgetServiceContext as Client,
+} from "../rest/index.js";
+import {
+  StreamableMethod,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import {
+  ListWidgetsOptions,
+  GetWidgetOptions,
+  CreateWidgetOptions,
+  UpdateWidgetOptions,
+  DeleteWidgetOptions,
+  AnalyzeWidgetOptions,
+} from "../models/options.js";
+
+export function _listWidgetsSend(
+  context: Client,
+  options: ListWidgetsOptions = { requestOptions: {} }
+): StreamableMethod<ListWidgets200Response | ListWidgetsDefaultResponse> {
+  return context
+    .path("/widgets")
+    .get({ ...operationOptionsToRequestParameters(options) });
+}
+
+export async function _listWidgetsDeserialize(
+  result: ListWidgets200Response | ListWidgetsDefaultResponse
+): Promise<Widget[]> {
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return (result.body ?? []).map((p) => ({
+    id: p["id"],
+    weight: p["weight"],
+    color: p["color"],
+  }));
+}
+
+/**
+ * List all widgets in the system. This operation is not paginated, and returns a simple array of widgets.
+ *
+ * It does not accept any options or parameters.
+ */
+export async function listWidgets(
+  context: Client,
+  options: ListWidgetsOptions = { requestOptions: {} }
+): Promise<Widget[]> {
+  const result = await _listWidgetsSend(context, options);
+  return _listWidgetsDeserialize(result);
+}
+
+export function _getWidgetSend(
+  context: Client,
+  id: string,
+  options: GetWidgetOptions = { requestOptions: {} }
+): StreamableMethod<GetWidget200Response | GetWidgetDefaultResponse> {
+  return context
+    .path("/widgets/{id}", id)
+    .get({ ...operationOptionsToRequestParameters(options) });
+}
+
+export async function _getWidgetDeserialize(
+  result: GetWidget200Response | GetWidgetDefaultResponse
+): Promise<Widget> {
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    weight: result.body["weight"],
+    color: result.body["color"],
+  };
+}
+
+/** Get a widget by ID. */
+export async function getWidget(
+  context: Client,
+  id: string,
+  options: GetWidgetOptions = { requestOptions: {} }
+): Promise<Widget> {
+  const result = await _getWidgetSend(context, id, options);
+  return _getWidgetDeserialize(result);
+}
+
+export function _createWidgetSend(
+  context: Client,
+  weight: number,
+  color: ColorType,
+  options: CreateWidgetOptions = { requestOptions: {} }
+): StreamableMethod<CreateWidget201Response | CreateWidgetDefaultResponse> {
+  return context
+    .path("/widgets")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      body: { weight: weight, color: color },
+    });
+}
+
+export async function _createWidgetDeserialize(
+  result: CreateWidget201Response | CreateWidgetDefaultResponse
+): Promise<Widget> {
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    weight: result.body["weight"],
+    color: result.body["color"],
+  };
+}
+
+/**
+ * Create a new widget.
+ *
+ * The widget ID is not required during creation, as it is automatically set by the server. Providing an ID will
+ * result in an error.
+ */
+export async function createWidget(
+  context: Client,
+  weight: number,
+  color: ColorType,
+  options: CreateWidgetOptions = { requestOptions: {} }
+): Promise<Widget> {
+  const result = await _createWidgetSend(context, weight, color, options);
+  return _createWidgetDeserialize(result);
+}
+
+export function _updateWidgetSend(
+  context: Client,
+  id: string,
+  options: UpdateWidgetOptions = { requestOptions: {} }
+): StreamableMethod<UpdateWidget200Response | UpdateWidgetDefaultResponse> {
+  return context
+    .path("/widgets/{id}", id)
+    .patch({
+      ...operationOptionsToRequestParameters(options),
+      body: { weight: options?.weight, color: options?.color },
+    });
+}
+
+export async function _updateWidgetDeserialize(
+  result: UpdateWidget200Response | UpdateWidgetDefaultResponse
+): Promise<Widget> {
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    id: result.body["id"],
+    weight: result.body["weight"],
+    color: result.body["color"],
+  };
+}
+
+/**
+ * Update the contents of the widget. The widget ID is required in the input, but cannot be changed. All other fields
+ * are optional and will be updated within the widget if provided.
+ */
+export async function updateWidget(
+  context: Client,
+  id: string,
+  options: UpdateWidgetOptions = { requestOptions: {} }
+): Promise<Widget> {
+  const result = await _updateWidgetSend(context, id, options);
+  return _updateWidgetDeserialize(result);
+}
+
+export function _deleteWidgetSend(
+  context: Client,
+  id: string,
+  options: DeleteWidgetOptions = { requestOptions: {} }
+): StreamableMethod<DeleteWidget204Response | DeleteWidgetDefaultResponse> {
+  return context
+    .path("/widgets/{id}", id)
+    .delete({ ...operationOptionsToRequestParameters(options) });
+}
+
+export async function _deleteWidgetDeserialize(
+  result: DeleteWidget204Response | DeleteWidgetDefaultResponse
+): Promise<void> {
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return;
+}
+
+/** Delete a widget by ID. */
+export async function deleteWidget(
+  context: Client,
+  id: string,
+  options: DeleteWidgetOptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await _deleteWidgetSend(context, id, options);
+  return _deleteWidgetDeserialize(result);
+}
+
+export function _analyzeWidgetSend(
+  context: Client,
+  id: string,
+  options: AnalyzeWidgetOptions = { requestOptions: {} }
+): StreamableMethod<AnalyzeWidget200Response | AnalyzeWidgetDefaultResponse> {
+  return context
+    .path("/widgets/{id}/analyze", id)
+    .post({ ...operationOptionsToRequestParameters(options) });
+}
+
+export async function _analyzeWidgetDeserialize(
+  result: AnalyzeWidget200Response | AnalyzeWidgetDefaultResponse
+): Promise<AnalyzeResult> {
+  if (isUnexpected(result)) {
+    throw result.body;
+  }
+
+  return {
+    summary: result.body["summary"],
+  };
+}
+
+/** Analyze a widget. The only guarantee is that this method will return a string containing the results of the analysis. */
+export async function analyzeWidget(
+  context: Client,
+  id: string,
+  options: AnalyzeWidgetOptions = { requestOptions: {} }
+): Promise<AnalyzeResult> {
+  const result = await _analyzeWidgetSend(context, id, options);
+  return _analyzeWidgetDeserialize(result);
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/index.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export {
+  WidgetServiceClient,
+  WidgetServiceClientOptions,
+} from "./WidgetServiceClient.js";
+export {
+  Widget,
+  ColorType,
+  AnalyzeResult,
+  ListWidgetsOptions,
+  GetWidgetOptions,
+  CreateWidgetOptions,
+  UpdateWidgetOptions,
+  DeleteWidgetOptions,
+  AnalyzeWidgetOptions,
+} from "./models/index.js";

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/logger.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/logger.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("widget_dpg");

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/models/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/models/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { Widget, ColorType, AnalyzeResult } from "./models.js";
+export {
+  ListWidgetsOptions,
+  GetWidgetOptions,
+  CreateWidgetOptions,
+  UpdateWidgetOptions,
+  DeleteWidgetOptions,
+  AnalyzeWidgetOptions,
+} from "./options.js";

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/models/models.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/models/models.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface Widget {
+  /** The UUID of this widget. This is generated automatically by the service. */
+  id: string;
+  /** The weight of the widget. This is an int32, but must be greater than zero. */
+  weight: number;
+  /** The color of the widget. */
+  color: ColorType;
+}
+
+/** Type of ColorType */
+/** */
+export type ColorType = "red" | "blue";
+
+export interface AnalyzeResult {
+  summary: string;
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/models/options.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/models/options.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { OperationOptions } from "@azure-rest/core-client";
+import { ColorType } from "./models.js";
+
+export interface ListWidgetsOptions extends OperationOptions {}
+
+export interface GetWidgetOptions extends OperationOptions {}
+
+export interface CreateWidgetOptions extends OperationOptions {}
+
+export interface UpdateWidgetOptions extends OperationOptions {
+  /** The weight of the widget. This is an int32, but must be greater than zero. */
+  weight?: number;
+  /** The color of the widget. */
+  color?: ColorType;
+}
+
+export interface DeleteWidgetOptions extends OperationOptions {}
+
+export interface AnalyzeWidgetOptions extends OperationOptions {}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/clientDefinitions.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/clientDefinitions.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  ListWidgetsParameters,
+  CreateWidgetParameters,
+  GetWidgetParameters,
+  UpdateWidgetParameters,
+  DeleteWidgetParameters,
+  AnalyzeWidgetParameters,
+} from "./parameters.js";
+import {
+  ListWidgets200Response,
+  ListWidgetsDefaultResponse,
+  CreateWidget201Response,
+  CreateWidgetDefaultResponse,
+  GetWidget200Response,
+  GetWidgetDefaultResponse,
+  UpdateWidget200Response,
+  UpdateWidgetDefaultResponse,
+  DeleteWidget204Response,
+  DeleteWidgetDefaultResponse,
+  AnalyzeWidget200Response,
+  AnalyzeWidgetDefaultResponse,
+} from "./responses.js";
+import { Client, StreamableMethod } from "@azure-rest/core-client";
+
+export interface ListWidgets {
+  /**
+   * List all widgets in the system. This operation is not paginated, and returns a simple array of widgets.
+   *
+   * It does not accept any options or parameters.
+   */
+  get(
+    options?: ListWidgetsParameters
+  ): StreamableMethod<ListWidgets200Response | ListWidgetsDefaultResponse>;
+  /**
+   * Create a new widget.
+   *
+   * The widget ID is not required during creation, as it is automatically set by the server. Providing an ID will
+   * result in an error.
+   */
+  post(
+    options?: CreateWidgetParameters
+  ): StreamableMethod<CreateWidget201Response | CreateWidgetDefaultResponse>;
+}
+
+export interface GetWidget {
+  /** Get a widget by ID. */
+  get(
+    options?: GetWidgetParameters
+  ): StreamableMethod<GetWidget200Response | GetWidgetDefaultResponse>;
+  /**
+   * Update the contents of the widget. The widget ID is required in the input, but cannot be changed. All other fields
+   * are optional and will be updated within the widget if provided.
+   */
+  patch(
+    options?: UpdateWidgetParameters
+  ): StreamableMethod<UpdateWidget200Response | UpdateWidgetDefaultResponse>;
+  /** Delete a widget by ID. */
+  delete(
+    options?: DeleteWidgetParameters
+  ): StreamableMethod<DeleteWidget204Response | DeleteWidgetDefaultResponse>;
+}
+
+export interface AnalyzeWidget {
+  /** Analyze a widget. The only guarantee is that this method will return a string containing the results of the analysis. */
+  post(
+    options?: AnalyzeWidgetParameters
+  ): StreamableMethod<AnalyzeWidget200Response | AnalyzeWidgetDefaultResponse>;
+}
+
+export interface Routes {
+  /** Resource for '/widgets' has methods for the following verbs: get, post */
+  (path: "/widgets"): ListWidgets;
+  /** Resource for '/widgets/\{id\}' has methods for the following verbs: get, patch, delete */
+  (path: "/widgets/{id}", id: string): GetWidget;
+  /** Resource for '/widgets/\{id\}/analyze' has methods for the following verbs: post */
+  (path: "/widgets/{id}/analyze", id: string): AnalyzeWidget;
+}
+
+export type WidgetServiceContext = Client & {
+  path: Routes;
+};

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/index.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/index.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import WidgetServiceClient from "./widgetServiceClient.js";
+
+export * from "./widgetServiceClient.js";
+export * from "./parameters.js";
+export * from "./responses.js";
+export * from "./clientDefinitions.js";
+export * from "./isUnexpected.js";
+export * from "./models.js";
+export * from "./outputModels.js";
+
+export default WidgetServiceClient;

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/isUnexpected.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/isUnexpected.ts
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  ListWidgets200Response,
+  ListWidgetsDefaultResponse,
+  CreateWidget201Response,
+  CreateWidgetDefaultResponse,
+  GetWidget200Response,
+  GetWidgetDefaultResponse,
+  UpdateWidget200Response,
+  UpdateWidgetDefaultResponse,
+  DeleteWidget204Response,
+  DeleteWidgetDefaultResponse,
+  AnalyzeWidget200Response,
+  AnalyzeWidgetDefaultResponse,
+} from "./responses.js";
+
+const responseMap: Record<string, string[]> = {
+  "GET /widgets": ["200"],
+  "POST /widgets": ["201"],
+  "GET /widgets/{id}": ["200"],
+  "PATCH /widgets/{id}": ["200"],
+  "DELETE /widgets/{id}": ["204"],
+  "POST /widgets/{id}/analyze": ["200"],
+};
+
+export function isUnexpected(
+  response: ListWidgets200Response | ListWidgetsDefaultResponse
+): response is ListWidgetsDefaultResponse;
+export function isUnexpected(
+  response: CreateWidget201Response | CreateWidgetDefaultResponse
+): response is CreateWidgetDefaultResponse;
+export function isUnexpected(
+  response: GetWidget200Response | GetWidgetDefaultResponse
+): response is GetWidgetDefaultResponse;
+export function isUnexpected(
+  response: UpdateWidget200Response | UpdateWidgetDefaultResponse
+): response is UpdateWidgetDefaultResponse;
+export function isUnexpected(
+  response: DeleteWidget204Response | DeleteWidgetDefaultResponse
+): response is DeleteWidgetDefaultResponse;
+export function isUnexpected(
+  response: AnalyzeWidget200Response | AnalyzeWidgetDefaultResponse
+): response is AnalyzeWidgetDefaultResponse;
+export function isUnexpected(
+  response:
+    | ListWidgets200Response
+    | ListWidgetsDefaultResponse
+    | CreateWidget201Response
+    | CreateWidgetDefaultResponse
+    | GetWidget200Response
+    | GetWidgetDefaultResponse
+    | UpdateWidget200Response
+    | UpdateWidgetDefaultResponse
+    | DeleteWidget204Response
+    | DeleteWidgetDefaultResponse
+    | AnalyzeWidget200Response
+    | AnalyzeWidgetDefaultResponse
+): response is
+  | ListWidgetsDefaultResponse
+  | CreateWidgetDefaultResponse
+  | GetWidgetDefaultResponse
+  | UpdateWidgetDefaultResponse
+  | DeleteWidgetDefaultResponse
+  | AnalyzeWidgetDefaultResponse {
+  const lroOriginal = response.headers["x-ms-original-url"];
+  const url = new URL(lroOriginal ?? response.request.url);
+  const method = response.request.method;
+  let pathDetails = responseMap[`${method} ${url.pathname}`];
+  if (!pathDetails) {
+    pathDetails = getParametrizedPathSuccess(method, url.pathname);
+  }
+  return !pathDetails.includes(response.status);
+}
+
+function getParametrizedPathSuccess(method: string, path: string): string[] {
+  const pathParts = path.split("/");
+
+  // Traverse list to match the longest candidate
+  // matchedLen: the length of candidate path
+  // matchedValue: the matched status code array
+  let matchedLen = -1,
+    matchedValue: string[] = [];
+
+  // Iterate the responseMap to find a match
+  for (const [key, value] of Object.entries(responseMap)) {
+    // Extracting the path from the map key which is in format
+    // GET /path/foo
+    if (!key.startsWith(method)) {
+      continue;
+    }
+    const candidatePath = getPathFromMapKey(key);
+    // Get each part of the url path
+    const candidateParts = candidatePath.split("/");
+
+    // track if we have found a match to return the values found.
+    let found = true;
+    for (
+      let i = candidateParts.length - 1, j = pathParts.length - 1;
+      i >= 1 && j >= 1;
+      i--, j--
+    ) {
+      if (
+        candidateParts[i]?.startsWith("{") &&
+        candidateParts[i]?.indexOf("}") !== -1
+      ) {
+        const start = candidateParts[i]!.indexOf("}") + 1,
+          end = candidateParts[i]?.length;
+        // If the current part of the candidate is a "template" part
+        // Try to use the suffix of pattern to match the path
+        // {guid} ==> $
+        // {guid}:export ==> :export$
+        const isMatched = new RegExp(
+          `${candidateParts[i]?.slice(start, end)}`
+        ).test(pathParts[j] || "");
+
+        if (!isMatched) {
+          found = false;
+          break;
+        }
+        continue;
+      }
+
+      // If the candidate part is not a template and
+      // the parts don't match mark the candidate as not found
+      // to move on with the next candidate path.
+      if (candidateParts[i] !== pathParts[j]) {
+        found = false;
+        break;
+      }
+    }
+
+    // We finished evaluating the current candidate parts
+    // Update the matched value if and only if we found the longer pattern
+    if (found && candidatePath.length > matchedLen) {
+      matchedLen = candidatePath.length;
+      matchedValue = value;
+    }
+  }
+
+  return matchedValue;
+}
+
+function getPathFromMapKey(mapKey: string): string {
+  const pathStart = mapKey.indexOf("/");
+  return mapKey.slice(pathStart);
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/models.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/models.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface CreateWidget {
+  /** The weight of the widget. This is an int32, but must be greater than zero. */
+  weight: number;
+  /** The color of the widget. */
+  color: "red" | "blue";
+}
+
+export interface UpdateWidget {
+  /** The weight of the widget. This is an int32, but must be greater than zero. */
+  weight?: number;
+  /** The color of the widget. */
+  color?: "red" | "blue";
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/outputModels.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/outputModels.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface WidgetOutput {
+  /** The UUID of this widget. This is generated automatically by the service. */
+  id: string;
+  /** The weight of the widget. This is an int32, but must be greater than zero. */
+  weight: number;
+  /** The color of the widget. */
+  color: "red" | "blue";
+}
+
+export interface WidgetErrorOutput {
+  /** The HTTP error code. */
+  code: number;
+  /** A human-readable message describing the error. */
+  message: string;
+}
+
+export interface AnalyzeResultOutput {
+  summary: string;
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/parameters.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/parameters.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestParameters } from "@azure-rest/core-client";
+import { CreateWidget, UpdateWidget } from "./models.js";
+
+export type ListWidgetsParameters = RequestParameters;
+export type GetWidgetParameters = RequestParameters;
+
+export interface CreateWidgetBodyParam {
+  body?: CreateWidget;
+}
+
+export type CreateWidgetParameters = CreateWidgetBodyParam & RequestParameters;
+
+export interface UpdateWidgetBodyParam {
+  body?: UpdateWidget;
+}
+
+export type UpdateWidgetParameters = UpdateWidgetBodyParam & RequestParameters;
+export type DeleteWidgetParameters = RequestParameters;
+export type AnalyzeWidgetParameters = RequestParameters;

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/responses.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/responses.ts
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpResponse } from "@azure-rest/core-client";
+import {
+  WidgetOutput,
+  WidgetErrorOutput,
+  AnalyzeResultOutput,
+} from "./outputModels.js";
+
+/** The request has succeeded. */
+export interface ListWidgets200Response extends HttpResponse {
+  status: "200";
+  body: Array<WidgetOutput>;
+}
+
+export interface ListWidgetsDefaultResponse extends HttpResponse {
+  status: string;
+  body: WidgetErrorOutput;
+}
+
+/** The request has succeeded. */
+export interface GetWidget200Response extends HttpResponse {
+  status: "200";
+  body: WidgetOutput;
+}
+
+export interface GetWidgetDefaultResponse extends HttpResponse {
+  status: string;
+  body: WidgetErrorOutput;
+}
+
+/** The request has succeeded and a new resource has been created as a result. */
+export interface CreateWidget201Response extends HttpResponse {
+  status: "201";
+  body: WidgetOutput;
+}
+
+export interface CreateWidgetDefaultResponse extends HttpResponse {
+  status: string;
+  body: WidgetErrorOutput;
+}
+
+/** The request has succeeded. */
+export interface UpdateWidget200Response extends HttpResponse {
+  status: "200";
+  body: WidgetOutput;
+}
+
+export interface UpdateWidgetDefaultResponse extends HttpResponse {
+  status: string;
+  body: WidgetErrorOutput;
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DeleteWidget204Response extends HttpResponse {
+  status: "204";
+}
+
+export interface DeleteWidgetDefaultResponse extends HttpResponse {
+  status: string;
+  body: WidgetErrorOutput;
+}
+
+/** The request has succeeded. */
+export interface AnalyzeWidget200Response extends HttpResponse {
+  status: "200";
+  body: AnalyzeResultOutput;
+}
+
+export interface AnalyzeWidgetDefaultResponse extends HttpResponse {
+  status: string;
+  body: WidgetErrorOutput;
+}

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/widgetServiceClient.ts
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/sources/generated/src/rest/widgetServiceClient.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { logger } from "../logger.js";
+import { WidgetServiceContext } from "./clientDefinitions.js";
+
+/**
+ * Initialize a new instance of `WidgetServiceContext`
+ * @param endpoint - The parameter endpoint
+ * @param options - the parameter for all optional parameters
+ */
+export default function createClient(
+  endpoint: string,
+  options: ClientOptions = {}
+): WidgetServiceContext {
+  const baseUrl = options.baseUrl ?? `${endpoint}`;
+  options.apiVersion = options.apiVersion ?? "1.0.0";
+
+  const userAgentInfo = `azsdk-js-widget_dpg-rest/1.0.0-beta.1`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix,
+    },
+    loggingOptions: {
+      logger: options.loggingOptions?.logger ?? logger.info,
+    },
+  };
+
+  const client = getClient(baseUrl, options) as WidgetServiceContext;
+
+  return client;
+}

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -78,7 +78,7 @@ export async function $onEmit(context: EmitContext) {
     let sourcesRoot = join(projectRoot, "src");
     const customizationFolder = join(projectRoot, "sources");
     if (await fsextra.pathExists(customizationFolder)) {
-      sourcesRoot = join(customizationFolder, "genereated");
+      sourcesRoot = join(customizationFolder, "genereated", "src");
     }
     return {
       rootDir: projectRoot,

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -72,7 +72,6 @@ export async function $onEmit(context: EmitContext) {
   await generateRLC();
   // 3. Generate Modular sources
   await generateModular();
-  // 4. Generate metadata and samples/tests
 
   async function calculateGenerationDir(): Promise<GenerationDirDetail> {
     const projectRoot = context.emitterOutputDir ?? "";

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -34,10 +34,7 @@ import {
 } from "@azure-tools/rlc-common";
 import { transformRLCModel } from "./transform/transform.js";
 import { emitContentByBuilder, emitModels } from "./utils/emitUtil.js";
-import {
-  SdkContext,
-  createSdkContext
-} from "@azure-tools/typespec-client-generator-core";
+import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
 import * as path from "path";
 import { Project, SyntaxKind } from "ts-morph";
 import { buildClientContext } from "./modular/buildClientContext.js";
@@ -96,9 +93,7 @@ export async function $onEmit(context: EmitContext) {
   }
 
   async function generateRLC() {
-    let count = -1;
     for (const client of clients) {
-      count++;
       const rlcModels = await transformRLCModel(
         program,
         options,

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -78,7 +78,7 @@ export async function $onEmit(context: EmitContext) {
     let sourcesRoot = join(projectRoot, "src");
     const customizationFolder = join(projectRoot, "sources");
     if (await fsextra.pathExists(customizationFolder)) {
-      sourcesRoot = join(customizationFolder, "genereated", "src");
+      sourcesRoot = join(customizationFolder, "generated", "src");
     }
     return {
       rootDir: projectRoot,

--- a/packages/typespec-ts/src/modular/buildClassicalClient.ts
+++ b/packages/typespec-ts/src/modular/buildClassicalClient.ts
@@ -30,7 +30,7 @@ export function buildClassicalClient(
   const params = getClientParameters(client);
 
   const clientFile = project.createSourceFile(
-    `${srcPath}/src/${
+    `${srcPath}/${
       subfolder !== "" ? subfolder + "/" : ""
     }${classicalClientname}.ts`
   );
@@ -85,7 +85,7 @@ function importAllApis(
 ) {
   const project = clientFile.getProject();
   const apiModels = project.getSourceFile(
-    `${srcPath}/src/${subfolder !== "" ? subfolder + "/" : ""}api/index.ts`
+    `${srcPath}/${subfolder !== "" ? subfolder + "/" : ""}api/index.ts`
   );
 
   if (!apiModels) {
@@ -107,7 +107,7 @@ function importAllModels(
 ) {
   const project = clientFile.getProject();
   const apiModels = project.getSourceFile(
-    `${srcPath}/src/${subfolder !== "" ? subfolder + "/" : ""}models/models.ts`
+    `${srcPath}/${subfolder !== "" ? subfolder + "/" : ""}models/models.ts`
   );
 
   if (!apiModels) {
@@ -122,7 +122,7 @@ function importAllModels(
   });
 
   const apiModelsOptions = project.getSourceFile(
-    `${srcPath}/src/${subfolder !== "" ? subfolder + "/" : ""}models/options.ts`
+    `${srcPath}/${subfolder !== "" ? subfolder + "/" : ""}models/options.ts`
   );
 
   if (!apiModelsOptions) {

--- a/packages/typespec-ts/src/modular/buildClassicalClient.ts
+++ b/packages/typespec-ts/src/modular/buildClassicalClient.ts
@@ -14,8 +14,8 @@ import { getClientName } from "./helpers/namingHelpers.js";
 import { getOperationFunction } from "./helpers/operationHelpers.js";
 import { Client } from "./modularCodeModel.js";
 import { isRLCMultiEndpoint } from "../utils/clientUtils.js";
-import { SdkContext } from "@azure-tools/typespec-client-generator-core";
 import { getDocsFromDescription } from "./helpers/docsHelpers.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function buildClassicalClient(
   dpgContext: SdkContext,

--- a/packages/typespec-ts/src/modular/buildClientContext.ts
+++ b/packages/typespec-ts/src/modular/buildClientContext.ts
@@ -4,9 +4,9 @@ import { importCredential } from "./helpers/credentialHelpers.js";
 import { getClientName } from "./helpers/namingHelpers.js";
 import { Client, Parameter } from "./modularCodeModel.js";
 import { isRLCMultiEndpoint } from "../utils/clientUtils.js";
-import { SdkContext } from "@azure-tools/typespec-client-generator-core";
 import { getDocsFromDescription } from "./helpers/docsHelpers.js";
 import { importModels } from "./buildOperations.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 /**
  * This function creates the file containing the modular client context

--- a/packages/typespec-ts/src/modular/buildClientContext.ts
+++ b/packages/typespec-ts/src/modular/buildClientContext.ts
@@ -21,7 +21,7 @@ export function buildClientContext(
   const { description, parameters } = client;
   const name = getClientName(client);
   const clientContextFile = project.createSourceFile(
-    `${srcPath}/src/${
+    `${srcPath}/${
       subfolder && subfolder !== "" ? subfolder + "/" : ""
     }/api/${name}Context.ts`
   );

--- a/packages/typespec-ts/src/modular/buildCodeModel.ts
+++ b/packages/typespec-ts/src/modular/buildCodeModel.ts
@@ -65,7 +65,6 @@ import {
   getDefaultApiVersion,
   getClientNamespaceString,
   createSdkContext,
-  SdkContext,
   getSdkUnion,
   getAllModels,
   SdkSimpleType,
@@ -90,6 +89,7 @@ import {
   getOperationGroupName,
   getOperationName
 } from "../utils/operationUtil.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 interface HttpServerParameter {
   type: "endpointPath";

--- a/packages/typespec-ts/src/modular/buildCodeModel.ts
+++ b/packages/typespec-ts/src/modular/buildCodeModel.ts
@@ -1509,11 +1509,7 @@ export function emitCodeModel(
     getClientNamespaceString(dpgContext)?.toLowerCase();
   // Get types
   const codeModel: ModularCodeModel = {
-    options: transformRLCOptions(
-      context.options as any,
-      context.emitterOutputDir,
-      dpgContext
-    ),
+    options: transformRLCOptions(context.options as any, dpgContext),
     namespace: clientNamespaceString,
     subnamespaceToClients: {},
     clients: [],

--- a/packages/typespec-ts/src/modular/buildOperations.ts
+++ b/packages/typespec-ts/src/modular/buildOperations.ts
@@ -9,8 +9,9 @@ import {
 } from "./helpers/operationHelpers.js";
 import { Client, Operation } from "./modularCodeModel.js";
 import { isRLCMultiEndpoint } from "../utils/clientUtils.js";
-import { SdkContext } from "@azure-tools/typespec-client-generator-core";
+// import { SdkContext } from "@azure-tools/typespec-client-generator-core";
 import { getDocsFromDescription } from "./helpers/docsHelpers.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 /**
  * This function creates a file under /api for each operation group.

--- a/packages/typespec-ts/src/modular/buildOperations.ts
+++ b/packages/typespec-ts/src/modular/buildOperations.ts
@@ -9,7 +9,6 @@ import {
 } from "./helpers/operationHelpers.js";
 import { Client, Operation } from "./modularCodeModel.js";
 import { isRLCMultiEndpoint } from "../utils/clientUtils.js";
-// import { SdkContext } from "@azure-tools/typespec-client-generator-core";
 import { getDocsFromDescription } from "./helpers/docsHelpers.js";
 import { SdkContext } from "../utils/interfaces.js";
 
@@ -34,7 +33,7 @@ export function buildOperationFiles(
         "operations";
 
     const operationGroupFile = project.createSourceFile(
-      `${srcPath}/src/${
+      `${srcPath}/${
         subfolder && subfolder !== "" ? subfolder + "/" : ""
       }api/${fileName}.ts`
     );
@@ -110,7 +109,7 @@ export function importModels(
   subfolder: string = ""
 ) {
   const modelsFile = project.getSourceFile(
-    `${srcPath}/src/${
+    `${srcPath}/${
       subfolder && subfolder !== "" ? subfolder + "/" : ""
     }models/models.ts`
   );

--- a/packages/typespec-ts/src/modular/buildProjectFiles.ts
+++ b/packages/typespec-ts/src/modular/buildProjectFiles.ts
@@ -4,11 +4,11 @@ import { NameType, normalizeName } from "@azure-tools/rlc-common";
 
 export function emitPackage(
   project: Project,
-  srcPath: string,
+  metadataDir: string,
   codeModel: ModularCodeModel
 ) {
   const packageJson = project.createSourceFile(
-    `${srcPath}/package-files/package.json`,
+    `${metadataDir}/package-files/package.json`,
     "",
     {
       overwrite: true

--- a/packages/typespec-ts/src/modular/buildRootIndex.ts
+++ b/packages/typespec-ts/src/modular/buildRootIndex.ts
@@ -11,13 +11,11 @@ export function buildRootIndex(
 ) {
   const clientName = `${getClientName(client)}Client`;
   const clientFile = project.getSourceFile(
-    `${srcPath}/src/${subfolder !== "" ? subfolder + "/" : ""}${clientName}.ts`
+    `${srcPath}/${subfolder !== "" ? subfolder + "/" : ""}${clientName}.ts`
   );
 
   if (!clientFile) {
-    throw new Error(
-      `Couldn't find client file: ${srcPath}/src/${clientName}.ts`
-    );
+    throw new Error(`Couldn't find client file: ${srcPath}/${clientName}.ts`);
   }
 
   exportClassicalClient(client, rootIndexFile, subfolder);
@@ -48,7 +46,7 @@ function exportModels(
   isTopLevel: boolean = false
 ) {
   const modelsFile = project.getSourceFile(
-    `${srcPath}/src/${subfolder !== "" ? subfolder + "/" : ""}models/index.ts`
+    `${srcPath}/${subfolder !== "" ? subfolder + "/" : ""}models/index.ts`
   );
   if (!modelsFile) {
     return;
@@ -79,12 +77,12 @@ export function buildSubClientIndexFile(
   subfolder: string
 ) {
   const subClientIndexFile = project.createSourceFile(
-    `${srcPath}/src/${subfolder !== "" ? subfolder + "/" : ""}index.ts`,
+    `${srcPath}/${subfolder !== "" ? subfolder + "/" : ""}index.ts`,
     undefined,
     { overwrite: true }
   );
   const clientName = `${getClientName(client)}Client`;
-  const clientFilePath = `${srcPath}/src/${
+  const clientFilePath = `${srcPath}/${
     subfolder !== "" ? subfolder + "/" : ""
   }${clientName}.ts`;
   const clientFile = project.getSourceFile(clientFilePath);

--- a/packages/typespec-ts/src/modular/buildSubpathIndex.ts
+++ b/packages/typespec-ts/src/modular/buildSubpathIndex.ts
@@ -8,7 +8,7 @@ export function buildSubpathIndexFile(
 ) {
   const apiFiles = project.getSourceFiles(`**/src/${subfolder}/${subpath}/**`);
   const indexFile = project.createSourceFile(
-    `${srcPath}/src/${subfolder}/${subpath}/index.ts`
+    `${srcPath}/${subfolder}/${subpath}/index.ts`
   );
   for (const file of apiFiles) {
     const exports = [...file.getExportedDeclarations().keys()].filter(

--- a/packages/typespec-ts/src/modular/emitModels.ts
+++ b/packages/typespec-ts/src/modular/emitModels.ts
@@ -15,7 +15,7 @@ export function buildModels(
   subfolder: string = ""
 ): SourceFile {
   const modelsFile = project.createSourceFile(
-    path.join(`${srcPath}/src/`, subfolder, `models/models.ts`)
+    path.join(`${srcPath}/`, subfolder, `models/models.ts`)
   );
 
   // We are generating both models and enums here
@@ -127,7 +127,7 @@ export function buildModelsOptions(
   subfolder: string = ""
 ) {
   const modelOptionsFile = project.createSourceFile(
-    `${srcPath}/src/${subfolder}/models/options.ts`,
+    `${srcPath}/${subfolder}/models/options.ts`,
     undefined,
     {
       overwrite: true

--- a/packages/typespec-ts/src/transform/transform.ts
+++ b/packages/typespec-ts/src/transform/transform.ts
@@ -41,20 +41,12 @@ export async function transformRLCModel(
   program: Program,
   emitterOptions: RLCOptions,
   client: SdkClient,
-  emitterOutputDir: string,
   dpgContext: SdkContext
 ): Promise<RLCModel> {
-  const options: RLCOptions = transformRLCOptions(
-    emitterOptions,
-    emitterOutputDir,
-    dpgContext
-  );
+  const options: RLCOptions = transformRLCOptions(emitterOptions, dpgContext);
   dpgContext.rlcOptions = options;
   const srcPath = join(
-    emitterOutputDir ?? "",
-    "src",
-    // When generating modular library, RLC has to go under rest folder
-    options.isModularLibrary ? "rest" : "",
+    dpgContext.generationPathDetail?.rlcSourcesDir!,
     options.batch && options.batch.length > 1
       ? normalizeName(client.name.replace("Client", ""), NameType.File)
       : ""

--- a/packages/typespec-ts/src/transform/transform.ts
+++ b/packages/typespec-ts/src/transform/transform.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import {
-  SdkClient,
-  SdkContext
-} from "@azure-tools/typespec-client-generator-core";
+import { SdkClient } from "@azure-tools/typespec-client-generator-core";
 import {
   ImportKind,
   NameType,
@@ -38,17 +35,14 @@ import { transformRLCOptions } from "./transfromRLCOptions.js";
 import { transformApiVersionInfo } from "./transformApiVersionInfo.js";
 import { getClientLroOverload } from "../utils/operationUtil.js";
 import { transformTelemetryInfo } from "./transformTelemetryInfo.js";
-
-export interface RLCSdkContext extends SdkContext {
-  options?: RLCOptions;
-}
+import { SdkContext } from "../utils/interfaces.js";
 
 export async function transformRLCModel(
   program: Program,
   emitterOptions: RLCOptions,
   client: SdkClient,
   emitterOutputDir: string,
-  dpgContext: RLCSdkContext
+  dpgContext: SdkContext
 ): Promise<RLCModel> {
   const options: RLCOptions = transformRLCOptions(
     emitterOptions,

--- a/packages/typespec-ts/src/transform/transform.ts
+++ b/packages/typespec-ts/src/transform/transform.ts
@@ -49,7 +49,7 @@ export async function transformRLCModel(
     emitterOutputDir,
     dpgContext
   );
-  dpgContext.options = options;
+  dpgContext.rlcOptions = options;
   const srcPath = join(
     emitterOutputDir ?? "",
     "src",

--- a/packages/typespec-ts/src/transform/transform.ts
+++ b/packages/typespec-ts/src/transform/transform.ts
@@ -46,7 +46,7 @@ export async function transformRLCModel(
   const options: RLCOptions = transformRLCOptions(emitterOptions, dpgContext);
   dpgContext.rlcOptions = options;
   const srcPath = join(
-    dpgContext.generationPathDetail?.rlcSourcesDir!,
+    dpgContext.generationPathDetail?.rlcSourcesDir ?? "",
     options.batch && options.batch.length > 1
       ? normalizeName(client.name.replace("Client", ""), NameType.File)
       : ""

--- a/packages/typespec-ts/src/transform/transformApiVersionInfo.ts
+++ b/packages/typespec-ts/src/transform/transformApiVersionInfo.ts
@@ -1,6 +1,5 @@
 import {
   SdkClient,
-  SdkContext,
   isApiVersion,
   listOperationGroups,
   listOperationsInOperationGroup
@@ -19,6 +18,7 @@ import {
   getSchemaForType,
   trimUsage
 } from "../utils/modelUtils.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformApiVersionInfo(
   client: SdkClient,

--- a/packages/typespec-ts/src/transform/transformHelperFunctionDetails.ts
+++ b/packages/typespec-ts/src/transform/transformHelperFunctionDetails.ts
@@ -1,7 +1,6 @@
 import { PagedResultMetadata } from "@azure-tools/typespec-azure-core";
 import {
   SdkClient,
-  SdkContext,
   listOperationGroups,
   listOperationsInOperationGroup
 } from "@azure-tools/typespec-client-generator-core";
@@ -14,6 +13,7 @@ import {
   hasPollingOperations
 } from "../utils/operationUtil.js";
 import { getSpecialSerializeInfo } from "./transformParameters.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformHelperFunctionDetails(
   client: SdkClient,

--- a/packages/typespec-ts/src/transform/transformParameters.ts
+++ b/packages/typespec-ts/src/transform/transformParameters.ts
@@ -39,12 +39,12 @@ import {
   listOperationsInOperationGroup,
   isApiVersion
 } from "@azure-tools/typespec-client-generator-core";
-import { RLCSdkContext } from "./transform.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformToParameterTypes(
   importDetails: Map<ImportKind, Set<string>>,
   client: SdkClient,
-  dpgContext: RLCSdkContext
+  dpgContext: SdkContext
 ): OperationParameter[] {
   const program = dpgContext.program;
   const operationGroups = listOperationGroups(dpgContext, client);
@@ -114,7 +114,7 @@ export function transformToParameterTypes(
 }
 
 function getParameterMetadata(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   paramType: "query" | "path" | "header",
   parameter: HttpOperationParameter
 ): ParameterMetadata {
@@ -180,7 +180,7 @@ function getParameterName(name: string) {
 }
 
 function transformQueryParameters(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   parameters: HttpOperationParameters
 ): ParameterMetadata[] {
   const queryParameters = parameters.parameters.filter(
@@ -207,7 +207,7 @@ function transformPathParameters() {
 }
 
 function transformHeaderParameters(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   parameters: HttpOperationParameters
 ): ParameterMetadata[] {
   const headerParameters = parameters.parameters.filter(
@@ -222,7 +222,7 @@ function transformHeaderParameters(
 }
 
 function transformBodyParameters(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   parameters: HttpOperationParameters,
   headers: ParameterMetadata[],
   importedModels: Set<string>,
@@ -264,7 +264,7 @@ function transformBodyParameters(
 }
 
 function transformNormalBody(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   bodyType: Type,
   parameters: HttpOperationParameters,
   importedModels: Set<string>,
@@ -307,7 +307,7 @@ function transformNormalBody(
 }
 
 function transformMultiFormBody(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   bodyType: Type,
   parameters: HttpOperationParameters,
   importedModels: Set<string>
@@ -374,7 +374,7 @@ function transformMultiFormBody(
 }
 
 function getBodyDetail(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   bodyType: Type,
   headers: ParameterMetadata[]
 ) {
@@ -389,7 +389,7 @@ function getBodyDetail(
 }
 
 function extractNameFromCadlType(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   cadlType: Type,
   importedModels: Set<string>,
   headers?: ParameterMetadata[]
@@ -454,7 +454,7 @@ function generateAnomymousModelSigniture(
 }
 
 function extractDescriptionsFromBody(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   bodyType: Type,
   parameters: HttpOperationParameters
 ) {

--- a/packages/typespec-ts/src/transform/transformPaths.ts
+++ b/packages/typespec-ts/src/transform/transformPaths.ts
@@ -32,12 +32,12 @@ import {
   isDefinedStatusCode,
   isPagingOperation
 } from "../utils/operationUtil.js";
-import { RLCSdkContext } from "./transform.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformPaths(
   program: Program,
   client: SdkClient,
-  dpgContext: RLCSdkContext
+  dpgContext: SdkContext
 ): Paths {
   const operationGroups = listOperationGroups(dpgContext, client);
   const paths: Paths = {};
@@ -72,7 +72,7 @@ export function transformPaths(
  * an operation can end up returning.
  */
 function getResponseTypes(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   operation: HttpOperation
 ): ResponseTypes {
   const returnTypes: ResponseTypes = {
@@ -104,7 +104,7 @@ function getResponseTypes(
 }
 
 function transformOperation(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   route: HttpOperation,
   paths: Paths
 ) {
@@ -180,7 +180,7 @@ function escapeCoreName(name: string) {
   return name;
 }
 function hasRequiredOptions(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   routeParameters: HttpOperationParameters
 ) {
   const isRequiredBodyParam = routeParameters.bodyParameter?.optional === false;

--- a/packages/typespec-ts/src/transform/transformResponses.ts
+++ b/packages/typespec-ts/src/transform/transformResponses.ts
@@ -34,12 +34,12 @@ import {
   getOperationLroOverload,
   getOperationName
 } from "../utils/operationUtil.js";
-import { RLCSdkContext } from "./transform.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformToResponseTypes(
   importDetails: Map<ImportKind, Set<string>>,
   client: SdkClient,
-  dpgContext: RLCSdkContext
+  dpgContext: SdkContext
 ): OperationResponse[] {
   const program = dpgContext.program;
   const operationGroups = listOperationGroups(dpgContext, client);
@@ -114,7 +114,7 @@ export function transformToResponseTypes(
  * @returns rlc header shcema
  */
 function transformHeaders(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   response: HttpOperationResponse
 ): ResponseHeaderSchema[] | undefined {
   if (!response.responses.length) {
@@ -154,7 +154,7 @@ function transformHeaders(
 }
 
 function transformBody(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   response: HttpOperationResponse,
   importedModels: Set<string>
 ) {
@@ -210,7 +210,7 @@ function transformBody(
 }
 
 function transformLroLogicalResponse(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   route: HttpOperation,
   operationGroupName: string,
   existingResponses: ResponseMetadata[]

--- a/packages/typespec-ts/src/transform/transformSchemas.ts
+++ b/packages/typespec-ts/src/transform/transformSchemas.ts
@@ -15,12 +15,12 @@ import {
   getBodyType,
   trimUsage
 } from "../utils/modelUtils.js";
-import { RLCSdkContext } from "./transform.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformSchemas(
   program: Program,
   client: SdkClient,
-  dpgContext: RLCSdkContext
+  dpgContext: SdkContext
 ) {
   const schemas: Map<string, SchemaContext[]> = new Map<
     string,

--- a/packages/typespec-ts/src/transform/transfromRLCOptions.ts
+++ b/packages/typespec-ts/src/transform/transfromRLCOptions.ts
@@ -14,14 +14,13 @@ import { SdkContext } from "../utils/interfaces.js";
 
 export function transformRLCOptions(
   emitterOptions: RLCOptions,
-  emitterOutputDir: string,
   dpgContext: SdkContext
 ): RLCOptions {
   // Extract the options from emitter option
   const options = extractRLCOptions(
     dpgContext.program,
     emitterOptions,
-    emitterOutputDir
+    dpgContext.generationPathDetail?.rootDir!
   );
   const batch = getRLCClients(dpgContext);
   options.batch = batch;
@@ -31,7 +30,7 @@ export function transformRLCOptions(
 function extractRLCOptions(
   program: Program,
   emitterOptions: RLCOptions,
-  emitterOutputDir: string
+  generationRootDir: string
 ): RLCOptions {
   const includeShortcuts = getIncludeShortcuts(emitterOptions);
   const packageDetails = getPackageDetails(program, emitterOptions);
@@ -40,7 +39,7 @@ function extractRLCOptions(
   const generateMetadata = getGenerateMetadata(emitterOptions);
   const generateTest = getGenerateTest(emitterOptions);
   const credentialInfo = getCredentialInfo(program, emitterOptions);
-  const azureOutputDirectory = getAzureOutputDirectory(emitterOutputDir);
+  const azureOutputDirectory = getAzureOutputDirectory(generationRootDir);
   const enableOperationGroup = getEnableOperationGroup(emitterOptions);
   return {
     ...emitterOptions,

--- a/packages/typespec-ts/src/transform/transfromRLCOptions.ts
+++ b/packages/typespec-ts/src/transform/transfromRLCOptions.ts
@@ -10,12 +10,12 @@ import { getAuthentication } from "@typespec/http";
 import { reportDiagnostic } from "../lib.js";
 import { getDefaultService } from "../utils/modelUtils.js";
 import { getRLCClients } from "../utils/clientUtils.js";
-import { RLCSdkContext } from "./transform.js";
+import { SdkContext } from "../utils/interfaces.js";
 
 export function transformRLCOptions(
   emitterOptions: RLCOptions,
   emitterOutputDir: string,
-  dpgContext: RLCSdkContext
+  dpgContext: SdkContext
 ): RLCOptions {
   // Extract the options from emitter option
   const options = extractRLCOptions(

--- a/packages/typespec-ts/src/transform/transfromRLCOptions.ts
+++ b/packages/typespec-ts/src/transform/transfromRLCOptions.ts
@@ -20,7 +20,7 @@ export function transformRLCOptions(
   const options = extractRLCOptions(
     dpgContext.program,
     emitterOptions,
-    dpgContext.generationPathDetail?.rootDir!
+    dpgContext.generationPathDetail?.rootDir ?? ""
   );
   const batch = getRLCClients(dpgContext);
   options.batch = batch;

--- a/packages/typespec-ts/src/utils/clientUtils.ts
+++ b/packages/typespec-ts/src/utils/clientUtils.ts
@@ -1,8 +1,6 @@
-import {
-  SdkClient,
-  SdkContext
-} from "@azure-tools/typespec-client-generator-core";
+import { SdkClient } from "@azure-tools/typespec-client-generator-core";
 import { listServices } from "@typespec/compiler";
+import { SdkContext } from "./interfaces.js";
 
 export function getRLCClients(dpgContext: SdkContext): SdkClient[] {
   const services = listServices(dpgContext.program);

--- a/packages/typespec-ts/src/utils/interfaces.ts
+++ b/packages/typespec-ts/src/utils/interfaces.ts
@@ -2,12 +2,12 @@ import { RLCOptions } from "@azure-tools/rlc-common";
 import { SdkContext as TCGCSdkContext } from "@azure-tools/typespec-client-generator-core";
 
 export interface SdkContext extends TCGCSdkContext {
-  options?: RLCOptions;
+  rlcOptions?: RLCOptions;
   generationDir?: GenerationDirDetail;
 }
 
 export interface GenerationDirDetail {
-  rlcSourcesDir: string;
+  rlcSourcesDir?: string;
   modularSourcesDir?: string;
   metadataDir?: string;
 }

--- a/packages/typespec-ts/src/utils/interfaces.ts
+++ b/packages/typespec-ts/src/utils/interfaces.ts
@@ -10,5 +10,5 @@ export interface GenerationDirDetail {
   rootDir: string;
   rlcSourcesDir: string;
   modularSourcesDir?: string;
-  metadataDir?: string;
+  metadataDir: string;
 }

--- a/packages/typespec-ts/src/utils/interfaces.ts
+++ b/packages/typespec-ts/src/utils/interfaces.ts
@@ -1,0 +1,6 @@
+import { RLCOptions } from "@azure-tools/rlc-common";
+import { SdkContext } from "@azure-tools/typespec-client-generator-core";
+
+export interface RLCSdkContext extends SdkContext {
+  options: RLCOptions;
+}

--- a/packages/typespec-ts/src/utils/interfaces.ts
+++ b/packages/typespec-ts/src/utils/interfaces.ts
@@ -1,6 +1,13 @@
 import { RLCOptions } from "@azure-tools/rlc-common";
-import { SdkContext } from "@azure-tools/typespec-client-generator-core";
+import { SdkContext as TCGCSdkContext } from "@azure-tools/typespec-client-generator-core";
 
-export interface RLCSdkContext extends SdkContext {
-  options: RLCOptions;
+export interface SdkContext extends TCGCSdkContext {
+  options?: RLCOptions;
+  generationDir?: GenerationDirDetail;
+}
+
+export interface GenerationDirDetail {
+  rlcSourcesDir: string;
+  modularSourcesDir?: string;
+  metadataDir?: string;
 }

--- a/packages/typespec-ts/src/utils/interfaces.ts
+++ b/packages/typespec-ts/src/utils/interfaces.ts
@@ -3,11 +3,12 @@ import { SdkContext as TCGCSdkContext } from "@azure-tools/typespec-client-gener
 
 export interface SdkContext extends TCGCSdkContext {
   rlcOptions?: RLCOptions;
-  generationDir?: GenerationDirDetail;
+  generationPathDetail?: GenerationDirDetail;
 }
 
 export interface GenerationDirDetail {
-  rlcSourcesDir?: string;
+  rootDir: string;
+  rlcSourcesDir: string;
   modularSourcesDir?: string;
   metadataDir?: string;
 }

--- a/packages/typespec-ts/src/utils/modelUtils.ts
+++ b/packages/typespec-ts/src/utils/modelUtils.ts
@@ -63,10 +63,10 @@ import {
 import { getPagedResult, isFixed } from "@azure-tools/typespec-azure-core";
 import { extractPagedMetadataNested } from "./operationUtil.js";
 import {
-  SdkContext,
   getDefaultApiVersion,
   isApiVersion
 } from "@azure-tools/typespec-client-generator-core";
+import { SdkContext } from "./interfaces.js";
 
 export function getBinaryType(usage: SchemaContext[]) {
   return usage.includes(SchemaContext.Output)

--- a/packages/typespec-ts/src/utils/operationUtil.ts
+++ b/packages/typespec-ts/src/utils/operationUtil.ts
@@ -32,7 +32,6 @@ import {
 } from "@azure-tools/typespec-azure-core";
 import {
   SdkClient,
-  SdkContext,
   listOperationGroups,
   listOperationsInOperationGroup
 } from "@azure-tools/typespec-client-generator-core";
@@ -42,7 +41,7 @@ import {
   OPERATION_LRO_HIGH_PRIORITY
 } from "@azure-tools/rlc-common";
 import { isByteOrByteUnion } from "./modelUtils.js";
-import { RLCSdkContext } from "../transform/transform.js";
+import { SdkContext } from "./interfaces.js";
 
 export function getOperationStatuscode(
   response: HttpOperationResponse
@@ -56,15 +55,15 @@ export function getOperationStatuscode(
 }
 
 export function getOperationGroupName(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   route?: HttpOperation
 ): string;
 export function getOperationGroupName(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   operation?: Operation
 ): string;
 export function getOperationGroupName(
-  dpgContext: RLCSdkContext,
+  dpgContext: SdkContext,
   operationOrRoute?: Operation | HttpOperation
 ) {
   if (!dpgContext.options?.enableOperationGroup || !operationOrRoute) {

--- a/packages/typespec-ts/src/utils/operationUtil.ts
+++ b/packages/typespec-ts/src/utils/operationUtil.ts
@@ -66,7 +66,7 @@ export function getOperationGroupName(
   dpgContext: SdkContext,
   operationOrRoute?: Operation | HttpOperation
 ) {
-  if (!dpgContext.options?.enableOperationGroup || !operationOrRoute) {
+  if (!dpgContext.rlcOptions?.enableOperationGroup || !operationOrRoute) {
     return "";
   }
   const program = dpgContext.program;


### PR DESCRIPTION
This is part of the pr - https://github.com/Azure/autorest.typescript/issues/1958

[Part 1] In this pr we would 
- Generate code in sources folder in customization case and in src folder in no customization

[Part 2] Below would be covered in my next pr:
- Generate modular version for package.json and tsconfig.json 
- Generate metadata if relevant files are absent and not generate if existing