### PR TITLE
Replace `esm` dev dependency with `tsx` for js mono repo

### DIFF
--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -201,7 +201,7 @@ function regularAutorestPackage(
     packageInfo.devDependencies["@azure-tools/test-credential"] = "^1.0.0";
     packageInfo.devDependencies["mocha"] = "^10.0.0";
     packageInfo.devDependencies["@types/mocha"] = "^10.0.0";
-    packageInfo.devDependencies["esm"] = "^3.2.18";
+    packageInfo.devDependencies["tsx"] = "^4.7.1";
     packageInfo.devDependencies["@types/chai"] = "^4.2.8";
     packageInfo.devDependencies["chai"] = "^4.2.0";
     packageInfo.devDependencies["cross-env"] = "^7.0.2";

--- a/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/additionalProperties/package.json
@@ -33,7 +33,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/integration/generated/datasearch/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datasearch/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/integration/generated/patterntest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/patterntest/package.json
@@ -34,7 +34,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/arm-package-subscriptions-2019-06/package.json
@@ -35,7 +35,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/compute-resource-manager/package.json
@@ -37,7 +37,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/keyvault-resource-manager/package.json
@@ -37,7 +37,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/msi-resource-manager/package.json
@@ -35,7 +35,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/network-resource-manager/package.json
@@ -37,7 +37,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/sql-resource-manager/package.json
@@ -37,7 +37,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/storage-resource-manager/package.json
@@ -37,7 +37,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
+++ b/packages/autorest.typescript/test/smoke/generated/web-resource-manager/package.json
@@ -37,7 +37,7 @@
     "@azure-tools/test-credential": "^1.0.0",
     "mocha": "^10.0.0",
     "@types/mocha": "^10.0.0",
-    "esm": "^3.2.18",
+    "tsx": "^4.7.1",
     "@types/chai": "^4.2.8",
     "chai": "^4.2.0",
     "cross-env": "^7.0.2",

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -164,7 +164,7 @@ function getCjsDevDependencies({
       "karma-sourcemap-loader": "^0.3.8",
       karma: "^6.2.0",
       c8: "^8.0.0",
-      esm: "^3.2.18"
+      tsx: "^4.7.1"
     };
   }
 

--- a/packages/rlc-common/test/integration/packageJson.spec.ts
+++ b/packages/rlc-common/test/integration/packageJson.spec.ts
@@ -376,7 +376,7 @@ describe("Package file generation", () => {
       );
       expect(packageFile.devDependencies).to.have.property("karma");
       expect(packageFile.devDependencies).to.have.property("c8");
-      expect(packageFile.devDependencies).to.have.property("esm");
+      expect(packageFile.devDependencies).to.have.property("tsx");
     });
 
     it("[cjs] should include correct scripts with tests", () => {


### PR DESCRIPTION
as we already switched to `tsx` in PR https://github.com/Azure/azure-sdk-for-js/pull/28826/files#diff-164a9ae95cf7571742ca1882b5fdc0a43e7000c271ff566de5e99ef2c2820021R34

and removed `esm` https://github.com/Azure/azure-sdk-for-js/commit/446e9d831bb77c8dec881c660c64df04384be45c