### PR TITLE
use `dev-tool run extract-api` in packages generated for JS mono repo

### DIFF
--- a/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
+++ b/packages/autorest.typescript/src/generators/static/packageFileGenerator.ts
@@ -185,6 +185,7 @@ function regularAutorestPackage(
     packageInfo.devDependencies["@azure/dev-tool"] = "^1.0.0";
     packageInfo.scripts["build"] =
       "npm run clean && tsc && dev-tool run bundle && npm run minify && mkdirp ./review && npm run extract-api";
+    packageInfo.scripts["extract-api"] = "dev-tool run extract-api";
   } else {
     packageInfo.devDependencies["@rollup/plugin-commonjs"] = "^24.0.0";
     packageInfo.devDependencies["@rollup/plugin-json"] = "^6.0.0";

--- a/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfiguration/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/appconfigurationexport/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/arrayConstraints/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/attestation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/attestation/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureParameterGrouping/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureReport/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
+++ b/packages/autorest.typescript/test/integration/generated/azureSpecialProperties/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyArray/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBoolean/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyBooleanQuirks/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyByte/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplex/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyComplexWithTracing/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDate/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTime/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDateTimeRfc1123/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDictionary/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyDuration/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFile/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyFormData/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyInteger/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyNumber/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyString/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyString/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
+++ b/packages/autorest.typescript/test/integration/generated/bodyTime/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/constantParam/package.json
+++ b/packages/autorest.typescript/test/integration/generated/constantParam/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
+++ b/packages/autorest.typescript/test/integration/generated/corecompattest/package.json
@@ -53,7 +53,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/customUrl/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrl/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlMoreOptions/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/customUrlPaging/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/datafactory/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datafactory/package.json
@@ -54,7 +54,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
+++ b/packages/autorest.typescript/test/integration/generated/datalakestorage/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/deviceprovisioningservice/package.json
@@ -54,7 +54,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/domainservices/package.json
+++ b/packages/autorest.typescript/test/integration/generated/domainservices/package.json
@@ -54,7 +54,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
+++ b/packages/autorest.typescript/test/integration/generated/extensibleEnums/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/header/package.json
+++ b/packages/autorest.typescript/test/integration/generated/header/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
+++ b/packages/autorest.typescript/test/integration/generated/headerprefix/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
+++ b/packages/autorest.typescript/test/integration/generated/healthcareapis/package.json
@@ -54,7 +54,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
+++ b/packages/autorest.typescript/test/integration/generated/httpInfrastructure/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
+++ b/packages/autorest.typescript/test/integration/generated/iotspaces/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/licenseHeader/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lro/package.json
@@ -54,7 +54,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
+++ b/packages/autorest.typescript/test/integration/generated/lroParametrizedEndpoints/package.json
@@ -53,7 +53,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mapperrequired/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypes/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesV3Lro/package.json
@@ -53,7 +53,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
+++ b/packages/autorest.typescript/test/integration/generated/mediaTypesWithTracing/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
+++ b/packages/autorest.typescript/test/integration/generated/modelFlattening/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
+++ b/packages/autorest.typescript/test/integration/generated/multipleInheritance/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nameChecker/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noLicenseHeader/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/noMappers/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noMappers/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/noOperation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/noOperation/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
+++ b/packages/autorest.typescript/test/integration/generated/nonStringEnum/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/objectType/package.json
+++ b/packages/autorest.typescript/test/integration/generated/objectType/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
+++ b/packages/autorest.typescript/test/integration/generated/odataDiscriminator/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
+++ b/packages/autorest.typescript/test/integration/generated/operationgroupclash/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
+++ b/packages/autorest.typescript/test/integration/generated/optionalnull/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/paging/package.json
+++ b/packages/autorest.typescript/test/integration/generated/paging/package.json
@@ -55,7 +55,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
+++ b/packages/autorest.typescript/test/integration/generated/pagingNoIterators/package.json
@@ -53,7 +53,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/petstore/package.json
+++ b/packages/autorest.typescript/test/integration/generated/petstore/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
+++ b/packages/autorest.typescript/test/integration/generated/readmeFileChecker/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
+++ b/packages/autorest.typescript/test/integration/generated/regexConstraint/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/report/package.json
+++ b/packages/autorest.typescript/test/integration/generated/report/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
+++ b/packages/autorest.typescript/test/integration/generated/requiredOptional/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/resources/package.json
+++ b/packages/autorest.typescript/test/integration/generated/resources/package.json
@@ -52,7 +52,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/sealedchoice/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/storageblob/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storageblob/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
+++ b/packages/autorest.typescript/test/integration/generated/storagefileshare/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
+++ b/packages/autorest.typescript/test/integration/generated/subscriptionIdApiVersion/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
+++ b/packages/autorest.typescript/test/integration/generated/textanalytics/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/url/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/url2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/url2/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
+++ b/packages/autorest.typescript/test/integration/generated/urlMulti/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev1/package.json
@@ -47,7 +47,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
+++ b/packages/autorest.typescript/test/integration/generated/useragentcorev2/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/uuid/package.json
+++ b/packages/autorest.typescript/test/integration/generated/uuid/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/validation/package.json
+++ b/packages/autorest.typescript/test/integration/generated/validation/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmlservice/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
+++ b/packages/autorest.typescript/test/integration/generated/xmsErrorResponses/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/azureReport/package.json
@@ -51,7 +51,7 @@
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
     "prepack": "npm run build",
     "pack": "npm pack 2>&1",
-    "extract-api": "api-extractor run --local",
+    "extract-api": "dev-tool run extract-api",
     "lint": "echo skipped",
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
     "build:node": "echo skipped",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/package.json
@@ -66,7 +66,7 @@
   },
   "scripts": {
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "extract-api": "rimraf review && mkdirp ./review && api-extractor run --local",
+    "extract-api": "rimraf review && mkdirp ./review && dev-tool run extract-api",
     "pack": "npm pack 2>&1",
     "lint": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts --fix --fix-type [problem,suggestion]",
@@ -80,10 +80,10 @@
     "generate:client": "echo skipped",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local",
+    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:test": "tsc -p . && dev-tool run bundle",
-    "build:debug": "tsc -p . && dev-tool run bundle && api-extractor run --local",
+    "build:debug": "tsc -p . && dev-tool run bundle && dev-tool run extract-api",
     "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts'",
     "unit-test:browser": "dev-tool run test:browser"
   },

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "extract-api": "rimraf review && mkdirp ./review && api-extractor run --local",
+    "extract-api": "rimraf review && mkdirp ./review && dev-tool run extract-api",
     "pack": "npm pack 2>&1",
     "lint": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts --fix --fix-type [problem,suggestion]",
