### PR TITLE
Add rlc coverage cases for server versions in cadl-ranch

### DIFF
--- a/packages/typespec-ts/test/commands/cadl-ranch-list.ts
+++ b/packages/typespec-ts/test/commands/cadl-ranch-list.ts
@@ -208,6 +208,14 @@ export const rlcTsps: TypeSpecRanchConfig[] = [
   {
     outputPath: "payload/pageable",
     inputPath: "payload/pageable"
+  },
+  {
+    outputPath: "server/versions/versioned",
+    inputPath: "server/versions/versioned"
+  },
+  {
+    outputPath: "server/versions/not-versioned",
+    inputPath: "server/versions/not-versioned"
   }
 ];
 

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/clientDefinitions.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/clientDefinitions.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  WithoutApiVersionParameters,
+  WithQueryApiVersionParameters,
+  WithPathApiVersionParameters,
+} from "./parameters";
+import {
+  WithoutApiVersion200Response,
+  WithQueryApiVersion200Response,
+  WithPathApiVersion200Response,
+} from "./responses";
+import { Client, StreamableMethod } from "@azure-rest/core-client";
+
+export interface WithoutApiVersion {
+  head(
+    options?: WithoutApiVersionParameters,
+  ): StreamableMethod<WithoutApiVersion200Response>;
+}
+
+export interface WithQueryApiVersion {
+  head(
+    options?: WithQueryApiVersionParameters,
+  ): StreamableMethod<WithQueryApiVersion200Response>;
+}
+
+export interface WithPathApiVersion {
+  head(
+    options?: WithPathApiVersionParameters,
+  ): StreamableMethod<WithPathApiVersion200Response>;
+}
+
+export interface Routes {
+  /** Resource for '/server/versions/not-versioned/without-api-version' has methods for the following verbs: head */
+  (
+    path: "/server/versions/not-versioned/without-api-version",
+  ): WithoutApiVersion;
+  /** Resource for '/server/versions/not-versioned/with-query-api-version' has methods for the following verbs: head */
+  (
+    path: "/server/versions/not-versioned/with-query-api-version",
+  ): WithQueryApiVersion;
+  /** Resource for '/server/versions/not-versioned/with-path-api-version/\{apiVersion\}' has methods for the following verbs: head */
+  (
+    path: "/server/versions/not-versioned/with-path-api-version/{apiVersion}",
+    apiVersion: string,
+  ): WithPathApiVersion;
+}
+
+export type NotVersionedParamInServerVersionsClient = Client & {
+  path: Routes;
+};

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/index.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import NotVersionedParamInServerVersionsClient from "./notVersionedParamInServerVersionsClient";
+
+export * from "./notVersionedParamInServerVersionsClient";
+export * from "./parameters";
+export * from "./responses";
+export * from "./clientDefinitions";
+
+export default NotVersionedParamInServerVersionsClient;

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/logger.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/logger.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("not-versioned");

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/notVersionedParamInServerVersionsClient.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/notVersionedParamInServerVersionsClient.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { logger } from "./logger";
+import { NotVersionedParamInServerVersionsClient } from "./clientDefinitions";
+
+/**
+ * Initialize a new instance of `NotVersionedParamInServerVersionsClient`
+ * @param endpoint - Need to be set as 'http://localhost:3000' in client.
+ * @param options - the parameter for all optional parameters
+ */
+export default function createClient(
+  endpoint: string,
+  options: ClientOptions = {},
+): NotVersionedParamInServerVersionsClient {
+  const baseUrl = options.baseUrl ?? `${endpoint}`;
+
+  const userAgentInfo = `azsdk-js-not-versioned-rest/1.0.0-beta.1`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix,
+    },
+    loggingOptions: {
+      logger: options.loggingOptions?.logger ?? logger.info,
+    },
+  };
+
+  const client = getClient(
+    baseUrl,
+    options,
+  ) as NotVersionedParamInServerVersionsClient;
+
+  client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
+
+  return client;
+}

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/parameters.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestParameters } from "@azure-rest/core-client";
+
+export type WithoutApiVersionParameters = RequestParameters;
+
+export interface WithQueryApiVersionQueryParamProperties {
+  "api-version": string;
+}
+
+export interface WithQueryApiVersionQueryParam {
+  queryParameters: WithQueryApiVersionQueryParamProperties;
+}
+
+export type WithQueryApiVersionParameters = WithQueryApiVersionQueryParam &
+  RequestParameters;
+export type WithPathApiVersionParameters = RequestParameters;

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/responses.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/src/responses.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpResponse } from "@azure-rest/core-client";
+
+/** The request has succeeded. */
+export interface WithoutApiVersion200Response extends HttpResponse {
+  status: "200";
+}
+
+/** The request has succeeded. */
+export interface WithQueryApiVersion200Response extends HttpResponse {
+  status: "200";
+}
+
+/** The request has succeeded. */
+export interface WithPathApiVersion200Response extends HttpResponse {
+  status: "200";
+}

