### PR TITLE
Add coverage cases for arrays-item-types in cadl-ranch

### DIFF
--- a/packages/typespec-ts/test/commands/cadl-ranch-list.ts
+++ b/packages/typespec-ts/test/commands/cadl-ranch-list.ts
@@ -259,5 +259,9 @@ export const modularTsps: TypeSpecRanchConfig[] = [
   {
     outputPath: "authentication/union",
     inputPath: "authentication/union"
+  },
+  {
+    outputPath: "arrays/itemTypes",
+    inputPath: "type/array"
   }
 ];

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/logger.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/logger.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("arrays-item-types");

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/arrayClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/arrayClient.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { logger } from "../logger.js";
+import { ArrayContext } from "./clientDefinitions.js";
+
+/**
+ * Initialize a new instance of `ArrayContext`
+ * @param options - the parameter for all optional parameters
+ */
+export default function createClient(
+  options: ClientOptions = {}
+): ArrayContext {
+  const baseUrl = options.baseUrl ?? `http://localhost:3000`;
+  options.apiVersion = options.apiVersion ?? "1.0.0";
+  const userAgentInfo = `azsdk-js-arrays-item-types-rest/1.0.0-beta.1`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix,
+    },
+    loggingOptions: {
+      logger: options.loggingOptions?.logger ?? logger.info,
+    },
+  };
+
+  const client = getClient(baseUrl, options) as ArrayContext;
+
+  return client;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/clientDefinitions.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/clientDefinitions.ts
@@ -1,0 +1,165 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  Int32ValueGetParameters,
+  Int32ValuePutParameters,
+  Int64ValueGetParameters,
+  Int64ValuePutParameters,
+  BooleanValueGetParameters,
+  BooleanValuePutParameters,
+  StringValueGetParameters,
+  StringValuePutParameters,
+  Float32ValueGetParameters,
+  Float32ValuePutParameters,
+  DatetimeValueGetParameters,
+  DatetimeValuePutParameters,
+  DurationValueGetParameters,
+  DurationValuePutParameters,
+  UnknownValueGetParameters,
+  UnknownValuePutParameters,
+  ModelValueGetParameters,
+  ModelValuePutParameters,
+  NullableFloatValueGetParameters,
+  NullableFloatValuePutParameters,
+} from "./parameters.js";
+import {
+  Int32ValueGet200Response,
+  Int32ValuePut204Response,
+  Int64ValueGet200Response,
+  Int64ValuePut204Response,
+  BooleanValueGet200Response,
+  BooleanValuePut204Response,
+  StringValueGet200Response,
+  StringValuePut204Response,
+  Float32ValueGet200Response,
+  Float32ValuePut204Response,
+  DatetimeValueGet200Response,
+  DatetimeValuePut204Response,
+  DurationValueGet200Response,
+  DurationValuePut204Response,
+  UnknownValueGet200Response,
+  UnknownValuePut204Response,
+  ModelValueGet200Response,
+  ModelValuePut204Response,
+  NullableFloatValueGet200Response,
+  NullableFloatValuePut204Response,
+} from "./responses.js";
+import { Client, StreamableMethod } from "@azure-rest/core-client";
+
+export interface Int32ValueGet {
+  get(
+    options?: Int32ValueGetParameters
+  ): StreamableMethod<Int32ValueGet200Response>;
+  put(
+    options: Int32ValuePutParameters
+  ): StreamableMethod<Int32ValuePut204Response>;
+}
+
+export interface Int64ValueGet {
+  get(
+    options?: Int64ValueGetParameters
+  ): StreamableMethod<Int64ValueGet200Response>;
+  put(
+    options: Int64ValuePutParameters
+  ): StreamableMethod<Int64ValuePut204Response>;
+}
+
+export interface BooleanValueGet {
+  get(
+    options?: BooleanValueGetParameters
+  ): StreamableMethod<BooleanValueGet200Response>;
+  put(
+    options: BooleanValuePutParameters
+  ): StreamableMethod<BooleanValuePut204Response>;
+}
+
+export interface StringValueGet {
+  get(
+    options?: StringValueGetParameters
+  ): StreamableMethod<StringValueGet200Response>;
+  put(
+    options: StringValuePutParameters
+  ): StreamableMethod<StringValuePut204Response>;
+}
+
+export interface Float32ValueGet {
+  get(
+    options?: Float32ValueGetParameters
+  ): StreamableMethod<Float32ValueGet200Response>;
+  put(
+    options: Float32ValuePutParameters
+  ): StreamableMethod<Float32ValuePut204Response>;
+}
+
+export interface DatetimeValueGet {
+  get(
+    options?: DatetimeValueGetParameters
+  ): StreamableMethod<DatetimeValueGet200Response>;
+  put(
+    options: DatetimeValuePutParameters
+  ): StreamableMethod<DatetimeValuePut204Response>;
+}
+
+export interface DurationValueGet {
+  get(
+    options?: DurationValueGetParameters
+  ): StreamableMethod<DurationValueGet200Response>;
+  put(
+    options: DurationValuePutParameters
+  ): StreamableMethod<DurationValuePut204Response>;
+}
+
+export interface UnknownValueGet {
+  get(
+    options?: UnknownValueGetParameters
+  ): StreamableMethod<UnknownValueGet200Response>;
+  put(
+    options: UnknownValuePutParameters
+  ): StreamableMethod<UnknownValuePut204Response>;
+}
+
+export interface ModelValueGet {
+  get(
+    options?: ModelValueGetParameters
+  ): StreamableMethod<ModelValueGet200Response>;
+  put(
+    options: ModelValuePutParameters
+  ): StreamableMethod<ModelValuePut204Response>;
+}
+
+export interface NullableFloatValueGet {
+  get(
+    options?: NullableFloatValueGetParameters
+  ): StreamableMethod<NullableFloatValueGet200Response>;
+  put(
+    options: NullableFloatValuePutParameters
+  ): StreamableMethod<NullableFloatValuePut204Response>;
+}
+
+export interface Routes {
+  /** Resource for '/type/array/int32' has methods for the following verbs: get, put */
+  (path: "/type/array/int32"): Int32ValueGet;
+  /** Resource for '/type/array/int64' has methods for the following verbs: get, put */
+  (path: "/type/array/int64"): Int64ValueGet;
+  /** Resource for '/type/array/boolean' has methods for the following verbs: get, put */
+  (path: "/type/array/boolean"): BooleanValueGet;
+  /** Resource for '/type/array/string' has methods for the following verbs: get, put */
+  (path: "/type/array/string"): StringValueGet;
+  /** Resource for '/type/array/float32' has methods for the following verbs: get, put */
+  (path: "/type/array/float32"): Float32ValueGet;
+  /** Resource for '/type/array/datetime' has methods for the following verbs: get, put */
+  (path: "/type/array/datetime"): DatetimeValueGet;
+  /** Resource for '/type/array/duration' has methods for the following verbs: get, put */
+  (path: "/type/array/duration"): DurationValueGet;
+  /** Resource for '/type/array/unknown' has methods for the following verbs: get, put */
+  (path: "/type/array/unknown"): UnknownValueGet;
+  /** Resource for '/type/array/model' has methods for the following verbs: get, put */
+  (path: "/type/array/model"): ModelValueGet;
+  /** Resource for '/type/array/nullable-float' has methods for the following verbs: get, put */
+  (path: "/type/array/nullable-float"): NullableFloatValueGet;
+}
+
+export type ArrayContext = Client & {
+  path: Routes;
+};

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/index.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import ArrayClient from "./arrayClient.js";
+
+export * from "./arrayClient.js";
+export * from "./parameters.js";
+export * from "./responses.js";
+export * from "./clientDefinitions.js";
+export * from "./models.js";
+export * from "./outputModels.js";
+
+export default ArrayClient;

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/models.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/models.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/** Array inner model */
+export interface InnerModel {
+  /** Required string property */
+  property: string;
+  children?: Array<InnerModel>;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/outputModels.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/outputModels.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+/** Array inner model */
+export interface InnerModelOutput {
+  /** Required string property */
+  property: string;
+  children?: Array<InnerModelOutput>;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/parameters.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/parameters.ts
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestParameters } from "@azure-rest/core-client";
+import { InnerModel } from "./models.js";
+
+export type Int32ValueGetParameters = RequestParameters;
+
+export interface Int32ValuePutBodyParam {
+  body: number[];
+}
+
+export type Int32ValuePutParameters = Int32ValuePutBodyParam &
+  RequestParameters;
+export type Int64ValueGetParameters = RequestParameters;
+
+export interface Int64ValuePutBodyParam {
+  body: number[];
+}
+
+export type Int64ValuePutParameters = Int64ValuePutBodyParam &
+  RequestParameters;
+export type BooleanValueGetParameters = RequestParameters;
+
+export interface BooleanValuePutBodyParam {
+  body: boolean[];
+}
+
+export type BooleanValuePutParameters = BooleanValuePutBodyParam &
+  RequestParameters;
+export type StringValueGetParameters = RequestParameters;
+
+export interface StringValuePutBodyParam {
+  body: string[];
+}
+
+export type StringValuePutParameters = StringValuePutBodyParam &
+  RequestParameters;
+export type Float32ValueGetParameters = RequestParameters;
+
+export interface Float32ValuePutBodyParam {
+  body: number[];
+}
+
+export type Float32ValuePutParameters = Float32ValuePutBodyParam &
+  RequestParameters;
+export type DatetimeValueGetParameters = RequestParameters;
+
+export interface DatetimeValuePutBodyParam {
+  body: Date[] | string[];
+}
+
+export type DatetimeValuePutParameters = DatetimeValuePutBodyParam &
+  RequestParameters;
+export type DurationValueGetParameters = RequestParameters;
+
+export interface DurationValuePutBodyParam {
+  body: string[];
+}
+
+export type DurationValuePutParameters = DurationValuePutBodyParam &
+  RequestParameters;
+export type UnknownValueGetParameters = RequestParameters;
+
+export interface UnknownValuePutBodyParam {
+  body: unknown[];
+}
+
+export type UnknownValuePutParameters = UnknownValuePutBodyParam &
+  RequestParameters;
+export type ModelValueGetParameters = RequestParameters;
+
+export interface ModelValuePutBodyParam {
+  body: Array<InnerModel>;
+}
+
+export type ModelValuePutParameters = ModelValuePutBodyParam &
+  RequestParameters;
+export type NullableFloatValueGetParameters = RequestParameters;
+
+export interface NullableFloatValuePutBodyParam {
+  body: (number | null)[];
+}
+
+export type NullableFloatValuePutParameters = NullableFloatValuePutBodyParam &
+  RequestParameters;

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/responses.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/src/rest/responses.ts
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpResponse } from "@azure-rest/core-client";
+import { InnerModelOutput } from "./outputModels.js";
+
+/** The request has succeeded. */
+export interface Int32ValueGet200Response extends HttpResponse {
+  status: "200";
+  body: number[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Int32ValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface Int64ValueGet200Response extends HttpResponse {
+  status: "200";
+  body: number[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Int64ValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface BooleanValueGet200Response extends HttpResponse {
+  status: "200";
+  body: boolean[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface BooleanValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface StringValueGet200Response extends HttpResponse {
+  status: "200";
+  body: string[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface StringValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface Float32ValueGet200Response extends HttpResponse {
+  status: "200";
+  body: number[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Float32ValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface DatetimeValueGet200Response extends HttpResponse {
+  status: "200";
+  body: string[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DatetimeValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface DurationValueGet200Response extends HttpResponse {
+  status: "200";
+  body: string[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DurationValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface UnknownValueGet200Response extends HttpResponse {
+  status: "200";
+  body: any[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface UnknownValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface ModelValueGet200Response extends HttpResponse {
+  status: "200";
+  body: Array<InnerModelOutput>;
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface ModelValuePut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface NullableFloatValueGet200Response extends HttpResponse {
+  status: "200";
+  body: (number | null)[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface NullableFloatValuePut204Response extends HttpResponse {
+  status: "204";
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/arrays/items/tspconfig.yaml
+++ b/packages/typespec-ts/test/modularIntegration/generated/arrays/items/tspconfig.yaml
@@ -1,0 +1,13 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    "emitter-output-dir": "{project-root}"
+    generateMetadata: false
+    generateTest: false
+    azureSdkForJs: false
+    isTypeSpecTest: true
+    isModularLibrary: true
+    hierarchyClient: false
+    packageDetails:
+      name: "@msinternal/arrays-item-types"


### PR DESCRIPTION
When generate test SDK for arrays-item-types, it failed and returns an error which is shown as following:
![image](https://github.com/Azure/autorest.typescript/assets/20970631/edd5d8e5-c60b-453e-86b3-dafb60ccabae)
