### PR TITLE
Support decimal type in RLC

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
       '@azure-rest/core-client': ^1.1.6
       '@azure-tools/cadl-ranch': ^0.10.0
       '@azure-tools/cadl-ranch-expect': ^0.9.0
-      '@azure-tools/cadl-ranch-specs': ^0.26.1
+      '@azure-tools/cadl-ranch-specs': ^0.26.2
       '@azure-tools/rlc-common': workspace:^0.19.0
       '@azure-tools/typespec-azure-core': '>=0.36.0 <1.0.0'
       '@azure-tools/typespec-client-generator-core': '>=0.36.1 <1.0.0'
@@ -256,6 +256,7 @@ importers:
       chai: ^4.3.6
       chalk: ^4.0.0
       cross-env: ^7.0.3
+      decimal.js: 10.4.3
       eslint: ^8.9.0
       eslint-plugin-require-extensions: 0.1.3
       fs-extra: ^11.1.0
@@ -283,7 +284,7 @@ importers:
       '@azure-rest/core-client': 1.1.6
       '@azure-tools/cadl-ranch': 0.10.0_3hgbimueyj4cov2ejjvw37nlra
       '@azure-tools/cadl-ranch-expect': 0.9.0_34oeiyjczsyn4xxwbbzj3xeide
-      '@azure-tools/cadl-ranch-specs': 0.26.1_d6rreab6h3zzjhymhpmevgdlii
+      '@azure-tools/cadl-ranch-specs': 0.26.2_d6rreab6h3zzjhymhpmevgdlii
       '@azure/core-auth': 1.5.0
       '@azure/core-lro': 2.5.4
       '@azure/core-paging': 1.5.0
@@ -301,6 +302,7 @@ importers:
       chai: 4.3.8
       chalk: 4.1.2
       cross-env: 7.0.3
+      decimal.js: 10.4.3
       eslint: 8.50.0
       eslint-plugin-require-extensions: 0.1.3_eslint@8.50.0
       mkdirp: 2.1.6
@@ -402,8 +404,8 @@ packages:
       '@typespec/versioning': 0.50.0_@typespec+compiler@0.50.0
     dev: true
 
-  /@azure-tools/cadl-ranch-specs/0.26.1_d6rreab6h3zzjhymhpmevgdlii:
-    resolution: {integrity: sha512-BkOp1ZTl8X08Dq1wgzBHQirrge1DNzhhyaugEsnFnsWIPWmidj3yfSgWem6I4qmc4r1+jq2iVdeMyXTYDeMEcg==}
+  /@azure-tools/cadl-ranch-specs/0.26.2_d6rreab6h3zzjhymhpmevgdlii:
+    resolution: {integrity: sha512-752/7At1Fs51i4LOLByD6voV4cqf7cgIZuNZkqAROza8mFk+KVqEOTGdRM9JbMspTTUwDM+z5dx6dxN9ARhNnA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@azure-tools/cadl-ranch-expect': ~0.9.0
@@ -2246,6 +2248,10 @@ packages:
   /decamelize/4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
+    dev: true
+
+  /decimal.js/10.4.3:
+    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
     dev: true
 
   /deep-eql/4.1.3:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -256,7 +256,6 @@ importers:
       chai: ^4.3.6
       chalk: ^4.0.0
       cross-env: ^7.0.3
-      decimal.js: 10.4.3
       eslint: ^8.9.0
       eslint-plugin-require-extensions: 0.1.3
       fs-extra: ^11.1.0
@@ -302,7 +301,6 @@ importers:
       chai: 4.3.8
       chalk: 4.1.2
       cross-env: 7.0.3
-      decimal.js: 10.4.3
       eslint: 8.50.0
       eslint-plugin-require-extensions: 0.1.3_eslint@8.50.0
       mkdirp: 2.1.6
@@ -2248,10 +2246,6 @@ packages:
   /decamelize/4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
-    dev: true
-
-  /decimal.js/10.4.3:
-    resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
     dev: true
 
   /deep-eql/4.1.3:

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -58,7 +58,7 @@
     "ts-node": "~10.9.1",
     "typescript": "~5.2.0",
     "prettier": "~2.7.1",
-    "@azure-tools/cadl-ranch-specs": "^0.26.1",
+    "@azure-tools/cadl-ranch-specs": "^0.26.2",
     "@azure-tools/cadl-ranch-expect": "^0.9.0",
     "@azure-tools/cadl-ranch": "^0.10.0",
     "chalk": "^4.0.0",
@@ -71,7 +71,8 @@
     "@azure/logger": "^1.0.4",
     "@azure/core-util": "^1.4.0",
     "eslint-plugin-require-extensions": "0.1.3",
-    "@typespec/ts-http-runtime": "1.0.0-alpha.20231129.4"
+    "@typespec/ts-http-runtime": "1.0.0-alpha.20231129.4",
+    "decimal.js": "10.4.3"
   },
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -71,8 +71,7 @@
     "@azure/logger": "^1.0.4",
     "@azure/core-util": "^1.4.0",
     "eslint-plugin-require-extensions": "0.1.3",
