### PR TITLE
Document package-version in README.md

### DIFF
--- a/packages/autorest.typescript/README.md
+++ b/packages/autorest.typescript/README.md
@@ -152,6 +152,9 @@ help-content:
       - key: package-name
         type: string
         description: The name of your package. This is the name your package will be published under.
+      - key: package-version
+        type: string
+        description: The version of your package.
       - key: source-code-folder-path
         type: string
         description: Where to output the generated code inside the output-folder. Defaults to src.


### PR DESCRIPTION
It appears that using `package-version` is already supported ([code](https://github.com/Azure/autorest.typescript/blob/cbe71a7d83ac6d0240fe99973ee94f7266191083/packages/typespec-ts/src/modular/buildCodeModel.ts#L134)) to set the `version` attribute in `package.json`, but not yet documented.

PR adds this to README.