### PR TITLE
fix sample generation

### DIFF
--- a/packages/autorest.typescript/src/utils/valueHelpers.ts
+++ b/packages/autorest.typescript/src/utils/valueHelpers.ts
@@ -179,13 +179,8 @@ export function getParameterAssignment(
           propName = normalizeName(initPropName, NameType.Property, true);
         }
         let propRetValue: string;
-        if (propName.indexOf("/") > -1 || propName.match(/^\d/)) {
-          propRetValue =
+        propRetValue =
             `"${propName}": ` + getParameterAssignment(property, isRLCSample);
-        } else {
-          propRetValue =
-            `${propName}: ` + getParameterAssignment(property, isRLCSample);
-        }
         values.push(propRetValue);
       }
       if (values.length > 0) {

--- a/packages/autorest.typescript/src/utils/valueHelpers.ts
+++ b/packages/autorest.typescript/src/utils/valueHelpers.ts
@@ -178,9 +178,7 @@ export function getParameterAssignment(
             : prop;
           propName = normalizeName(initPropName, NameType.Property, true);
         }
-        let propRetValue: string;
-        propRetValue =
-            `"${propName}": ` + getParameterAssignment(property, isRLCSample);
+        const propRetValue = `"${propName}": ` + getParameterAssignment(property, isRLCSample);
         values.push(propRetValue);
       }
       if (values.length > 0) {


### PR DESCRIPTION
fix https://github.com/Azure/autorest.typescript/issues/2098
Special character can not be generated as a parameter name from sample generation, this pr is to fix this