### PR TITLE
Add rlc coverage cases for payload-content-negotiation in cadl-ranch

### DIFF
--- a/packages/typespec-ts/test/commands/cadl-ranch-list.ts
+++ b/packages/typespec-ts/test/commands/cadl-ranch-list.ts
@@ -200,6 +200,10 @@ export const rlcTsps: TypeSpecRanchConfig[] = [
   {
     outputPath: "payload/pageable",
     inputPath: "payload/pageable"
+  },
+  {
+    outputPath: "payload/content-negotiation",
+    inputPath: "payload/content-negotiation"
   }
 ];
 

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/clientDefinitions.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/clientDefinitions.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  SameBodyGetAvatarAsPngParameters,
+  SameBodyGetAvatarAsJpegParameters,
+  DifferentBodyGetAvatarAsPngParameters,
+  DifferentBodyGetAvatarAsJsonParameters,
+} from "./parameters";
+import {
+  SameBodyGetAvatarAsPng200Response,
+  SameBodyGetAvatarAsJpeg200Response,
+  DifferentBodyGetAvatarAsPng200Response,
+  DifferentBodyGetAvatarAsJson200Response,
+} from "./responses";
+import { Client, StreamableMethod } from "@azure-rest/core-client";
+
+export interface SameBodyGetAvatarAsPng {
+  get(
+    options: SameBodyGetAvatarAsPngParameters
+  ): StreamableMethod<SameBodyGetAvatarAsPng200Response>;
+  get(
+    options: SameBodyGetAvatarAsJpegParameters
+  ): StreamableMethod<SameBodyGetAvatarAsJpeg200Response>;
+}
+
+export interface DifferentBodyGetAvatarAsPng {
+  get(
+    options: DifferentBodyGetAvatarAsPngParameters
+  ): StreamableMethod<DifferentBodyGetAvatarAsPng200Response>;
+  get(
+    options: DifferentBodyGetAvatarAsJsonParameters
+  ): StreamableMethod<DifferentBodyGetAvatarAsJson200Response>;
+}
+
+export interface Routes {
+  /** Resource for '/content-negotiation/same-body' has methods for the following verbs: get */
+  (path: "/content-negotiation/same-body"): SameBodyGetAvatarAsPng;
+  /** Resource for '/content-negotiation/different-body' has methods for the following verbs: get */
+  (path: "/content-negotiation/different-body"): DifferentBodyGetAvatarAsPng;
+}
+
+export type ContentNegotiationClient = Client & {
+  path: Routes;
+};

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/contentNegotiationClient.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/contentNegotiationClient.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { logger } from "./logger";
+import { ContentNegotiationClient } from "./clientDefinitions";
+
+/**
+ * Initialize a new instance of `ContentNegotiationClient`
+ * @param options - the parameter for all optional parameters
+ */
+export default function createClient(
+  options: ClientOptions = {}
+): ContentNegotiationClient {
+  const baseUrl = options.baseUrl ?? `http://localhost:3000`;
+  options.apiVersion = options.apiVersion ?? "1.0.0";
+  const userAgentInfo = `azsdk-js-payload-content-negotiation-rest/1.0.0-beta.1`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix,
+    },
+    loggingOptions: {
+      logger: options.loggingOptions?.logger ?? logger.info,
+    },
+  };
+
+  const client = getClient(baseUrl, options) as ContentNegotiationClient;
+
+  return client;
+}

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/index.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/index.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import ContentNegotiationClient from "./contentNegotiationClient";
+
+export * from "./contentNegotiationClient";
+export * from "./parameters";
+export * from "./responses";
+export * from "./clientDefinitions";
+export * from "./outputModels";
+
+export default ContentNegotiationClient;

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/logger.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/logger.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("payload-content-negotiation");

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/outputModels.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/outputModels.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface PngImageAsJsonOutput {
+  content: string;
+}

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/parameters.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RawHttpHeadersInput } from "@azure/core-rest-pipeline";
+import { RequestParameters } from "@azure-rest/core-client";
+
+export interface SameBodyGetAvatarAsPngHeaders {
+  accept: "image/png";
+}
+
+export interface SameBodyGetAvatarAsPngHeaderParam {
+  headers: RawHttpHeadersInput & SameBodyGetAvatarAsPngHeaders;
+}
+
+export type SameBodyGetAvatarAsPngParameters =
+  SameBodyGetAvatarAsPngHeaderParam & RequestParameters;
+
+export interface SameBodyGetAvatarAsJpegHeaders {
+  accept: "image/jpeg";
+}
+
+export interface SameBodyGetAvatarAsJpegHeaderParam {
+  headers: RawHttpHeadersInput & SameBodyGetAvatarAsJpegHeaders;
+}
+
+export type SameBodyGetAvatarAsJpegParameters =
+  SameBodyGetAvatarAsJpegHeaderParam & RequestParameters;
+
+export interface DifferentBodyGetAvatarAsPngHeaders {
+  accept: "image/png";
+}
+
+export interface DifferentBodyGetAvatarAsPngHeaderParam {
+  headers: RawHttpHeadersInput & DifferentBodyGetAvatarAsPngHeaders;
+}
+
+export type DifferentBodyGetAvatarAsPngParameters =
+  DifferentBodyGetAvatarAsPngHeaderParam & RequestParameters;
+
+export interface DifferentBodyGetAvatarAsJsonHeaders {
+  accept: "application/json";
+}
+
+export interface DifferentBodyGetAvatarAsJsonHeaderParam {
+  headers: RawHttpHeadersInput & DifferentBodyGetAvatarAsJsonHeaders;
+}
+
+export type DifferentBodyGetAvatarAsJsonParameters =
+  DifferentBodyGetAvatarAsJsonHeaderParam & RequestParameters;

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/responses.ts
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/src/responses.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpResponse } from "@azure-rest/core-client";
+import { PngImageAsJsonOutput } from "./outputModels";
+
+/** The request has succeeded. */
+export interface SameBodyGetAvatarAsPng200Response extends HttpResponse {
+  status: "200";
+  /** Value may contain any sequence of octets */
+  body: Uint8Array;
+}
+
+/** The request has succeeded. */
+export interface SameBodyGetAvatarAsJpeg200Response extends HttpResponse {
+  status: "200";
+  /** Value may contain any sequence of octets */
+  body: Uint8Array;
+}
+
+/** The request has succeeded. */
+export interface DifferentBodyGetAvatarAsPng200Response extends HttpResponse {
+  status: "200";
+  /** Value may contain any sequence of octets */
+  body: Uint8Array;
+}
+
+/** The request has succeeded. */
+export interface DifferentBodyGetAvatarAsJson200Response extends HttpResponse {
+  status: "200";
+  body: PngImageAsJsonOutput;
+}