@@ -77,10 +77,10 @@
     "generate:client": "echo skipped",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local",
+    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:test": "tsc -p . && dev-tool run bundle",
-    "build:debug": "tsc -p . && dev-tool run bundle && api-extractor run --local",
+    "build:debug": "tsc -p . && dev-tool run bundle && dev-tool run extract-api",
     "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts'",
     "unit-test:browser": "dev-tool run test:browser"
   }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "extract-api": "rimraf review && mkdirp ./review && api-extractor run --local",
+    "extract-api": "rimraf review && mkdirp ./review && dev-tool run extract-api",
     "pack": "npm pack 2>&1",
     "lint": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts --fix --fix-type [problem,suggestion]",
@@ -77,10 +77,10 @@
     "generate:client": "echo skipped",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local",
+    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:test": "tsc -p . && dev-tool run bundle",
-    "build:debug": "tsc -p . && dev-tool run bundle && api-extractor run --local",
+    "build:debug": "tsc -p . && dev-tool run bundle && dev-tool run extract-api",
     "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts'",
     "unit-test:browser": "dev-tool run test:browser"
   }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "extract-api": "rimraf review && mkdirp ./review && api-extractor run --local",
+    "extract-api": "rimraf review && mkdirp ./review && dev-tool run extract-api",
     "pack": "npm pack 2>&1",
     "lint": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts --fix --fix-type [problem,suggestion]",
@@ -77,10 +77,10 @@
     "generate:client": "echo skipped",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local",
+    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:test": "tsc -p . && dev-tool run bundle",
-    "build:debug": "tsc -p . && dev-tool run bundle && api-extractor run --local",
+    "build:debug": "tsc -p . && dev-tool run bundle && dev-tool run extract-api",
     "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts'",
     "unit-test:browser": "dev-tool run test:browser"
   }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/package.json
@@ -63,7 +63,7 @@
   },
   "scripts": {
     "clean": "rimraf --glob dist dist-browser dist-esm test-dist temp types *.tgz *.log",
-    "extract-api": "rimraf review && mkdirp ./review && api-extractor run --local",
+    "extract-api": "rimraf review && mkdirp ./review && dev-tool run extract-api",
     "pack": "npm pack 2>&1",
     "lint": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts",
     "lint:fix": "eslint package.json api-extractor.json src test --ext .ts --ext .cts --ext .mts --fix --fix-type [problem,suggestion]",
@@ -77,10 +77,10 @@
     "generate:client": "echo skipped",
     "test:browser": "npm run clean && npm run build:test && npm run unit-test:browser && npm run integration-test:browser",
     "minify": "uglifyjs -c -m --comments --source-map \"content='./dist/index.js.map'\" -o ./dist/index.min.js ./dist/index.js",
-    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local",
+    "build": "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:test": "tsc -p . && dev-tool run bundle",
-    "build:debug": "tsc -p . && dev-tool run bundle && api-extractor run --local",
+    "build:debug": "tsc -p . && dev-tool run bundle && dev-tool run extract-api",
     "unit-test:node": "dev-tool run test:node-ts-input -- --timeout 1200000 --exclude 'test/**/browser/*.spec.ts' 'test/**/*.spec.ts'",
     "unit-test:browser": "dev-tool run test:browser"
   }

