### PR TITLE
[WIP] New design for multipart (type helper implementation)

### DIFF
--- a/packages/rlc-common/src/buildIndexFile.ts
+++ b/packages/rlc-common/src/buildIndexFile.ts
@@ -5,7 +5,6 @@ import { Project, SourceFile } from "ts-morph";
 import { NameType, normalizeName } from "./helpers/nameUtils.js";
 import {
   hasCsvCollection,
-  needsFilePolyfil,
   hasInputModels,
   hasMultiCollection,
   hasOutputModels,
@@ -19,7 +18,6 @@ import {
 import { RLCModel } from "./interfaces.js";
 import * as path from "path";
 import { getImportModuleName } from "./helpers/nameConstructors.js";
-import { getImportSpecifier } from "./helpers/importsUtil.js";
 
 export function buildIndexFile(model: RLCModel) {
   const multiClient = Boolean(model.options?.multiClient),
@@ -166,8 +164,6 @@ function generateRLCIndexForMultiClient(file: SourceFile, model: RLCModel) {
     });
     exports.push("SerializeHelper");
   }
-
-  reExportFileHelperFromCore(file, model);
 
   file.addExportDeclarations([
     {
@@ -331,30 +327,8 @@ function generateRLCIndex(file: SourceFile, model: RLCModel) {
     ]);
   }
 
-  reExportFileHelperFromCore(file, model);
-
   file.addExportAssignment({
     expression: createClientFuncName,
     isExportEquals: false
   });
-}
-
-// re-export file helpers from core
-function reExportFileHelperFromCore(file: SourceFile, model: RLCModel) {
-  if (needsFilePolyfil(model)) {
-    file.addExportDeclarations([
-      {
-        moduleSpecifier: getImportSpecifier(
-          "restPipeline",
-          model.importInfo.runtimeImports
-        ),
-        namedExports: [
-          "createFile",
-          "createFileFromStream",
-          "type CreateFileOptions",
-          "type CreateFileFromStreamOptions"
-        ]
-      }
-    ]);
-  }
 }

--- a/packages/rlc-common/src/buildParameterTypes.ts
+++ b/packages/rlc-common/src/buildParameterTypes.ts
@@ -22,6 +22,7 @@ import {
   getParameterTypeName
 } from "./helpers/nameConstructors.js";
 import { getImportSpecifier } from "./helpers/importsUtil.js";
+import { hasMultipartFormBody } from "./helpers/operationHelpers.js";
 
 export function buildParameterTypes(model: RLCModel) {
   const project = new Project();
@@ -146,9 +147,15 @@ export function buildParameterTypes(model: RLCModel) {
       }
     ]);
   }
+
+  const restClientImports = ["RequestParameters"];
+  if (hasMultipartFormBody(model)) {
+    restClientImports.push("type FormDataPayload");
+  }
+
   parametersFile.addImportDeclarations([
     {
-      namedImports: ["RequestParameters"],
+      namedImports: restClientImports,
       moduleSpecifier: getImportSpecifier(
         "restClient",
         model.importInfo.runtimeImports
@@ -173,6 +180,7 @@ export function buildParameterTypes(model: RLCModel) {
       }
     ]);
   }
+
   return { path: filePath, content: parametersFile.getFullText() };
 }
 

--- a/packages/rlc-common/src/helpers/operationHelpers.ts
+++ b/packages/rlc-common/src/helpers/operationHelpers.ts
@@ -123,9 +123,9 @@ function hasSchemaContextObject(model: RLCModel, schemaUsage: SchemaContext[]) {
   return objectSchemas.length > 0;
 }
 
-export function needsFilePolyfil(model: RLCModel) {
+export function hasMultipartFormBody(model: RLCModel) {
   return model.parameters?.some(
     (p: OperationParameter) =>
-      p.parameters?.some((p) => p.body?.needsFilePolyfil)
+      p.parameters?.some((p) => p.body?.isMultipartForm)
   );
 }

--- a/packages/rlc-common/src/interfaces.ts
+++ b/packages/rlc-common/src/interfaces.ts
@@ -341,10 +341,9 @@ export interface ParameterBodyMetadata {
    */
   isPartialBody?: boolean;
   /**
-   * The `File` type is only available in the browser and Node 20, so we need to check if the file type is included in the body
-   * If yes, we need to export the helpers for customers. This would be useful in multipart/form-data to upload files
+   * Whether the body is a multipart/form-data form. If so, we need to re-export the FormDataPayload helper from core client.
    */
-  needsFilePolyfil?: boolean;
+  isMultipartForm?: boolean;
   body?: ParameterBodySchema[];
 }
 

--- a/packages/typespec-ts/src/transform/transform.ts
+++ b/packages/typespec-ts/src/transform/transform.ts
@@ -154,8 +154,10 @@ export function transformUrlInfo(
           type: getTypeName(schema, usage),
           description:
             (getDoc(program, property) &&
-              getFormattedPropertyDoc(program, property, schema, " ")) ??
-            getFormattedPropertyDoc(program, type, schema, " " /* separator*/),
+              getFormattedPropertyDoc(program, property, schema, {
+                separator: " "
+              })) ??
+            getFormattedPropertyDoc(program, type, schema, { separator: " " }),
           value: predictDefaultValue(dpgContext, host?.[0]?.parameters.get(key))
         });
       }

