### PR TITLE
Extend from ../../../tsconfig instead of ../../../tsconfig.package

### DIFF
--- a/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/tsconfig.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/dpgCustomization/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.package",
+  "extends": "../../../tsconfig",
   "compilerOptions": {
     "outDir": "./dist-esm",
     "declarationDir": "./types",

--- a/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/tsconfig.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/httpInfrastructureRest/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.package",
+  "extends": "../../../tsconfig",
   "compilerOptions": { "outDir": "./dist-esm", "declarationDir": "./types" },
   "include": ["src/**/*.ts"]
 }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/tsconfig.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/multipleUrlParameters/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.package",
+  "extends": "../../../tsconfig",
   "compilerOptions": { "outDir": "./dist-esm", "declarationDir": "./types" },
   "include": ["src/**/*.ts"]
 }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/tsconfig.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityAADRest/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.package",
+  "extends": "../../../tsconfig",
   "compilerOptions": { "outDir": "./dist-esm", "declarationDir": "./types" },
   "include": ["src/**/*.ts"]
 }

--- a/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/tsconfig.json
+++ b/packages/autorest.typescript/test/rlcIntegration/generated/securityKeyRest/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "../../../tsconfig.package",
+  "extends": "../../../tsconfig",
   "compilerOptions": { "outDir": "./dist-esm", "declarationDir": "./types" },
   "include": ["src/**/*.ts"]
 }

--- a/packages/rlc-common/src/metadata/buildTsConfig.ts
+++ b/packages/rlc-common/src/metadata/buildTsConfig.ts
@@ -9,7 +9,7 @@ const restLevelTsConfigInAzureSdkForJs: (
 ) => Record<string, any> = function (model: RLCModel) {
   if (model.options?.moduleKind === "esm") {
     return {
-      extends: "../../../tsconfig.package",
+      extends: "../../../tsconfig",
       compilerOptions: {
         module: "NodeNext",
         moduleResolution: "NodeNext",
@@ -25,7 +25,7 @@ const restLevelTsConfigInAzureSdkForJs: (
   }
 
   return {
-    extends: "../../../tsconfig.package",
+    extends: "../../../tsconfig",
     compilerOptions: {
       outDir: "./dist-esm",
       declarationDir: "./types"


### PR DESCRIPTION
I plan to do the same for all packages in the Azure SDK for JS repository as the
latter just simply extends from the former. There might be more customization in
the early days but no longer the case.