--- a/packages/typespec-ts/test/integration/generated/payload/content-negotiation/tspconfig.yaml
+++ b/packages/typespec-ts/test/integration/generated/payload/content-negotiation/tspconfig.yaml
@@ -1,0 +1,13 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    "emitter-output-dir": "{project-root}"
+    generateMetadata: false
+    generateTest: false
+    addCredentials: false
+    azureSdkForJs: false
+    isTypeSpecTest: true
+    enableOperationGroup: true
+    packageDetails:
+      name: "@msinternal/payload-content-negotiation"

--- a/packages/typespec-ts/test/integration/payloadContentNegotiation.spec.ts
+++ b/packages/typespec-ts/test/integration/payloadContentNegotiation.spec.ts
@@ -1,0 +1,113 @@
+import { assert } from "chai";
+import ContentNegotiationClientFactory, {
+  ContentNegotiationClient
+} from "./generated/payload/content-negotiation/src/index.js";
+
+import { readFileSync } from "fs";
+import { resolvePath } from "@typespec/compiler";
+import { fileURLToPath } from "url";
+
+const root = resolvePath(fileURLToPath(import.meta.url), "../../../../../");
+const pngFile = readFileSync(resolvePath(root, "assets/image.png"));
+const jpegImage = readFileSync(resolvePath(root, "assets/image.jpg"));
+describe("Content Negotiation Client", () => {
+  let client: ContentNegotiationClient;
+
+  beforeEach(() => {
+    client = ContentNegotiationClientFactory({
+      allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0
+      }
+    });
+  });
+
+  it("should get image/png for same body in content negotiation", async () => {
+    try {
+      const result = await client
+        .path("/content-negotiation/same-body")
+        .get({ headers: { accept: "image/png" } });
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body.contentType, "image/png");
+      assert.strictEqual(result.body.rawContent, pngFile);
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get image/jpeg for same body in content negotiation", async () => {
+    try {
+      const result = await client
+        .path("/content-negotiation/same-body")
+        .get({ headers: { accept: "image/jpeg" } });
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body.contentType, "image/jpeg");
+      assert.strictEqual(result.body.rawContent, jpegImage);
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should return error if put wrong accept for same body in content negotiation", async () => {
+    try {
+      const result = await client
+        .path("/content-negotiation/same-body")
+        .get({ headers: { accept: "wrongAccept" } });
+      assert.strictEqual(
+        (result.body as any).message,
+        "Unsupported Accept header"
+      );
+      assert.strictEqual(
+        (result.body as any).expected,
+        `"image/png" | "image/jpeg"`
+      );
+      assert.strictEqual((result.body as any).actual, "wrongAccept");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get image/png for different body in content negotiation", async () => {
+    try {
+      const result = await client
+        .path("/content-negotiation/different-body")
+        .get({ headers: { accept: "image/png" } });
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body.contentType, "image/jpeg");
+      assert.strictEqual(result.body.rawContent, jpegImage);
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get application/json for different body in content negotiation", async () => {
+    try {
+      const result = await client
+        .path("/content-negotiation/different-body")
+        .get({ headers: { accept: "application/json" } });
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body.content, pngFile.toString("base64"));
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should return error if put wrong accept for different body in content negotiation", async () => {
+    try {
+      const result = await client
+        .path("/content-negotiation/different-body")
+        .get({ headers: { accept: "wrongAccept" } });
+      assert.strictEqual(
+        (result.body as any).message,
+        "Unsupported Accept header"
+      );
+      assert.strictEqual(
+        (result.body as any).expected,
+        `"image/png" | "application/json"`
+      );
+      assert.strictEqual((result.body as any).actual, "wrongAccept");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+});


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.typescript/issues/2137

Added List:
1.payload-content-negotiation