### PR TITLE
Remove `mocha-junit-reporter` dependency from generated packages

### DIFF
--- a/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/bodyStringRest/package.json
@@ -81,7 +81,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/agrifood-data-plane/package.json
@@ -84,7 +84,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/anomaly-detector-rest/package.json
@@ -84,7 +84,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/rlc-common/src/metadata/buildPackageFile.ts
+++ b/packages/rlc-common/src/metadata/buildPackageFile.ts
@@ -241,7 +241,6 @@ function restLevelPackage(model: RLCModel) {
     packageInfo.devDependencies["mocha"] = "^10.0.0";
     packageInfo.devDependencies["esm"] = "^3.2.18";
     packageInfo.devDependencies["@types/mocha"] = "^10.0.0";
-    packageInfo.devDependencies["mocha-junit-reporter"] = "^1.18.0";
     packageInfo.devDependencies["cross-env"] = "^7.0.2";
     packageInfo.devDependencies["@types/chai"] = "^4.2.8";
     packageInfo.devDependencies["chai"] = "^4.2.0";

--- a/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/anomalyDetector/generated/typespec-ts/package.json
@@ -82,7 +82,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/authoring/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/authoring/generated/typespec-ts/package.json
@@ -84,7 +84,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/batch_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/batch_modular/generated/typespec-ts/package.json
@@ -98,7 +98,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/chatApi_modular/generated/typespec-ts/package.json
@@ -97,7 +97,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/contoso/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/contoso/generated/typespec-ts/package.json
@@ -84,7 +84,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/customWrapper/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/customWrapper/generated/typespec-ts/package.json
@@ -81,7 +81,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/eventgrid_modular/generated/typespec-ts/package.json
@@ -97,7 +97,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/healthinsight/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/healthinsight/generated/typespec-ts/package.json
@@ -83,7 +83,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/hierarchy_generic/generated/typespec-ts/package.json
@@ -113,7 +113,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/loadTest/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/loadTest/generated/typespec-ts/package.json
@@ -84,7 +84,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/loadtesting_modular/generated/typespec-ts/package.json
@@ -116,7 +116,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/openai/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai/generated/typespec-ts/package.json
@@ -83,7 +83,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/openai_generic/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai_generic/generated/typespec-ts/package.json
@@ -145,7 +145,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/openai_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/openai_modular/generated/typespec-ts/package.json
@@ -99,7 +99,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/overloads_modular/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/overloads_modular/generated/typespec-ts/package.json
@@ -101,7 +101,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/translator/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/translator/generated/typespec-ts/package.json
@@ -81,7 +81,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-test/test/widget_dpg/generated/typespec-ts/package.json
+++ b/packages/typespec-test/test/widget_dpg/generated/typespec-ts/package.json
@@ -102,7 +102,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-ts/src/modular/buildProjectFiles.ts
+++ b/packages/typespec-ts/src/modular/buildProjectFiles.ts
@@ -383,7 +383,6 @@ function emitBrandedPackage(
     packageInfo.devDependencies["@azure-tools/test-recorder"] = "^3.0.0";
     packageInfo.devDependencies["mocha"] = "^10.0.0";
     packageInfo.devDependencies["@types/mocha"] = "^10.0.0";
-    packageInfo.devDependencies["mocha-junit-reporter"] = "^1.18.0";
     packageInfo.devDependencies["cross-env"] = "^7.0.2";
     packageInfo.devDependencies["@types/chai"] = "^4.2.8";
     packageInfo.devDependencies["chai"] = "^4.2.0";

--- a/packages/typespec-ts/test/integration/generated/authentication/apiKey/package.json
+++ b/packages/typespec-ts/test/integration/generated/authentication/apiKey/package.json
@@ -91,7 +91,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-ts/test/integration/generated/authentication/http-custom/package.json
+++ b/packages/typespec-ts/test/integration/generated/authentication/http-custom/package.json
@@ -91,7 +91,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-ts/test/integration/generated/azure/core-traits/package.json
+++ b/packages/typespec-ts/test/integration/generated/azure/core-traits/package.json
@@ -81,7 +81,6 @@
     "mocha": "^10.0.0",
     "esm": "^3.2.18",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",

--- a/packages/typespec-ts/test/integration/generated/union-body/package.json
+++ b/packages/typespec-ts/test/integration/generated/union-body/package.json
@@ -91,7 +91,6 @@
     "@azure-tools/test-recorder": "^3.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "mocha-junit-reporter": "^1.18.0",
     "cross-env": "^7.0.2",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",


### PR DESCRIPTION
- It has been replaced with Mocha builtin XUnit reporter in Azure SDK for JavaScript repo in PR https://github.com/Azure/azure-sdk-for-js/pull/27992

- For non-azuresdkjs we don't currently use any mocha reporters in the command line.