### PR TITLE
Add unit tests for serializer

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -257,6 +257,8 @@ importers:
       '@typespec/rest': '>=0.56.0 <1.0.0'
       '@typespec/ts-http-runtime': 1.0.0-alpha.20240314.2
       '@typespec/versioning': '>=0.56.0 <1.0.0'
+      '@vitest/coverage-istanbul': ~1.6.0
+      '@vitest/coverage-v8': ~1.6.0
       chai: ^4.3.6
       chalk: ^4.0.0
       cross-env: ^7.0.3
@@ -273,6 +275,7 @@ importers:
       ts-node: ~10.9.1
       tslib: ^2.3.1
       typescript: ~5.4.5
+      vitest: ~1.6.0
     dependencies:
       '@azure-tools/rlc-common': link:../rlc-common
       fs-extra: 11.1.1
@@ -309,6 +312,8 @@ importers:
       '@typespec/rest': 0.56.0_shwv7qwegi6hba73djsyxw3opq
       '@typespec/ts-http-runtime': 1.0.0-alpha.20240314.2
       '@typespec/versioning': 0.56.0_@typespec+compiler@0.56.0
+      '@vitest/coverage-istanbul': 1.6.0_vitest@1.6.0
+      '@vitest/coverage-v8': 1.6.0_vitest@1.6.0
       chai: 4.3.8
       chalk: 4.1.2
       cross-env: 7.0.3
@@ -320,12 +325,21 @@ importers:
       rimraf: 5.0.4
       ts-node: 10.9.1_zhb5j7z2epl224l2ylrhvblng4
       typescript: 5.4.5
+      vitest: 1.6.0_@types+node@18.18.0
 
 packages:
 
   /@aashutoshrathi/word-wrap/1.2.6:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /@ampproject/remapping/2.3.0:
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
   /@autorest/codemodel/4.19.3:
@@ -396,7 +410,7 @@ packages:
       glob: 10.3.9
       morgan: 1.10.0
       multer: 1.4.5-lts.1
