### PR TITLE
Add modular coverage cases for body-optionality in cadl-ranch

### DIFF
--- a/packages/typespec-ts/test/commands/cadl-ranch-list.ts
+++ b/packages/typespec-ts/test/commands/cadl-ranch-list.ts
@@ -270,6 +270,10 @@ export const modularTsps: TypeSpecRanchConfig[] = [
   {
     outputPath: "headers/repeatability",
     inputPath: "special-headers/repeatability"
+  },
+  {
+    outputPath: "parameters/body-optionality",
+    inputPath: "parameters/body-optionality"
   }
 ];
 

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/BodyOptionalityClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/BodyOptionalityClient.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { Pipeline } from "@azure/core-rest-pipeline";
+import { BodyModel } from "./models/models.js";
+import {
+  RequiredExplicitOptions,
+  RequiredImplicitOptions,
+} from "./models/options.js";
+import {
+  getOptionalExplicitOperations,
+  OptionalExplicitOperations,
+} from "./classic/optionalExplicit/index.js";
+import {
+  createBodyOptionality,
+  BodyOptionalityClientOptions,
+  BodyOptionalityContext,
+  requiredExplicit,
+  requiredImplicit,
+} from "./api/index.js";
+
+export { BodyOptionalityClientOptions } from "./api/BodyOptionalityContext.js";
+
+export class BodyOptionalityClient {
+  private _client: BodyOptionalityContext;
+  /** The pipeline used by this client to make requests */
+  public readonly pipeline: Pipeline;
+
+  /** Test describing optionality of the request body. */
+  constructor(options: BodyOptionalityClientOptions = {}) {
+    this._client = createBodyOptionality(options);
+    this.pipeline = this._client.pipeline;
+    this.optionalExplicit = getOptionalExplicitOperations(this._client);
+  }
+
+  /** The operation groups for OptionalExplicit */
+  public readonly optionalExplicit: OptionalExplicitOperations;
+
+  requiredExplicit(
+    body: BodyModel,
+    options: RequiredExplicitOptions = { requestOptions: {} }
+  ): Promise<void> {
+    return requiredExplicit(this._client, body, options);
+  }
+
+  requiredImplicit(
+    body: BodyModel,
+    options: RequiredImplicitOptions = { requestOptions: {} }
+  ): Promise<void> {
+    return requiredImplicit(this._client, body, options);
+  }
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/BodyOptionalityContext.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/BodyOptionalityContext.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { ClientOptions } from "@azure-rest/core-client";
+import { BodyOptionalityContext } from "../rest/index.js";
+import getClient from "../rest/index.js";
+
+export interface BodyOptionalityClientOptions extends ClientOptions {}
+
+export { BodyOptionalityContext } from "../rest/index.js";
+
+/** Test describing optionality of the request body. */
+export function createBodyOptionality(
+  options: BodyOptionalityClientOptions = {}
+): BodyOptionalityContext {
+  const clientContext = getClient(options);
+  return clientContext;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/index.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export {
+  createBodyOptionality,
+  BodyOptionalityClientOptions,
+  BodyOptionalityContext,
+} from "./BodyOptionalityContext.js";
+export { requiredExplicit, requiredImplicit } from "./operations.js";
+export { set, omit } from "./optionalExplicit/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/operations.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/operations.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { BodyModel } from "../models/models.js";
+import {
+  BodyOptionalityContext as Client,
+  RequiredExplicit204Response,
+  RequiredImplicit204Response,
+} from "../rest/index.js";
+import {
+  StreamableMethod,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import {
+  RequiredExplicitOptions,
+  RequiredImplicitOptions,
+} from "../models/options.js";
+
+export function _requiredExplicitSend(
+  context: Client,
+  body: BodyModel,
+  options: RequiredExplicitOptions = { requestOptions: {} }
+): StreamableMethod<RequiredExplicit204Response> {
+  return context
+    .path("/parameters/body-optionality/required-explicit")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      body: { name: body["name"] },
+    });
+}
+
+export async function _requiredExplicitDeserialize(
+  result: RequiredExplicit204Response
+): Promise<void> {
+  if (result.status !== "204") {
+    throw result.body;
+  }
+
+  return;
+}
+
+export async function requiredExplicit(
+  context: Client,
+  body: BodyModel,
+  options: RequiredExplicitOptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await _requiredExplicitSend(context, body, options);
+  return _requiredExplicitDeserialize(result);
+}
+
+export function _requiredImplicitSend(
+  context: Client,
+  body: BodyModel,
+  options: RequiredImplicitOptions = { requestOptions: {} }
+): StreamableMethod<RequiredImplicit204Response> {
+  return context
+    .path("/parameters/body-optionality/required-implicit")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      body: { name: body["name"] },
+    });
+}
+
+export async function _requiredImplicitDeserialize(
+  result: RequiredImplicit204Response
+): Promise<void> {
+  if (result.status !== "204") {
+    throw result.body;
+  }
+
+  return;
+}
+
+export async function requiredImplicit(
+  context: Client,
+  body: BodyModel,
+  options: RequiredImplicitOptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await _requiredImplicitSend(context, body, options);
+  return _requiredImplicitDeserialize(result);
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/optionalExplicit/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/api/optionalExplicit/index.ts
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { BodyModel } from "../../models/models.js";
+import {
+  BodyOptionalityContext as Client,
+  Omit204Response,
+  SetModel204Response,
+} from "../../rest/index.js";
+import {
+  StreamableMethod,
+  operationOptionsToRequestParameters,
+} from "@azure-rest/core-client";
+import {
+  OptionalExplicitSetOptions,
+  OptionalExplicitOmitOptions,
+} from "../../models/options.js";
+
+export function _setSend(
+  context: Client,
+  body: BodyModel,
+  options: OptionalExplicitSetOptions = { requestOptions: {} }
+): StreamableMethod<SetModel204Response> {
+  return context
+    .path("/parameters/body-optionality/optional-explicit/set")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      body: { name: body["name"] },
+    });
+}
+
+export async function _setDeserialize(
+  result: SetModel204Response
+): Promise<void> {
+  if (result.status !== "204") {
+    throw result.body;
+  }
+
+  return;
+}
+
+export async function set(
+  context: Client,
+  body: BodyModel,
+  options: OptionalExplicitSetOptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await _setSend(context, body, options);
+  return _setDeserialize(result);
+}
+
+export function _omitSend(
+  context: Client,
+  body: BodyModel,
+  options: OptionalExplicitOmitOptions = { requestOptions: {} }
+): StreamableMethod<Omit204Response> {
+  return context
+    .path("/parameters/body-optionality/optional-explicit/omit")
+    .post({
+      ...operationOptionsToRequestParameters(options),
+      body: { name: body["name"] },
+    });
+}
+
+export async function _omitDeserialize(result: Omit204Response): Promise<void> {
+  if (result.status !== "204") {
+    throw result.body;
+  }
+
+  return;
+}
+
+export async function omit(
+  context: Client,
+  body: BodyModel,
+  options: OptionalExplicitOmitOptions = { requestOptions: {} }
+): Promise<void> {
+  const result = await _omitSend(context, body, options);
+  return _omitDeserialize(result);
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/classic/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/classic/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { OptionalExplicitOperations } from "./optionalExplicit/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/classic/optionalExplicit/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/classic/optionalExplicit/index.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { BodyOptionalityContext } from "../../api/BodyOptionalityContext.js";
+import { BodyModel } from "../../models/models.js";
+import { set, omit } from "../../api/optionalExplicit/index.js";
+import {
+  OptionalExplicitSetOptions,
+  OptionalExplicitOmitOptions,
+} from "../../models/options.js";
+
+export interface OptionalExplicitOperations {
+  set: (body: BodyModel, options?: OptionalExplicitSetOptions) => Promise<void>;
+  omit: (
+    body: BodyModel,
+    options?: OptionalExplicitOmitOptions
+  ) => Promise<void>;
+}
+
+export function getOptionalExplicit(context: BodyOptionalityContext) {
+  return {
+    set: (body: BodyModel, options?: OptionalExplicitSetOptions) =>
+      set(context, body, options),
+    omit: (body: BodyModel, options?: OptionalExplicitOmitOptions) =>
+      omit(context, body, options),
+  };
+}
+
+export function getOptionalExplicitOperations(
+  context: BodyOptionalityContext
+): OptionalExplicitOperations {
+  return {
+    ...getOptionalExplicit(context),
+  };
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export {
+  BodyOptionalityClient,
+  BodyOptionalityClientOptions,
+} from "./BodyOptionalityClient.js";
+export {
+  BodyModel,
+  OptionalExplicitSetOptions,
+  OptionalExplicitOmitOptions,
+  RequiredExplicitOptions,
+  RequiredImplicitOptions,
+} from "./models/index.js";
+export { OptionalExplicitOperations } from "./classic/index.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/logger.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/logger.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("body-optionality");

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/models/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/models/index.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export { BodyModel } from "./models.js";
+export {
+  OptionalExplicitSetOptions,
+  OptionalExplicitOmitOptions,
+  RequiredExplicitOptions,
+  RequiredImplicitOptions,
+} from "./options.js";

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/models/models.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/models/models.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface BodyModel {
+  name: string;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/models/options.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/models/options.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { OperationOptions } from "@azure-rest/core-client";
+
+export interface OptionalExplicitSetOptions extends OperationOptions {}
+
+export interface OptionalExplicitOmitOptions extends OperationOptions {}
+
+export interface RequiredExplicitOptions extends OperationOptions {}
+
+export interface RequiredImplicitOptions extends OperationOptions {}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/bodyOptionalityClient.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/bodyOptionalityClient.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { logger } from "../logger.js";
+import { BodyOptionalityContext } from "./clientDefinitions.js";
+
+/**
+ * Initialize a new instance of `BodyOptionalityContext`
+ * @param options - the parameter for all optional parameters
+ */
+export default function createClient(
+  options: ClientOptions = {}
+): BodyOptionalityContext {
+  const baseUrl = options.baseUrl ?? `http://localhost:3000`;
+  options.apiVersion = options.apiVersion ?? "1.0.0";
+  const userAgentInfo = `azsdk-js-body-optionality-rest/1.0.0-beta.1`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix,
+    },
+    loggingOptions: {
+      logger: options.loggingOptions?.logger ?? logger.info,
+    },
+  };
+
+  const client = getClient(baseUrl, options) as BodyOptionalityContext;
+
+  return client;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/clientDefinitions.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/clientDefinitions.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  SetModelParameters,
+  OmitParameters,
+  RequiredExplicitParameters,
+  RequiredImplicitParameters,
+} from "./parameters.js";
+import {
+  SetModel204Response,
+  Omit204Response,
+  RequiredExplicit204Response,
+  RequiredImplicit204Response,
+} from "./responses.js";
+import { Client, StreamableMethod } from "@azure-rest/core-client";
+
+export interface SetModel {
+  post(options?: SetModelParameters): StreamableMethod<SetModel204Response>;
+}
+
+export interface Omit {
+  post(options?: OmitParameters): StreamableMethod<Omit204Response>;
+}
+
+export interface RequiredExplicit {
+  post(
+    options: RequiredExplicitParameters
+  ): StreamableMethod<RequiredExplicit204Response>;
+}
+
+export interface RequiredImplicit {
+  post(
+    options?: RequiredImplicitParameters
+  ): StreamableMethod<RequiredImplicit204Response>;
+}
+
+export interface Routes {
+  /** Resource for '/parameters/body-optionality/optional-explicit/set' has methods for the following verbs: post */
+  (path: "/parameters/body-optionality/optional-explicit/set"): SetModel;
+  /** Resource for '/parameters/body-optionality/optional-explicit/omit' has methods for the following verbs: post */
+  (path: "/parameters/body-optionality/optional-explicit/omit"): Omit;
+  /** Resource for '/parameters/body-optionality/required-explicit' has methods for the following verbs: post */
+  (path: "/parameters/body-optionality/required-explicit"): RequiredExplicit;
+  /** Resource for '/parameters/body-optionality/required-implicit' has methods for the following verbs: post */
+  (path: "/parameters/body-optionality/required-implicit"): RequiredImplicit;
+}
+
+export type BodyOptionalityContext = Client & {
+  path: Routes;
+};

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/index.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import BodyOptionalityClient from "./bodyOptionalityClient.js";
+
+export * from "./bodyOptionalityClient.js";
+export * from "./parameters.js";
+export * from "./responses.js";
+export * from "./clientDefinitions.js";
+export * from "./models.js";
+
+export default BodyOptionalityClient;

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/models.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/models.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface BodyModel {
+  name: string;
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/parameters.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/parameters.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestParameters } from "@azure-rest/core-client";
+import { BodyModel } from "./models.js";
+
+export interface SetModelBodyParam {
+  body?: BodyModel;
+}
+
+export type SetModelParameters = SetModelBodyParam & RequestParameters;
+
+export interface OmitBodyParam {
+  body?: BodyModel;
+}
+
+export type OmitParameters = OmitBodyParam & RequestParameters;
+
+export interface RequiredExplicitBodyParam {
+  body: BodyModel;
+}
+
+export type RequiredExplicitParameters = RequiredExplicitBodyParam &
+  RequestParameters;
+
+export interface RequiredImplicitBodyParam {
+  body?: BodyModel;
+}
+
+export type RequiredImplicitParameters = RequiredImplicitBodyParam &
+  RequestParameters;

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/responses.ts
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/generated/src/rest/responses.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpResponse } from "@azure-rest/core-client";
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface SetModel204Response extends HttpResponse {
+  status: "204";
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Omit204Response extends HttpResponse {
+  status: "204";
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface RequiredExplicit204Response extends HttpResponse {
+  status: "204";
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface RequiredImplicit204Response extends HttpResponse {
+  status: "204";
+}

--- a/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/tspconfig.yaml
+++ b/packages/typespec-ts/test/modularIntegration/generated/parameters/body-optionality/tspconfig.yaml
@@ -1,0 +1,12 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    generateMetadata: false
+    generateTest: false
+    azureSdkForJs: false
+    isModularLibrary: true
+    hierarchyClient: false
+    "emitter-output-dir": "{project-root}/generated"
+    packageDetails:
+      name: "@msinternal/body-optionality"


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.typescript/issues/2114

Added List:
1.body-optionality