--- a/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/tspconfig.yaml
+++ b/packages/typespec-ts/test/integration/generated/server/versions/not-versioned/tspconfig.yaml
@@ -1,0 +1,14 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    "emitter-output-dir": "{project-root}"
+    generateMetadata: false
+    generateTest: false
+    addCredentials: false
+    azureSdkForJs: false
+    isTypeSpecTest: true
+    title: NotVersionedParamInServerVersionsClient
+    packageDetails:
+      name: "@msinternal/not-versioned"
+      description: "Not-versioned Test Service"

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/clientDefinitions.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/clientDefinitions.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import {
+  WithoutApiVersionParameters,
+  WithQueryApiVersionParameters,
+  WithPathApiVersionParameters,
+} from "./parameters";
+import {
+  WithoutApiVersion200Response,
+  WithQueryApiVersion200Response,
+  WithPathApiVersion200Response,
+} from "./responses";
+import { Client, StreamableMethod } from "@azure-rest/core-client";
+
+export interface WithoutApiVersion {
+  head(
+    options?: WithoutApiVersionParameters,
+  ): StreamableMethod<WithoutApiVersion200Response>;
+}
+
+export interface WithQueryApiVersion {
+  head(
+    options?: WithQueryApiVersionParameters,
+  ): StreamableMethod<WithQueryApiVersion200Response>;
+}
+
+export interface WithPathApiVersion {
+  head(
+    options?: WithPathApiVersionParameters,
+  ): StreamableMethod<WithPathApiVersion200Response>;
+}
+
+export interface Routes {
+  /** Resource for '/server/versions/versioned/without-api-version' has methods for the following verbs: head */
+  (path: "/server/versions/versioned/without-api-version"): WithoutApiVersion;
+  /** Resource for '/server/versions/versioned/with-query-api-version' has methods for the following verbs: head */
+  (
+    path: "/server/versions/versioned/with-query-api-version",
+  ): WithQueryApiVersion;
+  /** Resource for '/server/versions/versioned/with-path-api-version/\{apiVersion\}' has methods for the following verbs: head */
+  (
+    path: "/server/versions/versioned/with-path-api-version/{apiVersion}",
+    apiVersion: string,
+  ): WithPathApiVersion;
+}
+
+export type VersionedParamInServerVersionsClient = Client & {
+  path: Routes;
+};

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/index.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import VersionedParamInServerVersionsClient from "./versionedParamInServerVersionsClient";
+
+export * from "./versionedParamInServerVersionsClient";
+export * from "./parameters";
+export * from "./responses";
+export * from "./clientDefinitions";
+
+export default VersionedParamInServerVersionsClient;

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/logger.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/logger.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { createClientLogger } from "@azure/logger";
+export const logger = createClientLogger("versioned");

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/parameters.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/parameters.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { RequestParameters } from "@azure-rest/core-client";
+
+export type WithoutApiVersionParameters = RequestParameters;
+export type WithQueryApiVersionParameters = RequestParameters;
+export type WithPathApiVersionParameters = RequestParameters;

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/responses.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/responses.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { HttpResponse } from "@azure-rest/core-client";
+
+/** The request has succeeded. */
+export interface WithoutApiVersion200Response extends HttpResponse {
+  status: "200";
+}
+
+/** The request has succeeded. */
+export interface WithQueryApiVersion200Response extends HttpResponse {
+  status: "200";
+}
+
+/** The request has succeeded. */
+export interface WithPathApiVersion200Response extends HttpResponse {
+  status: "200";
+}

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/versionedParamInServerVersionsClient.ts
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/src/versionedParamInServerVersionsClient.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { getClient, ClientOptions } from "@azure-rest/core-client";
+import { logger } from "./logger";
+import { VersionedParamInServerVersionsClient } from "./clientDefinitions";
+
+/**
+ * Initialize a new instance of `VersionedParamInServerVersionsClient`
+ * @param endpoint - Need to be set as 'http://localhost:3000' in client.
+ * @param options - the parameter for all optional parameters
+ */
+export default function createClient(
+  endpoint: string,
+  options: ClientOptions = {},
+): VersionedParamInServerVersionsClient {
+  const baseUrl = options.baseUrl ?? `${endpoint}`;
+
+  const userAgentInfo = `azsdk-js-versioned-rest/1.0.0-beta.1`;
+  const userAgentPrefix =
+    options.userAgentOptions && options.userAgentOptions.userAgentPrefix
+      ? `${options.userAgentOptions.userAgentPrefix} ${userAgentInfo}`
+      : `${userAgentInfo}`;
+  options = {
+    ...options,
+    userAgentOptions: {
+      userAgentPrefix,
+    },
+    loggingOptions: {
+      logger: options.loggingOptions?.logger ?? logger.info,
+    },
+  };
+
+  const client = getClient(
+    baseUrl,
+    options,
+  ) as VersionedParamInServerVersionsClient;
+
+  client.pipeline.removePolicy({ name: "ApiVersionPolicy" });
+
+  return client;
+}