--- a/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
+++ b/packages/rlc-common/src/metadata/packageJson/buildAzureMonorepoPackage.ts
@@ -198,6 +198,8 @@ function getAzureMonorepoScripts(config: AzureMonorepoInfoConfig) {
     "check-format":
       'dev-tool run vendored prettier --list-different --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}"',
     "execute:samples": "dev-tool samples run samples-dev",
+    "extract-api":
+      "rimraf review && mkdirp ./review && dev-tool run extract-api",
     format:
       'dev-tool run vendored prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}"',
     "integration-test:browser": "echo skipped",
@@ -223,7 +225,7 @@ function getEsmScripts({ moduleKind }: AzureMonorepoInfoConfig) {
   return {
     "build:test": "npm run clean && tshy && dev-tool run build-test",
     build:
-      "npm run clean && tshy && mkdirp ./review && api-extractor run --local",
+      "npm run clean && tshy && mkdirp ./review && dev-tool run extract-api",
     "test:node":
       "npm run clean && tshy && npm run unit-test:node && npm run integration-test:node",
     test: "npm run clean && tshy && npm run unit-test:node && dev-tool run bundle && npm run unit-test:browser && npm run integration-test",
@@ -240,11 +242,11 @@ function getCjsScripts({ moduleKind }: AzureMonorepoInfoConfig) {
 
   return {
     build:
-      "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local",
+      "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api",
     "build:node": "tsc -p . && cross-env ONLY_NODE=true rollup -c 2>&1",
     "build:test": "tsc -p . && dev-tool run bundle",
     "build:debug":
-      "tsc -p . && dev-tool run bundle && api-extractor run --local",
+      "tsc -p . && dev-tool run bundle && dev-tool run extract-api",
     "integration-test:browser": "dev-tool run test:browser",
     "integration-test:node":
       "dev-tool run test:node-js-input -- --timeout 5000000 'dist-esm/test/**/*.spec.js'",

--- a/packages/rlc-common/test/integration/packageJson.spec.ts
+++ b/packages/rlc-common/test/integration/packageJson.spec.ts
@@ -426,7 +426,7 @@ describe("Package file generation", () => {
       );
       expect(packageFile.scripts).to.have.property(
         "extract-api",
-        "rimraf review && mkdirp ./review && api-extractor run --local"
+        "rimraf review && mkdirp ./review && dev-tool run extract-api"
       );
       expect(packageFile.scripts).to.have.property(
         "integration-test",

--- a/packages/rlc-common/test/integration/packageJson.spec.ts
+++ b/packages/rlc-common/test/integration/packageJson.spec.ts
@@ -295,7 +295,7 @@ describe("Package file generation", () => {
       );
       expect(packageFile.scripts).to.have.property(
         "build",
-        "npm run clean && tshy && mkdirp ./review && api-extractor run --local"
+        "npm run clean && tshy && mkdirp ./review && dev-tool run extract-api"
       );
       expect(packageFile.scripts).to.have.property(
         "test:node",
@@ -319,7 +319,7 @@ describe("Package file generation", () => {
       );
       expect(packageFile.scripts).to.have.property(
         "extract-api",
-        "rimraf review && mkdirp ./review && api-extractor run --local"
+        "rimraf review && mkdirp ./review && dev-tool run extract-api"
       );
       expect(packageFile.scripts).to.have.property(
         "integration-test",
@@ -390,7 +390,7 @@ describe("Package file generation", () => {
 
       expect(packageFile.scripts).to.have.property(
         "build",
-        "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local"
+        "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api"
       );
       expect(packageFile.scripts).to.have.property(
         "build:node",
@@ -402,7 +402,7 @@ describe("Package file generation", () => {
       );
       expect(packageFile.scripts).to.have.property(
         "build:debug",
-        "tsc -p . && dev-tool run bundle && api-extractor run --local"
+        "tsc -p . && dev-tool run bundle && dev-tool run extract-api"
       );
       expect(packageFile.scripts).to.have.property(
         "integration-test:browser",

--- a/packages/typespec-ts/src/modular/buildProjectFiles.ts
+++ b/packages/typespec-ts/src/modular/buildProjectFiles.ts
@@ -331,11 +331,12 @@ function emitBrandedPackage(codeModel: ModularCodeModel) {
       });
     }
     packageInfo.scripts["build"] =
-      "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && api-extractor run --local";
+      "npm run clean && tsc -p . && dev-tool run bundle && mkdirp ./review && dev-tool run extract-api";
     packageInfo.scripts["build:debug"] =
-      "tsc -p . && dev-tool run bundle && api-extractor run --local";
+      "tsc -p . && dev-tool run bundle && dev-tool run extract-api";
     packageInfo.scripts["build:browser"] = "tsc -p . && dev-tool run bundle";
     packageInfo.scripts["build:node"] = "tsc -p . && dev-tool run bundle";
+    packageInfo.scripts["extract-api"] = "dev-tool run extract-api";
     packageInfo.devDependencies["@azure/dev-tool"] = "^1.0.0";
     packageInfo.devDependencies["@azure/eslint-plugin-azure-sdk"] = "^3.0.0";
     // azsdkjs repo use dev-tool to run vendored prettier


### PR DESCRIPTION
This follows the commit in JS repo: https://github.com/Azure/azure-sdk-for-js/commit/224f7c1c1493ad737b22fd58ae634ccad8cdd71b