-      picocolors: 1.0.0
+      picocolors: 1.0.1
       winston: 3.10.0
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -821,21 +835,207 @@ packages:
     resolution: {integrity: sha512-y5+tLQyV8pg3fsiln67BVLD1P13Eg4lh5RW9mF0zUuvLrv9uIQ4MCL+CRT+FTsBlBjcIan6PGsLcBN0m3ClUyQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.24.2
-      picocolors: 1.0.0
+      '@babel/highlight': 7.24.7
+      picocolors: 1.0.1
 
-  /@babel/helper-validator-identifier/7.22.20:
-    resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/highlight/7.24.2:
-    resolution: {integrity: sha512-Yac1ao4flkTxTteCDZLEvdxg2fZfz1v8M4QpaGypq/WPDqg3ijHYbDfs+LG5hvzSoqaSZ9/Z9lKSP3CjZjv+pA==}
+  /@babel/code-frame/7.24.7:
+    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.20
+      '@babel/highlight': 7.24.7
+      picocolors: 1.0.1
+    dev: true
+
+  /@babel/compat-data/7.24.7:
+    resolution: {integrity: sha512-qJzAIcv03PyaWqxRgO4mSU3lihncDT296vnyuE2O8uA4w3UHWI4S3hgeZd1L8W1Bft40w9JxJ2b412iDUFFRhw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/core/7.24.7:
+    resolution: {integrity: sha512-nykK+LEK86ahTkX/3TgauT0ikKoNCfKHEaZYTUVupJdTLzGNvrblu4u6fa7DhZONAltdf8e662t/abY8idrd/g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@babel/code-frame': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/helper-compilation-targets': 7.24.7
+      '@babel/helper-module-transforms': 7.24.7_@babel+core@7.24.7
+      '@babel/helpers': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/template': 7.24.7
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+      convert-source-map: 2.0.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/generator/7.24.7:
+    resolution: {integrity: sha512-oipXieGC3i45Y1A41t4tAqpnEZWgB/lC6Ehh6+rOviR5XWpTtMmLN+fGjz9vOiNRt0p6RtO6DtD0pdU3vpqdSA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
+      jsesc: 2.5.2
+    dev: true
+
+  /@babel/helper-compilation-targets/7.24.7:
+    resolution: {integrity: sha512-ctSdRHBi20qWOfy27RUb4Fhp07KSJ3sXcuSvTrXrc4aG8NSYDo1ici3Vhg9bg69y5bj0Mr1lh0aeEgTvc12rMg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/compat-data': 7.24.7
+      '@babel/helper-validator-option': 7.24.7
+      browserslist: 4.23.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+    dev: true
+
+  /@babel/helper-environment-visitor/7.24.7:
+    resolution: {integrity: sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/helper-function-name/7.24.7:
+    resolution: {integrity: sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/helper-hoist-variables/7.24.7:
+    resolution: {integrity: sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/helper-module-imports/7.24.7:
+    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-module-transforms/7.24.7_@babel+core@7.24.7:
+    resolution: {integrity: sha512-1fuJEwIrp+97rM4RWdO+qrRsZlAeL1lQJoPqtCYWv0NL115XM93hIH4CSRln2w52SqvmY5hqdtauB6QFCDiZNQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-module-imports': 7.24.7
+      '@babel/helper-simple-access': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-simple-access/7.24.7:
+    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/traverse': 7.24.7
+      '@babel/types': 7.24.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/helper-split-export-declaration/7.24.7:
+    resolution: {integrity: sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/helper-string-parser/7.24.7:
+    resolution: {integrity: sha512-7MbVt6xrwFQbunH2DNQsAP5sTGxfqQtErvBIvIMi6EQnbgUOuVYanvREcmFrOPhoXBrTtjhhP+lW+o5UfK+tDg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helper-validator-identifier/7.24.7:
+    resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-validator-option/7.24.7:
+    resolution: {integrity: sha512-yy1/KvjhV/ZCL+SM7hBrvnZJ3ZuT9OuZgIJAGpPEToANvc3iM6iDvBnRjtElWibHU6n8/LPR/EjX9EtIEYO3pw==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/helpers/7.24.7:
+    resolution: {integrity: sha512-NlmJJtvcw72yRJRcnCmGvSi+3jDEg8qFu3z0AFoymmzLx5ERVWyzd9kVXr7Th9/8yIJi2Zc6av4Tqz3wFs8QWg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.24.7
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/highlight/7.24.7:
+    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.24.7
       chalk: 2.4.2
       js-tokens: 4.0.0
-      picocolors: 1.0.0
+      picocolors: 1.0.1
+
+  /@babel/parser/7.24.7:
+    resolution: {integrity: sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dev: true
+
+  /@babel/template/7.24.7:
+    resolution: {integrity: sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
+    dev: true
+
+  /@babel/traverse/7.24.7:
+    resolution: {integrity: sha512-yb65Ed5S/QAcewNPh0nZczy9JdYXkkAbIsEo+P7BE7yO3txAY30Y/oPa3QkQ5It3xVG2kpKMg9MsdxZaO31uKA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.24.7
+      '@babel/generator': 7.24.7
+      '@babel/helper-environment-visitor': 7.24.7
+      '@babel/helper-function-name': 7.24.7
+      '@babel/helper-hoist-variables': 7.24.7
+      '@babel/helper-split-export-declaration': 7.24.7
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@babel/types/7.24.7:
+    resolution: {integrity: sha512-XEFXSlxiG5td2EJRe8vOmRbaXVgfcBlszKujvVmWIK/UpywWljQCfzAv3RQCGujWQ1RD4YYWEAqDXfuJiy8f5Q==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.24.7
+      '@babel/helper-validator-identifier': 7.24.7
+      to-fast-properties: 2.0.0
+    dev: true
+
+  /@bcoe/v8-coverage/0.2.3:
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+    dev: true
 
   /@colors/colors/1.5.0:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -861,6 +1061,213 @@ packages:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
     dev: true
+
+  /@esbuild/aix-ppc64/0.20.2:
+    resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm/0.20.2:
+    resolution: {integrity: sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64/0.20.2:
+    resolution: {integrity: sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64/0.20.2:
+    resolution: {integrity: sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64/0.20.2:
+    resolution: {integrity: sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64/0.20.2:
+    resolution: {integrity: sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64/0.20.2:
+    resolution: {integrity: sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64/0.20.2:
+    resolution: {integrity: sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm/0.20.2:
+    resolution: {integrity: sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64/0.20.2:
+    resolution: {integrity: sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32/0.20.2:
+    resolution: {integrity: sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64/0.20.2:
+    resolution: {integrity: sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el/0.20.2:
+    resolution: {integrity: sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64/0.20.2:
+    resolution: {integrity: sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64/0.20.2:
+    resolution: {integrity: sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x/0.20.2:
+    resolution: {integrity: sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64/0.20.2:
+    resolution: {integrity: sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64/0.20.2:
+    resolution: {integrity: sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64/0.20.2:
+    resolution: {integrity: sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64/0.20.2:
+    resolution: {integrity: sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64/0.20.2:
+    resolution: {integrity: sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32/0.20.2:
+    resolution: {integrity: sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64/0.20.2:
+    resolution: {integrity: sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@eslint-community/eslint-utils/4.4.0_eslint@8.50.0:
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
@@ -931,13 +1338,25 @@ packages:
       wrap-ansi-cjs: /wrap-ansi/7.0.0
     dev: true
 
-  /@jridgewell/gen-mapping/0.3.3:
-    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+  /@istanbuljs/schema/0.1.3:
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /@jest/schemas/29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
+  /@jridgewell/gen-mapping/0.3.5:
+    resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.19
+      '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
   /@jridgewell/resolve-uri/3.1.1:
@@ -945,24 +1364,24 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: true
 
-  /@jridgewell/set-array/1.1.2:
-    resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
+  /@jridgewell/set-array/1.2.1:
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
     dev: true
 
   /@jridgewell/source-map/0.3.5:
     resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.19
+      '@jridgewell/gen-mapping': 0.3.5
+      '@jridgewell/trace-mapping': 0.3.25
     dev: true
 
   /@jridgewell/sourcemap-codec/1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
-  /@jridgewell/trace-mapping/0.3.19:
-    resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
+  /@jridgewell/trace-mapping/0.3.25:
+    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -1049,6 +1468,138 @@ packages:
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /@rollup/rollup-android-arm-eabi/4.18.0:
+    resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64/4.18.0:
+    resolution: {integrity: sha512-avCea0RAP03lTsDhEyfy+hpfr85KfyTctMADqHVhLAF3MlIkq83CP8UfAHUssgXTYd+6er6PaAhx/QGv4L1EiA==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64/4.18.0:
+    resolution: {integrity: sha512-IWfdwU7KDSm07Ty0PuA/W2JYoZ4iTj3TUQjkVsO/6U+4I1jN5lcR71ZEvRh52sDOERdnNhhHU57UITXz5jC1/w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64/4.18.0:
+    resolution: {integrity: sha512-n2LMsUz7Ynu7DoQrSQkBf8iNrjOGyPLrdSg802vk6XT3FtsgX6JbE8IHRvposskFm9SNxzkLYGSq9QdpLYpRNA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf/4.18.0:
+    resolution: {integrity: sha512-C/zbRYRXFjWvz9Z4haRxcTdnkPt1BtCkz+7RtBSuNmKzMzp3ZxdM28Mpccn6pt28/UWUCTXa+b0Mx1k3g6NOMA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf/4.18.0:
+    resolution: {integrity: sha512-l3m9ewPgjQSXrUMHg93vt0hYCGnrMOcUpTz6FLtbwljo2HluS4zTXFy2571YQbisTnfTKPZ01u/ukJdQTLGh9A==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu/4.18.0:
+    resolution: {integrity: sha512-rJ5D47d8WD7J+7STKdCUAgmQk49xuFrRi9pZkWoRD1UeSMakbcepWXPF8ycChBoAqs1pb2wzvbY6Q33WmN2ftw==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl/4.18.0:
+    resolution: {integrity: sha512-be6Yx37b24ZwxQ+wOQXXLZqpq4jTckJhtGlWGZs68TgdKXJgw54lUUoFYrg6Zs/kjzAQwEwYbp8JxZVzZLRepQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-powerpc64le-gnu/4.18.0:
+    resolution: {integrity: sha512-hNVMQK+qrA9Todu9+wqrXOHxFiD5YmdEi3paj6vP02Kx1hjd2LLYR2eaN7DsEshg09+9uzWi2W18MJDlG0cxJA==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-gnu/4.18.0:
+    resolution: {integrity: sha512-ROCM7i+m1NfdrsmvwSzoxp9HFtmKGHEqu5NNDiZWQtXLA8S5HBCkVvKAxJ8U+CVctHwV2Gb5VUaK7UAkzhDjlg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu/4.18.0:
+    resolution: {integrity: sha512-0UyyRHyDN42QL+NbqevXIIUnKA47A+45WyasO+y2bGJ1mhQrfrtXUpTxCOrfxCR4esV3/RLYyucGVPiUsO8xjg==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu/4.18.0:
+    resolution: {integrity: sha512-xuglR2rBVHA5UsI8h8UbX4VJ470PtGCf5Vpswh7p2ukaqBGFTnsfzxUBetoWBWymHMxbIG0Cmx7Y9qDZzr648w==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl/4.18.0:
+    resolution: {integrity: sha512-LKaqQL9osY/ir2geuLVvRRs+utWUNilzdE90TpyoX0eNqPzWjRm14oMEE+YLve4k/NAqCdPkGYDaDF5Sw+xBfg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc/4.18.0:
+    resolution: {integrity: sha512-7J6TkZQFGo9qBKH0pk2cEVSRhJbL6MtfWxth7Y5YmZs57Pi+4x6c2dStAUvaQkHQLnEQv1jzBUW43GvZW8OFqA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc/4.18.0:
+    resolution: {integrity: sha512-Txjh+IxBPbkUB9+SXZMpv+b/vnTEtFyfWZgJ6iyCmt2tdx0OF5WhFowLmnh8ENGNpfUlUZkdI//4IEmhwPieNg==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc/4.18.0:
+    resolution: {integrity: sha512-UOo5FdvOL0+eIVTgS4tIdbW+TtnBLWg1YBCcU2KWM7nuNwRz9bksDX1bekJJCpu25N1DVWaCwnT39dVQxzqS8g==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@sinclair/typebox/0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
   /@sindresorhus/merge-streams/2.3.0:
@@ -1164,12 +1715,16 @@ packages:
   /@types/eslint/8.44.3:
     resolution: {integrity: sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==}
     dependencies:
-      '@types/estree': 1.0.2
+      '@types/estree': 1.0.5
       '@types/json-schema': 7.0.13
     dev: true
 
   /@types/estree/1.0.2:
     resolution: {integrity: sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==}
+    dev: true
+
+  /@types/estree/1.0.5:
+    resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
     dev: true
 
   /@types/fs-extra/8.1.3:
@@ -1486,6 +2041,87 @@ packages:
     resolution: {integrity: sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==}
     dev: true
 
+  /@vitest/coverage-istanbul/1.6.0_vitest@1.6.0:
+    resolution: {integrity: sha512-h/BwpXehkkS0qsNCS00QxiupAqVkNi0WT19BR0dQvlge5oHghoSVLx63fABYFoKxVb7Ue7+k6V2KokmQ1zdMpg==}
+    peerDependencies:
+      vitest: 1.6.0
+    dependencies:
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-instrument: 6.0.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.4
+      istanbul-reports: 3.1.7
+      magicast: 0.3.4
+      picocolors: 1.0.1
+      test-exclude: 6.0.0
+      vitest: 1.6.0_@types+node@18.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitest/coverage-v8/1.6.0_vitest@1.6.0:
+    resolution: {integrity: sha512-KvapcbMY/8GYIG0rlwwOKCVNRc0OL20rrhFkg/CHNzncV03TE2XWvO5w9uZYoxNiMEBacAJt3unSOiZ7svePew==}
+    peerDependencies:
+      vitest: 1.6.0
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.4
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.10
+      magicast: 0.3.4
+      picocolors: 1.0.1
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      test-exclude: 6.0.0
+      vitest: 1.6.0_@types+node@18.18.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vitest/expect/1.6.0:
+    resolution: {integrity: sha512-ixEvFVQjycy/oNgHjqsL6AZCDduC+tflRluaHIzKIsdbzkLn2U/iBnVeJwB6HsIjQBdfMR8Z0tRxKUsvFJEeWQ==}
+    dependencies:
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      chai: 4.4.1
+    dev: true
+
+  /@vitest/runner/1.6.0:
+    resolution: {integrity: sha512-P4xgwPjwesuBiHisAVz/LSSZtDjOTPYZVmNAnpHHSR6ONrf8eCJOFRvUwdHn30F5M1fxhqtl7QZQUk2dprIXAg==}
+    dependencies:
+      '@vitest/utils': 1.6.0
+      p-limit: 5.0.0
+      pathe: 1.1.2
+    dev: true
+
+  /@vitest/snapshot/1.6.0:
+    resolution: {integrity: sha512-+Hx43f8Chus+DCmygqqfetcAZrDJwvTj0ymqjQq4CvmpKFSTVteEOBzCusu1x2tt4OJcvBflyHUE0DZSLgEMtQ==}
+    dependencies:
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy/1.6.0:
+    resolution: {integrity: sha512-leUTap6B/cqi/bQkXUu6bQV5TZPx7pmMBKBQiI0rJA8c3pB56ZsaTbREnF7CJfmvAS4V2cXIBAh/3rVwrrCYgw==}
+    dependencies:
+      tinyspy: 2.2.1
+    dev: true
+
+  /@vitest/utils/1.6.0:
+    resolution: {integrity: sha512-21cPiuGMoMZwiOHa2i4LXkMkMkCGzA+MVFV70jRwHo95dL4x/ts5GZhML1QWuy7yfp3WzK3lRvZi3JnXTYqrBw==}
+    dependencies:
+      diff-sequences: 29.6.3
+      estree-walker: 3.0.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
+    dev: true
+
   /@webassemblyjs/ast/1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
     dependencies:
@@ -1664,8 +2300,19 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: true
 
+  /acorn-walk/8.3.2:
+    resolution: {integrity: sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /acorn/8.10.0:
     resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /acorn/8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
     dev: true
@@ -1737,6 +2384,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
+
+  /ansi-styles/5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+    dev: true
 
   /ansi-styles/6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
@@ -1988,6 +2640,17 @@ packages:
       update-browserslist-db: 1.0.13_browserslist@4.21.11
     dev: true
 
+  /browserslist/4.23.1:
+    resolution: {integrity: sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+    dependencies:
+      caniuse-lite: 1.0.30001632
+      electron-to-chromium: 1.4.798
+      node-releases: 2.0.14
+      update-browserslist-db: 1.0.16_browserslist@4.23.1
+    dev: true
+
   /buffer-crc32/0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
     dev: true
@@ -2025,6 +2688,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /cac/6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /call-bind/1.0.2:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
@@ -2044,6 +2712,10 @@ packages:
 
   /caniuse-lite/1.0.30001539:
     resolution: {integrity: sha512-hfS5tE8bnNiNvEOEkm8HElUHroYwlqMMENEzELymy77+tJ6m+gA2krtHl5hxJaj71OlpC2cHZbdSMX1/YEqEkA==}
+    dev: true
+
+  /caniuse-lite/1.0.30001632:
+    resolution: {integrity: sha512-udx3o7yHJfUxMLkGohMlVHCvFvWmirKh9JAH/d7WOLPetlH+LTL5cocMZ0t7oZx/mdlOWXti97xLZWc8uURRHg==}
     dev: true
 
   /caseless/0.12.0:
@@ -2072,6 +2744,19 @@ packages:
       type-detect: 4.0.8
     dev: true
 
+  /chai/4.4.1:
+    resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.3
+      get-func-name: 2.0.2
+      loupe: 2.3.7
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -2093,6 +2778,12 @@ packages:
 
   /check-error/1.0.2:
     resolution: {integrity: sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==}
+    dev: true
+
+  /check-error/1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /chokidar/3.5.3:
@@ -2239,6 +2930,10 @@ packages:
       typedarray: 0.0.6
     dev: true
 
+  /confbox/0.1.7:
+    resolution: {integrity: sha512-uJcB/FKZtBMCJpK8MQji6bJHgu1tixKPxRLeGkNzBoOZzpnZUJm0jm2/sBDWcuBx1dYgxV4JU+g5hmNxCyAmdA==}
+    dev: true
+
   /connect/3.7.0:
     resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
     engines: {node: '>= 0.10.0'}
@@ -2259,6 +2954,10 @@ packages:
   /content-type/1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+    dev: true
+
+  /convert-source-map/2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
     dev: true
 
   /cookie-signature/1.0.6:
@@ -2510,6 +3209,11 @@ packages:
     resolution: {integrity: sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==}
     dev: true
 
+  /diff-sequences/29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dev: true
+
   /diff/4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
@@ -2577,6 +3281,10 @@ packages:
 
   /electron-to-chromium/1.4.529:
     resolution: {integrity: sha512-6uyPyXTo8lkv8SWAmjKFbG42U073TXlzD4R8rW3EzuznhFS2olCIAfjjQtV2dV2ar/vRF55KUd3zQYnCB0dd3A==}
+    dev: true
+
+  /electron-to-chromium/1.4.798:
+    resolution: {integrity: sha512-by9J2CiM9KPGj9qfp5U4FcPSbXJG7FNzqnYaY4WLzX+v2PHieVGmnsA4dxfpGE3QEC7JofpPZmn7Vn1B9NR2+Q==}
     dev: true
 
   /emoji-regex/8.0.0:
@@ -2745,9 +3453,45 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
+  /esbuild/0.20.2:
+    resolution: {integrity: sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.20.2
+      '@esbuild/android-arm': 0.20.2
+      '@esbuild/android-arm64': 0.20.2
+      '@esbuild/android-x64': 0.20.2
+      '@esbuild/darwin-arm64': 0.20.2
+      '@esbuild/darwin-x64': 0.20.2
+      '@esbuild/freebsd-arm64': 0.20.2
+      '@esbuild/freebsd-x64': 0.20.2
+      '@esbuild/linux-arm': 0.20.2
+      '@esbuild/linux-arm64': 0.20.2
+      '@esbuild/linux-ia32': 0.20.2
+      '@esbuild/linux-loong64': 0.20.2
+      '@esbuild/linux-mips64el': 0.20.2
+      '@esbuild/linux-ppc64': 0.20.2
+      '@esbuild/linux-riscv64': 0.20.2
+      '@esbuild/linux-s390x': 0.20.2
+      '@esbuild/linux-x64': 0.20.2
+      '@esbuild/netbsd-x64': 0.20.2
+      '@esbuild/openbsd-x64': 0.20.2
+      '@esbuild/sunos-x64': 0.20.2
+      '@esbuild/win32-arm64': 0.20.2
+      '@esbuild/win32-ia32': 0.20.2
+      '@esbuild/win32-x64': 0.20.2
+    dev: true
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
+
+  /escalade/3.1.2:
+    resolution: {integrity: sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==}
+    engines: {node: '>=6'}
+    dev: true
 
   /escape-html/1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -2889,6 +3633,12 @@ packages:
     engines: {node: '>=4.0'}
     dev: true
 
+  /estree-walker/3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+    dependencies:
+      '@types/estree': 1.0.5
+    dev: true
+
   /esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2906,6 +3656,21 @@ packages:
   /events/3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: true
+
+  /execa/8.0.1:
+    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
+    engines: {node: '>=16.17'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.3.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
     dev: true
 
   /express-promise-router/4.1.1_express@4.18.2:
@@ -3293,12 +4058,21 @@ packages:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
     dev: true
 
+  /gensync/1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /get-caller-file/2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
   /get-func-name/2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
+    dev: true
+
+  /get-func-name/2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
     dev: true
 
   /get-intrinsic/1.2.1:
@@ -3315,6 +4089,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       pump: 3.0.0
+    dev: true
+
+  /get-stream/8.0.1:
+    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
+    engines: {node: '>=16'}
     dev: true
 
   /get-symbol-description/1.0.0:
@@ -3403,6 +4182,11 @@ packages:
       inherits: 2.0.4
       minimatch: 5.1.6
       once: 1.4.0
+    dev: true
+
+  /globals/11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
     dev: true
 
   /globals/13.22.0:
@@ -3539,6 +4323,10 @@ packages:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
     dev: true
 
+  /html-escaper/2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+    dev: true
+
   /http-errors/2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
@@ -3629,6 +4417,11 @@ packages:
       - supports-color
     dev: true
 
+  /human-signals/5.0.0:
+    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
+    engines: {node: '>=16.17.0'}
+    dev: true
+
   /iconv-lite/0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3675,6 +4468,7 @@ packages:
 
   /inflight/1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -3858,6 +4652,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /is-stream/3.0.0:
+    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dev: true
+
   /is-string/1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
     engines: {node: '>= 0.4'}
@@ -3942,6 +4741,52 @@ packages:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: true
 
+  /istanbul-lib-coverage/3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /istanbul-lib-instrument/6.0.2:
+    resolution: {integrity: sha512-1WUsZ9R1lA0HtBSohTkm39WTPlNKSJ5iFk7UwqXkBLoHQT+hfqPsfsTDVuZdKGaBwn7din9bS7SsnoAr943hvw==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@babel/core': 7.24.7
+      '@babel/parser': 7.24.7
+      '@istanbuljs/schema': 0.1.3
+      istanbul-lib-coverage: 3.2.2
+      semver: 7.6.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-lib-report/3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+    dev: true
+
+  /istanbul-lib-source-maps/5.0.4:
+    resolution: {integrity: sha512-wHOoEsNJTVltaJp8eVkm8w+GVkVNHT2YDYo53YdzQEL2gWm1hBX5cGFR9hQJtuGLebidVX7et3+dmDZrmclduw==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.3.4
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /istanbul-reports/3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+    dev: true
+
   /jackspeak/2.1.1:
     resolution: {integrity: sha512-juf9stUEwUaILepraGOWIJTLwg48bUnBmRqd2ln2Os1sW987zeoj/hzhbvRB95oMuS2ZTpjULmdwHNX4rzZIZw==}
     engines: {node: '>=14'}
@@ -3972,6 +4817,10 @@ packages:
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-tokens/9.0.0:
+    resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+    dev: true
+
   /js-yaml/4.0.0:
     resolution: {integrity: sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==}
     hasBin: true
@@ -3988,6 +4837,12 @@ packages:
 
   /jsbn/0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: true
+
+  /jsesc/2.5.2:
+    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
+    engines: {node: '>=4'}
+    hasBin: true
     dev: true
 
   /json-buffer/3.0.1:
@@ -4209,6 +5064,14 @@ packages:
       json5: 2.2.3
     dev: true
 
+  /local-pkg/0.5.0:
+    resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
+    engines: {node: '>=14'}
+    dependencies:
+      mlly: 1.7.1
+      pkg-types: 1.1.1
+    dev: true
+
   /locate-path/5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -4300,13 +5163,26 @@ packages:
 
   /loupe/2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
     dependencies:
-      get-func-name: 2.0.0
+      get-func-name: 2.0.2
+    dev: true
+
+  /loupe/2.3.7:
+    resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /lru-cache/10.0.1:
     resolution: {integrity: sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==}
     engines: {node: 14 || >=16.14}
+    dev: true
+
+  /lru-cache/5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+    dependencies:
+      yallist: 3.1.1
     dev: true
 
   /lru-cache/6.0.0:
@@ -4318,6 +5194,27 @@ packages:
   /lru-cache/7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+    dev: true
+
+  /magic-string/0.30.10:
+    resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /magicast/0.3.4:
+    resolution: {integrity: sha512-TyDF/Pn36bBji9rWKHlZe+PZb6Mx5V8IHCSxk7X4aljM4e/vyDvZZYwHewdVaqiA0nb3ghfHU/6AUpDxWoER2Q==}
+    dependencies:
+      '@babel/parser': 7.24.7
+      '@babel/types': 7.24.7
+      source-map-js: 1.2.0
+    dev: true
+
+  /make-dir/4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+    dependencies:
+      semver: 7.6.0
     dev: true
 
   /make-error/1.3.6:
@@ -4384,6 +5281,11 @@ packages:
     hasBin: true
     dev: true
 
+  /mimic-fn/4.0.0:
+    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
     dependencies:
@@ -4446,6 +5348,15 @@ packages:
     resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
     engines: {node: '>=10'}
     hasBin: true
+    dev: true
+
+  /mlly/1.7.1:
+    resolution: {integrity: sha512-rrVRZRELyQzrIUAVMHxP97kv+G786pHmOKzuFII8zDYahFBS7qnHh2AlYSl1GAHhaMPCz6/oHjVMcfFYgFYHgA==}
+    dependencies:
+      acorn: 8.11.3
+      pathe: 1.1.2
+      pkg-types: 1.1.1
+      ufo: 1.5.3
     dev: true
 
   /mocha/10.2.0:
@@ -4589,6 +5500,12 @@ packages:
     hasBin: true
     dev: true
 
+  /nanoid/3.3.7:
+    resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+    dev: true
+
   /natural-compare/1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -4653,6 +5570,10 @@ packages:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
     dev: true
 
+  /node-releases/2.0.14:
+    resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+    dev: true
+
   /normalize-package-data/2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
@@ -4681,6 +5602,13 @@ packages:
       read-pkg: 3.0.0
       shell-quote: 1.8.1
       string.prototype.padend: 3.1.5
+    dev: true
+
+  /npm-run-path/5.3.0:
+    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      path-key: 4.0.0
     dev: true
 
   /oauth-sign/0.9.0:
@@ -4750,6 +5678,13 @@ packages:
       fn.name: 1.1.0
     dev: true
 
+  /onetime/6.0.0:
+    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: true
+
   /open/8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
@@ -4787,6 +5722,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
+    dev: true
+
+  /p-limit/5.0.0:
+    resolution: {integrity: sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      yocto-queue: 1.0.0
     dev: true
 
   /p-locate/4.1.0:
@@ -4852,7 +5794,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.24.2
+      '@babel/code-frame': 7.24.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -4884,6 +5826,11 @@ packages:
   /path-key/3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+    dev: true
+
+  /path-key/4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
     dev: true
 
   /path-parse/1.0.7:
@@ -4924,6 +5871,10 @@ packages:
     resolution: {integrity: sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==}
     engines: {node: '>=12'}
 
+  /pathe/1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+    dev: true
+
   /pathval/1.1.1:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
@@ -4938,6 +5889,9 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+
+  /picocolors/1.0.1:
+    resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -4961,9 +5915,26 @@ packages:
       find-up: 4.1.0
     dev: true
 
+  /pkg-types/1.1.1:
+    resolution: {integrity: sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==}
+    dependencies:
+      confbox: 0.1.7
+      mlly: 1.7.1
+      pathe: 1.1.2
+    dev: true
+
   /pluralize/8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  /postcss/8.4.38:
+    resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.7
+      picocolors: 1.0.1
+      source-map-js: 1.2.0
+    dev: true
 
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -4979,6 +5950,15 @@ packages:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
     engines: {node: '>=14'}
     hasBin: true
+
+  /pretty-format/29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.3.1
+    dev: true
 
   /process-nextick-args/2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
@@ -5138,6 +6118,10 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
+    dev: true
+
+  /react-is/18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
     dev: true
 
   /read-pkg/3.0.0:
@@ -5308,6 +6292,32 @@ packages:
       glob: 10.3.9
     dev: true
 
+  /rollup/4.18.0:
+    resolution: {integrity: sha512-QmJz14PX3rzbJCN1SG4Xe/bAAX2a6NpCP8ab2vfu2GiUr8AQcr2nCV/oEO3yneFarB67zk8ShlIyWb2LGTb3Sg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.5
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.18.0
+      '@rollup/rollup-android-arm64': 4.18.0
+      '@rollup/rollup-darwin-arm64': 4.18.0
+      '@rollup/rollup-darwin-x64': 4.18.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.18.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.18.0
+      '@rollup/rollup-linux-arm64-gnu': 4.18.0
+      '@rollup/rollup-linux-arm64-musl': 4.18.0
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.18.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.18.0
+      '@rollup/rollup-linux-s390x-gnu': 4.18.0
+      '@rollup/rollup-linux-x64-gnu': 4.18.0
+      '@rollup/rollup-linux-x64-musl': 4.18.0
+      '@rollup/rollup-win32-arm64-msvc': 4.18.0
+      '@rollup/rollup-win32-ia32-msvc': 4.18.0
+      '@rollup/rollup-win32-x64-msvc': 4.18.0
+      fsevents: 2.3.3
+    dev: true
+
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -5362,6 +6372,11 @@ packages:
 
   /semver/5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: true
+
+  /semver/6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
     dev: true
 
@@ -5476,6 +6491,10 @@ packages:
       object-inspect: 1.12.3
     dev: true
 
+  /siginfo/2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit/4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -5571,6 +6590,11 @@ packages:
       smart-buffer: 4.2.0
     dev: true
 
+  /source-map-js/1.2.0:
+    resolution: {integrity: sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /source-map-loader/1.1.3_webpack@5.88.2:
     resolution: {integrity: sha512-6YHeF+XzDOrT/ycFJNI53cgEsp/tHTMl37hi7uVyqFAlTXW109JazaQCkbc+jjoL2637qkH1amLi+JzrIpt5lA==}
     engines: {node: '>= 10.13.0'}
@@ -5638,6 +6662,10 @@ packages:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
     dev: true
 
+  /stackback/0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
   /statuses/1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -5646,6 +6674,10 @@ packages:
   /statuses/2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /std-env/3.7.0:
+    resolution: {integrity: sha512-JPbdCEQLj1w5GilpiHAx3qJvFndqybBysA3qUOnznweH4QbNYUsW/ea8QzSrnh0vNsezMMw5bcVool8lM0gwzg==}
     dev: true
 
   /stealthy-require/1.1.1:
@@ -5773,9 +6805,20 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
+  /strip-final-newline/3.0.0:
+    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
+    engines: {node: '>=12'}
+    dev: true
+
   /strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+    dev: true
+
+  /strip-literal/2.1.0:
+    resolution: {integrity: sha512-Op+UycaUt/8FbN/Z2TWPBLge3jWrP3xj10f3fnYxf052bKuS3EKs1ZQcVGjnEMdsNVAM+plXRdmjrZ/KgG3Skw==}
+    dependencies:
+      js-tokens: 9.0.0
     dev: true
 
   /strnum/1.0.5:
@@ -5846,7 +6889,7 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.19
+      '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
@@ -5860,9 +6903,18 @@ packages:
     hasBin: true
     dependencies:
       '@jridgewell/source-map': 0.3.5
-      acorn: 8.10.0
+      acorn: 8.11.3
       commander: 2.20.3
       source-map-support: 0.5.21
+    dev: true
+
+  /test-exclude/6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 7.2.3
+      minimatch: 3.1.2
     dev: true
 
   /text-hex/1.0.0:
@@ -5877,11 +6929,30 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
+  /tinybench/2.8.0:
+    resolution: {integrity: sha512-1/eK7zUnIklz4JUUlL+658n58XO2hHLQfSk1Zf2LKieUjxidN16eKFEoDEfjHc3ohofSSqK3X5yO6VGb6iW8Lw==}
+    dev: true
+
+  /tinypool/0.8.4:
+    resolution: {integrity: sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy/2.2.1:
+    resolution: {integrity: sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /tmp/0.2.1:
     resolution: {integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==}
     engines: {node: '>=8.17.0'}
     dependencies:
       rimraf: 3.0.2
+    dev: true
+
+  /to-fast-properties/2.0.0:
+    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
+    engines: {node: '>=4'}
     dev: true
 
   /to-regex-range/5.0.1:
@@ -6067,6 +7138,10 @@ packages:
     resolution: {integrity: sha512-CPPLoCts2p7D8VbybttE3P2ylv0OBZEAy7a12DsulIEcAiMtWJy+PBgMXgWDI80D5UwqE8oQPHYnk13tm38M2Q==}
     dev: true
 
+  /ufo/1.5.3:
+    resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
+    dev: true
+
   /uglify-js/3.17.4:
     resolution: {integrity: sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==}
     engines: {node: '>=0.8.0'}
@@ -6120,8 +7195,19 @@ packages:
       browserslist: '>= 4.21.0'
     dependencies:
       browserslist: 4.21.11
-      escalade: 3.1.1
-      picocolors: 1.0.0
+      escalade: 3.1.2
+      picocolors: 1.0.1
+    dev: true
+
+  /update-browserslist-db/1.0.16_browserslist@4.23.1:
+    resolution: {integrity: sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+    dependencies:
+      browserslist: 4.23.1
+      escalade: 3.1.2
+      picocolors: 1.0.1
     dev: true
 
   /uri-js/4.4.1:
@@ -6175,6 +7261,119 @@ packages:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+    dev: true
+
+  /vite-node/1.6.0_@types+node@18.18.0:
+    resolution: {integrity: sha512-de6HJgzC+TFzOu0NTC4RAIsyf/DY/ibWDYQUcuEA84EMHhcefTUGkjFHKKEJhQN4A+6I0u++kr3l36ZF2d7XRw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4
+      pathe: 1.1.2
+      picocolors: 1.0.1
+      vite: 5.2.13_@types+node@18.18.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite/5.2.13_@types+node@18.18.0:
+    resolution: {integrity: sha512-SSq1noJfY9pR3I1TUENL3rQYDQCFqgD+lM6fTRAM8Nv6Lsg5hDLaXkjETVeBt+7vZBCMoibD+6IWnT2mJ+Zb/A==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 18.18.0
+      esbuild: 0.20.2
+      postcss: 8.4.38
+      rollup: 4.18.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /vitest/1.6.0_@types+node@18.18.0:
+    resolution: {integrity: sha512-H5r/dN06swuFnzNFhq/dnz37bPXnq8xB2xB5JOVk8K09rUtoeNN+LHWkoQ0A/i3hvbUKKcCei9KpbxqHMLhLLA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 1.6.0
+      '@vitest/ui': 1.6.0
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/node': 18.18.0
+      '@vitest/expect': 1.6.0
+      '@vitest/runner': 1.6.0
+      '@vitest/snapshot': 1.6.0
+      '@vitest/spy': 1.6.0
+      '@vitest/utils': 1.6.0
+      acorn-walk: 8.3.2
+      chai: 4.4.1
+      debug: 4.3.4
+      execa: 8.0.1
+      local-pkg: 0.5.0
+      magic-string: 0.30.10
+      pathe: 1.1.2
+      picocolors: 1.0.1
+      std-env: 3.7.0
+      strip-literal: 2.1.0
+      tinybench: 2.8.0
+      tinypool: 0.8.4
+      vite: 5.2.13_@types+node@18.18.0
+      vite-node: 1.6.0_@types+node@18.18.0
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /void-elements/2.0.1:
@@ -6381,6 +7580,15 @@ packages:
       isexe: 2.0.0
     dev: true
 
+  /why-is-node-running/2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+    dev: true
+
   /wildcard/2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
     dev: true
@@ -6490,6 +7698,10 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
+  /yallist/3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
+
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -6562,4 +7774,9 @@ packages:
   /yocto-queue/0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yocto-queue/1.0.0:
+    resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
+    engines: {node: '>=12.20'}
     dev: true

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -5,6 +5,8 @@
   "main": "dist/src/index.js",
   "type": "module",
   "scripts": {
+    "test-next": "vitest ./test-next",
+    "test-next:coverage": "vitest ./test-next --coverage",
     "clean": "rimraf ./dist ./typespec-output",
     "build": "tsc -p .",
     "test": "npm run unit-test && npm run integration-test-ci",
@@ -89,7 +91,10 @@
     "prettier": "^3.1.0",
     "rimraf": "^5.0.0",
     "ts-node": "~10.9.1",
-    "typescript": "~5.4.5"
+    "typescript": "~5.4.5",
+    "vitest": "~1.6.0",
+    "@vitest/coverage-v8": "~1.6.0",
+    "@vitest/coverage-istanbul": "~1.6.0"
   },
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.42.0 <1.0.0",

--- a/packages/typespec-ts/src/modular/serialization/operationHelpers.ts
+++ b/packages/typespec-ts/src/modular/serialization/operationHelpers.ts
@@ -40,7 +40,7 @@ import { Parameter } from "../modularCodeModel.js";
 import { serializeType } from "../serialization/serializers.js";
 import { SerializerMap } from "../serialization/util.js";
 
-function getRLCResponseType(rlcResponse?: OperationResponse) {
+export function getRLCResponseType(rlcResponse?: OperationResponse) {
   if (!rlcResponse?.responses) {
     return;
   }
@@ -57,7 +57,7 @@ function getRLCResponseType(rlcResponse?: OperationResponse) {
     .join(" | ");
 }
 
-function getRLCLroLogicalResponse(rlcResponse?: OperationResponse) {
+export function getRLCLroLogicalResponse(rlcResponse?: OperationResponse) {
   const logicalResponse = (rlcResponse?.responses ?? []).filter(
     (r) => r.predefinedName && r.predefinedName.endsWith(`LogicalResponse`)
   );

--- a/packages/typespec-ts/test-next/serialization/operationHelper.test.ts
+++ b/packages/typespec-ts/test-next/serialization/operationHelper.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, assert } from "vitest";
+import { format } from "prettier";
 import {
+  buildLroReturnType,
+  getDeserializePrivateFunction,
+  getOperationFunction,
+  getOperationSignatureParameters,
+  getPagingOnlyOperationFunction,
   getRLCLroLogicalResponse,
   getRLCResponseType,
   getSendPrivateFunction
@@ -9,11 +15,17 @@ import {
   OperationResponse
 } from "@azure-tools/rlc-common";
 import { SerializerMap } from "../../src/modular/serialization/util.js";
-import { Operation } from "../../src/modular/modularCodeModel.js";
+import {
+  Operation,
+  Parameter,
+  Response
+} from "../../src/modular/modularCodeModel.js";
 import {
   SdkModelType,
+  SdkType,
   UsageFlags
 } from "@azure-tools/typespec-client-generator-core";
+import { a } from "vitest/dist/suite-IbNSsUWN.js";
 
 describe("Operation Helpers", () => {
   describe("getRLCResponseType", () => {
@@ -109,38 +121,10 @@ describe("Operation Helpers", () => {
   });
 
   describe("getSendPrivateFunction", () => {
-    const mockOperation: Operation = {
-      apiVersions: [],
-      bodyParameter: undefined,
-      description: "",
-      discriminator: "",
-      exceptions: [],
-      groupName: "",
-      isOverload: false,
-      name: "MyOperation",
-      method: "get",
-      namespaceHierarchies: [],
-      overloads: [],
-      parameters: [],
-      responses: [],
-      url: "/my/operation",
-      summary: "",
-      rlcResponse: {
-        operationGroup: "MyOperationGroup",
-        operationName: "MyOperation",
-        path: "/my/operation",
-        responses: [
-          {
-            statusCode: "200"
-          }
-        ]
-      }
-    };
-
     it("should generate an operation with no parameters", () => {
       const dpgContext = {} as any;
 
-      const operation = { ...mockOperation };
+      const operation: Operation = { ...mockOperation, parameters: [] };
       const clientType = "";
       let serializerMap: SerializerMap | undefined;
       const runtimeImports: RuntimeImports = {} as any;
@@ -162,31 +146,7 @@ describe("Operation Helpers", () => {
 
     it("should generate an operation with parameters", () => {
       const operation: Operation = {
-        ...mockOperation,
-        parameters: [
-          {
-            clientName: "niceParam",
-            description: "",
-            implementation: "Method",
-            inOverload: false,
-            location: "query",
-            optional: false,
-            restApiName: "uglyName",
-            type: { name: "uglyName", type: "model" } as any,
-            tcgcType: {
-              name: "niceParam",
-              kind: "model",
-              properties: [],
-              apiVersions: [],
-              crossLanguageDefinitionId: "",
-              isGeneratedName: false,
-              usage: UsageFlags.Input,
-              isFormDataType: false,
-              nullable: false,
-              isError: false
-            } as SdkModelType
-          }
-        ]
+        ...mockOperation
       };
 
       const result = getSendPrivateFunction(
@@ -202,33 +162,783 @@ describe("Operation Helpers", () => {
       assert.equal(result.parameters?.[1].name, "niceParam");
       assert.equal(result.parameters?.[2].name, "options");
       assert.equal(result.parameters?.[2].type, "MyOperationOptionalParams");
+      assert.isTrue(
+        (result.statements as string[])
+          .join("\n")
+          .includes(`return context.path("/my/operation"`)
+      );
+    });
+  });
+
+  describe("getDeserializePrivateFunction", () => {
+    it("should generate a deserialize function", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: []
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.parameters?.length, 1);
+      assert.equal(result.parameters?.[0].name, "result");
+    });
+
+    it("should generate a deserialize function when only error response is provided", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        responses: [
+          {
+            statusCodes: ["default"],
+            type: { name: "MyErrorType", type: "model" },
+            discriminator: "error",
+            headers: []
+          }
+        ]
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.deepEqual(result.statements, ["return result.body"]);
+    });
+
+    it("should generate a deserialize function when both success and error response is provided", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        responses: [
+          {
+            statusCodes: [201],
+            type: { name: "MyGoodType", type: "model" },
+            discriminator: "",
+            headers: []
+          },
+          {
+            statusCodes: ["default"],
+            type: { name: "MyErrorType", type: "model" },
+            discriminator: "error",
+            headers: []
+          }
+        ]
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.deepEqual(result.statements, [
+        'if(result.status !== "201"){',
+        "throw createRestError(result);",
+        "}",
+        "return result.body"
+      ]);
+    });
+
+    it("should generate a deserialize function when only success response is provided", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        responses: [
+          {
+            statusCodes: [200],
+            type: { name: "MyGoodType", type: "model" },
+            discriminator: "",
+            headers: []
+          }
+        ]
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.deepEqual(result.statements, [
+        'if(result.status !== "200"){',
+        "throw createRestError(result);",
+        "}",
+        "return result.body"
+      ]);
+    });
+
+    it("should generate a deserialize function when there is no response", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        responses: []
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.parameters?.length, 1);
+      assert.equal(result.parameters?.[0].name, "result");
+      assert.equal(result.returnType, "Promise<void>");
+
+      // There is nothing to deserialize, so return?
+      assert.deepEqual(result.statements, ["return"]);
+    });
+
+    // This is for the scenario where there is more than one client and need to use the
+    // right isUnexpected helper
+    it("should generate a deserialize function that needs subclient", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: []
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        true,
+        true,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.parameters?.length, 1);
+      assert.equal(result.parameters?.[0].name, "result");
+      assert.isTrue(
+        (result.statements as string[]).some((s) =>
+          s.includes("if(UnexpectedHelper.isUnexpected(result))")
+        )
+      );
+    });
+
+    it("should generate a deserialize function that needs isUnexpected", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: []
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        true,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.parameters?.length, 1);
+      assert.equal(result.parameters?.[0].name, "result");
+      assert.deepEqual(result.statements, [
+        "if(isUnexpected(result)){",
+        "throw createRestError(result);",
+        "}",
+        //TODO: Update when this is implemented
+        'return (()=>{throw Error("Not implemented.")})()'
+      ]);
+    });
+
+    it("should generate a deserialize when operation is lroOnly and non-patch and no finalResultPath", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [mockParameter],
+        discriminator: "lro",
+        method: "get",
+        lroMetadata: {
+          finalResultPath: undefined
+        }
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      // Not enough information to figure out the type so falling back to any
+      assert.deepEqual(result.statements, [
+        'if(result.status !== "200"){',
+        "throw createRestError(result);",
+        "}",
+        "result = result as any;",
+        "return"
+      ]);
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.returnType, "Promise<void>");
+    });
+
+    it("should generate a deserialize when operation is lroOnly and non-patch and has finalResultPath", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [mockParameter],
+        discriminator: "lro",
+        method: "get",
+        lroMetadata: {
+          finalResultPath: "result"
+        }
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.returnType, "Promise<void>");
+      assert.deepEqual(result.statements, [
+        'if(result.status !== "200"){',
+        "throw createRestError(result);",
+        "}",
+        "result = result as any;",
+        `if(result?.body?.result === undefined) {
+          throw createRestError(\`Expected a result in the response at position \"result.body.result\"\`, result);
+        }
+        `,
+        "return"
+      ]);
+    });
+
+    it("should generate a deserialize when operation is lroOnly and non-patch and no finalResultPath", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [mockParameter],
+        discriminator: "lro",
+        method: "get",
+        lroMetadata: {
+          finalResultPath: undefined
+        }
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.returnType, "Promise<void>");
+      assert.deepEqual(result.statements, [
+        'if(result.status !== "200"){',
+        "throw createRestError(result);",
+        "}",
+        "result = result as any;",
+        "return"
+      ]);
+    });
+
+    it("should generate a deserialize when operation is lroOnly and patch", () => {
+      const dpgContext = {} as any;
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [mockParameter],
+        discriminator: "lro",
+        method: "patch"
+      };
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getDeserializePrivateFunction(
+        dpgContext,
+        operation,
+        false,
+        false,
+        runtimeImports,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationDeserialize");
+      assert.equal(result.returnType, "Promise<MyResponseType>");
+    });
+  });
+  describe("getOperationSignatureParameters", () => {
+    it("should return default params context and options", () => {
+      const operation = { ...mockOperation, parameters: [] };
+      const result = getOperationSignatureParameters(
+        operation,
+        "MyClientContext"
+      );
+      assert.equal(result.length, 2);
+      assert.equal(result[0].name, "context");
+      assert.equal(Boolean(result[0].hasQuestionToken), false);
+      assert.equal(result[0].type, "MyClientContext");
+      assert.equal(result[1].name, "options");
+      assert.equal(result[1].type, "MyOperationOptionalParams");
+      assert.equal(result[1].initializer, `{ requestOptions: {} }`);
+    });
+
+    it("should return the the default params plus the operation param", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [
+          {
+            ...mockParameter,
+            clientName: "operationParam",
+            restApiName: "uglyName"
+          }
+        ]
+      };
+      const result = getOperationSignatureParameters(
+        operation,
+        "MyClientContext"
+      );
+      assert.equal(result.length, 3);
+      assert.equal(result[0].name, "context");
+      assert.equal(Boolean(result[0].hasQuestionToken), false);
+      assert.equal(result[0].type, "MyClientContext");
+      assert.equal(result[1].name, "operationParam");
+      assert.equal(result[2].name, "options");
+      assert.equal(result[2].type, "MyOperationOptionalParams");
+      assert.equal(result[2].initializer, `{ requestOptions: {} }`);
+    });
+
+    it("should not include non-method level params", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [
+          {
+            ...mockParameter,
+            clientName: "operationParam",
+            restApiName: "uglyName",
+            implementation: "Client"
+          }
+        ]
+      };
+      const result = getOperationSignatureParameters(
+        operation,
+        "MyClientContext"
+      );
+      assert.equal(result.length, 2);
+      assert.equal(result[0].name, "context");
+      assert.equal(Boolean(result[0].hasQuestionToken), false);
+      assert.equal(result[0].type, "MyClientContext");
+      assert.equal(result[1].name, "options");
+      assert.equal(result[1].type, "MyOperationOptionalParams");
+      assert.equal(result[1].initializer, `{ requestOptions: {} }`);
+    });
+
+    it("should not include constant params", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [
+          {
+            ...mockParameter,
+            clientName: "operationParam",
+            restApiName: "uglyName",
+            type: { type: "constant", value: "constantValue" }
+          }
+        ]
+      };
+      const result = getOperationSignatureParameters(
+        operation,
+        "MyClientContext"
+      );
+      assert.equal(result.length, 2);
+      assert.equal(result[0].name, "context");
+      assert.equal(Boolean(result[0].hasQuestionToken), false);
+      assert.isFalse(result.some((p) => p.name === "operationParam"));
+      assert.equal(result[0].type, "MyClientContext");
+      assert.equal(result[1].name, "options");
+      assert.equal(result[1].type, "MyOperationOptionalParams");
+      assert.equal(result[1].initializer, `{ requestOptions: {} }`);
+    });
+
+    it("should include the body parameter", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        bodyParameter: {
+          clientName: "niceBodyName",
+          restApiName: "uglyBodyName",
+          contentTypes: ["application/json"],
+          description: "",
+          inOverload: false,
+          isBinaryPayload: false,
+          location: "body",
+          optional: false,
+          tcgcType: {
+            apiVersions: [],
+            contentTypes: ["application/json"],
+            kind: "body",
+            name: "MyBodyType",
+            nullable: false,
+            optional: false,
+            defaultContentType: "application/json",
+            correspondingMethodParams: [],
+            type: {} as any,
+            nameInClient: "niceBodyName",
+            isApiVersionParam: false,
+            isGeneratedName: false,
+            onClient: false
+          },
+          type: { type: "model", name: "MyBodyType" }
+        }
+      };
+      const result = getOperationSignatureParameters(
+        operation,
+        "MyClientContext"
+      );
+      assert.equal(result.length, 3);
+      assert.equal(result[0].name, "context");
+      assert.equal(Boolean(result[0].hasQuestionToken), false);
+      assert.equal(result[0].type, "MyClientContext");
+
+      assert.equal(result[1].name, "niceBodyName");
+      assert.equal(result[1].type, "MyBodyType");
+
+      assert.equal(result[2].name, "options");
+      assert.equal(result[2].type, "MyOperationOptionalParams");
+      assert.equal(result[2].initializer, `{ requestOptions: {} }`);
+    });
+  });
+
+  describe("getOperationFunction", () => {
+    it("should generate a simple operation function", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: []
+      };
+
+      const result = getOperationFunction(operation, "MyClient");
+
+      assert.equal(result.name, "myOperation");
+      // Only context and options
+      assert.equal(result.parameters?.length, 2);
+      assert.equal(result.parameters?.[0].name, "context");
+      assert.equal(result.parameters?.[1].name, "options");
+      assert.equal(result.parameters?.[1].type, "MyOperationOptionalParams");
+      assert.deepEqual(result.statements, [
+        "const result = await _myOperationSend(context, options);",
+        "return _myOperationDeserialize(result);"
+      ]);
+    });
+
+    it("should generate a function for a pageable operation", async () => {
+      const operation: Operation = {
+        ...mockOperation,
+        discriminator: "paging",
+        parameters: []
+      };
+      const result = getOperationFunction(operation, "MyClient");
+
+      assert.equal(result.name, "myOperation");
+      // Only context and options
+      assert.equal(result.parameters?.length, 2);
+      assert.equal(result.parameters?.[0].name, "context");
+      assert.equal(result.parameters?.[1].name, "options");
+      assert.equal(result.parameters?.[1].type, "MyOperationOptionalParams");
+
+      const formattedExpected =
+        await reformatString(`return buildPagedAsyncIterator(
+        context, 
+        () => _myOperationSend(context, options), 
+        _myOperationDeserialize,);`);
+
+      const formattedActual = await Promise.all(
+        (result.statements as string[]).map(
+          async (s) => await reformatString(s)
+        )
+      );
+
+      assert.deepEqual(formattedActual, [formattedExpected]);
+      assert.equal(
+        result.returnType,
+        "PagedAsyncIterableIterator<MyResponseType>"
+      );
+    });
+
+    it("should generate a function for an lro operation", async () => {
+      const operation: Operation = {
+        ...mockOperation,
+        discriminator: "lro",
+        parameters: []
+      };
+      const result = getOperationFunction(operation, "MyClient");
+
+      assert.equal(result.name, "myOperation");
+      // Only context and options
+      assert.equal(result.parameters?.length, 2);
+      assert.equal(result.parameters?.[0].name, "context");
+      assert.equal(result.parameters?.[1].name, "options");
+      assert.equal(result.parameters?.[1].type, "MyOperationOptionalParams");
+
+      const formattedExpected = await reformatString(`
+          return getLongRunningPoller(
+            context, 
+            _myOperationDeserialize, {
+              updateIntervalInMs: options?.updateIntervalInMs,
+              abortSignal: options?.abortSignal,
+              getInitialResponse: () => _myOperationSend(context, options)}
+          ) as PollerLike<OperationState<void>, void>;`);
+
+      const formattedActual = await Promise.all(
+        (result.statements as string[]).map(
+          async (s) => await reformatString(s)
+        )
+      );
+
+      assert.deepEqual(formattedActual, [formattedExpected]);
+      assert.equal(result.returnType, "PollerLike<OperationState<void>, void>");
+    });
+  });
+
+  describe("buildLroReturnType", () => {
+    it("should return the correct return type for an lro operation without extra metadata", () => {
+      const operation: Operation = { ...mockOperation, discriminator: "lro" };
+      const result = buildLroReturnType(operation);
+
+      assert.equal(result.type, "void");
+    });
+
+    it("should return the correct return type for an lro operation with extra metadata", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        discriminator: "lro",
+        lroMetadata: {
+          finalResultPath: "result",
+          finalResult: { type: "string", name: "resourceName" }
+        }
+      };
+      const result = buildLroReturnType(operation);
+
+      assert.equal(result.type, "string");
+      assert.equal(result.name, "resourceName");
+    });
+  });
+
+  describe("getPagingOnlyOperationFunction", () => {
+    it("should generate a function for a pageable operation when there are no responses", async () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        responses: [],
+        discriminator: "paging"
+      };
+      const result = getPagingOnlyOperationFunction(operation, "MyClient");
+      assert.equal(result.returnType, "PagedAsyncIterableIterator<void>");
+
+      const formattedActualStatements = await reformatString(
+        result.statements.join("\n")
+      );
+      const formattedExpectedStatements = await reformatString(`
+        return buildPagedAsyncIterator(
+          context,
+          () => _myOperationSend(context, options),
+          _myOperationDeserialize
+        )`);
+
+      assert.equal(formattedActualStatements, formattedExpectedStatements);
+    });
+
+    it("should generate a function for a pageable operation", async () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        discriminator: "paging"
+      };
+      const result = getPagingOnlyOperationFunction(operation, "MyClient");
+      assert.equal(
+        result.returnType,
+        "PagedAsyncIterableIterator<MyResponseType>"
+      );
+
+      const formattedActualStatements = await reformatString(
+        result.statements.join("\n")
+      );
+      const formattedExpectedStatements = await reformatString(`
+        return buildPagedAsyncIterator(
+          context,
+          () => _myOperationSend(context, options),
+          _myOperationDeserialize
+        )`);
+
+      assert.equal(formattedActualStatements, formattedExpectedStatements);
+    });
+
+    it("should generate a function for a pageable operation when itemName is present", async () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        discriminator: "paging",
+        itemName: "myValues"
+      };
+      const result = getPagingOnlyOperationFunction(operation, "MyClient");
+      assert.equal(
+        result.returnType,
+        "PagedAsyncIterableIterator<MyResponseType>"
+      );
+
+      const formattedActualStatements = await reformatString(
+        result.statements.join("\n")
+      );
+      const formattedExpectedStatements = await reformatString(`
+        return buildPagedAsyncIterator(
+          context,
+          () => _myOperationSend(context, options),
+          _myOperationDeserialize,
+          { itemName: "myValues" },
+        )`);
+
+      assert.equal(formattedActualStatements, formattedExpectedStatements);
+    });
+
+    it("should generate a function for a pageable operation when continuationTokenName is present", async () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [],
+        discriminator: "paging",
+        continuationTokenName: "foo"
+      };
+      const result = getPagingOnlyOperationFunction(operation, "MyClient");
+      assert.equal(
+        result.returnType,
+        "PagedAsyncIterableIterator<MyResponseType>"
+      );
+
+      const formattedActualStatements = await reformatString(
+        result.statements.join("\n")
+      );
+      const formattedExpectedStatements = await reformatString(`
+        return buildPagedAsyncIterator(
+          context,
+          () => _myOperationSend(context, options),
+          _myOperationDeserialize,
+          { nextLinkName: "foo" },
+        )`);
+
+      assert.equal(formattedActualStatements, formattedExpectedStatements);
     });
   });
 });
 
-// {
-//     name: "MyOperation",
-//     parameters: {
-//       name: "",
-//       properties: createRekeyableMap(),
-//       kind: "Model",
-//       decorators: [],
-//       derivedModels: [],
-//       isFinished: true,
-//       sourceModels: [],
-//       projections: [],
-//       projectionsByName: () => {
-//         return {} as any;
-//       }
-//     },
-//     decorators: [],
-//     isFinished: true,
-//     kind: "Operation",
-//     node: {} as any,
-//     projections: [],
-//     projectionsByName: () => {
-//       return {} as any;
-//     },
-//     returnType: {} as any,
-//     instantiationParameters: []
-//   };
+const mockResponse: Response = {
+  discriminator: "",
+  headers: [],
+  statusCodes: [200],
+  type: {
+    name: "MyResponseType",
+    type: "model",
+    tcgcType: {
+      apiVersions: [],
+      crossLanguageDefinitionId: "",
+      isError: false,
+      isGeneratedName: false,
+      isFormDataType: false,
+      kind: "model",
+      name: "MyResponseType",
+      nullable: false,
+      properties: [],
+      usage: UsageFlags.Output
+    } as SdkModelType
+  }
+};
+
+const mockParameter: Parameter = {
+  clientName: "niceParam",
+  description: "",
+  implementation: "Method",
+  inOverload: false,
+  location: "query",
+  optional: false,
+  restApiName: "uglyName",
+  type: { name: "uglyName", type: "model" } as any,
+  tcgcType: {
+    name: "niceParam",
+    kind: "model",
+    properties: [],
+    apiVersions: [],
+    crossLanguageDefinitionId: "",
+    isGeneratedName: false,
+    usage: UsageFlags.Input,
+    isFormDataType: false,
+    nullable: false,
+    isError: false
+  } as SdkModelType
+};
+
+const mockOperation: Operation = {
+  apiVersions: [],
+  bodyParameter: undefined,
+  description: "",
+  discriminator: "",
+  exceptions: [],
+  groupName: "",
+  isOverload: false,
+  name: "MyOperation",
+  method: "get",
+  namespaceHierarchies: [],
+  overloads: [],
+  parameters: [mockParameter],
+  responses: [mockResponse],
+  url: "/my/operation",
+  summary: "",
+  rlcResponse: {
+    operationGroup: "MyOperationGroup",
+    operationName: "MyOperation",
+    path: "/my/operation",
+    responses: [
+      {
+        statusCode: "200"
+      }
+    ]
+  }
+};
+
+async function reformatString(str: string) {
+  return format(str, { parser: "typescript" });
+}

--- a/packages/typespec-ts/test-next/serialization/operationHelper.test.ts
+++ b/packages/typespec-ts/test-next/serialization/operationHelper.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, assert } from "vitest";
+import {
+  getRLCLroLogicalResponse,
+  getRLCResponseType,
+  getSendPrivateFunction
+} from "../../src/modular/serialization/operationHelpers.js";
+import {
+  Imports as RuntimeImports,
+  OperationResponse
+} from "@azure-tools/rlc-common";
+import { SerializerMap } from "../../src/modular/serialization/util.js";
+import { Operation } from "../../src/modular/modularCodeModel.js";
+import {
+  SdkModelType,
+  UsageFlags
+} from "@azure-tools/typespec-client-generator-core";
+
+describe("Operation Helpers", () => {
+  describe("getRLCResponseType", () => {
+    it("should return the response type for a given operation", () => {
+      const operation: OperationResponse = {
+        operationGroup: "MyOperationGroup",
+        operationName: "MyOperation",
+        path: "/my/operation",
+        responses: [
+          {
+            statusCode: "200",
+            predefinedName: "MyResponseType"
+          }
+        ]
+      };
+
+      const result = getRLCResponseType(operation as any);
+      assert.equal(result, "MyResponseType");
+    });
+
+    it("should return the response type for a given operation that has no predefinedName", () => {
+      const operation: OperationResponse = {
+        operationGroup: "MyOperationGroup",
+        operationName: "MyOperation",
+        path: "/my/operation",
+        responses: [
+          {
+            statusCode: "200"
+          }
+        ]
+      };
+
+      const result = getRLCResponseType(operation as any);
+      assert.equal(result, "MyOperationGroupMyOperation200Response");
+    });
+
+    it("should return the response type when multiple responses", () => {
+      const operation: OperationResponse = {
+        operationGroup: "MyOperationGroup",
+        operationName: "MyOperation",
+        path: "/my/operation",
+        responses: [
+          {
+            statusCode: "200"
+          },
+          {
+            statusCode: "201"
+          }
+        ]
+      };
+
+      const result = getRLCResponseType(operation as any);
+      assert.equal(
+        result,
+        "MyOperationGroupMyOperation200Response | MyOperationGroupMyOperation201Response"
+      );
+    });
+  });
+
+  describe("getRLCLroLogicalResponse", () => {
+    it("should return the LRO logical response for a given operation", () => {
+      const operation: OperationResponse = {
+        operationGroup: "MyOperationGroup",
+        operationName: "MyOperation",
+        path: "/my/operation",
+        responses: [
+          {
+            statusCode: "201",
+            predefinedName: "MyLogicalResponse"
+          }
+        ]
+      };
+
+      const result = getRLCLroLogicalResponse(operation);
+      assert.equal(result, "MyLogicalResponse");
+    });
+
+    it("should fallback to any if no LogicalResponse found", () => {
+      const operation: OperationResponse = {
+        operationGroup: "MyOperationGroup",
+        operationName: "MyOperation",
+        path: "/my/operation",
+        responses: [
+          {
+            statusCode: "201"
+          }
+        ]
+      };
+
+      const result = getRLCLroLogicalResponse(operation);
+      assert.equal(result, "any");
+    });
+  });
+
+  describe("getSendPrivateFunction", () => {
+    const mockOperation: Operation = {
+      apiVersions: [],
+      bodyParameter: undefined,
+      description: "",
+      discriminator: "",
+      exceptions: [],
+      groupName: "",
+      isOverload: false,
+      name: "MyOperation",
+      method: "get",
+      namespaceHierarchies: [],
+      overloads: [],
+      parameters: [],
+      responses: [],
+      url: "/my/operation",
+      summary: "",
+      rlcResponse: {
+        operationGroup: "MyOperationGroup",
+        operationName: "MyOperation",
+        path: "/my/operation",
+        responses: [
+          {
+            statusCode: "200"
+          }
+        ]
+      }
+    };
+
+    it("should generate an operation with no parameters", () => {
+      const dpgContext = {} as any;
+
+      const operation = { ...mockOperation };
+      const clientType = "";
+      let serializerMap: SerializerMap | undefined;
+      const runtimeImports: RuntimeImports = {} as any;
+
+      const result = getSendPrivateFunction(
+        dpgContext,
+        operation,
+        clientType,
+        serializerMap,
+        runtimeImports
+      );
+
+      assert.equal(result.name, "_myOperationSend");
+      assert.equal(result.parameters?.length, 2);
+      assert.equal(result.parameters?.[0].name, "context");
+      assert.equal(result.parameters?.[1].name, "options");
+      assert.equal(result.parameters?.[1].type, "MyOperationOptionalParams");
+    });
+
+    it("should generate an operation with parameters", () => {
+      const operation: Operation = {
+        ...mockOperation,
+        parameters: [
+          {
+            clientName: "niceParam",
+            description: "",
+            implementation: "Method",
+            inOverload: false,
+            location: "query",
+            optional: false,
+            restApiName: "uglyName",
+            type: { name: "uglyName", type: "model" } as any,
+            tcgcType: {
+              name: "niceParam",
+              kind: "model",
+              properties: [],
+              apiVersions: [],
+              crossLanguageDefinitionId: "",
+              isGeneratedName: false,
+              usage: UsageFlags.Input,
+              isFormDataType: false,
+              nullable: false,
+              isError: false
+            } as SdkModelType
+          }
+        ]
+      };
+
+      const result = getSendPrivateFunction(
+        {} as any,
+        operation,
+        "",
+        undefined,
+        {} as any
+      );
+
+      assert.equal(result.name, "_myOperationSend");
+      assert.equal(result.parameters?.[0].name, "context");
+      assert.equal(result.parameters?.[1].name, "niceParam");
+      assert.equal(result.parameters?.[2].name, "options");
+      assert.equal(result.parameters?.[2].type, "MyOperationOptionalParams");
+    });
+  });
+});
+
+// {
+//     name: "MyOperation",
+//     parameters: {
+//       name: "",
+//       properties: createRekeyableMap(),
+//       kind: "Model",
+//       decorators: [],
+//       derivedModels: [],
+//       isFinished: true,
+//       sourceModels: [],
+//       projections: [],
+//       projectionsByName: () => {
+//         return {} as any;
+//       }
+//     },
+//     decorators: [],
+//     isFinished: true,
+//     kind: "Operation",
+//     node: {} as any,
+//     projections: [],
+//     projectionsByName: () => {
+//       return {} as any;
+//     },
+//     returnType: {} as any,
+//     instantiationParameters: []
+//   };

--- a/packages/typespec-ts/test-next/serialization/util.test.ts
+++ b/packages/typespec-ts/test-next/serialization/util.test.ts
@@ -1,0 +1,157 @@
+import { assert } from "chai";
+import {
+  getEncodingFormat,
+  getModularTypeId,
+  getParameterTypePropertyName,
+  getRLCTypeId,
+  getReturnTypePropertyName
+} from "../../src/modular/serialization/util.js";
+import { UsageFlags } from "@typespec/compiler";
+import {
+  describe,
+  it,
+  afterEach,
+  vi,
+  MockedObject,
+  MockedFunction,
+  Mock
+} from "vitest";
+import { getLibraryName } from "@azure-tools/typespec-client-generator-core";
+import { beforeEach } from "node:test";
+
+// Mock the module
+vi.mock("@azure-tools/typespec-client-generator-core", async () => {
+  const actual = await vi.importActual(
+    "@azure-tools/typespec-client-generator-core"
+  );
+  return {
+    ...actual,
+    getWireName: vi.fn(),
+    getLibraryName: vi.fn()
+  };
+});
+
+type SdkType = any;
+describe("serialization utils", () => {
+  describe("getEncodingFormat", () => {
+    it("should return the encoding format for output", () => {
+      const type = { encode: "base64" } as SdkType & { kind: "bytes" };
+      const result = getEncodingFormat(UsageFlags.Output, type);
+      assert.equal(result, "base64");
+    });
+
+    it("should return the encoding format for input when it is supported", () => {
+      const type = { encode: "base64url" } as SdkType & { kind: "bytes" };
+      const result = getEncodingFormat(UsageFlags.Input, type);
+      assert.equal(result, "base64url");
+    });
+
+    it("should fallback to base64 when the provided encode is not supported", () => {
+      const type = { encode: "somerandom" } as SdkType & { kind: "bytes" };
+      const result = getEncodingFormat(UsageFlags.Input, type);
+      assert.equal(result, "base64");
+    });
+  });
+
+  describe("getModularTypeId", () => {
+    it("should return the name of the type", () => {
+      const type = { name: "myType" } as SdkType;
+      const result = getModularTypeId(type);
+      assert.equal(result, "myType");
+    });
+  });
+
+  // this needs the compiled types
+  describe("getParameterTypePropertyName", () => {
+    afterEach(() => {
+      // Restore all mocks after each test to ensure clean state
+      vi.restoreAllMocks();
+    });
+
+    it("should return the wire name for output", async () => {
+      const { getWireName, getLibraryName } = await import(
+        "@azure-tools/typespec-client-generator-core"
+      );
+
+      (getWireName as any).mockImplementation(() => "wireName");
+      (getLibraryName as any).mockImplementation(() => "libraryName");
+
+      const dpgContext = {} as any;
+      const functionType = UsageFlags.Output;
+      const p = { __raw: {} } as any;
+      const result = getParameterTypePropertyName(dpgContext, functionType, p);
+      assert.equal(result, "wireName");
+    });
+
+    it("should return the library name for input", async () => {
+      const { getWireName, getLibraryName } = await import(
+        "@azure-tools/typespec-client-generator-core"
+      );
+
+      (getWireName as any).mockImplementation(() => "wireName");
+      (getLibraryName as any).mockImplementation(() => "libraryName");
+      const dpgContext = {} as any;
+      const functionType = UsageFlags.Input;
+      const p = { __raw: {} } as any;
+      const result = getParameterTypePropertyName(dpgContext, functionType, p);
+      assert.equal(result, "libraryName");
+    });
+  });
+
+  // this needs the compiled types
+  describe("getReturnTypePropertyName", () => {
+    afterEach(() => {
+      // Restore all mocks after each test to ensure clean state
+      vi.restoreAllMocks();
+    });
+
+    it("should return the library name for output", async () => {
+      const { getWireName, getLibraryName } = await import(
+        "@azure-tools/typespec-client-generator-core"
+      );
+
+      (getWireName as any).mockImplementation(() => "wireName");
+      (getLibraryName as any).mockImplementation(() => "libraryName");
+
+      const result = getReturnTypePropertyName(
+        {} as any,
+        UsageFlags.Output,
+        {} as any
+      );
+      assert.equal(result, "libraryName");
+    });
+
+    it("should return the wire name for input", async () => {
+      const { getWireName, getLibraryName } = await import(
+        "@azure-tools/typespec-client-generator-core"
+      );
+
+      (getWireName as any).mockImplementation(() => "wireName");
+      (getLibraryName as any).mockImplementation(() => "libraryName");
+
+      const result = getReturnTypePropertyName(
+        {} as any,
+        UsageFlags.Input,
+        {} as any
+      );
+      assert.equal(result, "wireName");
+    });
+  });
+
+  describe("getRLCTypeId", () => {
+    it("should return the type name for input", async () => {
+      const dpgContext = {} as any;
+      const type = { name: "myType" } as SdkType;
+      const result = getRLCTypeId(dpgContext, type);
+      assert.equal(result, "myType");
+    });
+
+    // TODO: Enable when getUsage gets updated. Currently it always returns TCGCUsageFlags.Input | TCGCUsageFlags.Output
+    it.skip("should return the type name for output", async () => {
+      const dpgContext = {} as any;
+      const type = { name: "myType" } as SdkType;
+      const result = getRLCTypeId(dpgContext, type);
+      assert.equal(result, "myType Rest");
+    });
+  });
+});

--- a/packages/typespec-ts/tsconfig.json
+++ b/packages/typespec-ts/tsconfig.json
@@ -26,8 +26,7 @@
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     "resolveJsonModule": true,
-    "skipLibCheck": true,
-    "types": ["vitest/globals"]
+    "skipLibCheck": true
   },
   "ts-node": {
     "esm": true

--- a/packages/typespec-ts/tsconfig.json
+++ b/packages/typespec-ts/tsconfig.json
@@ -26,7 +26,8 @@
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
     "resolveJsonModule": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["vitest/globals"]
   },
   "ts-node": {
     "esm": true

--- a/packages/typespec-ts/vitest.config.ts
+++ b/packages/typespec-ts/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: "istanbul",
+      reporter: ["text", "json", "html"],
+      all: true,
+      include: ["src/modular/serialization/**/*.ts"],
+      exclude: ["**/*.spec.ts", "**/*.spec.tsx", ".next/*"]
+    }
+  }
+});


### PR DESCRIPTION
Keeping these tests under test-next since they are true unit test. Will consolidate later when re-organizing the tests. Using vitest for new unit tests since it has better support for ESModules