--- a/packages/typespec-ts/src/utils/mediaTypes.ts
+++ b/packages/typespec-ts/src/utils/mediaTypes.ts
@@ -127,7 +127,17 @@ export function isMediaTypeXml(mediaType: string): boolean {
     : false;
 }
 
-export function isMediaTypeMultipartFormData(mediaType: string): boolean {
+export function isMediaTypeMultipartFormData(
+  mediaType: string | string[]
+): boolean {
+  if (Array.isArray(mediaType)) {
+    return Boolean(
+      mediaType.length === 1 &&
+        mediaType[0] &&
+        isMediaTypeMultipartFormData(mediaType[0])
+    );
+  }
+
   const mt = parseMediaType(mediaType);
   return mt ? mt.type === multipart && mt.subtype === formData : false;
 }

--- a/packages/typespec-ts/src/utils/modelUtils.ts
+++ b/packages/typespec-ts/src/utils/modelUtils.ts
@@ -194,6 +194,7 @@ export function getSchemaForType(
       }
       schema.typeName = `${schema.name}`;
     }
+
     schema.usage = usage;
     return schema;
   } else if (type.kind === "Union") {
@@ -1420,12 +1421,13 @@ function getEnumStringDescription(type: any) {
   return undefined;
 }
 
+const formDataPayloadDescription = `This payload is a multipart/form-data body, represented as an array of parts. Each part is an object with a name property
+and a body property. A file name and a MIME type can be optionally provided for parts that represent file uploads.
+
+Alternatively, instead of an array of parts, an instance of FormData can also be passed as the body here.`;
+
 function getBinaryDescripton(type: any) {
   if (type?.typeName?.includes(BINARY_TYPE_UNION)) {
-    if (type?.typeName?.includes(BINARY_AND_FILE_TYPE_UNION)) {
-      return `NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.`;
-    }
     return `Value may contain any sequence of octets`;
   }
   return undefined;
@@ -1450,15 +1452,21 @@ export function getFormattedPropertyDoc(
   program: Program,
   type: ModelProperty | Type,
   schemaType: any,
-  sperator: string = "\n\n"
+  options?: {
+    separator?: string;
+    multipart?: boolean;
+  }
 ) {
   const propertyDoc = getDoc(program, type);
   const enhancedDocFromType =
     getEnumStringDescription(schemaType) ??
     getDecimalDescription(schemaType) ??
+    (options?.multipart ? formDataPayloadDescription : undefined) ??
     getBinaryDescripton(schemaType);
   if (propertyDoc && enhancedDocFromType) {
-    return `${propertyDoc}${sperator}${enhancedDocFromType}`;
+    return `${propertyDoc}${
+      options?.separator ?? "\n\n"
+    }${enhancedDocFromType}`;
   }
   return propertyDoc ?? enhancedDocFromType;
 }

--- a/packages/typespec-ts/test/unit/bytesGenerator.spec.ts
+++ b/packages/typespec-ts/test/unit/bytesGenerator.spec.ts
@@ -182,14 +182,16 @@ describe("bytes", () => {
         await assertEqualContent(
           parameters?.content!,
           `
-            import { RequestParameters } from "@azure-rest/core-client";
+            import { RequestParameters, type FormDataPayload } from "@azure-rest/core-client";
             
             export interface UploadFileBodyParam {
               /**
-               * NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-               * You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.
+               * This payload is a multipart/form-data body, represented as an array of parts. Each part is an object with a name property
+               * and a body property. A file name and a MIME type can be optionally provided for parts that represent file uploads.
+               *
+               * Alternatively, instead of an array of parts, an instance of FormData can also be passed as the body here.
                */
-              body: {
+              body: FormDataPayload<{
                 name: string;
                 file:
                   | string
@@ -203,7 +205,7 @@ describe("bytes", () => {
                   | ReadableStream<Uint8Array>
                   | NodeJS.ReadableStream
                   | File)[];
-              };
+              }>;
             }
             
             export interface UploadFileMediaTypesParam {
@@ -235,14 +237,16 @@ describe("bytes", () => {
         await assertEqualContent(
           parameters?.content!,
           `
-            import { RequestParameters } from "@azure-rest/core-client";
+            import { RequestParameters, type FormDataPayload } from "@azure-rest/core-client";
             
             export interface UploadFileBodyParam {
               /**
-               * NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-               * You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.
+               * This payload is a multipart/form-data body, represented as an array of parts. Each part is an object with a name property
+               * and a body property. A file name and a MIME type can be optionally provided for parts that represent file uploads.
+               *
+               * Alternatively, instead of an array of parts, an instance of FormData can also be passed as the body here.
                */
-              body: {
+              body: FormDataPayload<{
                 name: string;
                 file:
                   | string
@@ -256,7 +260,7 @@ describe("bytes", () => {
                   | ReadableStream<Uint8Array>
                   | NodeJS.ReadableStream
                   | File)[];
-              };
+              }>;
             }
             
             export interface UploadFileMediaTypesParam {
@@ -290,10 +294,19 @@ describe("bytes", () => {
         await assertEqualContent(
           parameters?.content!,
           `
-            import { RequestParameters } from "@azure-rest/core-client";
+            import { RequestParameters, type FormDataPayload } from "@azure-rest/core-client";
             
             export interface UploadFileBodyParam {
-              body: { name: string; file: { foo: string; foos: string[] } };
+              /**
+               * This payload is a multipart/form-data body, represented as an array of parts. Each part is an object with a name property
+               * and a body property. A file name and a MIME type can be optionally provided for parts that represent file uploads.
+               *
+               * Alternatively, instead of an array of parts, an instance of FormData can also be passed as the body here.
+               */
+              body: FormDataPayload<{ 
+                name: string;
+                file: { foo: string; foos: string[] } 
+              }>;
             }
             
             export interface UploadFileMediaTypesParam {
@@ -333,25 +346,13 @@ describe("bytes", () => {
           `
           export interface Foo {
             "name": string;
-            /**
-             * NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-             * You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.
-             */
+            /** Value may contain any sequence of octets */
             "encodeBytes": string | Uint8Array | ReadableStream<Uint8Array> | NodeJS.ReadableStream | File;
-            /**
-             * NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-             * You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.
-             */
+            /** Value may contain any sequence of octets */
             "withouEncode": string | Uint8Array | ReadableStream<Uint8Array> | NodeJS.ReadableStream | File;
-            /**
-             * NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-             * You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.
-             */
+            /** Value may contain any sequence of octets */
             "files": (string | Uint8Array | ReadableStream<Uint8Array> | NodeJS.ReadableStream | File)[];
-            /**
-             * NOTE: The following type 'File' is part of WebAPI and available since Node 20. If your Node version is lower than Node 20.
-             * You could leverage our helpers 'createFile' or 'createFileFromStream' to create a File object. They could help you specify filename, type, and others.
-             */
+            /** Value may contain any sequence of octets */
             "unionBytes": string | Uint8Array | ReadableStream<Uint8Array> | NodeJS.ReadableStream | File | number;
         }`
         );


### PR DESCRIPTION
For discussion -- possible implementation of new `multipart/form-data`. This implementation uses a type helper, `FormDataPayload<T>`, to construct the expected body shape. The type helper is [currently implemented in the Core client package](https://github.com/Azure/azure-sdk-for-js/blob/3800693d8d63ce6cd9efdacb391161330f3eb7df/sdk/core/core-client-rest/src/multipart.ts#L53-L115) next to the actual multipart serialization logic, although we could also export it from somewhere else or emit it directly as needed. I don't feel strongly any way.

### Why a type helper?

The new multipart body shape is a complex type which requires creating a union consisting of all the possible parts. For example, the following

```typespec
model ExampleMultipartBody {
  propertyA: string;
  propertyB: bytes;
  propertyC: string[];
}
```

Needs to be modelled as

```ts
type ExampleMultipartBody = Array<
  | { name: "propertyA", body: string }
  | {
      name: "propertyB",
      body: Uint8Array | /* ...etc, other binary types... */,
      filename?: string,
      type?: string,
    }
  | {
      name: "propertyC",
      body: string,
    }
>;
```

This presents a few potential issues:

- It is technically quite difficult to model this given the structure of the generator (limited support for type aliases in the rlc-common Schema model and in ts-morph)
- It is difficult to model certain concepts such as inheritance (if a model extends another we need to pull in all the inherited properties into the union)
- Information is lost when generating the type i.e. whether the property is optional or multiple values are permitted

If we use a helper type alias, generating the original model and then using the helper where required, we circumvent all of these issues. We also get the benefit of preserving the original model which could provide context to the user on what the expected shape is. Using the type helper, the body parameter looks something like this:

```ts
export interface ExampleMultipartBodyParam {
  body: FormDataPayload<ExampleMultipartBody>;
}
```

### Alternatives

The obvious alternative to this design is to straight up generate the type alias. This is probably achievable but will require more work and consideration of the different edge cases. However, it might be easier for users to understand when they look at the types. If we think that this is important enough then we could go this route instead.

### Other changes made in this PR

- We don't need to re-export the `File` polyfill anymore, since the file name and MIME type can be set using the part descriptor directly, so I have removed that and the associated comments. We still include `File` in the union of accepted types for file uploads; it's just not necessary to provide a fill since there are now other ways to provide a filename.

### To do

- [ ] Merge and release Core PR first
- [ ] Create and regenerate e2e tests