-    "@typespec/ts-http-runtime": "1.0.0-alpha.20231129.4",
-    "decimal.js": "10.4.3"
+    "@typespec/ts-http-runtime": "1.0.0-alpha.20231129.4"
   },
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.36.0 <1.0.0",

--- a/packages/typespec-ts/src/lib.ts
+++ b/packages/typespec-ts/src/lib.ts
@@ -198,6 +198,12 @@ const libDef = {
       messages: {
         default: paramMessage`Please specify @items property for the paging operation - ${"operationName"}.`
       }
+    },
+    "decimal-to-number": {
+      severity: "warning",
+      messages: {
+        default: paramMessage`Please note the decimal type will be converted to number. If you strongly care about precision you can use @encode to encode it as a string for the property - ${"propertyName"}.`
+      }
     }
   },
   emitter: {

--- a/packages/typespec-ts/src/utils/modelUtils.ts
+++ b/packages/typespec-ts/src/utils/modelUtils.ts
@@ -1274,7 +1274,12 @@ function getDecimalDescription(type: any) {
     (type.format === "decimal" || type.format === "decimal128") &&
     type.type === "number"
   ) {
-    return `Please note the field was supposed to be a ${type.format} but JavaScript does not have a native 'BigDecimal' data type.\nSo it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle\nany calculations.`;
+    return `NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   `;
   }
   return undefined;
 }

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/clientDefinitions.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/clientDefinitions.ts
@@ -12,6 +12,10 @@ import {
   IntPutParameters,
   FloatGetParameters,
   FloatPutParameters,
+  DecimalGetParameters,
+  DecimalPutParameters,
+  Decimal128GetParameters,
+  Decimal128PutParameters,
   DatetimeGetParameters,
   DatetimePutParameters,
   DurationGetParameters,
@@ -66,6 +70,10 @@ import {
   IntPut204Response,
   FloatGet200Response,
   FloatPut204Response,
+  DecimalGet200Response,
+  DecimalPut204Response,
+  Decimal128Get200Response,
+  Decimal128Put204Response,
   DatetimeGet200Response,
   DatetimePut204Response,
   DurationGet200Response,
@@ -152,6 +160,24 @@ export interface FloatGet {
   get(options?: FloatGetParameters): StreamableMethod<FloatGet200Response>;
   /** Put operation */
   put(options: FloatPutParameters): StreamableMethod<FloatPut204Response>;
+}
+
+export interface DecimalGet {
+  /** Get call */
+  get(options?: DecimalGetParameters): StreamableMethod<DecimalGet200Response>;
+  /** Put operation */
+  put(options: DecimalPutParameters): StreamableMethod<DecimalPut204Response>;
+}
+
+export interface Decimal128Get {
+  /** Get call */
+  get(
+    options?: Decimal128GetParameters
+  ): StreamableMethod<Decimal128Get200Response>;
+  /** Put operation */
+  put(
+    options: Decimal128PutParameters
+  ): StreamableMethod<Decimal128Put204Response>;
 }
 
 export interface DatetimeGet {
@@ -380,6 +406,10 @@ export interface Routes {
   (path: "/type/property/value-types/int"): IntGet;
   /** Resource for '/type/property/value-types/float' has methods for the following verbs: get, put */
   (path: "/type/property/value-types/float"): FloatGet;
+  /** Resource for '/type/property/value-types/decimal' has methods for the following verbs: get, put */
+  (path: "/type/property/value-types/decimal"): DecimalGet;
+  /** Resource for '/type/property/value-types/decimal128' has methods for the following verbs: get, put */
+  (path: "/type/property/value-types/decimal128"): Decimal128Get;
   /** Resource for '/type/property/value-types/datetime' has methods for the following verbs: get, put */
   (path: "/type/property/value-types/datetime"): DatetimeGet;
   /** Resource for '/type/property/value-types/duration' has methods for the following verbs: get, put */

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/models.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/models.ts
@@ -36,9 +36,12 @@ export interface DecimalProperty {
   /**
    * Property
    *
-   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   property: number;
 }
@@ -48,9 +51,12 @@ export interface Decimal128Property {
   /**
    * Property
    *
-   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   property: number;
 }

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/models.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/models.ts
@@ -31,6 +31,30 @@ export interface FloatProperty {
   property: number;
 }
 
+/** Model with a decimal property */
+export interface DecimalProperty {
+  /**
+   * Property
+   *
+   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  property: number;
+}
+
+/** Model with a decimal128 property */
+export interface Decimal128Property {
+  /**
+   * Property
+   *
+   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  property: number;
+}
+
 /** Model with a datetime property */
 export interface DatetimeProperty {
   /** Property */

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/outputModels.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/outputModels.ts
@@ -31,6 +31,30 @@ export interface FloatPropertyOutput {
   property: number;
 }
 
+/** Model with a decimal property */
+export interface DecimalPropertyOutput {
+  /**
+   * Property
+   *
+   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  property: number;
+}
+
+/** Model with a decimal128 property */
+export interface Decimal128PropertyOutput {
+  /**
+   * Property
+   *
+   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  property: number;
+}
+
 /** Model with a datetime property */
 export interface DatetimePropertyOutput {
   /** Property */

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/outputModels.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/outputModels.ts
@@ -36,9 +36,12 @@ export interface DecimalPropertyOutput {
   /**
    * Property
    *
-   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   property: number;
 }
@@ -48,9 +51,12 @@ export interface Decimal128PropertyOutput {
   /**
    * Property
    *
-   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   property: number;
 }

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/parameters.ts
@@ -8,6 +8,8 @@ import {
   BytesProperty,
   IntProperty,
   FloatProperty,
+  DecimalProperty,
+  Decimal128Property,
   DatetimeProperty,
   DurationProperty,
   EnumProperty,
@@ -73,6 +75,23 @@ export interface FloatPutBodyParam {
 }
 
 export type FloatPutParameters = FloatPutBodyParam & RequestParameters;
+export type DecimalGetParameters = RequestParameters;
+
+export interface DecimalPutBodyParam {
+  /** body */
+  body: DecimalProperty;
+}
+
+export type DecimalPutParameters = DecimalPutBodyParam & RequestParameters;
+export type Decimal128GetParameters = RequestParameters;
+
+export interface Decimal128PutBodyParam {
+  /** body */
+  body: Decimal128Property;
+}
+
+export type Decimal128PutParameters = Decimal128PutBodyParam &
+  RequestParameters;
 export type DatetimeGetParameters = RequestParameters;
 
 export interface DatetimePutBodyParam {

--- a/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/responses.ts
+++ b/packages/typespec-ts/test/integration/generated/models/propertyTypes/src/responses.ts
@@ -8,6 +8,8 @@ import {
   BytesPropertyOutput,
   IntPropertyOutput,
   FloatPropertyOutput,
+  DecimalPropertyOutput,
+  Decimal128PropertyOutput,
   DatetimePropertyOutput,
   DurationPropertyOutput,
   EnumPropertyOutput,
@@ -83,6 +85,28 @@ export interface FloatGet200Response extends HttpResponse {
 
 /** There is no content to send for this request, but the headers may be useful. */
 export interface FloatPut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface DecimalGet200Response extends HttpResponse {
+  status: "200";
+  body: DecimalPropertyOutput;
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DecimalPut204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface Decimal128Get200Response extends HttpResponse {
+  status: "200";
+  body: Decimal128PropertyOutput;
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Decimal128Put204Response extends HttpResponse {
   status: "204";
 }
 

--- a/packages/typespec-ts/test/integration/generated/scalar/src/clientDefinitions.ts
+++ b/packages/typespec-ts/test/integration/generated/scalar/src/clientDefinitions.ts
@@ -8,6 +8,16 @@ import {
   BooleanModelPutParameters,
   UnknownGetParameters,
   UnknownPutParameters,
+  DecimalTypeResponseBodyParameters,
+  DecimalTypeRequestBodyParameters,
+  DecimalTypeRequestParameterParameters,
+  Decimal128TypeResponseBodyParameters,
+  Decimal128TypeRequestBodyParameters,
+  Decimal128TypeRequestParameterParameters,
+  DecimalVerifyPrepareVerifyParameters,
+  DecimalVerifyVerifyParameters,
+  Decimal128VerifyPrepareVerifyParameters,
+  Decimal128VerifyVerifyParameters,
 } from "./parameters";
 import {
   StringModelGet200Response,
@@ -16,6 +26,16 @@ import {
   BooleanModelPut204Response,
   UnknownGet200Response,
   UnknownPut204Response,
+  DecimalTypeResponseBody200Response,
+  DecimalTypeRequestBody204Response,
+  DecimalTypeRequestParameter204Response,
+  Decimal128TypeResponseBody200Response,
+  Decimal128TypeRequestBody204Response,
+  Decimal128TypeRequestParameter204Response,
+  DecimalVerifyPrepareVerify200Response,
+  DecimalVerifyVerify204Response,
+  Decimal128VerifyPrepareVerify200Response,
+  Decimal128VerifyVerify204Response,
 } from "./responses";
 import { Client, StreamableMethod } from "@azure-rest/core-client";
 
@@ -48,6 +68,66 @@ export interface UnknownGet {
   put(options: UnknownPutParameters): StreamableMethod<UnknownPut204Response>;
 }
 
+export interface DecimalTypeResponseBody {
+  get(
+    options?: DecimalTypeResponseBodyParameters
+  ): StreamableMethod<DecimalTypeResponseBody200Response>;
+}
+
+export interface DecimalTypeRequestBody {
+  put(
+    options: DecimalTypeRequestBodyParameters
+  ): StreamableMethod<DecimalTypeRequestBody204Response>;
+}
+
+export interface DecimalTypeRequestParameter {
+  get(
+    options: DecimalTypeRequestParameterParameters
+  ): StreamableMethod<DecimalTypeRequestParameter204Response>;
+}
+
+export interface Decimal128TypeResponseBody {
+  get(
+    options?: Decimal128TypeResponseBodyParameters
+  ): StreamableMethod<Decimal128TypeResponseBody200Response>;
+}
+
+export interface Decimal128TypeRequestBody {
+  put(
+    options: Decimal128TypeRequestBodyParameters
+  ): StreamableMethod<Decimal128TypeRequestBody204Response>;
+}
+
+export interface Decimal128TypeRequestParameter {
+  get(
+    options: Decimal128TypeRequestParameterParameters
+  ): StreamableMethod<Decimal128TypeRequestParameter204Response>;
+}
+
+export interface DecimalVerifyPrepareVerify {
+  get(
+    options?: DecimalVerifyPrepareVerifyParameters
+  ): StreamableMethod<DecimalVerifyPrepareVerify200Response>;
+}
+
+export interface DecimalVerifyVerify {
+  post(
+    options: DecimalVerifyVerifyParameters
+  ): StreamableMethod<DecimalVerifyVerify204Response>;
+}
+
+export interface Decimal128VerifyPrepareVerify {
+  get(
+    options?: Decimal128VerifyPrepareVerifyParameters
+  ): StreamableMethod<Decimal128VerifyPrepareVerify200Response>;
+}
+
+export interface Decimal128VerifyVerify {
+  post(
+    options: Decimal128VerifyVerifyParameters
+  ): StreamableMethod<Decimal128VerifyVerify204Response>;
+}
+
 export interface Routes {
   /** Resource for '/type/scalar/string' has methods for the following verbs: get, put */
   (path: "/type/scalar/string"): StringModelGet;
@@ -55,6 +135,30 @@ export interface Routes {
   (path: "/type/scalar/boolean"): BooleanModelGet;
   /** Resource for '/type/scalar/unknown' has methods for the following verbs: get, put */
   (path: "/type/scalar/unknown"): UnknownGet;
+  /** Resource for '/type/scalar/decimal/response_body' has methods for the following verbs: get */
+  (path: "/type/scalar/decimal/response_body"): DecimalTypeResponseBody;
+  /** Resource for '/type/scalar/decimal/resquest_body' has methods for the following verbs: put */
+  (path: "/type/scalar/decimal/resquest_body"): DecimalTypeRequestBody;
+  /** Resource for '/type/scalar/decimal/request_parameter' has methods for the following verbs: get */
+  (path: "/type/scalar/decimal/request_parameter"): DecimalTypeRequestParameter;
+  /** Resource for '/type/scalar/decimal128/response_body' has methods for the following verbs: get */
+  (path: "/type/scalar/decimal128/response_body"): Decimal128TypeResponseBody;
+  /** Resource for '/type/scalar/decimal128/resquest_body' has methods for the following verbs: put */
+  (path: "/type/scalar/decimal128/resquest_body"): Decimal128TypeRequestBody;
+  /** Resource for '/type/scalar/decimal128/request_parameter' has methods for the following verbs: get */
+  (
+    path: "/type/scalar/decimal128/request_parameter"
+  ): Decimal128TypeRequestParameter;
+  /** Resource for '/type/scalar/decimal/prepare_verify' has methods for the following verbs: get */
+  (path: "/type/scalar/decimal/prepare_verify"): DecimalVerifyPrepareVerify;
+  /** Resource for '/type/scalar/decimal/verify' has methods for the following verbs: post */
+  (path: "/type/scalar/decimal/verify"): DecimalVerifyVerify;
+  /** Resource for '/type/scalar/decimal128/prepare_verify' has methods for the following verbs: get */
+  (
+    path: "/type/scalar/decimal128/prepare_verify"
+  ): Decimal128VerifyPrepareVerify;
+  /** Resource for '/type/scalar/decimal128/verify' has methods for the following verbs: post */
+  (path: "/type/scalar/decimal128/verify"): Decimal128VerifyVerify;
 }
 
 export type ScalarClient = Client & {

--- a/packages/typespec-ts/test/integration/generated/scalar/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/scalar/src/parameters.ts
@@ -29,3 +29,87 @@ export interface UnknownPutBodyParam {
 }
 
 export type UnknownPutParameters = UnknownPutBodyParam & RequestParameters;
+export type DecimalTypeResponseBodyParameters = RequestParameters;
+
+export interface DecimalTypeRequestBodyBodyParam {
+  /**
+   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  body: number;
+}
+
+export type DecimalTypeRequestBodyParameters = DecimalTypeRequestBodyBodyParam &
+  RequestParameters;
+
+export interface DecimalTypeRequestParameterQueryParamProperties {
+  /**
+   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  value: number;
+}
+
+export interface DecimalTypeRequestParameterQueryParam {
+  queryParameters: DecimalTypeRequestParameterQueryParamProperties;
+}
+
+export type DecimalTypeRequestParameterParameters =
+  DecimalTypeRequestParameterQueryParam & RequestParameters;
+export type Decimal128TypeResponseBodyParameters = RequestParameters;
+
+export interface Decimal128TypeRequestBodyBodyParam {
+  /**
+   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  body: number;
+}
+
+export type Decimal128TypeRequestBodyParameters =
+  Decimal128TypeRequestBodyBodyParam & RequestParameters;
+
+export interface Decimal128TypeRequestParameterQueryParamProperties {
+  /**
+   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  value: number;
+}
+
+export interface Decimal128TypeRequestParameterQueryParam {
+  queryParameters: Decimal128TypeRequestParameterQueryParamProperties;
+}
+
+export type Decimal128TypeRequestParameterParameters =
+  Decimal128TypeRequestParameterQueryParam & RequestParameters;
+export type DecimalVerifyPrepareVerifyParameters = RequestParameters;
+
+export interface DecimalVerifyVerifyBodyParam {
+  /**
+   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  body: number;
+}
+
+export type DecimalVerifyVerifyParameters = DecimalVerifyVerifyBodyParam &
+  RequestParameters;
+export type Decimal128VerifyPrepareVerifyParameters = RequestParameters;
+
+export interface Decimal128VerifyVerifyBodyParam {
+  /**
+   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
+   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
+   * any calculations.
+   */
+  body: number;
+}
+
+export type Decimal128VerifyVerifyParameters = Decimal128VerifyVerifyBodyParam &
+  RequestParameters;

--- a/packages/typespec-ts/test/integration/generated/scalar/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/scalar/src/parameters.ts
@@ -33,9 +33,12 @@ export type DecimalTypeResponseBodyParameters = RequestParameters;
 
 export interface DecimalTypeRequestBodyBodyParam {
   /**
-   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   body: number;
 }
@@ -45,9 +48,12 @@ export type DecimalTypeRequestBodyParameters = DecimalTypeRequestBodyBodyParam &
 
 export interface DecimalTypeRequestParameterQueryParamProperties {
   /**
-   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   value: number;
 }
@@ -62,9 +68,12 @@ export type Decimal128TypeResponseBodyParameters = RequestParameters;
 
 export interface Decimal128TypeRequestBodyBodyParam {
   /**
-   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   body: number;
 }
@@ -74,9 +83,12 @@ export type Decimal128TypeRequestBodyParameters =
 
 export interface Decimal128TypeRequestParameterQueryParamProperties {
   /**
-   * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   value: number;
 }
@@ -91,9 +103,12 @@ export type DecimalVerifyPrepareVerifyParameters = RequestParameters;
 
 export interface DecimalVerifyVerifyBodyParam {
   /**
-   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   body: number;
 }
@@ -104,9 +119,12 @@ export type Decimal128VerifyPrepareVerifyParameters = RequestParameters;
 
 export interface Decimal128VerifyVerifyBodyParam {
   /**
-   * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-   * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-   * any calculations.
+   * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+   * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+   * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+   * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+   * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+   *
    */
   body: number;
 }

--- a/packages/typespec-ts/test/integration/generated/scalar/src/responses.ts
+++ b/packages/typespec-ts/test/integration/generated/scalar/src/responses.ts
@@ -35,3 +35,58 @@ export interface UnknownGet200Response extends HttpResponse {
 export interface UnknownPut204Response extends HttpResponse {
   status: "204";
 }
+
+/** The request has succeeded. */
+export interface DecimalTypeResponseBody200Response extends HttpResponse {
+  status: "200";
+  body: number;
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DecimalTypeRequestBody204Response extends HttpResponse {
+  status: "204";
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DecimalTypeRequestParameter204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface Decimal128TypeResponseBody200Response extends HttpResponse {
+  status: "200";
+  body: number;
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Decimal128TypeRequestBody204Response extends HttpResponse {
+  status: "204";
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Decimal128TypeRequestParameter204Response
+  extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface DecimalVerifyPrepareVerify200Response extends HttpResponse {
+  status: "200";
+  body: number[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface DecimalVerifyVerify204Response extends HttpResponse {
+  status: "204";
+}
+
+/** The request has succeeded. */
+export interface Decimal128VerifyPrepareVerify200Response extends HttpResponse {
+  status: "200";
+  body: number[];
+}
+
+/** There is no content to send for this request, but the headers may be useful. */
+export interface Decimal128VerifyVerify204Response extends HttpResponse {
+  status: "204";
+}

--- a/packages/typespec-ts/test/integration/modelPropertyType.spec.ts
+++ b/packages/typespec-ts/test/integration/modelPropertyType.spec.ts
@@ -32,6 +32,14 @@ const testedTypes: TypeDetail[] = [
     defaultValue: 42.42
   },
   {
+    type: "decimal",
+    defaultValue: 0.33333
+  },
+  {
+    type: "decimal128",
+    defaultValue: 0.33333
+  },
+  {
     type: "datetime",
     defaultValue: "2022-08-26T18:38:00Z",
     convertedToFn: (value: string) => new Date(value).toISOString()

--- a/packages/typespec-ts/test/integration/scalar.spec.ts
+++ b/packages/typespec-ts/test/integration/scalar.spec.ts
@@ -157,7 +157,6 @@ describe("Scalar Client", () => {
       getResult.body.forEach((decimal: number) => {
         total += decimal;
       });
-      // convert to number from decimal
       const result = await client
         .path("/type/scalar/decimal/verify")
         .post({ body: total });

--- a/packages/typespec-ts/test/integration/scalar.spec.ts
+++ b/packages/typespec-ts/test/integration/scalar.spec.ts
@@ -2,7 +2,6 @@ import { assert } from "chai";
 import ScalarClientFactory, {
   ScalarClient
 } from "./generated/scalar/src/index.js";
-import { Decimal } from "decimal.js";
 
 describe("Scalar Client", () => {
   let client: ScalarClient;
@@ -147,47 +146,41 @@ describe("Scalar Client", () => {
     }
   });
 
-  it("should post decimal verify", async () => {
+  it("should fail to post decimal verify", async () => {
     try {
       // prepare the verification
       const getResult = await client
         .path("/type/scalar/decimal/prepare_verify")
         .get();
-      // do any calculation based on third party library
-      let total = new Decimal(0);
+      // do any calculation based on numbers
+      let total = 0;
       getResult.body.forEach((decimal: number) => {
-        total = total.add(decimal);
+        total += decimal;
       });
       // convert to number from decimal
       const result = await client
         .path("/type/scalar/decimal/verify")
-        .post({ body: total.toNumber() });
-      assert.strictEqual(result.status, "204");
+        .post({ body: total });
+      assert.strictEqual(result.status, "400");
     } catch (err) {
       assert.fail(err as string);
     }
   });
 
-  it("should get decimal128 prepare verify", async () => {
+  it("should fail to post decimal128 verify", async () => {
     try {
-      const result = await client
+      const getResult = await client
         .path("/type/scalar/decimal128/prepare_verify")
         .get();
-      assert.strictEqual(result.status, "200");
-      assert.strictEqual(result.body[0], 0.1);
-      assert.strictEqual(result.body[1], 0.1);
-      assert.strictEqual(result.body[2], 0.1);
-    } catch (err) {
-      assert.fail(err as string);
-    }
-  });
-
-  it("should post decimal128 verify", async () => {
-    try {
+      // do any calculation based on numbers
+      let total = 0;
+      getResult.body.forEach((decimal: number) => {
+        total += decimal;
+      });
       const result = await client
         .path("/type/scalar/decimal128/verify")
-        .post({ body: 0.3 });
-      assert.strictEqual(result.status, "204");
+        .post({ body: total });
+      assert.strictEqual(result.status, "400");
     } catch (err) {
       assert.fail(err as string);
     }

--- a/packages/typespec-ts/test/integration/scalar.spec.ts
+++ b/packages/typespec-ts/test/integration/scalar.spec.ts
@@ -2,6 +2,7 @@ import { assert } from "chai";
 import ScalarClientFactory, {
   ScalarClient
 } from "./generated/scalar/src/index.js";
+import { Decimal } from "decimal.js";
 
 describe("Scalar Client", () => {
   let client: ScalarClient;
@@ -72,6 +73,120 @@ describe("Scalar Client", () => {
       const result = await client
         .path("/type/scalar/unknown")
         .put({ body: JSON.stringify("test") });
+      assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get decimal response body", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal/response_body")
+        .get();
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body, 0.33333);
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should put decimal request body", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal/resquest_body")
+        .put({ body: 0.33333 });
+      assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get decimal request parameter", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal/request_parameter")
+        .get({ queryParameters: { value: 0.33333 } });
+      assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get decimal128 response body", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal128/response_body")
+        .get();
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body, 0.33333);
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should put decimal128 request body", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal128/resquest_body")
+        .put({ body: 0.33333 });
+      assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get decimal128 request parameter", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal128/request_parameter")
+        .get({ queryParameters: { value: 0.33333 } });
+      assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should post decimal verify", async () => {
+    try {
+      // prepare the verification
+      const getResult = await client
+        .path("/type/scalar/decimal/prepare_verify")
+        .get();
+      // do any calculation based on third party library
+      let total = new Decimal(0);
+      getResult.body.forEach((decimal: number) => {
+        total = total.add(decimal);
+      });
+      // convert to number from decimal
+      const result = await client
+        .path("/type/scalar/decimal/verify")
+        .post({ body: total.toNumber() });
+      assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should get decimal128 prepare verify", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal128/prepare_verify")
+        .get();
+      assert.strictEqual(result.status, "200");
+      assert.strictEqual(result.body[0], 0.1);
+      assert.strictEqual(result.body[1], 0.1);
+      assert.strictEqual(result.body[2], 0.1);
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should post decimal128 verify", async () => {
+    try {
+      const result = await client
+        .path("/type/scalar/decimal128/verify")
+        .post({ body: 0.3 });
       assert.strictEqual(result.status, "204");
     } catch (err) {
       assert.fail(err as string);

--- a/packages/typespec-ts/test/unit/modelsGenerator.spec.ts
+++ b/packages/typespec-ts/test/unit/modelsGenerator.spec.ts
@@ -369,9 +369,12 @@ describe("Input/output model type", () => {
         `
       export interface SimpleModel { 
         /**
-         * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-         * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-         * any calculations.
+         * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+         * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+         * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+         * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+         * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+         *
         */
         prop: number;
       }
@@ -382,9 +385,12 @@ describe("Input/output model type", () => {
         `
       export interface SimpleModelOutput { 
         /**
-         * Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
-         * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-         * any calculations.
+         * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+         * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+         * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+         * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+         * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+         *
         */
         prop: number;
       }
@@ -443,9 +449,12 @@ describe("Input/output model type", () => {
         `
       export interface SimpleModel { 
         /**
-         * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
-         * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-         * any calculations.
+         * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+         * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+         * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+         * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+         * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+         *
         */
         prop: number;
       }
@@ -456,9 +465,12 @@ describe("Input/output model type", () => {
         `
       export interface SimpleModelOutput { 
         /**
-         * Please note the field was supposed to be a decimal128 but JavaScript does not have a native 'BigDecimal' data type.
-         * So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle
-         * any calculations.
+         * NOTE: This property is represented as a 'number' in JavaScript, but it corresponds to a 'decimal' type in other languages.
+         * Due to the inherent limitations of floating-point arithmetic in JavaScript, precision issues may arise when performing arithmetic operations.
+         * If your application requires high precision for arithmetic operations or when round-tripping data back to other languages, consider using a library like decimal.js, which provides an arbitrary-precision Decimal type.
+         * For simpler cases, where you need to control the number of decimal places for display purposes, you can use the 'toFixed()' method. However, be aware that 'toFixed()' returns a string and may not be suitable for all arithmetic precision requirements.
+         * Always be cautious with direct arithmetic operations and consider implementing appropriate rounding strategies to maintain accuracy.
+         *
         */
         prop: number;
       }

--- a/packages/typespec-ts/test/util/emitUtil.ts
+++ b/packages/typespec-ts/test/util/emitUtil.ts
@@ -93,7 +93,8 @@ export async function emitModelsFromTypeSpec(
   tspContent: string,
   needAzureCore: boolean = false,
   needTCGC: boolean = false,
-  withRawContent: boolean = false
+  withRawContent: boolean = false,
+  mustEmptyDiagnostic: boolean = true
 ) {
   const context = await rlcEmitterFor(
     tspContent,
@@ -110,7 +111,9 @@ export async function emitModelsFromTypeSpec(
   if (clients && clients[0]) {
     rlcSchemas = transformSchemas(program, clients[0], dpgContext);
   }
-  expectDiagnosticEmpty(program.diagnostics);
+  if (mustEmptyDiagnostic && dpgContext.program.diagnostics.length > 0) {
+    throw dpgContext.program.diagnostics;
+  }
   return buildSchemaTypes({
     schemas: rlcSchemas,
     srcPath: "",


### PR DESCRIPTION
fixes https://github.com/Azure/autorest.typescript/issues/2157 
Support decimal in RLC - map the decimal to `number` in JS directly, and will 
- add below comments in generated code
```
Please note the field was supposed to be a decimal but JavaScript does not have a native 'BigDecimal' data type.
So it was converted to a number instead. It is recommended to use a third-party library like 'decimal.js' to handle 
any calculations.
```
- report a warning 
```
Please note the decimal type will be converted to number. If you strongly care about precision you can use @encode to encode it as a string for the property - {your prop name}.
```
Encoding as string is still pending typespec discussion https://github.com/microsoft/typespec/issues/2762.