--- a/packages/typespec-ts/test/integration/generated/server/versions/versioned/tspconfig.yaml
+++ b/packages/typespec-ts/test/integration/generated/server/versions/versioned/tspconfig.yaml
@@ -1,0 +1,14 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    "emitter-output-dir": "{project-root}"
+    generateMetadata: false
+    generateTest: false
+    addCredentials: false
+    azureSdkForJs: false
+    isTypeSpecTest: true
+    title: VersionedParamInServerVersionsClient
+    packageDetails:
+      name: "@msinternal/versioned"
+      description: "Versioned Test Service"

--- a/packages/typespec-ts/test/integration/server.spec.ts
+++ b/packages/typespec-ts/test/integration/server.spec.ts
@@ -5,6 +5,11 @@ import SingleParamInServerPathClientFactory, {
 import MultipleParamInServerPathClientFactory, {
   MultipleParamInServerPathClient
 } from "./generated/server/path/multiple/src/index.js";
+import NotVersionedParamInServerVersionsClientFactory, { 
+  NotVersionedParamInServerVersionsClient } from "./generated/server/versions/not-versioned/src/index.js"
+import VersionedParamInServerVersionsClientFactory, { 
+    VersionedParamInServerVersionsClient } from "./generated/server/versions/versioned/src/index.js"
+
 describe("SingleParamInServerPath Rest Client", () => {
   let client: SingleParamInServerPathClient;
 
@@ -52,6 +57,90 @@ describe("MultipleParamInServerPath Rest Client", () => {
     try {
       const result = await client.path("/{keyword}", "test").get();
       assert.strictEqual(result.status, "204");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+});
+
+describe(" NotVersionedParamInServerVersions Rest Client", () => {
+  let client: NotVersionedParamInServerVersionsClient;
+
+  beforeEach(() => {
+    client = NotVersionedParamInServerVersionsClientFactory("http://localhost:3000", {
+      allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0
+      }
+    });
+  });
+
+  it("should work with no param", async () => {
+    try {
+      const result = await client.path("/server/versions/not-versioned/without-api-version").head()
+      assert.strictEqual(result.status, "200");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should work with param", async () => {
+    try {
+      const result = await client.path("/server/versions/not-versioned/with-query-api-version").head(
+        {queryParameters:{"api-version":"v1.0"}}
+      )
+      assert.strictEqual(result.status, "200");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should work with path param", async () => {
+    try {
+      const result = await client.path("/server/versions/not-versioned/with-path-api-version/{apiVersion}","v1.0").head()
+      assert.strictEqual(result.status, "200");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+});
+
+describe(" VersionedParamInServerVersions Rest Client", () => {
+  let client: VersionedParamInServerVersionsClient;
+
+  beforeEach(() => {
+    client = VersionedParamInServerVersionsClientFactory("http://localhost:3000", {
+      allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0
+      }
+    });
+  });
+
+  it("should work with no param", async () => {
+    try {
+      const result = await client.path("/server/versions/versioned/without-api-version").head()
+      assert.strictEqual(result.status, "200");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should work with param", async () => {
+    try {
+      const result = await client.path("/server/versions/versioned/with-query-api-version").head(
+        {queryParameters:{"api-version":"2022-12-01-preview"}}
+      )
+      assert.strictEqual(result.status, "200");
+    } catch (err) {
+      assert.fail(err as string);
+    }
+  });
+
+  it("should work with path param", async () => {
+    try {
+      const result = await client.path("/server/versions/versioned/with-path-api-version/{apiVersion}","2022-12-01-preview").head()
+      assert.strictEqual(result.status, "200");
     } catch (err) {
       assert.fail(err as string);
     }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest.typescript/issues/2212